### PR TITLE
fix typos in example docs

### DIFF
--- a/docs/en/models/glm4-9B.md
+++ b/docs/en/models/glm4-9B.md
@@ -44,7 +44,7 @@ Execute the training:
 
 ```bash
 cd /root/slime
-bash script/run-glm4-9B.sh
+bash scripts/run-glm4-9B.sh
 ```
 
 ### Parameter Introduction

--- a/docs/en/models/qwen3-4B.md
+++ b/docs/en/models/qwen3-4B.md
@@ -43,7 +43,7 @@ Execute the training script:
 
 ```bash
 cd /root/slime
-bash script/run-qwen3-4B.sh
+bash scripts/run-qwen3-4B.sh
 ```
 
 ### Parameter Introduction


### PR DESCRIPTION
`script/run-glm4-9B.sh` -> `scripts/run-glm4-9B.sh`.

The same with Qwen.