### PR TITLE
build: add support for py 3.12 in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setup(
     classifiers=[
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Environment :: GPU :: NVIDIA CUDA",
         "Topic :: Scientific/Engineering :: Artificial Intelligence",
         "Topic :: System :: Distributed Computing",


### PR DESCRIPTION
slime supports Python 3.12, and the Docker image is based on pytorch:25.04-py3 where the default Python version is 3.12