### PR TITLE
Fix: Correct two bugs in agent rollout process

### DIFF
--- a/slime/ray/buffer.py
+++ b/slime/ray/buffer.py
@@ -191,12 +191,15 @@ class Buffer:
         del data_pool[rollout_id]
         return data
 
-    def _convert_samples_to_train_data(self, samples: list[Sample]):
+    def _convert_samples_to_train_data(self, samples: Union[list[Sample], list[list[Sample]]]):
         """
         Convert inference generated samples to training data.
         """
-
-        samples = sorted(samples, key=lambda x: x.index)
+        if isinstance(samples[0], list):
+            samples = [sample for group in samples for sample in group]
+        else:
+            samples = sorted(samples, key=lambda x: x.index)
+        
         train_data = {
             "tokens": [sample.tokens for sample in samples],
             "response_lengths": [sample.response_length for sample in samples],

--- a/slime/rollout/agent_rollout.py
+++ b/slime/rollout/agent_rollout.py
@@ -298,7 +298,7 @@ async def generate_agent_rollout(
                 tokens=token_ids,
                 response_length=response_length,
                 reward=record["reward"],
-                truncated=False,
+                status=Sample.Status.COMPLETED,
                 loss_mask=loss_mask,
                 metadata={**record["extra_info"], "raw_reward": record["raw_reward"]},
             )


### PR DESCRIPTION
## Fixes two bugs in agent rollout.

**[bug 1]**  Incorrect keyword argument for Sample initialization

Error:
``` bash
TypeError: Sample.__init__() got an unexpected keyword argument 'truncated'
```

The Sample class uses Sample.Status.TRUNCATED to manage its state, but the calling code was still using the old truncated keyword argument.

---

**[bug 2]**   Type error when processing grouped samples in buffer

Error:
```bash
File "./slime/slime/ray/buffer.py", line 199, in _convert_samples_to_train_data
    samples = sorted(samples, key=lambda x: x.index)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: '<' not supported between instances of 'builtin_function_or_method' and 'builtin_function_or_method'
```

This error was triggered by the `get_samples` function in `buffer.py`, which returns `list[list[Sample]]` in the new version but `list[Sample]` in the old version.

In agent rollout, we will return `list[list[Sample]]` to the buffer, but  the `_convert_samples_to_train_data` was not updated accordingly and still expects a flat list (list[Sample]), leading to a TypeError when it tries to sort the nested list.

---


## **Some Discussion: Handling of list[list[Sample]] vs. list[Sample]**

I've noticed a potential design inconsistency in how samples are handled. While fixing the bug, I observed the following:

1. The `get_samples` function in buffer.py has been updated to return `list[list[Sample]]`, which correctly groups samples by their original prompt. This preserves important grouping information.
2. However, other parts of the framework, such as the process in sglang_example.py, still produce and expect a flat `list[Sample]`. My current fix makes `_convert_samples_to_train_data` backward-compatible to handle both formats.

This raises a question: should we enforce `list[list[Sample]]` as the standard format throughout the pipeline?

Benefits of standardizing on `list[list[Sample]]`:

1. Preserves Group Information: It explicitly keeps samples from the same prompt together, which is crucial for group-based reward normalization and other advanced algorithms.
2. Supports Variable Group Sizes: It naturally handles cases where different prompts generate a different number of samples (n_samples_per_prompt), which is a more robust approach for complex agent rl scenarios.

**A Potential Fragility in the Current System:**

I've identified a potential issue in the current reward normalization logic for GRPO:
```python
# file: [./slime/slime/backends/megatron_utils/data.py#Line274]
rewards = rewards.reshape(-1, args.n_samples_per_prompt)
```

This line strictly requires that every prompt generates exactly `args.n_samples_per_prompt samples`. This assumption might be too rigid and could break in more complex agent scenarios where the number of responses per prompt can vary.

By standardizing on `list[list[Sample]]`, we could refactor this logic to iterate through each group and perform normalization dynamically, without relying on a fixed group size.

This discussion is likely beyond the scope of this specific bug fix, but I wanted to raise this point for future discussion on how we can improve the system's robustness.
