### PR TITLE
support --loss-type and always set loss_masks

### DIFF
--- a/slime/backends/megatron_utils/__init__.py
+++ b/slime/backends/megatron_utils/__init__.py
@@ -12,7 +12,7 @@ from .data import (
     set_metadata,
 )
 from .initialize import init
-from .loss import compute_advantages_and_returns, get_log_probs_and_entropy, policy_loss_func
+from .loss import compute_advantages_and_returns, get_log_probs_and_entropy, loss_function
 from .model import forward_only, initialize_model_and_optimizer, save, train
 
 __all__ = [
@@ -32,7 +32,7 @@ __all__ = [
     "log_eval_data",
     "log_perf_data",
     "compute_advantages_and_returns",
-    "policy_loss_func",
+    "loss_function",
     "forward_only",
     "train",
     "save",

--- a/slime/backends/megatron_utils/model.py
+++ b/slime/backends/megatron_utils/model.py
@@ -20,7 +20,7 @@ from megatron.training.training import get_model
 
 from .checkpoint import load_checkpoint, save_checkpoint
 from .data import get_batch, set_local_storage
-from .loss import get_log_probs_and_entropy, policy_loss_func
+from .loss import get_log_probs_and_entropy, loss_function
 from .models import get_model_provider_and_type
 
 
@@ -265,7 +265,7 @@ def train_one_step(args, rollout_id, step_id, data_iterator, model, optimizer, o
             packed_seq_params=batch["packed_seq_params"],
         )
 
-        return output_tensor, partial(policy_loss_func, args, batch, num_microbatches)
+        return output_tensor, partial(loss_function, args, batch, num_microbatches)
 
     # Forward pass.
     forward_backward_func = get_forward_backward_func()

--- a/slime/ray/buffer.py
+++ b/slime/ray/buffer.py
@@ -209,13 +209,18 @@ class Buffer:
             "truncated": [1 if sample.status == Sample.Status.TRUNCATED else 0 for sample in samples],
         }
 
-        if samples[0].loss_mask:
-            train_data["loss_masks"] = []
-            for sample in samples:
-                assert (
-                    len(sample.loss_mask) == sample.response_length
-                ), f"loss mask length {len(sample.loss_mask)} != response length {sample.response_length}"
-                train_data["loss_masks"].append(sample.loss_mask)
+        # loss mask
+        # TODO: compress the loss mask
+        loss_masks = []
+        for sample in samples:
+            # always instantiate loss_mask if not provided
+            if sample.loss_mask is None:
+                sample.loss_mask = [1] * sample.response_length
+            assert (
+                len(sample.loss_mask) == sample.response_length
+            ), f"loss mask length {len(sample.loss_mask)} != response length {sample.response_length}"
+            loss_masks.append(sample.loss_mask)
+        train_data["loss_masks"] = loss_masks
 
         # overwriting the raw reward
         if samples[0].metadata and "raw_reward" in samples[0].metadata:

--- a/slime/utils/arguments.py
+++ b/slime/utils/arguments.py
@@ -489,6 +489,25 @@ def get_slime_extra_args_provider(add_custom_arguments=None):
             )
             parser.add_argument("--kl-coef", type=float, default=0.01, help="KL penalty in PPO")
             parser.add_argument(
+                "--loss-type",
+                type=str,
+                choices=["policy_loss", "sft_loss", "custom_loss"],
+                default="policy_loss",
+                help=(
+                    "Choose loss type, currently support ppo policy_loss or sft_loss, "
+                    "if custom_loss is set, we will use the function path from `--custom-loss-function-path`."
+                ),
+            )
+            parser.add_argument(
+                "--custom-loss-function-path",
+                type=str,
+                default=None,
+                help=(
+                    "Path to the custom loss function, if the loss_type is `custom_loss`, "
+                    "we will use this function to calculate the loss. "
+                ),
+            )
+            parser.add_argument(
                 "--kl-loss-type",
                 type=str,
                 choices=["kl", "low_var_kl"],


### PR DESCRIPTION
This PR primarily includes the following changes:

1.  Adds support for a `--loss-type` parameter and introduces interfaces for `sft_loss` and `custom_loss`.
2.  To better support custom losses, a more generic signature has been extracted, for `policy_loss_function`, we have:
    ```python
    def policy_loss_function(args, batch, logits, sum_of_sample_mean):
        ...
        return (
            loss,
            {
                "loss": loss.clone().detach(),
                "pg_loss": pg_loss.clone().detach(),
                "entropy_loss": entropy_loss.clone().detach(),
                "pg_clipfrac": pg_clipfrac.clone().detach(),
                "ppo_kl": ppo_kl.clone().detach(),
                "kl_loss": kl_loss.clone().detach(),
            },
        )
    ```
3.  The loss mask is now set by default to simplify the implementation.