### PR TITLE
Tiny remove two flush caches

### DIFF
--- a/slime/backends/sglang_utils/sglang_engine.py
+++ b/slime/backends/sglang_utils/sglang_engine.py
@@ -94,6 +94,8 @@ class SglangEngine:
         self.llm.flush_cache()
 
     def sleep(self, level=1):
+        # Adhoc solution to ensure no running requests
+        self.llm.flush_cache()
         self.llm.release_memory_occupation()
 
     def wake_up(self):

--- a/slime/backends/sglang_utils/sglang_engine.py
+++ b/slime/backends/sglang_utils/sglang_engine.py
@@ -94,11 +94,9 @@ class SglangEngine:
         self.llm.flush_cache()
 
     def sleep(self, level=1):
-        self.llm.flush_cache()
         self.llm.release_memory_occupation()
 
     def wake_up(self):
-        self.llm.flush_cache()
         self.llm.resume_memory_occupation()
 
     def pause_generation(self):


### PR DESCRIPTION
Hi, when glancing at code, I find there seems to be a bit of redundant flush cache:

For release_memory_occupation, I already called flush_cache in SGLang

![image](https://github.com/user-attachments/assets/695c4ab8-42fd-4fef-a91b-bef0c2229cb0)

For resume_memory_occupation, if I understand correctly, SGLang do not run any req during sleeping, so no cache need to be flushed

(Note: I do not test this PR locally since not running slime yet)
