### PR TITLE
refactor: remove other_ports and used_port

### DIFF
--- a/docker/patch/sglang.patch
+++ b/docker/patch/sglang.patch
@@ -130,29 +130,27 @@ index a0a3374..3abb376 100644
              named_tensors=MultiprocessingSerializer.deserialize(
                  recv_req.serialized_named_tensors[self.tp_rank]
 diff --git a/python/sglang/srt/server_args.py b/python/sglang/srt/server_args.py
-index ef957dd..870fc7e 100644
+index ef957dd..46dcf7c 100644
 --- a/python/sglang/srt/server_args.py
 +++ b/python/sglang/srt/server_args.py
-@@ -124,6 +124,8 @@ class ServerArgs:
+@@ -124,6 +124,7 @@ class ServerArgs:
  
      # Multi-node distributed serving
      dist_init_addr: Optional[str] = None
 +    nccl_port: Optional[int] = None
-+    other_ports: Optional[List[int]] = None
      nnodes: int = 1
      node_rank: int = 0
  
-@@ -1196,6 +1198,9 @@ class ServerArgs:
+@@ -1196,6 +1197,8 @@ class ServerArgs:
              help="Set multimodal attention backend.",
          )
  
 +        parser.add_argument("--nccl-port", type=int, default=None)
-+        parser.add_argument("--other-ports", type=int, nargs="+", default=None)
 +
          # Expert parallelism
          parser.add_argument(
              "--expert-parallel-size",
-@@ -1739,14 +1744,17 @@ class PortArgs:
+@@ -1739,14 +1742,17 @@ class PortArgs:
  
      @staticmethod
      def init_new(server_args, dp_rank: Optional[int] = None) -> "PortArgs":
@@ -178,30 +176,3 @@ index ef957dd..870fc7e 100644
  
          if not server_args.enable_dp_attention:
              # Normal case, use IPC within a single node
-@@ -1768,6 +1776,26 @@ class PortArgs:
-             else:
-                 dist_init_addr = server_args.dist_init_addr.split(":")
- 
-+            if server_args.other_ports is not None:
-+                assert port not in server_args.other_ports
-+                tokenizer_port = server_args.other_ports[0]
-+                detokenizer_port = server_args.other_ports[1]
-+                rpc_ipc_port = server_args.other_ports[2]
-+                if dp_rank is None:
-+                    scheduler_input_port = server_args.other_ports[
-+                        3
-+                    ]  # TokenizerManager to DataParallelController
-+                else:
-+                    scheduler_input_port = server_args.other_ports[3 + 1 + dp_rank]
-+
-+                return PortArgs(
-+                    tokenizer_ipc_name=f"tcp://{dist_init_host}:{tokenizer_port}",
-+                    scheduler_input_ipc_name=f"tcp://{dist_init_host}:{scheduler_input_port}",
-+                    detokenizer_ipc_name=f"tcp://{dist_init_host}:{detokenizer_port}",
-+                    nccl_port=port,
-+                    rpc_ipc_name=f"tcp://{dist_init_host}:{rpc_ipc_port}",
-+                )
-+
-             assert (
-                 len(dist_init_addr) == 2
-             ), "please provide --dist-init-addr as host:port of head node"

--- a/slime/backends/sglang_utils/arguments.py
+++ b/slime/backends/sglang_utils/arguments.py
@@ -45,7 +45,6 @@ def add_sglang_arguments(parser):
         "gpu_id_step",
         "base_gpu_id",
         "nccl_port",
-        "other_ports",
         "skip_server_warmup",
     ]
 

--- a/slime/backends/sglang_utils/sglang_engine.py
+++ b/slime/backends/sglang_utils/sglang_engine.py
@@ -23,7 +23,7 @@ def get_base_gpu_id(args, rank):
 
 class SglangEngine:
 
-    def __init__(self, args, rank, dist_init_addr, port, nccl_port, other_ports=None, used_ports=None):
+    def __init__(self, args, rank, dist_init_addr, port, nccl_port):
         self.args = args
 
         # remove the CUDA_VISIBLE_DEVICES set by ray and use base_gpu_id
@@ -54,12 +54,6 @@ class SglangEngine:
             # always skip warmup to prevent warmup timeout.
             "skip_server_warmup": True,
         }
-
-        if nnodes > 1:
-            kwargs["other_ports"] = other_ports
-
-        if used_ports is not None:
-            os.environ["SGLANG_USED_PORT"] = ",".join(map(str, used_ports))
 
         unused_keys = set(kwargs.keys())
         for attr in dataclasses.fields(ServerArgs):

--- a/slime/ray/ray_actor.py
+++ b/slime/ray/ray_actor.py
@@ -4,22 +4,17 @@ from slime.utils.http_utils import is_port_available
 
 class RayActor:
     @staticmethod
-    def _get_current_node_ip_and_free_port(num_ports=1, start_port=50000):
+    def _get_current_node_ip_and_free_port(start_port=10000, consecutive=1):
         address = ray._private.services.get_node_ip_address()
         # strip ipv6 address
         address = address.strip("[]")
 
+        # find the port where port, port + 1, port + 2, ... port + consecutive - 1 are all available
         port = start_port
-        ports = []
-        while len(ports) < num_ports:
-            if is_port_available(port):
-                ports.append(port)
+        while not all(is_port_available(port + i) for i in range(consecutive)):
             port += 1
 
-        if num_ports == 1:
-            return address, ports[0]
-
-        return address, ports
+        return address, port
 
     def get_master_addr_and_port(self):
         return self.master_addr, self.master_port


### PR DESCRIPTION
This change obviates the need for the previous mechanism of patching `other_ports` and `used_port` to sglang.

The new approach simply requires guaranteeing that the port in `dist_init_addr` and the next `5 + args.sglang_dp_size` ports are all available. This makes the distributed setup more robust and easier to configure.