### PR TITLE
remove monkey_patch_torch_reductions by setting RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES

### DIFF
--- a/docker/patch/sglang.patch
+++ b/docker/patch/sglang.patch
@@ -109,26 +109,6 @@ index b16bb8a..cb88b15 100644
      async def update_weights_from_disk(
          self,
          obj: UpdateWeightFromDiskReqInput,
-diff --git a/python/sglang/srt/managers/tp_worker.py b/python/sglang/srt/managers/tp_worker.py
-index a0a3374..3abb376 100644
---- a/python/sglang/srt/managers/tp_worker.py
-+++ b/python/sglang/srt/managers/tp_worker.py
-@@ -41,6 +41,7 @@ from sglang.srt.mem_cache.allocator import BaseTokenToKVPoolAllocator
- from sglang.srt.mem_cache.memory_pool import ReqToTokenPool
- from sglang.srt.model_executor.forward_batch_info import ForwardBatch, PPProxyTensors
- from sglang.srt.model_executor.model_runner import ModelRunner
-+from sglang.srt.patch_torch import monkey_patch_torch_reductions
- from sglang.srt.server_args import ServerArgs
- from sglang.srt.utils import MultiprocessingSerializer, broadcast_pyobj, set_random_seed
- 
-@@ -264,6 +265,7 @@ class TpModelWorker:
-         return success, message
- 
-     def update_weights_from_tensor(self, recv_req: UpdateWeightsFromTensorReqInput):
-+        monkey_patch_torch_reductions()
-         success, message = self.model_runner.update_weights_from_tensor(
-             named_tensors=MultiprocessingSerializer.deserialize(
-                 recv_req.serialized_named_tensors[self.tp_rank]
 diff --git a/python/sglang/srt/server_args.py b/python/sglang/srt/server_args.py
 index ef957dd..46dcf7c 100644
 --- a/python/sglang/srt/server_args.py


### PR DESCRIPTION
By setting `RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES=1`, we prevent Ray from modifying `CUDA_VISIBLE_DEVICES`. This eliminates the need for the `monkey_patch_torch_reductions` workaround in `slime` and `sglang`, resulting in faster weight updates.
