### PR TITLE
Fix/bug

### DIFF
--- a/slime/backends/megatron_utils/initialize.py
+++ b/slime/backends/megatron_utils/initialize.py
@@ -128,6 +128,9 @@ def init(args):
         and mpu.get_tensor_model_parallel_rank() == 0
         and mpu.get_pipeline_model_parallel_rank() == mpu.get_pipeline_model_parallel_world_size() - 1
     ):
+        if args.wandb_offline:
+            os.environ["WANDB_MODE"] = "offline"
+            os.environ["WANDB_API_KEY"] = args.wandb_key
         if args.wandb_key is not None:
             wandb.login(key=args.wandb_key, host=args.wandb_host)
         # add random 6 length string with characters

--- a/slime/ray/placement_group.py
+++ b/slime/ray/placement_group.py
@@ -96,12 +96,12 @@ def create_placement_groups(args):
     }
 
 
-def allocate_train_group(num_nodes, num_gpus_per_node, pg):
+def allocate_train_group(num_nodes, num_gpus_per_node, pg, num_gpus_per_actor):
     return RayTrainGroup(
         num_nodes=num_nodes,
         num_gpus_per_node=num_gpus_per_node,
         pg=pg,
-        num_gpus_per_actor=0.8,
+        num_gpus_per_actor=num_gpus_per_actor,
     )
 
 
@@ -110,6 +110,7 @@ def create_actor_group(args, pg):
         num_nodes=args.actor_num_nodes,
         num_gpus_per_node=args.actor_num_gpus_per_node,
         pg=pg,
+        num_gpus_per_actor=0.8 if args.colocate else 1.0
     )
     return actor_model
 

--- a/slime/ray/rollout.py
+++ b/slime/ray/rollout.py
@@ -70,7 +70,7 @@ def create_rollout_engines(args, pg):
 
     rollout_engines = []
     for i in range(num_engines):
-        num_gpus = 0.2
+        num_gpus = 0.2 if args.colocate else 1.0
         num_cpus = num_gpus
 
         scheduling_strategy = PlacementGroupSchedulingStrategy(

--- a/slime/utils/arguments.py
+++ b/slime/utils/arguments.py
@@ -575,6 +575,7 @@ def get_slime_extra_args_provider(add_custom_arguments=None):
         def add_wandb_arguments(parser):
             # wandb parameters
             parser.add_argument("--use-wandb", action="store_true", default=False)
+            parser.add_argument("--wandb-offline", action="store_true", default=False)
             parser.add_argument("--wandb-key", type=str, default=None)
             parser.add_argument("--wandb-host", type=str, default=None)
             parser.add_argument("--wandb-team", type=str, default=None)


### PR DESCRIPTION
I've observed that in both colocated and separated configurations, the num_gpus_per_actor for the actor model and the rollout engine consistently uses a 0.8 and 0.2 combination, respectively. This configuration is impacting inference throughput.

beside, i also add wandb offline mode in some private env