### PR TITLE
Update sglang_example.py

### DIFF
--- a/slime/rollout/sglang_example.py
+++ b/slime/rollout/sglang_example.py
@@ -172,7 +172,7 @@ async def abort(args, rollout_id: int, data_buffer):
     # abort all the requests
     for url in response["urls"]:
         print(f"Abort request for {url}", flush=True)
-        await post(f"{url}/abort_request", {"abort_all": True}, use_http2=False)
+        await post(f"{url}/abort_request", {"rid":"", abort_all": True}, use_http2=False)
 
     # make sure all the pending tasks are finished
     count = 0


### PR DESCRIPTION
This may require adding rid in the request body to comply with the standard request body requirements of "/abort_request" in sglang.srt.entrypoints.http_server, otherwise the following error will occur.

(RolloutRayActor pid=512474) [2025-07-15 17:11:34] Decode batch. #running-req: 1, #token: 8295, token usage: 0.01, cuda graph: True, gen throughput (token/s): 454.62, #queue-req: 0
(Buffer pid=512473) Error: Client error '422 Unprocessable Entity' for url 'http://172.16.216.111:10000/abort_request'
(Buffer pid=512473) For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422, retrying... (attempt 9/60)
(RolloutRayActor pid=512474) [2025-07-15 17:11:34] INFO:     172.16.216.111:45418 - "POST /abort_request HTTP/1.1" 422 Unprocessable Entity
(Buffer pid=512473) Error: Client error '422 Unprocessable Entity' for url 'http://172.16.216.111:10000/abort_request'
(Buffer pid=512473) For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422, retrying... (attempt 10/60)
(RolloutRayActor pid=512474) [2025-07-15 17:11:35] INFO:     172.16.216.111:45430 - "POST /abort_request HTTP/1.1" 422 Unprocessable Entity
(RolloutRayActor pid=512474) [2025-07-15 17:11:36] INFO:     172.16.216.111:45436 - "POST /abort_request HTTP/1.1" 422 Unprocessable Entity
(Buffer pid=512473) Error: Client error '422 Unprocessable Entity' for url 'http://172.16.216.111:10000/abort_request'
(Buffer pid=512473) For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422, retrying... (attempt 11/60)
(Buffer pid=512473) Error: Client error '422 Unprocessable Entity' for url 'http://172.16.216.111:10000/abort_request'
(Buffer pid=512473) For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422, retrying... (attempt 12/60)
(RolloutRayActor pid=512474) [2025-07-15 17:11:38] INFO:     172.16.216.111:45446 - "POST /abort_request HTTP/1.1" 422 Unprocessable Entity.......