### PR TITLE
Fix truncated ratio in agent training

### DIFF
--- a/slime/ray/ppo_actor.py
+++ b/slime/ray/ppo_actor.py
@@ -544,8 +544,7 @@ class TrainRayActor(RayActor):
 
         if getattr(self.args, "keep_old_actor", False):
             print("update rollout model on cpu using actor model")
-            for cpu_module, src_module in zip(self.old_actor, self.model):
-                cpu_module.load_state_dict(src_module.state_dict(), strict=True)
+            self.update_cpu_params_dict(self.weights["old_actor"])
 
     def load_other_checkpoint(self, model_tag, path):
         old_args = self.args.load, self.args.no_load_optim, self.args.no_load_rng, self.args.finetune

--- a/slime/rollout/agent_rollout.py
+++ b/slime/rollout/agent_rollout.py
@@ -280,6 +280,7 @@ async def generate_agent_rollout(
 
     print("finally get rollout data with length: ", len(results))
     sample_results = []
+
     for i, record in enumerate(results):
         oai_messages = record["messages"]
 
@@ -296,7 +297,11 @@ async def generate_agent_rollout(
                 tokens=token_ids,
                 response_length=response_length,
                 reward=record["reward"],
-                status=Sample.Status.COMPLETED,
+                status=(
+                    Sample.Status.COMPLETED
+                    if "finish_reason" not in record["extra_info"] or record["extra_info"]["finish_reason"] != "length"
+                    else Sample.Status.TRUNCATED
+                ),
                 loss_mask=loss_mask,
                 metadata={**record["extra_info"], "raw_reward": record["raw_reward"]},
             )


### PR DESCRIPTION
Previously, the status was always set to complete, which didn’t reflect the true status during training. Now, by propagating the actual finish_reason, the status is accurately captured.
