### PR TITLE
Replace pandas with datasets in read_file

### DIFF
--- a/slime/utils/data.py
+++ b/slime/utils/data.py
@@ -1,6 +1,6 @@
 import random
 
-import pandas as pd
+from datasets import Dataset as hf_ds
 
 from slime.utils.types import Sample
 
@@ -9,15 +9,15 @@ __all__ = ["Dataset"]
 
 # TODO: don't read the whole file into memory.
 def read_file(path):
-    if path.endswith(".jsonl"):
-        df = pd.read_json(path, lines=True)
+    if path.endswith(".jsonl") or path.endswith(".json"):
+        ds = hf_ds.from_json(path)
     elif path.endswith(".parquet"):
-        df = pd.read_parquet(path)
+        ds = hf_ds.from_parquet(path)
     else:
         raise ValueError(f"Unsupported file format: {path}. Supported formats are .jsonl and .parquet.")
 
-    for _, row in df.iterrows():
-        yield row.to_dict()
+    for data in ds:
+        yield data
 
 
 class Dataset:


### PR DESCRIPTION
When reading Parquet files, Pandas defaults to using np.ndarray for list-type data. 
This can trigger type mismatch errors when passing the `tools` parameter to `apply_chat_template`. 
To resolve this, use huggingface datasets instead