### PR TITLE
[bug fix] CUDA error: invalid device ordinal when CUDA_VISIBLE_DEVICES start id is not equal to 0

### DIFF
--- a/scripts/run-qwen3-4B-amd.sh
+++ b/scripts/run-qwen3-4B-amd.sh
@@ -188,6 +188,7 @@ ray job submit --address="http://127.0.0.1:8265" \
    -- python3 train.py \
    --actor-num-nodes 1 \
    --actor-num-gpus-per-node 8 \
+   --rollout-num-gpus-per-node 8 \
    --colocate \
    ${MODEL_ARGS[@]} \
    ${CKPT_ARGS[@]} \

--- a/scripts/run-qwen3-4B.sh
+++ b/scripts/run-qwen3-4B.sh
@@ -137,6 +137,7 @@ ray job submit --address="http://127.0.0.1:8265" \
    -- python3 train.py \
    --actor-num-nodes 1 \
    --actor-num-gpus-per-node 8 \
+   --rollout-num-gpus-per-node 8 \
    --colocate \
    ${MODEL_ARGS[@]} \
    ${CKPT_ARGS[@]} \

--- a/slime/backends/megatron_utils/update_weight_utils.py
+++ b/slime/backends/megatron_utils/update_weight_utils.py
@@ -15,6 +15,7 @@ from slime.utils.types import ParamInfo
 from .initialize import get_gloo_group
 from .megatron_to_hf import convert_to_hf  # noqa: F401
 from slime.utils.distributed_utils import init_process_group
+from sglang.srt.patch_torch import monkey_patch_torch_reductions
 
 
 def all_gather_param(name, param):
@@ -331,6 +332,7 @@ class UpdateWeightFromTensor:
             del pool
 
     def _update_bucket_weights_from_tensor(self, param_infos):
+        monkey_patch_torch_reductions()
         pp_size = mpu.get_pipeline_model_parallel_world_size()
         ep_size = mpu.get_expert_model_parallel_world_size()
         rank = dist.get_rank()

--- a/slime/backends/sglang_utils/sglang_engine.py
+++ b/slime/backends/sglang_utils/sglang_engine.py
@@ -82,9 +82,6 @@ class SGLangEngine(RayActor):
         args = self.args
         rank = self.rank
 
-        # remove the CUDA_VISIBLE_DEVICES set by ray and use base_gpu_id
-        os.environ.pop("CUDA_VISIBLE_DEVICES", None)
-
         nnodes = max(1, args.rollout_num_gpus_per_engine // args.rollout_num_gpus_per_node)
         node_rank = rank % nnodes
         kwargs = {

--- a/slime/ray/actor_group.py
+++ b/slime/ray/actor_group.py
@@ -56,6 +56,8 @@ class RayTrainGroup:
             # because sglang will always set NCCL_CUMEM_ENABLE to 0
             # we need also set it to 0 to prevent nccl error.
             "NCCL_CUMEM_ENABLE": "0",
+            "RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES": "1",
+            "RAY_EXPERIMENTAL_NOSET_HIP_VISIBLE_DEVICES": "1",
         }
 
         if self.args.experimental_offload:

--- a/slime/ray/actor_group.py
+++ b/slime/ray/actor_group.py
@@ -56,8 +56,6 @@ class RayTrainGroup:
             # because sglang will always set NCCL_CUMEM_ENABLE to 0
             # we need also set it to 0 to prevent nccl error.
             "NCCL_CUMEM_ENABLE": "0",
-            "RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES": "1",
-            "RAY_EXPERIMENTAL_NOSET_HIP_VISIBLE_DEVICES": "1",
         }
 
         if self.args.experimental_offload:

--- a/slime/ray/ppo_actor.py
+++ b/slime/ray/ppo_actor.py
@@ -3,7 +3,6 @@ import os
 import ctypes
 from datetime import timedelta
 
-import ray
 import torch
 import torch.distributed as dist
 
@@ -26,7 +25,7 @@ class TrainRayActor(RayActor):
         # TODO: currently this doesn't work as ray has already set torch.cuda.device_count().
         # os.environ.pop("CUDA_VISIBLE_DEVICES", None)
         # os.environ["LOCAL_RANK"] = str(ray.get_gpu_ids()[0])
-        os.environ["LOCAL_RANK"] = str(ray.get_gpu_ids()[0])
+        os.environ["LOCAL_RANK"] = "0"
 
     def init(self, args, role, wandb_run_id, with_ref=False):
         if args.experimental_offload:
@@ -37,13 +36,11 @@ class TrainRayActor(RayActor):
         self.role = role
         self.with_ref = with_ref
 
-        local_rank = int(os.environ.get("LOCAL_RANK", 0))
-        torch.cuda.set_device(f"cuda:{local_rank}")
-
-        dist.init_process_group(
-            backend=args.distributed_backend,
-            timeout=timedelta(minutes=args.distributed_timeout_minutes),
-        )
+        if not dist.is_initialized():
+            dist.init_process_group(
+                backend=args.distributed_backend,
+                timeout=timedelta(minutes=args.distributed_timeout_minutes),
+            )
 
         args.rank = dist.get_rank()
         args.world_size = dist.get_world_size()

--- a/slime/ray/rollout.py
+++ b/slime/ray/rollout.py
@@ -39,6 +39,12 @@ def create_rollout_engines(args, pg):
                 num_cpus=num_cpus,
                 num_gpus=num_gpus,
                 scheduling_strategy=scheduling_strategy,
+                runtime_env={
+                    "env_vars": {
+                        "RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES": "1",
+                        "RAY_EXPERIMENTAL_NOSET_HIP_VISIBLE_DEVICES": "1",
+                    }
+                },
             ).remote(args, rank=i)
         )
 

--- a/slime/utils/arguments.py
+++ b/slime/utils/arguments.py
@@ -45,7 +45,13 @@ def get_slime_extra_args_provider(add_custom_arguments=None):
                 help="Number of GPUs per inference engine, just like the tp_size in sglang.",
             )
             parser.add_argument(
-                "--rollout-num-gpus-per-node", type=int, default=8, help="Number of gpus per node for rollout"
+                "--rollout-num-gpus-per-node",
+                type=int,
+                default=8,
+                help=(
+                    "Number of gpus per node for rollout."
+                    "Notice: If you are going to use less than 8 gpus per node under colocate mode, you should set this number."
+                ),
             )
             parser.add_argument(
                 "--colocate",


### PR DESCRIPTION
NOTE: This PR may have better implementation after [#54928 in ray](https://github.com/ray-project/ray/pull/54928) is merged.

The bug should be devided into two problems:
1. The start gpu id has to be 0.
2. Visible gpu id list has to be continuous.

And the expected behavior is: We can simply assign the physical GPU id by setting `CUDA_VISIBLE_DEVICES` before ray start and ray job submit.

On train side: 

- `LOCAL_RANK` in `TrainRayActor` should be logical gpu id rather than physical gpu id. Then `torch.cuda.set_device` will works correctly. 
- [deprecated] use ray allocated gpu id.

On rollout side: 

- The GPU allocated for RolloutRayActor (set to 0.2) is just a placeholder. In the original behavior, `SglangEngine` class clear the `CUDA_VISIBLE_DEVICES` settings, and allocate GPU for sglang starting from physical GPU 0 continously. This behavior leads to the two problems.

- In this PR, we set `RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES` in RolloutRayActor to avoid ray from modifying `CUDA_VISIBLE_DEVICES`. So SGLang server can be launched using external `CUDA_VISIBLE_DEVICES`, which resolve the two problems.

Test result:
After logging `nvidia-smi` every 3 seconds, there is no GPU utilization out of CUDA_VISIBLE_DEVICES. We can assume the modification is correct.