### PR TITLE
Feature: Token-in/Token-out for RL Sampling

### DIFF
--- a/slime/rollout/sglang_example.py
+++ b/slime/rollout/sglang_example.py
@@ -198,6 +198,7 @@ async def abort(args, rollout_id: int):
     return aborted_samples
 
 
+# TODO Change into token-in-token-out generation
 async def generate_rollout_async(args, rollout_id: int, data_source) -> list[list[Sample]]:
     """An example to implement the generate_rollout function for an rule based rm rollout generation.
 


### PR DESCRIPTION

## Motivation

Currently, RL sampling is performed at the text level (text-in, text-out). This approach may introduce potential issues. If we label the model’s original output token ID sequence as `id1`, this sequence is first decoded into `text`, and the resulting text is then re-encoded into a new token ID sequence `id2` for the next turn. The transformation `id1` → `text` → `id2` can cause `id1` and `id2` to diverge, potentially leading to unstable training dynamics.

To address this, we propose switching the RL rollout process to operate entirely at the token level (token-in, token-out), eliminating the intermediate text encoding/decoding step.

## Proposed Feature

- Replace text-in/text-out with token-in/token-out for RL sampling.
- Integrate the feature with the existing rollout buffer (in the OpenAI-compatible server) and the logging system.
- Ensure that the model’s output token IDs are used **directly** as the future input.
   - For tool outputs or environment feedback that are originally in text format, convert them into encoded token ID lists instead of raw text.

## Initial Considerations

### Obtaining Output Token IDs from the SGLang Server:

- Using `/generate`:
    - One option is to launch the SGL servers with `--skip-tokenizer-init` and use input_ids instead of text in the payload.
        - Issue: This prevents the use of the `stop` parameter, which may lead to problems and make the interface harder for users to work with.
    - Another option is to set the `return_logprob=True` parameter to the payload.
        - Minor issue: The returned data will include log probabilities (floats), which may slightly increase overhead.
- Using `/v1/chat/completions` or `/v1/completions` (used by most agent frameworks):
    - Currently, there is no way to obtain output token IDs from the SGLang server for these endpoints.

### Handling Multi-turn Conversations:

- We must maintain a mapping between message lists and token ID sequences since we cannot reliably re-tokenize message lists after the fact.
- Open questions:
    - How can we efficiently identify the corresponding token ID sequence for a new incoming request?
    - What is the best way to integrate this mechanism with existing agent frameworks?

## Status
- This PR is a Draft for discussion.
- No implementation yet; this proposal focuses on design considerations and gathering feedback.