### PR TITLE
feat: support multi nic

### DIFF
--- a/slime/utils/http_utils.py
+++ b/slime/utils/http_utils.py
@@ -2,9 +2,10 @@ import asyncio
 import multiprocessing
 import random
 import socket
-
+import os
 import httpx
 
+SLIME_HOST_IP_ENV = "SLIME_HOST_IP"
 
 def find_available_port(base_port: int):
     port = base_port + random.randint(100, 1000)
@@ -35,6 +36,9 @@ def get_host_info():
     hostname = socket.gethostname()
 
     local_ip = socket.gethostbyname(hostname)
+    
+    if SLIME_HOST_IP_ENV in os.environ:
+        local_ip = os.environ[SLIME_HOST_IP_ENV]
 
     return hostname, local_ip
 


### PR DESCRIPTION
- In some cloud environment, ECS might have multi Nic for different usage, for better isolation and flow control
- This PR allows user to specify the IP that Slime use, (now is for sglang router)