### PR TITLE
Enable path forwarding and Ray dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Based on the `zhuzilin/slime:latest` image (pre-installed with SGLang 0.4.7 and 
 ```bash
 docker run --rm --gpus all --ipc=host --shm-size=16g \
   --ulimit memlock=-1 --ulimit stack=67108864 \
+  -p 8265:8265 \
   -it zhuzilin/slime:latest /bin/bash
 
 git clone https://github.com/THUDM/slime.git

--- a/scripts/run-deepseek-r1.sh
+++ b/scripts/run-deepseek-r1.sh
@@ -147,7 +147,7 @@ MISC_ARGS=(
 
 # launch the master node of ray in container
 export no_proxy="127.0.0.1,${MASTER_ADDR}"
-ray start --head --node-ip-address ${MASTER_ADDR} --num-gpus 8 --disable-usage-stats
+ray start --head --node-ip-address ${MASTER_ADDR} --num-gpus 8 --disable-usage-stats --dashboard-host=0.0.0.0 --dashboard-port=8265
 
 
 ray job submit --address="http://127.0.0.1:8265" \

--- a/scripts/run-glm4-9B.sh
+++ b/scripts/run-glm4-9B.sh
@@ -121,7 +121,7 @@ MISC_ARGS=(
 
 # launch the master node of ray in container
 export MASTER_ADDR=${MASTER_ADDR:-"127.0.0.1"}
-ray start --head --node-ip-address ${MASTER_ADDR} --num-gpus 8 --disable-usage-stats
+ray start --head --node-ip-address ${MASTER_ADDR} --num-gpus 8 --disable-usage-stats --dashboard-host=0.0.0.0 --dashboard-port=8265
 
 # Build the runtime environment JSON with proper variable substitution
 RUNTIME_ENV_JSON="{

--- a/scripts/run-glm4.5-355B-A32B.sh
+++ b/scripts/run-glm4.5-355B-A32B.sh
@@ -127,14 +127,14 @@ MISC_ARGS=(
 # launch the master node of ray in container
 export MASTER_ADDR=${MLP_WORKER_0_HOST}
 export no_proxy="127.0.0.1,${MASTER_ADDR}"
-ray start --head --node-ip-address ${MASTER_ADDR} --num-gpus 8 --disable-usage-stats
+ray start --head --node-ip-address ${MASTER_ADDR} --num-gpus 8 --disable-usage-stats --dashboard-host=0.0.0.0 --dashboard-port=8265
 for WORKER_IP in $(awk '{print $1}' /root/mpi_rack_hostfile); do
   if [[ "$WORKER_IP" == "$MLP_WORKER_0_HOST" ]]; then
     continue
   fi
   echo "Starting Ray worker on ${WORKER_IP}"
   ssh root@"${WORKER_IP}" \
-    "pkill -9 sglang ; ray stop --force ; pkill -9 python ; ray start --address=${MASTER_ADDR}:6379 --num-gpus 8 --node-ip-address ${WORKER_IP} --disable-usage-stats" &
+    "pkill -9 sglang ; ray stop --force ; pkill -9 python ; ray start --address=${MASTER_ADDR}:6379 --num-gpus 8 --node-ip-address ${WORKER_IP} --disable-usage-stats --dashboard-host=0.0.0.0 --dashboard-port=8265" &
 done
 wait
 

--- a/scripts/run-qwen3-235B-A22B-sft.sh
+++ b/scripts/run-qwen3-235B-A22B-sft.sh
@@ -112,14 +112,14 @@ MISC_ARGS=(
 
 # launch the master node of ray in container
 export no_proxy="127.0.0.1,${MASTER_ADDR}"
-ray start --head --node-ip-address ${MASTER_ADDR} --num-gpus 8 --disable-usage-stats
+ray start --head --node-ip-address ${MASTER_ADDR} --num-gpus 8 --disable-usage-stats --dashboard-host=0.0.0.0 --dashboard-port=8265
 for WORKER_IP in $(awk '{print $1}' /root/mpi_rack_hostfile); do
   if [[ "$WORKER_IP" == "$MLP_WORKER_0_HOST" ]]; then
     continue
   fi
   echo "Starting Ray worker on ${WORKER_IP}"
   ssh root@"${WORKER_IP}" \
-    "pkill -9 sglang ; ray stop --force ; pkill -9 python ; ray start --address=${MASTER_ADDR}:6379 --num-gpus 8 --node-ip-address ${WORKER_IP} --disable-usage-stats" &
+    "pkill -9 sglang ; ray stop --force ; pkill -9 python ; ray start --address=${MASTER_ADDR}:6379 --num-gpus 8 --node-ip-address ${WORKER_IP} --disable-usage-stats --dashboard-host=0.0.0.0 --dashboard-port=8265" &
 done
 wait
 

--- a/scripts/run-qwen3-235B-A22B.sh
+++ b/scripts/run-qwen3-235B-A22B.sh
@@ -142,14 +142,14 @@ MISC_ARGS=(
 
 # launch the master node of ray in container
 export no_proxy="127.0.0.1,${MASTER_ADDR}"
-ray start --head --node-ip-address ${MASTER_ADDR} --num-gpus 8 --disable-usage-stats
+ray start --head --node-ip-address ${MASTER_ADDR} --num-gpus 8 --disable-usage-stats --dashboard-host=0.0.0.0 --dashboard-port=8265
 for WORKER_IP in $(awk '{print $1}' /root/mpi_rack_hostfile); do
   if [[ "$WORKER_IP" == "$MLP_WORKER_0_HOST" ]]; then
     continue
   fi
   echo "Starting Ray worker on ${WORKER_IP}"
   ssh root@"${WORKER_IP}" \
-    "pkill -9 sglang ; ray stop --force ; pkill -9 python ; ray start --address=${MASTER_ADDR}:6379 --num-gpus 8 --node-ip-address ${WORKER_IP} --disable-usage-stats" &
+    "pkill -9 sglang ; ray stop --force ; pkill -9 python ; ray start --address=${MASTER_ADDR}:6379 --num-gpus 8 --node-ip-address ${WORKER_IP} --disable-usage-stats --dashboard-host=0.0.0.0 --dashboard-port=8265" &
 done
 wait
 

--- a/scripts/run-qwen3-30B-A3B.sh
+++ b/scripts/run-qwen3-30B-A3B.sh
@@ -126,7 +126,7 @@ MISC_ARGS=(
 
 # launch the master node of ray in container
 export MASTER_ADDR=${MASTER_ADDR:-"127.0.0.1"}
-ray start --head --node-ip-address ${MASTER_ADDR} --num-gpus 8 --disable-usage-stats
+ray start --head --node-ip-address ${MASTER_ADDR} --num-gpus 8 --disable-usage-stats --dashboard-host=0.0.0.0 --dashboard-port=8265
 
 # Build the runtime environment JSON with proper variable substitution
 RUNTIME_ENV_JSON="{

--- a/scripts/run-qwen3-4B-amd.sh
+++ b/scripts/run-qwen3-4B-amd.sh
@@ -172,7 +172,7 @@ MISC_ARGS=(
 export MASTER_ADDR=${MASTER_ADDR:-"127.0.0.1"}
 
 NUM_GPUS=$(echo ${HIP_VISIBLE_DEVICES} | tr ',' '\n' | wc -l)
-ray start --head --node-ip-address ${MASTER_ADDR} --num-gpus ${NUM_GPUS} --disable-usage-stats
+ray start --head --node-ip-address ${MASTER_ADDR} --num-gpus ${NUM_GPUS} --disable-usage-stats --dashboard-host=0.0.0.0 --dashboard-port=8265
 
 
 # "PYTHONPATH": "/workspace/Megatron-LM-amd_version/",

--- a/scripts/run-qwen3-4B-base-sft.sh
+++ b/scripts/run-qwen3-4B-base-sft.sh
@@ -99,7 +99,7 @@ MISC_ARGS=(
 # launch the master node of ray in container
 export MASTER_ADDR=${MASTER_ADDR:-"127.0.0.1"}
 export no_proxy="127.0.0.1,${MASTER_ADDR}"
-ray start --head --node-ip-address ${MASTER_ADDR} --num-gpus 8 --disable-usage-stats
+ray start --head --node-ip-address ${MASTER_ADDR} --num-gpus 8 --disable-usage-stats --dashboard-host=0.0.0.0 --dashboard-port=8265
 
 
 # Build the runtime environment JSON with proper variable substitution

--- a/scripts/run-qwen3-4B-rf-baseline.sh
+++ b/scripts/run-qwen3-4B-rf-baseline.sh
@@ -123,7 +123,7 @@ MISC_ARGS=(
 # launch the master node of ray in container
 export MASTER_ADDR=${MASTER_ADDR:-"127.0.0.1"}
 export MASTER_PORT=${MASTER_PORT:-"12345"}
-ray start --head --node-ip-address ${MASTER_ADDR} --num-gpus 8 --disable-usage-stats
+ray start --head --node-ip-address ${MASTER_ADDR} --num-gpus 8 --disable-usage-stats --dashboard-host=0.0.0.0 --dashboard-port=8265
 
 # Build the runtime environment JSON with proper variable substitution
 RUNTIME_ENV_JSON="{

--- a/scripts/run-qwen3-4B-rf.sh
+++ b/scripts/run-qwen3-4B-rf.sh
@@ -124,7 +124,7 @@ MISC_ARGS=(
 # launch the master node of ray in container
 export MASTER_ADDR=${MASTER_ADDR:-"127.0.0.1"}
 export MASTER_PORT=${MASTER_PORT:-"12345"}
-ray start --head --node-ip-address ${MASTER_ADDR} --num-gpus 8 --disable-usage-stats
+ray start --head --node-ip-address ${MASTER_ADDR} --num-gpus 8 --disable-usage-stats --dashboard-host=0.0.0.0 --dashboard-port=8265
 
 # Build the runtime environment JSON with proper variable substitution
 RUNTIME_ENV_JSON="{

--- a/scripts/run-qwen3-4B.sh
+++ b/scripts/run-qwen3-4B.sh
@@ -121,7 +121,7 @@ MISC_ARGS=(
 
 # launch the master node of ray in container
 export MASTER_ADDR=${MASTER_ADDR:-"127.0.0.1"}
-ray start --head --node-ip-address ${MASTER_ADDR} --num-gpus 8 --disable-usage-stats
+ray start --head --node-ip-address ${MASTER_ADDR} --num-gpus 8 --disable-usage-stats --dashboard-host=0.0.0.0 --dashboard-port=8265
 
 # Build the runtime environment JSON with proper variable substitution
 RUNTIME_ENV_JSON="{


### PR DESCRIPTION
## Motivation

It might be useful to enable Ray Dashboard for observability (in a nice and visualized fashion).

## Solution

Start container with path forwarding args first then run Ray with dashboard. So users can view the UI from  their machines' browser, like below:

<img width="1277" height="715" alt="Screenshot 2025-07-31 at 6 58 48 PM" src="https://github.com/user-attachments/assets/ed5c4af3-f7a4-4493-a5d8-3f4147688b97" />
<img width="389" height="315" alt="Screenshot 2025-07-31 at 6 59 53 PM" src="https://github.com/user-attachments/assets/8e2b2e71-ef44-4931-96f9-2550b04893e3" />


## Code Modified

1. In `Readme.md`, start container with arg: `-p 8265:8265`. Maps port `8265` from the host machine to port `8265` inside the container. This is for the Ray dashboard access that we set up port forwarding for.

2. Add two args, `dashboard-host` and `dashboard-port` in each launch script for training. It starts Ray nodes with built-in dashboard enabled. Pleas check Ray docs for more advanced usage: https://docs.ray.io/en/latest/ray-observability/getting-started.html



