### PR TITLE
[memory] support offload with pytorch_malloc

### DIFF
--- a/slime/backends/megatron_utils/model.py
+++ b/slime/backends/megatron_utils/model.py
@@ -80,8 +80,11 @@ def setup_model_and_optimizer(
 
     model = get_model(get_model_provider_func(args), ModelType.encoder_or_decoder, wrap_with_ddp=False)
 
-    allocator = CuMemAllocator.get_instance() if args.colocate else None
-    with allocator.use_memory_pool(tag="model") if args.colocate else nullcontext():
+    with (
+        CuMemAllocator.get_instance().use_memory_pool(tag="model")
+        if args.offload and not args.experimental_offload
+        else nullcontext()
+    ):
         config = get_model_config(model[0])
 
         kwargs = {}

--- a/slime/backends/megatron_utils/update_weight_utils.py
+++ b/slime/backends/megatron_utils/update_weight_utils.py
@@ -2,6 +2,7 @@ import re
 import socket
 import time
 from tqdm import tqdm
+from contextlib import nullcontext
 from sglang.srt.utils import MultiprocessingSerializer
 import inspect
 
@@ -290,6 +291,13 @@ class UpdateWeightFromTensor:
         self.quantization_config = quantization_config
         self.param_info_buckets = get_param_info_buckets(self.args, self.model)
 
+        if self.args.experimental_offload:
+            import pytorch_malloc
+
+            self.allocator = torch.cuda.memory.CUDAPluggableAllocator(
+                pytorch_malloc.get_library_path(), "my_malloc", "my_free"
+            ).allocator()
+
     def connect_rollout_engines(self, rollout_engines, rollout_engine_lock):
         self.rollout_engines = rollout_engines
 
@@ -312,8 +320,15 @@ class UpdateWeightFromTensor:
         if rank == 0:
             ray.get([engine.flush_cache.remote() for engine in self.rollout_engines])
         dist.barrier(group=get_gloo_group())
-        for param_infos in tqdm(self.param_info_buckets, disable=rank != 0, desc="Update weights"):
-            self._update_bucket_weights_from_tensor(param_infos)
+        if self.args.experimental_offload:
+            pool = torch.cuda.MemPool(self.allocator)
+        with torch.cuda.use_mem_pool(pool) if self.args.experimental_offload else nullcontext():
+            for param_infos in tqdm(self.param_info_buckets, disable=rank != 0, desc="Update weights"):
+                self._update_bucket_weights_from_tensor(param_infos)
+
+        if self.args.experimental_offload:
+            # must manually delete here to release the memory
+            del pool
 
     def _update_bucket_weights_from_tensor(self, param_infos):
         pp_size = mpu.get_pipeline_model_parallel_world_size()

--- a/slime/ray/placement_group.py
+++ b/slime/ray/placement_group.py
@@ -96,8 +96,9 @@ def create_placement_groups(args):
     }
 
 
-def allocate_train_group(num_nodes, num_gpus_per_node, pg, wandb_run_id):
+def allocate_train_group(args, num_nodes, num_gpus_per_node, pg, wandb_run_id):
     return RayTrainGroup(
+        args=args,
         num_nodes=num_nodes,
         num_gpus_per_node=num_gpus_per_node,
         pg=pg,
@@ -108,6 +109,7 @@ def allocate_train_group(num_nodes, num_gpus_per_node, pg, wandb_run_id):
 
 def create_actor_group(args, pg, wandb_run_id):
     actor_model = allocate_train_group(
+        args=args,
         num_nodes=args.actor_num_nodes,
         num_gpus_per_node=args.actor_num_gpus_per_node,
         pg=pg,

--- a/slime/ray/ppo_actor.py
+++ b/slime/ray/ppo_actor.py
@@ -1,5 +1,6 @@
 import abc
 import os
+import ctypes
 from datetime import timedelta
 
 import ray
@@ -28,6 +29,10 @@ class TrainRayActor(RayActor):
         os.environ["LOCAL_RANK"] = str(ray.get_gpu_ids()[0])
 
     def init(self, args, role, wandb_run_id, with_ref=False):
+        if args.experimental_offload:
+            import pytorch_malloc
+
+            self.libcudart = ctypes.PyDLL(pytorch_malloc.get_library_path())
         self.args = args
         self.role = role
         self.with_ref = with_ref

--- a/slime/utils/arguments.py
+++ b/slime/utils/arguments.py
@@ -65,6 +65,14 @@ def get_slime_extra_args_provider(add_custom_arguments=None):
                     "This will always be true when --colocate is set."
                 ),
             )
+            parser.add_argument(
+                "--experimental-offload",
+                action="store_true",
+                default=False,
+                help=(
+                    "Enable a more aggressive offload strategy that uses pytorch_malloc to offload the CUDA memory. "
+                ),
+            )
 
             return parser
 


### PR DESCRIPTION
This PR introduces an external library [zhuzilin/pytorch-malloc](https://github.com/zhuzilin/pytorch-malloc) to do offload the memory of megatron.

The main idea is to hijack the `cudaMalloc` and `cudaFree` to offload the memory allocated by the default pytorch cache allocator.

We need to add `--experimental-offload` to enable this.