### PR TITLE
[add]add blockwise quant method and profiler test

### DIFF
--- a/slime/tests/test_per_block_quant_fp8.py
+++ b/slime/tests/test_per_block_quant_fp8.py
@@ -1,0 +1,129 @@
+import io
+import math
+from typing import Any, Dict, List, Tuple, Union
+import torch.nn.functional as F
+
+import pytest
+import torch
+import triton
+from slime.utils.fp8_kernel import blockwise_cast_to_fp8_triton
+from transformer_engine.pytorch.tensor.float8_blockwise_tensor import (
+    Float8BlockQuantizer,
+    Float8BlockwiseQTensor,
+)
+import transformer_engine_torch as tex
+
+device = 'cuda'
+dtype = torch.bfloat16
+fp8_dtype = torch.float8_e4m3fn
+fp8_max = torch.finfo(fp8_dtype).max
+fp8_min = -fp8_max
+
+def ceil_div(x: int, y: int) -> int:
+    """
+    Perform ceiling division of two integers.
+
+    Args:
+        x: the dividend.
+        y: the divisor.
+
+    Returns:
+        The result of the ceiling division.
+    """
+    return (x + y - 1) // y
+
+def per_block_cast_to_fp8_slime(weight, weight_block_size=[128, 128]):
+    FP8_MIN = torch.finfo(torch.float8_e4m3fn).min
+    FP8_MAX = torch.finfo(torch.float8_e4m3fn).max
+
+    # per block quant
+    block_n, block_k = weight_block_size[0], weight_block_size[1]
+
+    shape_0, shape_1 = weight.shape
+
+    n_tiles = ceil_div(shape_0, block_n)
+    k_tiles = ceil_div(shape_1, block_k)
+
+    q_weight = F.pad(
+     weight,
+     (0, k_tiles * block_k - shape_1, 0, n_tiles * block_n - shape_0),
+     mode="constant",
+     value=0.0,
+    )
+
+    qweight = q_weight.reshape(n_tiles, block_n, k_tiles, block_k)
+    block_max = torch.max(torch.abs(qweight), dim=1, keepdim=True)[0]
+    block_max = torch.max(block_max, dim=3, keepdim=True)[0]
+
+    scale = block_max.to(torch.float32) / FP8_MAX
+    qweight = (
+     (qweight / scale)
+     .clamp(min=FP8_MIN, max=FP8_MAX)
+     .reshape((n_tiles * block_n, k_tiles * block_k))
+     .to(torch.float8_e4m3fn)
+    )
+    qweight = qweight[:shape_0, :shape_1]
+    scale = scale.squeeze()
+    return qweight, scale
+
+def te_per_token_group_quant_8bit(weight: torch.Tensor, quantizer, weight_block_size=[128, 128]):
+    block_n, block_k = weight_block_size[0], weight_block_size[1]
+    shape_0, shape_1 = weight.shape
+    n_tiles = ceil_div(shape_0, block_n)
+    k_tiles = ceil_div(shape_1, block_k)
+    param = quantizer(weight)
+    return param._rowwise_data, param._rowwise_scale_inv[:n_tiles, :k_tiles]
+
+ref_lib = 'pytorch'     # pytorch or te
+configs = []
+configs.append(
+    triton.testing.Benchmark(
+        x_names=["M", "N"],  # Argument names to use as an x-axis for the plot
+        x_vals=[128 * i for i in range(2, 33)],  # Different possible values for `x_name`
+        line_arg="provider",  # Argument name whose value corresponds to a different line in the plot
+        # Possible values for `line_arg`
+        # Don't compare to cublas for fp8 cases as torch.matmul doesn't support fp8 at the moment.
+        line_vals=[ref_lib, "triton"],  # Label name for the lines
+        line_names=[ref_lib, "Triton"],  # Line styles
+        styles=[("green", "-"), ("blue", "-")],
+        ylabel="GB/s",  # Label name for the y-axis
+        plot_name="quant-performance",  # Name for the plot, used also as a file name for saving the plot.
+        args={},  # Values for function arguments not in `x_names` and `y_name`.
+    ))
+
+@triton.testing.perf_report(configs)
+def benchmark(M, N, provider):
+    x = torch.randn((M, N), device=device, dtype=dtype)
+    quantiles = [0.5, 0.2, 0.8]
+    if provider == 'pytorch':
+        ms, min_ms, max_ms = triton.testing.do_bench(lambda: per_block_cast_to_fp8_slime(x), quantiles=quantiles)
+    if provider == 'triton':
+        ms, min_ms, max_ms = triton.testing.do_bench(lambda: blockwise_cast_to_fp8_triton(x), quantiles=quantiles)
+    if provider == 'te':
+        quantizer = Float8BlockQuantizer(
+            fp8_dtype=tex.DType.kFloat8E4M3,
+            rowwise=True,
+            columnwise=True,
+            force_pow_2_scales=False,
+            block_scaling_dim=2
+        )
+        ms, min_ms, max_ms = triton.testing.do_bench(lambda: te_per_token_group_quant_8bit(x, quantizer), quantiles=quantiles)
+    gbps = lambda ms: x.numel() * x.element_size() * 1e-9 / (ms * 1e-3)
+    return gbps(ms), gbps(max_ms), gbps(min_ms)
+
+def benchmark_percise():
+    for M in (7168, 2112, 1536, 24576, 512, 32768, 16384, 4096, 2048):
+        for N in (2048, 4096, 8192):
+            x_ref = torch.rand(M, N, dtype=dtype, device=device)
+            x_triton, x_s_triton = blockwise_cast_to_fp8_triton(x_ref)
+            x_slime, x_s_slime = per_block_cast_to_fp8_slime(x_ref)
+            torch.testing.assert_close(
+                x_triton.to(torch.float32), x_slime.to(torch.float32), rtol=1e-3, atol=1e-5
+            )
+            torch.testing.assert_close(
+                x_s_triton, x_s_slime, rtol=1e-3, atol=1e-5
+            )
+
+if __name__ == '__main__':
+    benchmark_percise()
+    benchmark.run(show_plots=True, print_data=True, save_path=f'./plot/{ref_lib}')

--- a/slime/utils/fp8_kernel.py
+++ b/slime/utils/fp8_kernel.py
@@ -1,0 +1,73 @@
+import torch
+import triton
+import triton.language as tl
+from typing import Any, Dict, List, Optional, Tuple
+
+fp8_dtype = torch.float8_e4m3fn
+fp8_max = torch.finfo(fp8_dtype).max
+fp8_min = -fp8_max
+
+def ceil_div(x: int, y: int) -> int:
+	"""
+	Perform ceiling division of two integers.
+
+	Args:
+		x: the dividend.
+		y: the divisor.
+
+	Returns:
+		The result of the ceiling division.
+	"""
+	return (x + y - 1) // y
+
+@triton.jit
+def _blockwise_cast_to_fp8_triton(X, Y, S,
+								  stride_xm, stride_xn,
+								  stride_ym, stride_yn,
+								  stride_sm, stride_sn,
+								  M, N, eps,
+								  fp8_min,
+								  fp8_max,
+								  BLOCK_M: tl.constexpr = 32,
+								  BLOCK_N: tl.constexpr = 128,
+								  ):
+	pid_m = tl.cast(tl.program_id(axis=0), tl.int64)
+	pid_n = tl.cast(tl.program_id(axis=1), tl.int64)
+	off_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+	off_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+	mask_m = off_m < M
+	mask_n = off_n < N
+	mask = mask_m[:, None] & mask_n[None, :]
+	
+	x = tl.load(X + off_m[:, None] * stride_xm + off_n[None, :] * stride_xn, mask=mask, other=0.).to(tl.float32)
+	_absmax = tl.maximum(tl.max(tl.abs(x)), eps)
+	x_s = _absmax / fp8_max
+	s_inv = 1.0 / x_s
+	y_q = tl.clamp(x * s_inv, fp8_min, fp8_max).to(Y.dtype.element_ty)
+	
+	tl.store(Y + off_m[:, None] * stride_ym + off_n[None, :] * stride_yn, y_q, mask=mask)
+	tl.store(S + pid_m * stride_sm + pid_n * stride_sn, x_s)
+
+
+def blockwise_cast_to_fp8_triton(x: torch.Tensor, block_size=None) -> Tuple[torch.Tensor, torch.Tensor]:
+	BLOCK_M, BLOCK_N = 128, 128
+	if block_size:
+		BLOCK_M, BLOCK_N = block_size[0], block_size[1]
+	M, N = x.shape
+	y = torch.empty(M, N, device=x.device, dtype=torch.float8_e4m3fn)
+	s = torch.empty(ceil_div(M, BLOCK_M), ceil_div(N, BLOCK_N), dtype=torch.float32, device=x.device)
+	grid = lambda meta: (triton.cdiv(M, meta['BLOCK_M']), triton.cdiv(N, meta['BLOCK_N']))
+	if x.is_contiguous():
+		kwargs = {'BLOCK_M': BLOCK_M, 'BLOCK_N': BLOCK_N, 'num_warps': 8, 'num_stages': 2}
+	else:
+		kwargs = {'BLOCK_M': BLOCK_M, 'BLOCK_N': BLOCK_N, 'num_warps': 1, 'num_stages': 4}
+	_blockwise_cast_to_fp8_triton[grid](
+		x, y, s,
+		*x.stride(),
+		*y.stride(),
+		*s.stride(),
+		M, N, 1e-10,
+		fp8_min, fp8_max,
+		**kwargs
+	)
+	return y, s


### PR DESCRIPTION
### Key Changes
Added custom Triton kernel blockwise_cast_to_fp8_triton for blockwise weight quantization
### Testing
**case1:** test with script test_per_block_quant_fp8.py， it compare the kernel with pytorch implementation and transformer-engine implementation in precise case in benchmark_percise and throughtput case in triton benchmark，there is some plot to show the difference

the triton kernel and pytorch kernel
<img width="1188" height="890" alt="image" src="https://github.com/user-attachments/assets/8a1e414f-e7b1-4225-a534-b757697f8edc" />

the triton kernel and transformer-engine kernel
<img width="1182" height="902" alt="image" src="https://github.com/user-attachments/assets/8688c1be-d2fd-4f20-b61f-e4085001cc21" />


**case2:** Run scripts/run-qwen3-4B.sh
perform in 8xh800， using torch.profiler,  testing in actor method: update_weights
and the modify param in run-qwen3-4B.sh is：
--hf-checkpoint /root/Qwen3-4B-FP8

now show the first 2 rollout step profiler

**orgin_kernel**
```
(MegatronTrainRayActor pid=680717) -------------------------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  
(MegatronTrainRayActor pid=680717)                                                    Name    Self CPU %      Self CPU   CPU total %     CPU total  CPU time avg     Self CUDA   Self CUDA %    CUDA total  CUDA time avg       CPU Mem  Self CPU Mem      CUDA Mem  Self CUDA Mem    # of Calls  
(MegatronTrainRayActor pid=680717) -------------------------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  
(MegatronTrainRayActor pid=680717)                                     aten::empty_strided         5.84%      18.593ms         7.65%      24.335ms      18.215us       0.000us         0.00%       0.000us       0.000us           0 b           0 b      21.41 Gb      21.41 Gb          1336  
(MegatronTrainRayActor pid=680717)                                               aten::div         4.30%      13.684ms         6.08%      19.347ms      38.387us      23.639ms        12.77%      23.639ms      46.903us           0 b           0 b      13.54 Gb      13.54 Gb           504  
(MegatronTrainRayActor pid=680717)                                               aten::abs         2.89%       9.205ms         9.50%      30.238ms      59.995us       4.648ms         2.51%       9.295ms      18.443us           0 b           0 b      13.54 Gb           0 b           504  
(MegatronTrainRayActor pid=680717)                                             aten::clamp         2.28%       7.248ms         3.23%      10.271ms      40.759us       9.756ms         5.27%       9.756ms      38.713us           0 b           0 b      13.54 Gb      13.44 Gb           252  
(MegatronTrainRayActor pid=680717)                                             aten::empty         2.36%       7.507ms         2.43%       7.723ms      12.850us       0.000us         0.00%       0.000us       0.000us     895.62 Kb     895.62 Kb       8.55 Gb       8.54 Gb           601  
(MegatronTrainRayActor pid=680717)                                        aten::empty_like         0.76%       2.413ms         2.44%       7.770ms      19.522us       0.000us         0.00%       0.000us       0.000us           0 b           0 b       8.55 Gb           0 b           398  
(MegatronTrainRayActor pid=680717)                                             aten::clone         1.25%       3.967ms         7.87%      25.062ms      69.618us       0.000us         0.00%       7.979ms      22.163us           0 b           0 b       7.83 Gb           0 b           360  
(MegatronTrainRayActor pid=680717)                                        c10d::allgather_         3.33%      10.613ms        21.09%      67.128ms     416.947us       0.000us         0.00%      41.349ms     256.827us           0 b           0 b       7.49 Gb           0 b           161  
(MegatronTrainRayActor pid=680717)                                      record_param_comms         9.53%      30.320ms        18.25%      58.074ms     200.257us      34.544ms        18.66%      41.349ms     142.583us           0 b           0 b       7.49 Gb           0 b           290  
(MegatronTrainRayActor pid=680717)                                               aten::cat         2.30%       7.315ms         3.75%      11.944ms      82.371us       9.088ms         4.91%       9.088ms      62.674us     -78.19 Kb     -78.19 Kb       7.49 Gb       7.49 Gb           145  
(MegatronTrainRayActor pid=680717) -------------------------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  
(MegatronTrainRayActor pid=680717) Self CPU time total: 318.274ms
(MegatronTrainRayActor pid=680717) Self CUDA time total: 185.101ms
```

```
(MegatronTrainRayActor pid=680717) -------------------------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  
(MegatronTrainRayActor pid=680717)                                                    Name    Self CPU %      Self CPU   CPU total %     CPU total  CPU time avg     Self CUDA   Self CUDA %    CUDA total  CUDA time avg       CPU Mem  Self CPU Mem      CUDA Mem  Self CUDA Mem    # of Calls  
(MegatronTrainRayActor pid=680717) -------------------------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  
(MegatronTrainRayActor pid=680717)                                     aten::empty_strided         5.88%      17.791ms         7.52%      22.770ms      17.043us       0.000us         0.00%       0.000us       0.000us           0 b           0 b      21.40 Gb      21.38 Gb          1336  
(MegatronTrainRayActor pid=680717)                                               aten::abs         2.80%       8.481ms         9.14%      27.674ms      54.908us       4.688ms         2.54%       9.377ms      18.605us           0 b           0 b      13.54 Gb           0 b           504  
(MegatronTrainRayActor pid=680717)                                               aten::div         4.27%      12.920ms         6.09%      18.445ms      36.598us      23.483ms        12.71%      23.483ms      46.594us           0 b           0 b      13.54 Gb      13.54 Gb           504  
(MegatronTrainRayActor pid=680717)                                             aten::clamp         2.26%       6.857ms         3.24%       9.817ms      38.958us       9.698ms         5.25%       9.698ms      38.485us           0 b           0 b      13.54 Gb      13.54 Gb           252  
(MegatronTrainRayActor pid=680717)                                             aten::empty         2.35%       7.117ms         2.41%       7.295ms      12.138us       0.000us         0.00%       0.000us       0.000us     896.20 Kb     896.20 Kb       8.55 Gb       8.55 Gb           601  
(MegatronTrainRayActor pid=680717)                                        aten::empty_like         0.75%       2.268ms         2.45%       7.431ms      18.671us       0.000us         0.00%       0.000us       0.000us           0 b           0 b       8.55 Gb           0 b           398  
(MegatronTrainRayActor pid=680717)                                             aten::clone         1.25%       3.771ms         7.51%      22.742ms      63.172us       0.000us         0.00%       7.997ms      22.214us           0 b           0 b       7.83 Gb           0 b           360  
(MegatronTrainRayActor pid=680717)                                        c10d::allgather_         3.29%       9.974ms        20.72%      62.725ms     389.594us       0.000us         0.00%      41.262ms     256.288us           0 b           0 b       7.49 Gb           0 b           161  
(MegatronTrainRayActor pid=680717)                                      record_param_comms         9.53%      28.867ms        17.91%      54.232ms     187.008us      34.441ms        18.63%      41.262ms     142.284us           0 b           0 b       7.49 Gb           0 b           290  
(MegatronTrainRayActor pid=680717)                                               aten::cat         2.25%       6.800ms         3.87%      11.702ms      80.706us       9.036ms         4.89%       9.036ms      62.320us     -78.19 Kb     -78.19 Kb       7.49 Gb       7.49 Gb           145  
(MegatronTrainRayActor pid=680717) -------------------------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  
(MegatronTrainRayActor pid=680717) Self CPU time total: 302.772ms
(MegatronTrainRayActor pid=680717) Self CUDA time total: 184.833ms
```


**triton_kernel**
```
(MegatronTrainRayActor pid=649586) -------------------------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  
(MegatronTrainRayActor pid=649586)                                                    Name    Self CPU %      Self CPU   CPU total %     CPU total  CPU time avg     Self CUDA   Self CUDA %    CUDA total  CUDA time avg       CPU Mem  Self CPU Mem      CUDA Mem  Self CUDA Mem    # of Calls  
(MegatronTrainRayActor pid=649586) -------------------------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  
(MegatronTrainRayActor pid=649586)                                             aten::empty         6.40%      12.467ms         6.87%      13.388ms      15.695us       0.000us         0.00%       0.000us       0.000us     896.45 Kb     896.45 Kb      11.95 Gb      11.95 Gb           853  
(MegatronTrainRayActor pid=649586)                                     aten::empty_strided         4.26%       8.310ms         6.89%      13.432ms      23.158us       0.000us         0.00%       0.000us       0.000us           0 b           0 b      11.24 Gb      11.24 Gb           580  
(MegatronTrainRayActor pid=649586)                                        aten::empty_like         1.36%       2.654ms         4.46%       8.688ms      21.829us       0.000us         0.00%       0.000us       0.000us           0 b           0 b       8.55 Gb           0 b           398  
(MegatronTrainRayActor pid=649586)                                        c10d::allgather_         5.02%       9.789ms        32.89%      64.108ms     398.189us       0.000us         0.00%      41.902ms     260.261us           0 b           0 b       7.49 Gb           0 b           161  
(MegatronTrainRayActor pid=649586)                                      record_param_comms        14.50%      28.256ms        28.63%      55.798ms     192.409us      34.968ms        26.48%      41.902ms     144.490us           0 b           0 b       7.49 Gb           0 b           290  
(MegatronTrainRayActor pid=649586)                                               aten::cat         3.58%       6.978ms         5.96%      11.614ms      80.098us       9.423ms         7.14%       9.423ms      64.984us     -78.19 Kb     -78.19 Kb       7.49 Gb       7.49 Gb           145  
(MegatronTrainRayActor pid=649586)                                                aten::to         0.65%       1.262ms        10.89%      21.235ms      48.929us       0.000us         0.00%      74.131ms     170.808us           0 b           0 b       3.75 Gb           0 b           434  
(MegatronTrainRayActor pid=649586)                                          aten::_to_copy         1.81%       3.529ms        10.25%      19.972ms      68.870us       0.000us         0.00%      74.131ms     255.622us           0 b           0 b       3.75 Gb           0 b           290  
(MegatronTrainRayActor pid=649586)                                           aten::reshape         0.76%       1.472ms         4.47%       8.716ms      80.707us       0.000us         0.00%       1.906ms      17.646us           0 b           0 b       1.06 Gb           0 b           108  
(MegatronTrainRayActor pid=649586)                                             aten::clone         0.55%       1.068ms         3.55%       6.911ms      63.993us       0.000us         0.00%       1.906ms      17.646us           0 b           0 b       1.06 Gb           0 b           108  
(MegatronTrainRayActor pid=649586) -------------------------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  
(MegatronTrainRayActor pid=649586) Self CPU time total: 194.924ms
(MegatronTrainRayActor pid=649586) Self CUDA time total: 132.040ms
```

```
(MegatronTrainRayActor pid=649586) -------------------------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  
(MegatronTrainRayActor pid=649586)                                                    Name    Self CPU %      Self CPU   CPU total %     CPU total  CPU time avg     Self CUDA   Self CUDA %    CUDA total  CUDA time avg       CPU Mem  Self CPU Mem      CUDA Mem  Self CUDA Mem    # of Calls  
(MegatronTrainRayActor pid=649586) -------------------------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  
(MegatronTrainRayActor pid=649586)                                             aten::empty         6.44%      12.648ms         6.92%      13.583ms      15.924us       0.000us         0.00%       0.000us       0.000us     896.72 Kb     896.72 Kb      11.95 Gb      11.93 Gb           853  
(MegatronTrainRayActor pid=649586)                                     aten::empty_strided         4.21%       8.264ms         6.48%      12.723ms      21.936us       0.000us         0.00%       0.000us       0.000us           0 b           0 b      11.25 Gb      11.25 Gb           580  
(MegatronTrainRayActor pid=649586)                                        aten::empty_like         1.42%       2.794ms         4.53%       8.901ms      22.363us       0.000us         0.00%       0.000us       0.000us           0 b           0 b       8.56 Gb           0 b           398  
(MegatronTrainRayActor pid=649586)                                        c10d::allgather_         5.07%       9.948ms        33.10%      64.971ms     403.550us       0.000us         0.00%      42.511ms     264.042us           0 b           0 b       7.49 Gb           0 b           161  
(MegatronTrainRayActor pid=649586)                                      record_param_comms        14.67%      28.791ms        28.82%      56.555ms     195.019us      35.562ms        26.66%      42.511ms     146.589us           0 b           0 b       7.49 Gb           0 b           290  
(MegatronTrainRayActor pid=649586)                                               aten::cat         3.61%       7.081ms         5.88%      11.547ms      79.635us       9.399ms         7.05%       9.399ms      64.819us     -78.19 Kb     -78.19 Kb       7.49 Gb       7.49 Gb           145  
(MegatronTrainRayActor pid=649586)                                                aten::to         0.62%       1.210ms        10.52%      20.641ms      47.561us       0.000us         0.00%      74.920ms     172.626us           0 b           0 b       3.75 Gb           0 b           434  
(MegatronTrainRayActor pid=649586)                                          aten::_to_copy         1.84%       3.618ms         9.90%      19.431ms      67.003us       0.000us         0.00%      74.920ms     258.344us           0 b           0 b       3.75 Gb           0 b           290  
(MegatronTrainRayActor pid=649586)                                           aten::reshape         0.77%       1.518ms         4.58%       8.989ms      83.232us       0.000us         0.00%       1.897ms      17.566us           0 b           0 b       1.07 Gb           0 b           108  
(MegatronTrainRayActor pid=649586)                                             aten::clone         0.56%       1.095ms         3.63%       7.122ms      65.941us       0.000us         0.00%       1.897ms      17.566us           0 b           0 b       1.07 Gb           0 b           108  
(MegatronTrainRayActor pid=649586) -------------------------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  
(MegatronTrainRayActor pid=649586) Self CPU time total: 196.265ms
(MegatronTrainRayActor pid=649586) Self CUDA time total: 133.397ms
```