### PR TITLE
rename --partial-rollout to be --collect-aborted-samples

### DIFF
--- a/slime/rollout/sglang_rollout.py
+++ b/slime/rollout/sglang_rollout.py
@@ -116,7 +116,7 @@ async def abort(state, args, pendings, rollout_id: int):
     while pendings:
         done, pendings = await asyncio.wait(pendings, return_when=asyncio.FIRST_COMPLETED)
 
-        if not args.partial_rollout:
+        if not args.collect_aborted_samples:
             continue
 
         # for partial rollout, collect the partial samples into the data buffer
@@ -128,10 +128,11 @@ async def abort(state, args, pendings, rollout_id: int):
             aborted_samples.append(group)
             count += len(group)
 
-    if args.partial_rollout:
+    if args.collect_aborted_samples:
         print(f"Collected {count} partial samples into the data buffer", flush=True)
 
     return aborted_samples
+
 
 def _submit_generate_tasks(state, get_samples, min_submit_size: int):
     new_pendings = set()
@@ -190,7 +191,34 @@ def _postprocess_done_data(
 
 
 async def generate_rollout_async(state, args, rollout_id: int, get_samples):
-    """An example to implement the generate_rollout function for an rule based rm rollout generation.
+    """Generate one rollout round (async) with optional dynamic filtering, over-sampling, and partial buffering.
+
+    Behavior matrix and interactions:
+    - dynamic_sampling_filter_path (optional):
+        Each finished group of `n_samples_per_prompt` is filtered online. Failed
+        groups are dropped immediately and do not count toward the target.
+
+    - over_sampling_filter (optional):
+        After collecting enough valid groups, apply the final selector to rank
+        and keep only `rollout_batch_size` groups; the rest are discarded and not
+        written back to the partial buffer.
+
+    - over_sampling_batch_size (submission granularity):
+        Task replenishment submits in chunks of `over_sampling_batch_size` groups
+        even if the remaining gap is smaller. This intentional oversubmission keeps
+        throughput high, and any leftover in-flight tasks will be aborted once the
+        target is met.
+
+    - collect_aborted_samples (aka --partial-rollout):
+        When the target is reached, abort remaining pending requests. If enabled,
+        partially generated groups from those aborted tasks are buffered and can be
+        resumed in later rounds to mitigate long-tail latency.
+
+    Notes:
+    - If `over_sampling_filter` is set, this loop stops after collecting
+      `over_sampling_batch_size` VALID groups, then downsamples to `rollout_batch_size`.
+    - If both filters are disabled and `over_sampling_batch_size == rollout_batch_size`,
+      typically there are no pending tasks to abort, so partial buffering will not trigger.
 
     Args:
         args: the whole args
@@ -210,13 +238,20 @@ async def generate_rollout_async(state, args, rollout_id: int, get_samples):
         load_function(args.over_sampling_filter_path) if args.over_sampling_filter_path is not None else None
     )
 
-    # target_data_size is the total number of valid samples to get
+    # target_data_size is the number of VALID groups to collect this round.
+    # - If over_sampling_filter is set: collect `over_sampling_batch_size` groups,
+    #   then rank/select the top `rollout_batch_size` at the end.
+    # - Else: collect `rollout_batch_size` groups directly.
     target_data_size = args.over_sampling_batch_size if over_sampling_filter is not None else args.rollout_batch_size
 
     data = []
     pendings = set()
     do_print = True
     pbar = tqdm(total=target_data_size * args.n_samples_per_prompt, desc="Rollout generation")
+    # Replenish tasks according to the current gap:
+    #   gap = target_data_size - len(data) - len(pendings)
+    # Note: _submit_generate_tasks() submits in chunks of `over_sampling_batch_size`,
+    # so it can overshoot the exact gap by design to keep the pipeline saturated.
     while len(data) < target_data_size:
         pendings |= _submit_generate_tasks(
             state,

--- a/slime/utils/arguments.py
+++ b/slime/utils/arguments.py
@@ -245,13 +245,12 @@ def get_slime_extra_args_provider(add_custom_arguments=None):
                 ),
             )
 
-            # partial rollout
             parser.add_argument(
-                "--partial-rollout",
+                "--collect-aborted-samples",
                 action="store_true",
                 default=False,
                 help=(
-                    "Whether to use partial rollout. "
+                    "Whether to Collected aborted samples into the data buffer"
                     "If set, the unfinished samples during dynamic sampling will be recycled back to data buffer. "
                     "This is useful for long responses."
                 ),

--- a/slime_plugins/mbridge/glm4moe.py
+++ b/slime_plugins/mbridge/glm4moe.py
@@ -36,18 +36,20 @@ class GLM4MoEBridge(Qwen2MoEBridge):
         convert_names = []
         for keyword, mapping_names in self._MTP_MAPPING.items():
             if keyword in name:
-                convert_names.extend(
-                    [x.format(layer_number=num_layers) for x in mapping_names]
-                )
+                convert_names.extend([x.format(layer_number=num_layers) for x in mapping_names])
                 break
             elif "mlp" in name:
                 mtp_layer_index = int(re.findall(r"mtp\.layers\.(\d+)\.", name)[0])
-                name_ = re.sub(r"^mtp\.layers.\d+.transformer_layer", f"model.layers.{num_layers+mtp_layer_index}", name)
+                name_ = re.sub(
+                    r"^mtp\.layers.\d+.transformer_layer", f"model.layers.{num_layers+mtp_layer_index}", name
+                )
                 convert_names = self._weight_name_mapping_mlp(name_)
                 break
             elif "self_attention" in name:
                 mtp_layer_index = int(re.findall(r"mtp\.layers.(\d+)\.", name)[0])
-                name_ = re.sub(r"^mtp\.layers.\d+.transformer_layer", f"model.layers.{num_layers+mtp_layer_index}", name)
+                name_ = re.sub(
+                    r"^mtp\.layers.\d+.transformer_layer", f"model.layers.{num_layers+mtp_layer_index}", name
+                )
                 convert_names = self._weight_name_mapping_attention(name_)
                 break
 
@@ -65,9 +67,7 @@ class GLM4MoEBridge(Qwen2MoEBridge):
         Returns:
             list: Corresponding Hugging Face weight names
         """
-        assert (
-            "_extra_state" not in mcore_weights_name
-        ), "extra_state should not be loaded"
+        assert "_extra_state" not in mcore_weights_name, "extra_state should not be loaded"
         direct_name_mapping = {
             "embedding.word_embeddings.weight": "model.embed_tokens.weight",
             "decoder.final_layernorm.weight": "model.norm.weight",
@@ -83,9 +83,7 @@ class GLM4MoEBridge(Qwen2MoEBridge):
         elif "mlp" in mcore_weights_name:
             return self._weight_name_mapping_mlp(mcore_weights_name)
         else:
-            raise NotImplementedError(
-                f"Unsupported parameter name: {mcore_weights_name}"
-            )
+            raise NotImplementedError(f"Unsupported parameter name: {mcore_weights_name}")
 
     def _build_config(self):
         """


### PR DESCRIPTION
This pull request renames the `--partial-rollout flag` to be more accurate.

The existing `--partial-rollout flag` is misleading. It doesn't actually control a partial rollout; instead, it determines whether aborted samples are collected into the buffer when partial rollout is enabled.

Partial rollout functionality is actually controlled by:

`--over-sampling-batch-size`, `--over-sampling-filter-path`, `--dynamic-sampling-filter-path`

This change may be backward-incompatible for existing users, so feel free to close the PR if this is not a desired change.