### PR TITLE
update main readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,6 @@
 
   - [Architecture Overview](#architecture-overview)
   - [Quick Start](#quick-start)
-      - [Environment Setup](#environment-setup)
-      - [Examples](#examples)
-        - [Dense Model Examples: GLM-4-9B and Qwen3-4B](#Dense-Model-Examples-GLM-4-9B-and-Qwen3-4B)
-        - [MoE Model Examples: GLM-4.5, Qwen3-30B-A3B and DeepSeek-R1](#MoE-Model-Examples-GLM-45-Qwen3-30B-A3B-and-DeepSeek-R1)
-        - [Multi-Turn + Tool Calling Example: Search-R1 lite](#Multi-Turn--Tool-Calling-Example-Search-R1-lite)
-        - [SFT Example: Qwen3-4B-Base with OpenHermes-2.5](#SFT-Example-Qwen3-4B-Base-with-OpenHermes-25)
   - [Checkpoint Format Conversion](#checkpoint-format-conversion)
   - [Starting the Training Process](#starting-the-training-process)
   - [Argument Descriptions](#argument-descriptions)
@@ -41,54 +35,10 @@
 
 ## Quick Start
 
-### Environment Setup
+For a comprehensive quick start guide covering environment setup, data preparation, training startup, and key code analysis, please refer to:
+- [Quick Start Guide](./docs/en/quick_start.md)
 
-Based on the `zhuzilin/slime:latest` image (pre-installed with latest SGLang and Megatron):
-
-```bash
-docker run --rm --gpus all --ipc=host --shm-size=16g \
-  --ulimit memlock=-1 --ulimit stack=67108864 \
-  -p 8265:8265 \
-  -it zhuzilin/slime:latest /bin/bash
-
-git clone https://github.com/THUDM/slime.git
-cd slime
-pip install -e .
-```
-
-- If you prefer not to use Docker, or if it's inconvenient, please refer to [Setting up the Environment from Scratch](./docs/en/build.md).
-- For AMD support, please refer to [AMD Tutorial](./docs/en/amd_tutorial.md).
-
-### Examples
-
-#### Dense Model Examples: GLM-4-9B and Qwen3-4B
-
-We provide examples to use [GLM-4-9B](https://huggingface.co/THUDM/GLM-Z1-9B-0414) and [Qwen3-4B](https://huggingface.co/Qwen/Qwen3-4B), please refer to:
-
-- [Example: GLM-4-9B](docs/en/models/glm4-9B.md).
-- [Example: Qwen3-4B](docs/en/models/qwen3-4B.md).
-
-#### MoE Model Examples: GLM-4.5, Qwen3-30B-A3B and DeepSeek-R1
-
-For MoE example, please refer to:
-
-- [Example: Training GLM-4.5 wtih 64xH100](docs/en/models/glm4.5-355B-A32B.md)
-- [Example: Training Qwen3-30B-A3B with 8xH100](docs/en/models/qwen3-30B-A3B.md).
-- [Example: Training DeepSeek R1 with 128xH100](docs/en/models/deepseek-r1.md)
-
-#### Multi-Turn + Tool Calling Example: Search-R1 lite
-
-For multi-turn and tool calling, we also provides an minimal reimplenmentation of Search-R1, please refer to:
-
-- [Example: Search-R1 lite](examples/search-r1/README.md).
-
-#### SFT Example: Qwen3-4B-Base with OpenHermes-2.5
-
-slime is not just a RL framework, we support a diverse set of post-training setups. For an SFT example, please refer to:
-
-- [Example: Qwen3-4B-Base with OpenHermes-2.5](docs/en/sft.md).
-
-### Checkpoint Format Conversion
+## Checkpoint Format Conversion
 
 Since slime uses Megatron, and Megatron does not support loading Hugging Face checkpoints directly, we need to convert the model to the `torch_dist` format that Megatron supports.
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -11,12 +11,6 @@
 
 - [架构总览](#架构总览)
 - [快速开始](#快速开始)
-  - [环境准备](#环境准备)
-  - [示例](#示例)
-    - [Dense 模型示例：GLM-4-9B 与 Qwen3-4B](#Dense-模型示例GLM-4-9B-与-Qwen3-4B)
-    - [MoE 模型示例：GLM-4.5、Qwen3-30B-A3B 与 DeepSeek-R1](#MoE-模型示例GLM-45Qwen3-30B-A3B-与-DeepSeek-R1)
-    - [多轮对话 + 工具调用示例：Search-R1 lite](#多轮对话--工具调用示例Search-R1-lite)
-    - [SFT 示例：Qwen3-4B-Base + OpenHermes-2.5](#SFT-示例Qwen3-4B-Base--OpenHermes-25)
 - [Checkpoint 格式转换](#checkpoint-格式转换)
 - [启动训练流程](#启动训练流程)
 - [参数说明](#参数说明)
@@ -35,55 +29,11 @@
 
 ## 快速开始
 
-### 环境准备
+有关环境配置、数据准备、训练启动和关键代码分析的完整快速开始指南，请参考：
 
-基于镜像 zhuzilin/slime:latest（已预装最新版 SGLang 和 Megatron）：
+- [快速开始指南](./docs/zh/quick_start.md)
 
-```bash
-docker run --rm --gpus all --ipc=host --shm-size=16g \
-  --ulimit memlock=-1 --ulimit stack=67108864 \
-  -it zhuzilin/slime:latest /bin/bash
-
-git clone https://github.com/THUDM/slime.git
-cd slime
-pip install -e .
-```
-
-- 对于不方便使用 docker 的场景，请参考 [从零搭建环境](./docs/zh/build.md)；
-- 对于 AMD 支持，请参考 [AMD 使用教程](./docs/en/amd_tutorial.md)。
-
-### 示例
-
-#### Dense 模型示例：GLM-4-9B 与 Qwen3-4B
-
-我们提供了 [GLM-4-9B](https://huggingface.co/THUDM/GLM-Z1-9B-0414) 和 [Qwen3-4B](https://huggingface.co/Qwen/Qwen3-4B) 的使用示例，可以通过他们对 slime 的使用方法有个基本的了解：
-
-- [示例：GLM-4-9B](docs/zh/models/glm4-9B.md)
-- [示例：Qwen3-4B](docs/zh/models/qwen3-4B.md)
-
-#### MoE 模型示例：GLM-4.5、Qwen3-30B-A3B 与 DeepSeek-R1
-
-我们也提供了 MoE 模型的示例，请查看：
-
-- [示例：64xH100 训练 GLM-4.5](docs/zh/models/glm4.5-355B-A32B.md)
-- [示例：8xH100 训练 Qwen3-30B-A3B](docs/zh/models/qwen3-30B-A3B.md)
-- [示例：128xH100 训练 DeepSeek-R1](docs/zh/models/deepseek-r1.md)
-
-#### 多轮对话 + 工具调用示例：Search-R1 lite
-
-针对多轮对话和工具调用场景，我们提供了一个简化版的 Search-R1 复现，请查看：
-
-- [示例：Search-R1 lite](examples/search-r1/README_zh.md)
-
-#### SFT 示例：Qwen3-4B-Base + OpenHermes-2.5
-
-slime is not just a RL framework, we support a diverse set of post-training setups. For an SFT example, please refer to:
-
-slime 不仅仅是一个 RL 框架，我们还支持了各种后训练流程。如果想使用 SFT，请参看：
-
-- [示例: Qwen3-4B-Base + OpenHermes-2.5](docs/zh/sft.md).
-
-### Checkpoint 格式转换
+## Checkpoint 格式转换
 
 由于 slime 使用 megatron，而 megatron 不支持加载 huggingface checkpoint，我们需要将模型转换至 megatron 可以支持的 torch_dist 格式。
 


### PR DESCRIPTION
Update the main readme files, use new link to replace the current part. 
But I keep the [Checkpoint Format Conversion] and [Starting the Training Process] sections, as I am not sure if they are included as part of the quick start. 