### PR TITLE
fix: Add FSDP module backward compatibility to megatron.patch

### DIFF
--- a/docker/patch/latest/megatron.patch
+++ b/docker/patch/latest/megatron.patch
@@ -1,3 +1,23 @@
+diff --git a/megatron/core/distributed/__init__.py b/megatron/core/distributed/__init__.py
+index fe26e8b4..500da66c 100644
+--- a/megatron/core/distributed/__init__.py
++++ b/megatron/core/distributed/__init__.py
+@@ -11,3 +11,20 @@ from .finalize_model_grads import finalize_model_grads
+ from .fsdp.mcore_fsdp_adapter import FullyShardedDataParallel
+ from .torch_fully_sharded_data_parallel import TorchFullyShardedDataParallel
+ from .torch_fully_sharded_data_parallel_config import TorchFullyShardedDataParallelConfig
++
++# Backward compatibility patch for FSDP module reorganization
++import sys
++import importlib.util
++
++spec = importlib.util.find_spec('megatron.core.distributed.fsdp.src.megatron_fsdp')
++if spec:
++    custom_fsdp = importlib.util.module_from_spec(spec)
++    spec.loader.exec_module(custom_fsdp)
++    sys.modules['megatron.core.distributed.custom_fsdp'] = custom_fsdp
++    if hasattr(custom_fsdp, 'MegatronFSDP'):
++        custom_fsdp.FullyShardedDataParallel = custom_fsdp.MegatronFSDP
 diff --git a/megatron/core/extensions/transformer_engine.py b/megatron/core/extensions/transformer_engine.py
 index 99c3edc0..26ea5cb4 100644
 --- a/megatron/core/extensions/transformer_engine.py

--- a/slime/backends/megatron_utils/actor.py
+++ b/slime/backends/megatron_utils/actor.py
@@ -96,10 +96,7 @@ class MegatronTrainRayActor(TrainRayActor):
             self.rollout_data_postprocess = load_function(self.args.rollout_data_postprocess_path)
 
         self.prof = None
-        if (
-            args.use_pytorch_profiler
-            and torch.distributed.get_rank() == 0
-        ):
+        if args.use_pytorch_profiler and torch.distributed.get_rank() == 0:
             self.prof = torch.profiler.profile(
                 schedule=torch.profiler.schedule(
                     wait=max(args.profile_step_start - 1, 0),
@@ -253,11 +250,7 @@ class MegatronTrainRayActor(TrainRayActor):
 
             log_rollout_data(rollout_id, self.args, rollout_data)
 
-            if (
-                self.args.use_pytorch_profiler
-                and torch.distributed.get_rank() == 0
-                and self.prof is not None
-            ):
+            if self.args.use_pytorch_profiler and torch.distributed.get_rank() == 0 and self.prof is not None:
                 self.prof.step()
 
             # Train

--- a/slime/backends/megatron_utils/model_provider.py
+++ b/slime/backends/megatron_utils/model_provider.py
@@ -37,18 +37,18 @@ def get_model_provider_func(args):
                 max_entries=100000,
                 # record stack information for the trace events
                 # trace_alloc_record_context=True,
-                stacks='all'
+                stacks="all",
             )
 
             def oom_observer(device, alloc, device_alloc, device_free):
                 # snapshot right after an OOM happened
-                print('saving allocated state during OOM')
+                print("saving allocated state during OOM")
                 snapshot = torch.cuda.memory._snapshot()
                 from pickle import dump
 
                 dump(
                     snapshot,
-                    open(f"oom_rank-{torch.distributed.get_rank()}_{args.memory_snapshot_path}", 'wb'),
+                    open(f"oom_rank-{torch.distributed.get_rank()}_{args.memory_snapshot_path}", "wb"),
                 )
 
             torch._C._cuda_attach_out_of_memory_observer(oom_observer)


### PR DESCRIPTION
Solve `ModuleNotFoundError: No module named 'megatron.core.distributed.custom_fsdp'` due to mismatch in mbridge and Megatron-LM version.