### PR TITLE
[fix] Incorrect variable name in custom_reward_post_process_func

### DIFF
--- a/slime/ray/buffer.py
+++ b/slime/ray/buffer.py
@@ -81,7 +81,7 @@ class RolloutController:
 
     def post_process_rewards(self, samples: Union[list[Sample], list[list[Sample]]]):
         if self.custom_reward_post_process_func is not None:
-            return self.custom_reward_post_process_func(self.args, raw_rewards)
+            return self.custom_reward_post_process_func(self.args, samples)
 
         raw_rewards = [sample.get_reward_value(self.args) for sample in samples]
         if (


### PR DESCRIPTION
There is no variable named `raw_rewards` before Line84 in the function `post_process_rewards`. I think it should be `samples` instead.