### PR TITLE
[bugfix] use fp32 for rollout_log_probs

### DIFF
--- a/slime/backends/utils/data.py
+++ b/slime/backends/utils/data.py
@@ -145,7 +145,7 @@ def process_rollout_data(args, rollout_data_ref, dp_rank, dp_size):
             torch.tensor(
                 slice_log_prob_with_cp(log_prob, total_length, response_length),
                 device=torch.cuda.current_device(),
-                dtype=torch.bfloat16,  # TODO: hardcode to bf16 at the moment
+                dtype=torch.float32,
             )
             for log_prob, total_length, response_length in zip(
                 rollout_data["rollout_log_probs"], rollout_data["total_lengths"], rollout_data["response_lengths"]

--- a/slime/ray/train_actor.py
+++ b/slime/ray/train_actor.py
@@ -43,7 +43,10 @@ class TrainRayActor(RayActor):
         local_rank = int(os.environ.get("LOCAL_RANK", 0))
         torch.cuda.set_device(f"cuda:{local_rank}")
 
-        dist.init_process_group(backend="nccl", timeout=timedelta(minutes=30))
+        dist.init_process_group(
+            backend=args.distributed_backend,
+            timeout=timedelta(minutes=args.distributed_timeout_minutes),
+        )
 
         args.rank = dist.get_rank()
         args.world_size = dist.get_world_size()


### PR DESCRIPTION
When using bf16, the metric in wandb may have great precision error... This should not affect actual training.