### PR TITLE
Update speculative decoding doc and add sglang patch

### DIFF
--- a/docker/patch/latest/sglang.patch
+++ b/docker/patch/latest/sglang.patch
@@ -1,5 +1,5 @@
 diff --git a/python/sglang/srt/configs/model_config.py b/python/sglang/srt/configs/model_config.py
-index bdb124e51..3edf30ab1 100644
+index 1b96ae6..3b7023c 100644
 --- a/python/sglang/srt/configs/model_config.py
 +++ b/python/sglang/srt/configs/model_config.py
 @@ -454,14 +454,14 @@ class ModelConfig:
@@ -26,7 +26,7 @@ index bdb124e51..3edf30ab1 100644
              # Verify quantization configurations.
              if self.quantization is None:
 diff --git a/python/sglang/srt/entrypoints/http_server.py b/python/sglang/srt/entrypoints/http_server.py
-index 2dd2c75f1..f2adb18f8 100644
+index a6bcb0b..1ef6abe 100644
 --- a/python/sglang/srt/entrypoints/http_server.py
 +++ b/python/sglang/srt/entrypoints/http_server.py
 @@ -264,6 +264,10 @@ async def validate_json_request(raw_request: Request):
@@ -41,7 +41,7 @@ index 2dd2c75f1..f2adb18f8 100644
  async def health_generate(request: Request) -> Response:
      """
 diff --git a/python/sglang/srt/layers/moe/token_dispatcher/deepep.py b/python/sglang/srt/layers/moe/token_dispatcher/deepep.py
-index 372717bf9..40665cc90 100644
+index 372717b..40665cc 100644
 --- a/python/sglang/srt/layers/moe/token_dispatcher/deepep.py
 +++ b/python/sglang/srt/layers/moe/token_dispatcher/deepep.py
 @@ -190,6 +190,7 @@ class DeepEPBuffer:
@@ -53,7 +53,7 @@ index 372717bf9..40665cc90 100644
              group,
              num_nvl_bytes,
 diff --git a/python/sglang/srt/layers/quantization/fp8.py b/python/sglang/srt/layers/quantization/fp8.py
-index 956264fc9..69f729336 100644
+index 956264f..7801d29 100644
 --- a/python/sglang/srt/layers/quantization/fp8.py
 +++ b/python/sglang/srt/layers/quantization/fp8.py
 @@ -351,10 +351,10 @@ class Fp8LinearMethod(LinearMethodBase):
@@ -72,10 +72,10 @@ index 956264fc9..69f729336 100644
  
          layer.weight = torch.nn.Parameter(layer.weight.data, requires_grad=False)
 diff --git a/python/sglang/srt/managers/scheduler.py b/python/sglang/srt/managers/scheduler.py
-index 95a529c89..758fbfd5f 100644
+index 3856bf2..5f6a657 100644
 --- a/python/sglang/srt/managers/scheduler.py
 +++ b/python/sglang/srt/managers/scheduler.py
-@@ -1359,7 +1359,7 @@ class Scheduler(
+@@ -1346,7 +1346,7 @@ class Scheduler(
  
          if memory_leak:
              msg = "token_to_kv_pool_allocator memory leak detected! " f"{token_msg}"
@@ -84,7 +84,7 @@ index 95a529c89..758fbfd5f 100644
  
          if self.disaggregation_mode == DisaggregationMode.DECODE:
              req_total_size = (
-@@ -1374,7 +1374,7 @@ class Scheduler(
+@@ -1361,7 +1361,7 @@ class Scheduler(
                  f"available_size={len(self.req_to_token_pool.free_slots)}, "
                  f"total_size={self.req_to_token_pool.size}\n"
              )
@@ -93,7 +93,7 @@ index 95a529c89..758fbfd5f 100644
  
          if (
              self.enable_metrics
-@@ -1830,6 +1830,7 @@ class Scheduler(
+@@ -1817,6 +1817,7 @@ class Scheduler(
              deepep_mode=DeepEPMode(self.server_args.deepep_mode),
              require_mlp_tp_gather=require_mlp_tp_gather(self.server_args),
              disable_overlap_schedule=self.server_args.disable_overlap_schedule,
@@ -101,7 +101,7 @@ index 95a529c89..758fbfd5f 100644
          )
  
      def handle_dp_balance_data(self, local_batch: ScheduleBatch):
-@@ -1927,6 +1928,7 @@ class Scheduler(
+@@ -1914,6 +1915,7 @@ class Scheduler(
          deepep_mode: DeepEPMode,
          require_mlp_tp_gather: bool,
          disable_overlap_schedule: bool,
@@ -109,7 +109,7 @@ index 95a529c89..758fbfd5f 100644
      ):
          # Check if other DP workers have running batches
          if local_batch is None:
-@@ -1957,7 +1959,7 @@ class Scheduler(
+@@ -1944,7 +1946,7 @@ class Scheduler(
          )
  
          tbo_preparer = TboDPAttentionPreparer()
@@ -119,10 +119,10 @@ index 95a529c89..758fbfd5f 100644
              device = tp_group.device
          else:
 diff --git a/python/sglang/srt/managers/tokenizer_manager.py b/python/sglang/srt/managers/tokenizer_manager.py
-index 58220b1d6..3c3d081a8 100644
+index 50ac39f..33782a8 100644
 --- a/python/sglang/srt/managers/tokenizer_manager.py
 +++ b/python/sglang/srt/managers/tokenizer_manager.py
-@@ -1044,10 +1044,15 @@ class TokenizerManager:
+@@ -1045,10 +1045,15 @@ class TokenizerManager:
          request: Optional[fastapi.Request] = None,
      ) -> Tuple[bool, str]:
          self.auto_create_handle_loop()
@@ -142,7 +142,7 @@ index 58220b1d6..3c3d081a8 100644
          return result.success, result.message
  
      async def update_weights_from_distributed(
-@@ -1056,9 +1061,6 @@ class TokenizerManager:
+@@ -1057,9 +1062,6 @@ class TokenizerManager:
          request: Optional[fastapi.Request] = None,
      ) -> Tuple[bool, str]:
          self.auto_create_handle_loop()
@@ -152,7 +152,7 @@ index 58220b1d6..3c3d081a8 100644
  
          if obj.abort_all_requests:
              self.abort_request(abort_all=True)
-@@ -1066,8 +1068,15 @@ class TokenizerManager:
+@@ -1067,8 +1069,15 @@ class TokenizerManager:
          # This means that weight sync
          # cannot run while requests are in progress.
          async with self.model_update_lock.writer_lock:
@@ -170,8 +170,35 @@ index 58220b1d6..3c3d081a8 100644
  
      async def update_weights_from_tensor(
          self,
+diff --git a/python/sglang/srt/model_executor/cuda_graph_runner.py b/python/sglang/srt/model_executor/cuda_graph_runner.py
+index 3039195..df2407e 100644
+--- a/python/sglang/srt/model_executor/cuda_graph_runner.py
++++ b/python/sglang/srt/model_executor/cuda_graph_runner.py
+@@ -759,6 +759,22 @@ class CudaGraphRunner:
+             )
+         if forward_batch.forward_mode.is_idle() and forward_batch.spec_info is not None:
+             forward_batch.spec_info.custom_mask = self.custom_mask
++
++        if forward_batch.forward_mode.is_target_verify() and bs - raw_bs > 0:
++            # pad the spec_info custom mask
++            spec_info = forward_batch.spec_info
++            pad_len = (
++                (bs - raw_bs)
++                * spec_info.draft_token_num
++                * (spec_info.draft_token_num + self.seq_len_fill_value)
++            )
++            pad_mask = torch.full(
++                (pad_len,),
++                True,
++                device=spec_info.custom_mask.device,
++            )
++            spec_info.custom_mask = torch.cat([spec_info.custom_mask, pad_mask], dim=0)
++
+         # Attention backend
+         self.model_runner.attn_backend.init_forward_metadata_replay_cuda_graph(
+             bs,
 diff --git a/python/sglang/srt/model_executor/model_runner.py b/python/sglang/srt/model_executor/model_runner.py
-index 5222bff0a..ff0bbc62a 100644
+index ee83c2d..5145d7f 100644
 --- a/python/sglang/srt/model_executor/model_runner.py
 +++ b/python/sglang/srt/model_executor/model_runner.py
 @@ -22,6 +22,7 @@ import os
@@ -182,7 +209,7 @@ index 5222bff0a..ff0bbc62a 100644
  
  import torch
  import torch.distributed as dist
-@@ -675,7 +676,7 @@ class ModelRunner:
+@@ -667,7 +668,7 @@ class ModelRunner:
          monkey_patch_vllm_parallel_state()
          monkey_patch_isinstance_for_vllm_base_layer()
  
@@ -192,7 +219,7 @@ index 5222bff0a..ff0bbc62a 100644
                  model_config=self.model_config,
                  load_config=self.load_config,
 diff --git a/python/sglang/srt/models/glm4_moe.py b/python/sglang/srt/models/glm4_moe.py
-index e0f0b373d..a18ac10f1 100644
+index 67ef6ca..1a3db99 100644
 --- a/python/sglang/srt/models/glm4_moe.py
 +++ b/python/sglang/srt/models/glm4_moe.py
 @@ -1108,5 +1108,4 @@ class Glm4MoeForCausalLM(DeepseekV2ForCausalLM):

--- a/docs/en/speculative-decoding.md
+++ b/docs/en/speculative-decoding.md
@@ -2,43 +2,70 @@
 
 ### Support Status
 
-* ✅ MTP layer: **inference only**, not training yet
+* ✅ **MTP layer for inference only (no training)**
 
-  * ✅ Models with a **native MTP layer**
+  * ✅ Models with native MTP layers:
 
     * ✅ Mimo-7B-RL
-    * 🧪 DeepSeek-V3 / DeepSeek-R1
+    * 🧪 Deepseek-V3/R1
     * 🧪 GLM-4.5
-  * ⏳ Draft models **trained with SpecForge**
-* ⏳ MTP layer **training**
+  * 🚧 External draft models trained with SpecForge:
 
-  * 🚧 Add sequence packing support for the MTP layer in **Megatron**
+    * 🚧 [sglang-EAGLE3-LLaMA3.1-Instruct-8B](https://huggingface.co/lmsys/sglang-EAGLE3-LLaMA3.1-Instruct-8B)
+    * 🚧 [Qwen3-235B-A22B-EAGLE3](https://huggingface.co/lmsys/Qwen3-235B-A22B-EAGLE3)
+* ⏳ **MTP layer training with RL**
 
-### How to Use
+  * 🚧 Sequence packing with MTP layers is under development in Megatron.
+
+### Usage
 
 Add the following flags to `SGLANG_ARGS`:
 
-```
+```bash
+# for speculative decoding
 --sglang-speculative-algorithm EAGLE
 --sglang-speculative-num-steps 3
 --sglang-speculative-eagle-topk 1
 --sglang-speculative-num-draft-tokens 4
 ```
 
-For detailed parameter meanings and configuration, see SGLang’s speculative decoding [documentation](https://docs.sglang.ai/advanced_features/speculative_decoding.html).
+For details on parameter meanings and configuration, see the [SGLang speculative decoding documentation](https://docs.sglang.ai/advanced_features/speculative_decoding.html).
 
 ### Known Issues
 
-* In the **verify** phase of speculative decoding, there is a CUDA Graph **padding** bug that can surface as two kinds of errors: [SGLang #9521](https://github.com/sgl-project/sglang/issues/9521) and [SGLang #8336](https://github.com/sgl-project/sglang/issues/8336).
+#### [SGLang issue #9888](https://github.com/sgl-project/sglang/issues/9888) or [SGLang issue #9521](https://github.com/sgl-project/sglang/issues/9521)
 
-  * **Workarounds:**
+* Error occurs during CUDA graph padding in the speculative decoding draft stage.
+* Workarounds:
 
-    1. Increase `--sglang-cuda-graph-bs` to avoid CUDA Graph padding.
-    2. Disable CUDA Graph padding via `--sglang-disable-cuda-graph-padding`.
-    3. Disable CUDA Graph entirely (**not recommended**).
-  * This issue exists with **fa3** and **FlashInfer**, so it’s **backend-agnostic**.
-  * For debugging, try enabling Slime’s `--debug-rollout-only` to rule out effects from parameter updates or model offload.
-  * The bug is **more severe inside RL frameworks** (vs. running SGLang alone) and often appears at the **start of a rollout**, likely related to large **batch size fluctuations** common in RL.
-* FlashInfer’s speculative decoding has an additional CUDA Graph padding bug: [SGLang #9481](https://github.com/sgl-project/sglang/issues/9481).
+  1. Switch the inference backend to **fa3 Triton** (bug only occurs in **flashInfer**).
+  2. Specify a broader range for `--sglang-cuda-graph-bs` to avoid batch sizes that trigger CUDA graph padding.
+  3. Disable CUDA graph (not recommended due to significant performance loss).
+  4. **Notice:** Disabling CUDA graph padding with `--sglang-disable-cuda-graph-padding` is currently ineffective for speculative decoding. See [SGLang `cuda_graph_runner.py`](tbd).
+* For debugging, enable Slime’s `--debug-rollout-only` flag to isolate rollout behavior from parameter updates or model offloading.
 
-  * **Workaround:** switch the attention backend with `--sglang-attention-backend fa3`.
+```bash
+# If speculative decoding fails, this can help debug
+--debug-rollout-only
+
+# If flashInfer causes issues with speculative decoding, use fa3 or triton instead
+--sglang-attention-backend fa3
+
+# If CUDA graph fails due to padding, extend the CUDA graph batch size
+--sglang-cuda-graph-bs $(seq 1 32) $(seq 40 8 64) $(seq 80 16 160)
+
+# Improve performance by enlarging the running batch size limit
+--sglang-max-running-requests 128
+```
+
+#### [SGLang issue #9481](https://github.com/sgl-project/sglang/issues/9481)
+
+* Solution:
+
+  1. Apply the latest SGLang patch.
+  2. See [PR #9687](https://github.com/sgl-project/sglang/pull/9687) for reference changes.
+
+#### [SGLang PR #9388](https://github.com/sgl-project/sglang/pull/9388)
+
+* If using an external draft model results in **illegal memory access**, it may be caused by a context length mismatch between the draft and target models.
+* Please update to **SGLang ≥ 0.5.1** (and update `sgl-kernel`) to apply this fix.

--- a/docs/zh/speculative-decoding .md
+++ b/docs/zh/speculative-decoding .md
@@ -6,12 +6,15 @@
 		- ✅ Mimo-7B-RL
 		- 🧪 Deepseek-V3/R1
 		- 🧪 GLM-4.5
-	- ⏳ SpecForge 训练的 draft model
-- ⏳ mtp layer 训练
+	- 🚧 SpecForge 训练的外部 draft model
+		- 🚧 [sglang-EAGLE3-LLaMA3.1-Instruct-8B](https://huggingface.co/lmsys/sglang-EAGLE3-LLaMA3.1-Instruct-8B)
+		- 🚧 [Qwen3-235B-A22B-EAGLE3](https://huggingface.co/lmsys/Qwen3-235B-A22B-EAGLE3)
+- ⏳ mtp layer 的 RL 训练
 	- 🚧 在Megatron 支持 mtp layer 的 sequence packing
 ### 使用方法
 在 SGLANG_ARGS 里添加如下参数
-```
+```bash
+# for speculative decoding
 --sglang-speculative-algorithm EAGLE
 --sglang-speculative-num-steps 3
 --sglang-speculative-eagle-topk 1
@@ -19,14 +22,31 @@
 ```
 详细参数含义及配置方法，请参考 SGLang 的 speculative decoding [文档](https://docs.sglang.ai/advanced_features/speculative_decoding.html)
 ### 已知问题
-- 目前在 speculative decoding 的 verify 阶段，cuda graph 的 padding 存在 bug。会出现两种可能的报错。[SGLang #9521](https://github.com/sgl-project/sglang/issues/9521) 和 [SGLang #8336](https://github.com/sgl-project/sglang/issues/8336)。
-	- 解决方法: 
-		1. 扩大 `--sglang-cuda-graph-bs` 来避免 cuda graph padding
-		2. 禁用 cuda graph padding `--sglang-disable-cuda-graph-padding`
-		3. 禁用 cuda graph（不推荐）
-	- fa3 和 flashInfer 都存在该问题，与推理后端无关。
-	- 如需 debug，可尝试开启 slime 的 `--debug-rollout-only` 参数，来排除参数更新或模型 offload 的影响
-	- 该 bug 在 RL 框架内较严重（相比单跑 SGLang），且集中在某轮 rollout 的起始阶段发生。可能与 RL 场景 batch 波动较大有关。
-- flashInfer 的 speculative decoding 存在另一个 cuda graph padding 的 bug。[SGLang #9481](https://github.com/sgl-project/sglang/issues/9481)
-	- 解决方法：
-		- 1. 切换推理后端 `--sglang-attention-backend fa3`
+[SGLang issue #9888](https://github.com/sgl-project/sglang/issues/9888) 或 [SGLang issue #9521](https://github.com/sgl-project/sglang/issues/9521)
+- 报错发生在 speculative decoding draft 阶段的 cuda graph padding
+- 解决方法: 
+	1. 切换推理后端为 fa3 triton。该 bug 仅发生在 flashInfer 。
+	2. 覆盖更宽的 `--sglang-cuda-graph-bs` 来避免某些 batch size 做 cuda graph padding
+	3. 禁用 cuda graph（性能损失太大，不推荐）
+	4. Notice：禁用 cuda graph padding `--sglang-disable-cuda-graph-padding` 目前对 speculative decoding 不生效。参考 [SGLang cuda_graph_runner.py](tbd)
+- 如需 debug，可尝试开启 slime 的 `--debug-rollout-only` 参数，来排除参数更新或模型 offload 的影响
+```bash
+# if speculative decoding has bug, this can help debug
+--debug-rollout-only
+
+# If flashInfer has bug with speculative decoding, use fa3 or triton instead
+--sglang-attention-backend fa3
+
+# If bug exists when cuda graph do padding, extend the cuda graph batch size
+--sglang-cuda-graph-bs $(seq 1 32) $(seq 40 8 64) $(seq 80 16 160)
+
+# Improve performance by enlarging running batch size limit
+--sglang-max-running-requests 128
+```
+[SGLang issue #9481](https://github.com/sgl-project/sglang/issues/9481)
+- 解决方法：
+	1. 应用最新的 sglang patch。
+	2. 参考这个 pr 修改 sglang https://github.com/sgl-project/sglang/pull/9687 
+[SGLang PR #9388](https://github.com/sgl-project/sglang/pull/9388)
+- 如果使用外部 draft model 出现 illegal memory access，可能是由于 draft model 和 target model 的 context length 不匹配导致的 bug。
+- 请更新 SGLang >= 0.5.1 来应用这个 PR。（并更新 `sgl-kernel`）

--- a/scripts/run-mimo-7B-rl-eagle.sh
+++ b/scripts/run-mimo-7B-rl-eagle.sh
@@ -107,27 +107,12 @@ WANDB_ARGS=(
 SGLANG_ARGS=(
    --rollout-num-gpus-per-engine 1
    --sglang-mem-fraction-static 0.7
-   # if speculative decoding has bug, this can help debug
-   # --debug-rollout-only
 
    # for speculative decoding
    --sglang-speculative-algorithm EAGLE
    --sglang-speculative-num-steps 3
    --sglang-speculative-eagle-topk 1
    --sglang-speculative-num-draft-tokens 4
-
-   # bug exists when cuda graph do padding (both fa3 and flashInfer)
-   # temporarily skip this problem by extending the original cuda graph batch size
-   # https://github.com/sgl-project/sglang/issues/8336
-   # https://github.com/sgl-project/sglang/issues/9521
-   --sglang-cuda-graph-bs $(seq 1 32) $(seq 40 8 64) $(seq 80 16 160)
-
-   # improve performance by enlarging the max running requests
-   # --sglang-max-running-requests 128
-
-   # If flashInfer has bug with speculative decoding, use fa3 instead
-   # https://github.com/sgl-project/sglang/issues/9481
-   # --sglang-attention-backend fa3
 )
 
 MISC_ARGS=(


### PR DESCRIPTION
- Update docs for speculative decoding.
- Add sglang patch for cuda graph runner, about this issue [SGLang #9687](https://github.com/sgl-project/sglang/pull/9687)