### PR TITLE
[bugfix] fix read data containing "tools" field

### DIFF
--- a/slime/utils/data.py
+++ b/slime/utils/data.py
@@ -1,7 +1,6 @@
 import random
 import numpy as np
-
-from pandas as pd
+import pandas as pd
 
 from slime.utils.types import Sample
 


### PR DESCRIPTION
When reading data with tools field, huggingface datasets always attempts to merge their schemas.

```python
import json
from datasets import Dataset

tools = [{"param_a": 1}, {"param_b": 2}]
json.dump(tools, open("./tools.json", "w"))

ds = Dataset.from_json("./tools.json")

print(ds[0])
# {'param_a': 1, 'param_b': None}
```

This causes the read-in data to have all tools include the fields of all other tools (defaulting to None), which significantly affects prompt generation.

So, switch back to using pandas.