### PR TITLE
[feat] init support for FSDP

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,11 @@
 accelerate
+datasets
 httpx[http2]
 mcp[cli]
 pylatexenc
+pyyaml
 ray[default]
 sglang
 torch
+transformers
 wandb

--- a/slime/backends/fsdp_utils/__init__.py
+++ b/slime/backends/fsdp_utils/__init__.py
@@ -1,0 +1,4 @@
+from .actor import FSDPTrainRayActor  # noqa: F401
+from .arguments import load_fsdp_args  # noqa: F401
+
+__all__ = ["load_fsdp_args", "FSDPTrainRayActor"]

--- a/slime/backends/fsdp_utils/actor.py
+++ b/slime/backends/fsdp_utils/actor.py
@@ -1,0 +1,315 @@
+from contextlib import nullcontext
+
+import torch
+import torch.distributed as dist
+from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
+from torch.distributed.fsdp import ShardingStrategy
+from torch_memory_saver import torch_memory_saver
+from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer
+
+import wandb
+from slime.backends.utils.data import process_rollout_data
+from slime.ray.train_actor import TrainRayActor
+from slime.utils.distributed_utils import get_gloo_group
+from slime.utils.ppo_utils import compute_approx_kl, compute_policy_loss
+from slime.utils.timer import Timer, timer
+
+from .update_weight_utils import UpdateWeightFromTensor
+
+
+class FSDPTrainRayActor(TrainRayActor):
+    """Simplified TrainRayActor for pure HF+FSDP training.
+
+    Responsibilities:
+      * Initialize model/tokenizer on rank0 sequentially to avoid race on cache
+      * Wrap model with FSDP
+      * Provide minimal train / save / update_weights hooks compatible with existing RayTrainGroup
+
+    Weight update strategy:
+      * Rank0 gathers state_dict (full) and broadcasts tensor-by-tensor.
+      * For small models this is fine; for larger models consider sharded state_dict type.
+    """
+
+    def init(self, args, role, wandb_run_id, with_ref: bool = False):  # type: ignore[override]
+        super().init(args, role, wandb_run_id, with_ref)
+        self.args = args
+        torch.manual_seed(args.seed)
+
+        # Serialize tokenizer/config loading across ranks to avoid HF cache race
+        for i in range(dist.get_world_size()):
+            if i == dist.get_rank():
+                self.hf_config = AutoConfig.from_pretrained(self.args.hf_checkpoint, trust_remote_code=True)
+                self.tokenizer = AutoTokenizer.from_pretrained(self.args.hf_checkpoint, trust_remote_code=True)
+            dist.barrier(group=get_gloo_group())
+
+        # Load model
+        with torch.device(f"cuda:{torch.cuda.current_device()}"):
+            model = AutoModelForCausalLM.from_pretrained(
+                self.args.hf_checkpoint,
+                trust_remote_code=True,
+            )
+        model.train()
+
+        if args.gradient_checkpointing:
+            model.gradient_checkpointing_enable()
+
+        # TODO: set correct auto_wrap_policy
+        auto_wrap_policy = None
+
+        self.model = FSDP(
+            model,
+            auto_wrap_policy=auto_wrap_policy,
+            device_id=torch.cuda.current_device(),
+            use_orig_params=True,
+            sharding_strategy=ShardingStrategy[self.args.fsdp_sharding_strategy],
+            cpu_offload=self.args.fsdp_cpu_offload,
+            forward_prefetch=self.args.fsdp_forward_prefetch,
+            backward_prefetch=self.args.fsdp_backward_prefetch,
+            limit_all_gathers=self.args.fsdp_limit_all_gathers,
+        )
+
+        self.optimizer = torch.optim.AdamW(
+            self.model.parameters(),
+            lr=args.lr,
+            betas=(args.adam_beta1, args.adam_beta2),
+            eps=args.adam_eps,
+            weight_decay=args.weight_decay,
+        )
+
+        # TODO: load
+
+        self.ref_model = None
+        # TODO: support ref model
+        if with_ref:
+            raise NotImplementedError()
+
+        self.weight_updator = UpdateWeightFromTensor(self.args, self.model)
+
+        if self.args.offload:
+            self.sleep(("model"))
+
+        Timer().start("train_wait")
+        self.global_step = 0
+        self.micro_step = 0
+        return 0
+
+    def sleep(self, tags):
+        if not getattr(self.args, "offload", False):
+            return
+        if torch_memory_saver is not None:
+            torch_memory_saver.pause()
+
+    def wake_up(self, tags):
+        if not getattr(self.args, "offload", False):
+            return
+        if torch_memory_saver is not None:
+            torch_memory_saver.resume()
+
+    def connect_rollout_engines(self, rollout_engines, rollout_engine_lock):
+        self.rollout_engines = rollout_engines
+
+        if self.args.debug_train_only or self.args.debug_rollout_only:
+            return
+
+        self.weight_updator.connect_rollout_engines(rollout_engines, rollout_engine_lock)
+        dist.barrier(group=get_gloo_group())
+
+    def compute_log_prob(
+        self,
+        model_tag,
+        padded_batches,
+        store_prefix="",
+    ):
+        rollout_data = {f"{store_prefix}log_probs": []}
+        with timer(f"{store_prefix}log_probs") and torch.no_grad():
+            for batch in padded_batches:
+                with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                    logits = self.model(input_ids=batch["tokens"]).logits
+                batch[f"{store_prefix}log_probs"] = gather_log_probs(logits, batch["tokens"])
+        return rollout_data
+
+    def pad_and_move_to_device(self, rollout_data):
+        tokens = rollout_data["tokens"]
+        loss_masks = rollout_data["loss_masks"]
+
+        padded_batches = []
+        for i in range(0, len(tokens), self.args.micro_batch_size):
+            batch_tokens = tokens[i : i + self.args.micro_batch_size]
+            batch_loss_masks = loss_masks[i : i + self.args.micro_batch_size]
+            max_len = max(len(t) for t in batch_tokens)
+            padded_tokens = [t + [self.tokenizer.pad_token_id] * (max_len - len(t)) for t in batch_tokens]
+            padded_loss_masks = [
+                # -1 because its the loss mask for logprob
+                [0] * (len(t) - len(l) - 1) + l + [0] * (max_len - len(t))
+                for l, t in batch_loss_masks
+            ]
+            padded_batches.append(
+                {
+                    "tokens": torch.tensor(padded_tokens, dtype=torch.long, device=torch.cuda.current_device()),
+                    "loss_masks": torch.tensor(
+                        padded_loss_masks, dtype=torch.long, device=torch.cuda.current_device()
+                    ),
+                    "rewards": torch.tensor(
+                        rollout_data["rewards"][i : i + self.args.micro_batch_size],
+                        dtype=torch.float,
+                        device=torch.cuda.current_device(),
+                    ),
+                }
+            )
+        return padded_batches
+
+    def train(self, rollout_id, rollout_data_ref):  # type: ignore[override]
+        Timer().end("train_wait")
+
+        world_size = dist.get_world_size()
+        rank = dist.get_rank()
+
+        rollout_data = process_rollout_data(self.args, rollout_data_ref, rank, world_size)
+        padded_batches = self.pad_and_move_to_device(rollout_data)
+
+        grad_accum = self.args.global_batch_size // (self.args.micro_batch_size * world_size)
+        assert (
+            grad_accum > 0
+        ), f"Invalid grad_accum {grad_accum} for micro_batch_size {self.args.micro_batch_size} and global_batch_size {self.args.global_batch_size}"
+        grad_accum = getattr(self.args, "gradient_accumulation_steps", 1)
+
+        if self.ref_model is not None:
+            self.compute_log_prob("ref", padded_batches, store_prefix="ref_")
+
+        self.compute_log_prob("actor", padded_batches)
+
+        # TODO: compute rewards and adv for t
+        for batch in padded_batches:
+            if self.args.advantage_estimator in ["grpo", "gspo"]:
+                batch["advantages"] = batch["returns"] = batch["rewards"].expand_as(batch["log_probs"])
+            else:
+                raise NotImplementedError(f"Unsupported advantage_estimator {self.args.advantage_estimator}")
+
+        # TODO: finish log rollout_data
+        log_dict = {}
+        for key in ["log_probs", "ref_log_probs", "advantages", "returns"]:
+            val = torch.tensor([0.0], device=torch.cuda.current_device())
+            for batch in padded_batches:
+                val += per_sample_mean(batch[key], batch["loss_masks"]).item()
+            dist.all_reduce(val, op=dist.ReduceOp.SUM)
+            log_dict[f"rollout/{key}"] = val / len(padded_batches) / world_size
+        if dist.get_rank() == 0:
+            print(f"rollout {rollout_id}: {log_probs}")
+            if self.args.use_wandb:
+                log_dict["rollout/step"] = (
+                    rollout_id
+                    if not self.args.wandb_always_use_train_step
+                    else rollout_id
+                    * self.args.rollout_batch_size
+                    * self.args.n_samples_per_prompt
+                    // self.args.global_batch_size
+                )
+                wandb.log(log_dict)
+
+        reported_accum: dict[str, list[torch.Tensor]] = {}
+        self.optimizer.zero_grad(set_to_none=True)
+        for mbs_id, batch in enumerate(padded_batches):
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                logits = self.model(input_ids=batch["tokens"]).logits
+            log_probs = gather_log_probs(logits, batch["tokens"])
+
+            if self.args.advantage_estimator == "gspo":
+                raise NotImplementedError("implement GSPO")
+
+            ppo_kl = batch["log_probs"] - log_probs
+            pg_loss, pg_clipfrac = compute_policy_loss(
+                ppo_kl, batch["advantages"], self.args.eps_clip, self.args.eps_clip_high
+            )
+
+            pg_loss = per_sample_mean(pg_loss, batch["loss_masks"])
+            pg_clipfrac = per_sample_mean(pg_clipfrac, batch["loss_masks"])
+            ppo_kl = per_sample_mean(ppo_kl.abs(), batch["loss_masks"])
+
+            if self.args.use_tis:
+                raise NotImplementedError("implement TIS")
+
+            if self.args.entropy_coef != 0:
+                raise NotImplementedError("implement entropy bonus")
+
+            if self.args.use_kl_loss:
+                kl = compute_approx_kl(
+                    log_probs,
+                    batch["ref_log_probs"],
+                    kl_loss_type=self.args.kl_loss_type,
+                )
+                kl_loss = per_sample_mean(kl, batch["loss_masks"])
+
+                loss = loss + self.args.kl_loss_coef * kl_loss
+
+            reported = {
+                "loss": pg_loss.detach(),
+                "pg_clipfrac": pg_clipfrac.detach(),
+                "ppo_kl": ppo_kl.detach(),
+            }
+            if self.args.use_kl_loss:
+                reported["kl_loss"] = kl_loss.detach()
+
+            # Scale loss for gradient accumulation
+            loss = loss / grad_accum
+            loss.backward()
+
+            # Accumulate reported metrics (store tensors for later mean)
+            for k, v in reported.items():
+                reported_accum.setdefault(k, []).append(v)
+
+            if (mbs_id + 1) % grad_accum == 0:
+                grad_norm = torch.nn.utils.clip_grad_norm_(self.model.parameters(), self.args.clip_grad)
+                self.optimizer.step()
+                self.optimizer.zero_grad(set_to_none=True)
+                # Aggregate logs
+                aggregated = {k: torch.stack(v).mean() for k, v in reported_accum.items()}
+                # TODO: mean value across dp ranks
+                reported_accum = {}
+                if dist.get_rank() == 0:
+                    if self.args.use_wandb:
+                        log_dict = {
+                            f"train/{k}": (val.item() if torch.is_tensor(val) else val)
+                            for k, val in aggregated.items()
+                        }
+                        log_dict["train/grad_norm"] = (
+                            grad_norm.item() if not isinstance(grad_norm, float) else grad_norm
+                        )
+                        for gid, group in enumerate(self.optimizer.param_groups):
+                            if "lr" in group:
+                                log_dict[f"train/lr-pg_{gid}"] = group["lr"]
+                        log_dict["train/step"] = self.global_step
+                        wandb.log(log_dict)
+                    print(f"step {self.global_step}: {log_dict}")
+                self.global_step += 1
+
+        Timer().start("train_wait")
+        return
+
+    def update_weights(self):  # type: ignore[override]
+        if self.args.debug_train_only or self.args.debug_rollout_only:
+            return
+
+        if self.args.offload:
+            # TODO: don't wake up here
+            self.wake_up(("model"))
+
+        with torch_memory_saver.disable() if self.args.offload and not torch.version.hip else nullcontext():
+            self.weight_updator.update_weights()
+
+        if self.args.offload:
+            # TODO: don't wake up here
+            self.sleep(("model"))
+
+
+def gather_log_probs(logits: torch.Tensor, input_ids: torch.Tensor) -> torch.Tensor:
+    # log_probs: [B, T-1, V]; input_ids: [B, T]
+    pred_logits = logits[:, :-1]
+    log_probs_all = torch.log_softmax(pred_logits, dim=-1)
+    tgt = input_ids[:, 1:].contiguous()
+    log_probs = log_probs_all.gather(-1, tgt.unsqueeze(-1)).squeeze(-1)
+    return log_probs
+
+
+def per_sample_mean(x, loss_mask):
+    # TODO: impl per token loss
+    return ((x * loss_mask).sum(dim=1) / loss_mask.sum(dim=1).clamp_min(1)).mean()

--- a/slime/backends/fsdp_utils/arguments.py
+++ b/slime/backends/fsdp_utils/arguments.py
@@ -1,0 +1,79 @@
+import argparse
+import dataclasses
+from dataclasses import dataclass
+from typing import Optional
+
+import yaml
+
+
+@dataclass
+class FSDPArgs:
+    # General
+    seed: int = 42
+    micro_batch_size: int = 1  # per-rank micro batch size
+    global_batch_size: int = 1  # used for LR schedule steps estimation
+    max_steps: int = 10
+    save_interval: int = 0  # 0 => only final
+    log_interval: int = 1
+    eval_interval: int = 0
+    max_seq_len: int = 2048
+    resume_from: Optional[str] = None
+
+    # Optim
+    optimizer: str = "adam"
+    lr: float = 2e-5
+    lr_decay_style: str = "constant"
+    weight_decay: float = 0.0
+    adam_beta1: float = 0.9
+    adam_beta2: float = 0.95
+    adam_eps: float = 1e-8
+    warmup_ratio: float = 0.03
+    clip_grad: float = 1.0
+
+    # FSDP specific
+    fsdp_wrap: str = "transformer_blocks"  # future use: auto wrap policy
+    fsdp_sharding_strategy: str = "FULL_SHARD"
+    fsdp_cpu_offload: bool = False
+    fsdp_limit_all_gathers: bool = False
+    fsdp_sync_module_states: bool = True
+    fsdp_forward_prefetch: bool = True
+    fsdp_backward_prefetch: bool = True
+
+    # Logging
+    wandb_project: str = "slime-fsdp"
+    wandb_run_name: Optional[str] = None
+
+    # Precision
+    gradient_checkpointing: bool = False
+
+    # YAML bookkeeping
+    config: Optional[str] = None
+
+
+def parse_fsdp_cli(extra_args_provider=None):
+    parser = argparse.ArgumentParser("FSDP SFT Training (slime)")
+    parser.add_argument("--config", type=str, default=None, help="YAML config path")
+    for f in dataclasses.fields(FSDPArgs):
+        if f.name == "config":
+            continue
+        arg_type = f.type if f.type != Optional[str] else str
+        if arg_type is bool:
+            parser.add_argument(f"--{f.name.replace('_', '-')}", action="store_true")
+        else:
+            parser.add_argument(f"--{f.name.replace('_', '-')}", type=arg_type, default=f.default)
+
+    if extra_args_provider is not None:
+        parser = extra_args_provider(parser)
+    args = parser.parse_args()
+    return args
+
+
+def load_fsdp_args(extra_args_provider=None):
+    args = parse_fsdp_cli(extra_args_provider)
+    if args.config:
+        with open(args.config, "r") as f:
+            data = yaml.safe_load(f) or {}
+        for k, v in data.items():
+            if not hasattr(args, k):
+                setattr(args, k, v)
+    return args

--- a/slime/backends/fsdp_utils/update_weight_utils.py
+++ b/slime/backends/fsdp_utils/update_weight_utils.py
@@ -1,0 +1,75 @@
+import ray
+import torch
+import torch.distributed as dist
+from sglang.srt.patch_torch import monkey_patch_torch_reductions
+from sglang.srt.utils import MultiprocessingSerializer
+from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
+from torch.distributed.fsdp import StateDictType
+
+try:
+    from sglang.srt.model_executor.model_runner import FlattenedTensorBucket
+
+    use_flattened_tensor_bucket = True
+except:
+    use_flattened_tensor_bucket = False
+
+
+class UpdateWeightFromTensor:
+    def __init__(self, args, model):
+        self.args = args
+        self.model = model
+
+    def connect_rollout_engines(self, rollout_engines, rollout_engine_lock):
+        self.rollout_engines = rollout_engines
+
+        # Here we assume the gpu id of rollout engines and train actors are the same.
+        for i, engine in enumerate(self.rollout_engines):
+            start_rank = i * self.args.rollout_num_gpus_per_engine
+            end_rank = (i + 1) * self.args.rollout_num_gpus_per_engine
+            group_ranks = list(range(start_rank, end_rank))
+            new_group = dist.new_group(
+                ranks=group_ranks,
+                backend="gloo",
+            )
+            if dist.get_rank() in group_ranks:
+                self._ipc_gather_src = start_rank
+                self._ipc_gather_group = new_group
+                self._ipc_engine = engine
+
+    @torch.no_grad()
+    def update_weights(self):
+        monkey_patch_torch_reductions()
+        with FSDP.state_dict_type(self.model, StateDictType.FULL_STATE_DICT):
+            named_tensors = [(name, param) for name, param in self.model.state_dict().items()]
+
+        if use_flattened_tensor_bucket:
+            flattened_tensor_bucket = FlattenedTensorBucket(named_tensors=named_tensors)
+            metadata = flattened_tensor_bucket.get_metadata()
+
+            flattened_tensor_data = {
+                "flattened_tensor": flattened_tensor_bucket.get_flattened_tensor(),
+                "metadata": metadata,
+            }
+            serialized_tensors = MultiprocessingSerializer.serialize(flattened_tensor_data, output_str=True)
+        else:
+            serialized_tensors = MultiprocessingSerializer.serialize(named_tensors, output_str=True)
+
+        serialized_named_tensors = (
+            [None] * dist.get_world_size(self._ipc_gather_group) if self._ipc_gather_src == dist.get_rank() else None
+        )
+        dist.gather_object(
+            serialized_tensors,
+            object_gather_list=serialized_named_tensors,
+            dst=self._ipc_gather_src,
+            group=self._ipc_gather_group,
+        )
+
+        if dist.get_rank() == self._ipc_gather_src:
+            kwargs = {
+                "serialized_named_tensors": serialized_named_tensors,
+            }
+            if use_flattened_tensor_bucket:
+                kwargs["load_format"] = "flattened_bucket"
+
+            ref = self._ipc_engine.update_weights_from_tensor.remote(**kwargs)
+            ray.get(ref)

--- a/slime/backends/megatron_utils/actor.py
+++ b/slime/backends/megatron_utils/actor.py
@@ -29,7 +29,7 @@ from .update_weight_utils import UpdateWeightFromDistributed, UpdateWeightFromTe
 
 class MegatronTrainRayActor(TrainRayActor):
     def init(self, args, role, wandb_run_id, with_ref=False):
-        super().init(args, role, with_ref)
+        super().init(args, role, wandb_run_id, with_ref)
 
         init(args)
 

--- a/slime/backends/megatron_utils/loss.py
+++ b/slime/backends/megatron_utils/loss.py
@@ -287,8 +287,6 @@ def policy_loss_function(args, batch, logits, sum_of_sample_mean):
         kl_loss = sum_of_sample_mean(kl)
 
         loss = loss + args.kl_loss_coef * kl_loss
-    else:
-        kl_loss = torch.tensor(0.0, device=log_probs.device)
 
     # make sure the gradient could backprop correctly.
     if log_probs.numel() == 0:

--- a/slime/backends/utils/data.py
+++ b/slime/backends/utils/data.py
@@ -3,7 +3,6 @@ from typing import Optional
 import ray
 import torch
 import torch.distributed as dist
-from megatron.core import mpu
 
 from slime.utils.seqlen_balancing import get_seqlen_balanced_partitions
 from slime.utils.timer import Timer
@@ -78,6 +77,8 @@ def get_data_iterator(args, model, rollout_data):
             - data_iterator: List of DataIterator objects for log probability evaluation.
             - num_microbatches: Number of microbatches for log probability evaluation.
     """
+    from megatron.core import mpu
+
     dp_size = mpu.get_data_parallel_world_size(with_context_parallel=False)
     dp_group = mpu.get_data_parallel_group()
     vpp_size = mpu.get_virtual_pipeline_model_parallel_world_size()

--- a/slime/ray/actor_group.py
+++ b/slime/ray/actor_group.py
@@ -6,7 +6,6 @@ import torch
 from ray.util.placement_group import PlacementGroup
 from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 
-from slime.backends.megatron_utils import MegatronTrainRayActor
 from slime.ray.utils import NOSET_VISIBLE_DEVICES_ENV_VARS_LIST
 
 
@@ -80,10 +79,20 @@ class RayTrainGroup:
             env_vars["TMS_INIT_ENABLE"] = "1"
             env_vars["TMS_INIT_ENABLE_CPU_BACKUP"] = "1"
 
+        backend = os.environ.get("SLIME_BACKEND", "megatron").lower()
+        if backend == "megatron":
+            from slime.backends.megatron_utils import MegatronTrainRayActor
+
+            actor_impl = MegatronTrainRayActor
+        else:
+            from slime.backends.fsdp_utils import FSDPTrainRayActor
+
+            actor_impl = FSDPTrainRayActor
+
         TrainRayActor = ray.remote(
             num_gpus=1,
             runtime_env={"env_vars": env_vars},
-        )(MegatronTrainRayActor)
+        )(actor_impl)
 
         # Create worker actors
         self._actor_handlers = []

--- a/slime/ray/train_actor.py
+++ b/slime/ray/train_actor.py
@@ -74,10 +74,6 @@ class TrainRayActor(RayActor):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def eval(self, rollout_id, rollout_data_ref):
-        raise NotImplementedError
-
-    @abc.abstractmethod
     def save_model(self, iteration, with_optimizer=True):
         raise NotImplementedError
 

--- a/slime/utils/arguments.py
+++ b/slime/utils/arguments.py
@@ -74,6 +74,9 @@ def get_slime_extra_args_provider(add_custom_arguments=None):
                 ),
             )
 
+            reset_megatron_args(parser, "--distributed-backend", str, "nccl")
+            reset_megatron_args(parser, "--distributed-timeout-minutes", int, 10)
+
             return parser
 
         # rollout
@@ -866,19 +869,25 @@ def get_slime_extra_args_provider(add_custom_arguments=None):
 def parse_args(add_custom_arguments=None):
     add_slime_arguments = get_slime_extra_args_provider(add_custom_arguments)
 
-    from slime.backends.megatron_utils import parse_args as megatron_parse_args
-    from slime.backends.megatron_utils import set_default_megatron_args
-    from slime.backends.megatron_utils import validate_args as megatron_validate_args
+    backend = os.environ.get("SLIME_BACKEND", "megatron").lower()
+    if backend == "megatron":
+        from slime.backends.megatron_utils import parse_args as megatron_parse_args
+        from slime.backends.megatron_utils import set_default_megatron_args
+        from slime.backends.megatron_utils import validate_args as megatron_validate_args
 
-    args = megatron_parse_args(extra_args_provider=add_slime_arguments)
-    if args.hf_checkpoint:
-        hf_config = AutoConfig.from_pretrained(args.hf_checkpoint, trust_remote_code=True)
-        hf_validate_args(args, hf_config)
+        args = megatron_parse_args(extra_args_provider=add_slime_arguments)
+        if getattr(args, "hf_checkpoint", None):
+            hf_config = AutoConfig.from_pretrained(args.hf_checkpoint, trust_remote_code=True)
+            hf_validate_args(args, hf_config)
 
-    args.rank = 0
-    args.world_size = args.actor_num_nodes * args.actor_num_gpus_per_node
+        args.rank = 0
+        args.world_size = args.actor_num_nodes * args.actor_num_gpus_per_node
+        args = set_default_megatron_args(args)
+    else:
+        # 直接走 FSDP 的解析与返回（目前与 megatron 风格不同，不复用额外 slime 参数）
+        from slime.backends.fsdp_utils.arguments import load_fsdp_args
 
-    args = set_default_megatron_args(args)
+        args = load_fsdp_args(extra_args_provider=add_slime_arguments)
 
     if args.kl_coef != 0 or args.use_kl_loss:
         if not os.path.exists(args.ref_load):
@@ -1008,16 +1017,17 @@ def parse_args(add_custom_arguments=None):
             "num_epoch is not set, but num_rollout is not set, " "please set --num-rollout or --num-epoch"
         )
 
-    megatron_validate_args(args)
+    if backend == "megatron":
+        megatron_validate_args(args)
 
-    # always use varlen
-    args.variable_seq_lengths = True
-    if getattr(args, "moe_token_dispatcher_type", None) == "allgather":
-        print(
-            "--moe-token-dispatcher-type allgather does not support variable sequence length, "
-            "please use alltoall dispatcher instead."
-        )
-        args.moe_token_dispatcher_type = "alltoall"
+        # always use varlen
+        args.variable_seq_lengths = True
+        if getattr(args, "moe_token_dispatcher_type", None) == "allgather":
+            print(
+                "--moe-token-dispatcher-type allgather does not support variable sequence length, "
+                "please use alltoall dispatcher instead."
+            )
+            args.moe_token_dispatcher_type = "alltoall"
 
     sglang_validate_args(args)
 

--- a/slime/utils/ppo_utils.py
+++ b/slime/utils/ppo_utils.py
@@ -5,8 +5,6 @@ from typing import List, Optional
 import torch
 import torch.distributed as dist
 
-from slime.backends.megatron_utils.cp_utils import get_logits_and_tokens_offset_with_cp
-
 
 @torch.compile(dynamic=True)
 def compute_approx_kl(
@@ -171,6 +169,8 @@ def get_reinforce_plus_plus_returns(
         prompt_len = total_len - response_len
 
         if cp_size > 1:
+            from slime.backends.megatron_utils.cp_utils import get_logits_and_tokens_offset_with_cp
+
             # Step 1: Gather all KL chunks and token_offsets from all ranks
             _, _, _, token_offsets = get_logits_and_tokens_offset_with_cp(total_len, response_len)
 


### PR DESCRIPTION
Relates to #74 . The goal of this PR is to provide a runnable fsdp grpo example with small model with minimal functionality.

The script for this PR is:

```bash
#!/bin/bash

# for rerun the task
pkill -9 sglang
sleep 3
ray stop --force
pkill -9 ray
pkill -9 python
sleep 3
pkill -9 ray
pkill -9 python

set -ex

# will prevent ray from buffering stdout/stderr
export PYTHONBUFFERED=16

CKPT_ARGS=(
   --hf-checkpoint /root/Qwen3-0.6B
)

ROLLOUT_ARGS=(
   --prompt-data /root/dapo-math-17k/dapo-math-17k.jsonl
   --input-key prompt
   --label-key label
   --apply-chat-template
   --rollout-shuffle
   --rm-type deepscaler
   --num-rollout 3000
   --rollout-batch-size 16
   --n-samples-per-prompt 16
   --rollout-max-response-len 8192
   --rollout-temperature 0.8

   --global-batch-size 128
)

GRPO_ARGS=(
   --advantage-estimator grpo
   #--use-kl-loss
   --kl-loss-coef 0.00
   --kl-loss-type low_var_kl
   --kl-coef 0.00
   --entropy-coef 0.00
   --eps-clip 0.2
   --eps-clip-high 0.28
)

OPTIMIZER_ARGS=(
   --optimizer adam
   --lr 1e-6
   --lr-decay-style constant
   --weight-decay 0.1
   --adam-beta1 0.9
   --adam-beta2 0.98
)

SGLANG_ARGS=(
   --rollout-num-gpus-per-engine 1
)

# launch the master node of ray in container
ray start --head --node-ip-address 127.0.0.1 --num-gpus 8 --disable-usage-stats

ray job submit --address="http://127.0.0.1:8265" \
   --runtime-env-json='{
     "env_vars": {
        "no_proxy": "localhost,127.0.0.1,0.0.0.0,${MASTER_ADDR}",
        "SLIME_BACKEND": "fsdp"
     }
   }' \
   -- python3 train.py \
   --actor-num-nodes 1 \
   --actor-num-gpus-per-node 8 \
   --colocate \
   --load-debug-rollout-data data.pt \
   ${CKPT_ARGS[@]} \
   ${ROLLOUT_ARGS[@]} \
   ${OPTIMIZER_ARGS[@]} \
   ${GRPO_ARGS[@]} \
   ${DISTRIBUTED_ARGS[@]} \
   ${SGLANG_ARGS[@]}
```