### PR TITLE
Remove get_rollout_data from actor_group

### DIFF
--- a/slime/ray/actor_group.py
+++ b/slime/ray/actor_group.py
@@ -132,9 +132,6 @@ class RayTrainGroup:
             for actor in self._actor_handlers
         ]
 
-    def get_rollout_data(self, rollout_id):
-        ray.get([actor.get_rollout_data.remote(rollout_id) for actor in self._actor_handlers])
-
     def async_train(self, rollout_id, rollout_data_ref):
         """Do one rollout training"""
         return [actor.train.remote(rollout_id, rollout_data_ref) for actor in self._actor_handlers]


### PR DESCRIPTION
`get_rollout_data` in actor group calls each actor's `get_rollout_data` function, but neither megatron nor fsdp actors have this function. Instead it's an internal function that post processes the rollout data that  does not need to be accessed by the actor group.