### PR TITLE
Fix comment for --load parameter in checkpoint configuration (Quick Start Doc)

### DIFF
--- a/docs/en/get_started/quick_start.md
+++ b/docs/en/get_started/quick_start.md
@@ -130,7 +130,8 @@ CKPT_ARGS=(
    --hf-checkpoint /root/GLM-Z1-9B-0414
    # Reference Model's Megatron format checkpoint
    --ref-load /root/GLM-Z1-9B-0414_torch_dist
-   # Actor model loading path. If empty or doesn't contain a valid checkpoint, load from --ref-load
+   # Actor model loading path. Should typically match --save for checkpoint resumption
+   # If empty or doesn't contain a valid checkpoint, loads from --ref-load instead
    --load /root/GLM-Z1-9B-0414_slime/
    # Model save path during training
    --save /root/GLM-Z1-9B-0414_slime/

--- a/docs/en/get_started/quick_start.md
+++ b/docs/en/get_started/quick_start.md
@@ -130,7 +130,7 @@ CKPT_ARGS=(
    --hf-checkpoint /root/GLM-Z1-9B-0414
    # Reference Model's Megatron format checkpoint
    --ref-load /root/GLM-Z1-9B-0414_torch_dist
-   # Actor model loading path. If empty, load from --ref-load
+   # Actor model loading path. If empty or doesn't contain a valid checkpoint, load from --ref-load
    --load /root/GLM-Z1-9B-0414_slime/
    # Model save path during training
    --save /root/GLM-Z1-9B-0414_slime/
@@ -185,7 +185,7 @@ ROLLOUT_ARGS=(
    --n-samples-per-prompt 8
    --num-steps-per-rollout 1
    --global-batch-size 128
-   
+
    # Rollout sampling parameters
    --rollout-max-response-len 8192
    --rollout-temperature 0.8
@@ -490,7 +490,7 @@ async def generate(args, sample: Sample, sampling_params) -> Sample:
             # ... tokenization and appending ...
             loss_masks += [0] * len(tool_tokens) # loss_mask = 0
             full_response += tool_output
-            
+
         elif action == "answer":
             break # end loop
 
@@ -553,4 +553,4 @@ ray job submit --address="http://127.0.0.1:8265" \
 slime has been deeply optimized for distributed training of large-scale Mixture of Experts (MoE) models. We provide some end-to-end training cases for reference:
 
 - [Example: 64xH100 Training GLM-4.5](models/glm4.5-355B-A32B.md)
-- [Example: 128xH100 Training DeepSeek-R1](models/deepseek-r1.md) 
+- [Example: 128xH100 Training DeepSeek-R1](models/deepseek-r1.md)


### PR DESCRIPTION
This is the original comment in quick start doc:
```
   # Actor model loading path. If empty, load from --ref-load
   --load /root/GLM-Z1-9B-0414_slime/
```

This is the updated version:
```
   # Actor model loading path. Should typically match --save for checkpoint resumption
   # If empty or doesn't contain a valid checkpoint, loads from --ref-load instead
   --load /root/GLM-Z1-9B-0414_slime/
```

`--load` specified the path to the Megatron-format checkpoint for the actor model (the model being trained). If this path is empty or doesn't contain a valid checkpoint (no latest_checkpointed_iteration.txt), the actor will be initialized from `--ref-load` instead. The original comment is too simple and makes it a bit confusing for users to understand.

The updated version explains both the fallback behavior and clarified that `--load` should typically be the same as `--save` to improve user understanding.