### PR TITLE
feat: auto configure megatron from hf config.

### DIFF
--- a/slime/backends/megatron_utils/config_mapping/__init__.py
+++ b/slime/backends/megatron_utils/config_mapping/__init__.py
@@ -1,0 +1,12 @@
+from .registry import mapper_registry, register_mapper
+
+
+def get_mapper(name: str):
+    return mapper_registry.get_mapper(name)
+
+
+__all__ = [
+    "register_mapper",
+    "mapper_registry",
+    "get_mapper",
+]

--- a/slime/backends/megatron_utils/config_mapping/predefined_config_mappers.py
+++ b/slime/backends/megatron_utils/config_mapping/predefined_config_mappers.py
@@ -1,0 +1,131 @@
+from collections import namedtuple
+import torch.nn.functional as F
+from transformers import PretrainedConfig
+from .registry import register_mapper
+
+
+MegatronModelConfig = namedtuple("MegatronModelConfig", ["transformer_config", "gpt_model_args"])
+
+
+def _get_activation_func(name: str):
+    if name == "silu":
+        return F.silu
+    elif name == "gelu":
+        return F.gelu
+    else:
+        raise ValueError(f"Unsupported activation function: {name}")
+
+
+def _to_n_args(value):
+    if isinstance(value, list):
+        return value
+    return [value]
+
+
+def _map_common_configs(hf_config: PretrainedConfig) -> MegatronModelConfig:
+    rope_scaling_args = {}
+    if "rope_scaling" in hf_config and hf_config.rope_scaling is not None:
+        rope_scaling_args["seq_len_interpolation_factor"] = hf_config.rope_scaling["factor"]
+    return MegatronModelConfig(
+        transformer_config={
+            # Model architecture parameters
+            "num_layers": hf_config.num_hidden_layers,
+            "hidden_size": hf_config.hidden_size,
+            "num_attention_heads": hf_config.num_attention_heads,
+            "num_query_groups": hf_config.num_key_value_heads,
+            "ffn_hidden_size": hf_config.intermediate_size,
+            "attention_dropout": hf_config.attention_dropout,
+            "hidden_dropout": getattr(hf_config, "hidden_dropout", 0.0),
+            "kv_channels": getattr(hf_config, "head_dim", None),
+            "layernorm_epsilon": hf_config.rms_norm_eps,
+            # Activation and normalization
+            "activation_func": _get_activation_func(hf_config.hidden_act),
+            "normalization": "RMSNorm",
+            "gated_linear_unit": True,
+        },
+        gpt_model_args={
+            "vocab_size": hf_config.vocab_size,
+            "max_sequence_length": hf_config.max_position_embeddings,
+            "rotary_base": hf_config.rope_theta,
+            "position_embedding_type": "rope" if "rope_scaling" in hf_config or "rope_theta" in hf_config else "none",
+            "untie_embeddings_and_output_weights": not hf_config.tie_word_embeddings,
+        },
+    )
+
+
+@register_mapper("qwen2")
+def qwen2_config_mapper(hf_config: PretrainedConfig) -> MegatronModelConfig:
+    mapped_config = _map_common_configs(hf_config)
+    mapped_config.transformer_config.update(
+        {
+            "add_bias_linear": False,
+            "add_qkv_bias": hf_config.attention_bias,
+        }
+    )
+
+    return mapped_config
+
+
+@register_mapper("qwen3")
+def qwen3_config_mapper(hf_config: PretrainedConfig) -> MegatronModelConfig:
+    mapped_config = _map_common_configs(hf_config)
+    mapped_config.transformer_config.update(
+        {
+            "add_bias_linear": False,
+            "add_qkv_bias": hf_config.attention_bias,
+            "qk_layernorm": True,
+        }
+    )
+
+    return mapped_config
+
+
+@register_mapper("qwen3_moe")
+def qwen3_moe_config_mapper(hf_config: PretrainedConfig) -> MegatronModelConfig:
+    mapped_config = _map_common_configs(hf_config)
+    mapped_config.transformer_config.update(
+        {
+            "add_bias_linear": False,
+            "add_qkv_bias": hf_config.attention_bias,
+            "moe_ffn_hidden_size": hf_config.moe_intermediate_size,
+            "moe_router_topk": hf_config.num_experts_per_tok,
+            "num_moe_experts": hf_config.num_experts,
+            "moe_aux_loss_coeff": _to_n_args(hf_config.router_aux_loss_coef),
+            "moe_router_load_balancing_type": _to_n_args("none"),  # turn off aux_loss as it hurts perf in RL
+            "moe_router_score_function": "softmax",
+            "moe_router_pre_softmax": False,
+            "qk_layernorm": True,
+        }
+    )
+
+    return mapped_config
+
+
+@register_mapper("glm4_moe")
+def glm4_moe_config_mapper(hf_config: PretrainedConfig) -> MegatronModelConfig:
+    moe_layer_freq = [1] * hf_config.num_hidden_layers
+    for i in range(min(hf_config.first_k_dense_replace, hf_config.num_hidden_layers)):
+        moe_layer_freq[i] = 0
+
+    mapped_config = _map_common_configs(hf_config)
+    mapped_config.transformer_config.update(
+        {
+            "add_bias_linear": False,
+            "qk_layernorm": hf_config.use_qk_norm,
+            "add_qkv_bias": hf_config.attention_bias,
+            "moe_ffn_hidden_size": hf_config.moe_intermediate_size,
+            "moe_router_topk": hf_config.num_experts_per_tok,
+            "moe_router_topk_scaling_factor": hf_config.routed_scaling_factor,
+            "moe_router_dtype": "fp32",
+            "num_moe_experts": hf_config.num_experts,
+            "moe_router_enable_expert_bias": True,
+            "moe_layer_freq": moe_layer_freq,
+            "moe_router_bias_update_rate": 0.0,
+            "moe_aux_loss_coeff": _to_n_args(hf_config.router_aux_loss_coef),
+            "moe_router_load_balancing_type": _to_n_args("seq_aux_loss"),
+            "moe_router_score_function": "sigmoid",
+            "rotary_percent": hf_config.partial_rotary_factor,
+        }
+    )
+
+    return mapped_config

--- a/slime/backends/megatron_utils/config_mapping/registry.py
+++ b/slime/backends/megatron_utils/config_mapping/registry.py
@@ -1,0 +1,55 @@
+import logging
+from typing import Callable, Dict, List
+
+logger = logging.getLogger(__name__)
+
+
+class MapperRegistry:
+    """
+    Registry for config mappers.
+    """
+
+    def __init__(self):
+        self._mappers: Dict[str, Callable] = {}
+
+    def register(self, model_types: List[str], mapper_func: Callable):
+        if not callable(mapper_func):
+            raise TypeError(f"Mapper for {model_types} must be callable")
+
+        for name in model_types:
+            if name in self._mappers:
+                logger.warning(f"Mapper for {name} is being overridden")
+            self._mappers[name] = mapper_func
+            logger.info(f"Registered config mapper for model type: {name}")
+
+    def get_mapper(self, name: str) -> Callable:
+        """
+        Get the mapper by model_type.
+        """
+        if name not in self._mappers:
+            raise ValueError(f"Mapper for {name} is not registered.")
+        return self._mappers[name]
+
+    def list_registered_mappers(self) -> List[str]:
+        return list(self._mappers.keys())
+
+
+# Global registry instance
+mapper_registry = MapperRegistry()
+
+
+def register_mapper(*args):
+    """
+    Decorator: register config mapper.
+
+    Args: suppotred model_types.
+    """
+
+    def decorator(func: Callable):
+        mapper_registry.register(
+            model_types=list(args),
+            mapper_func=func,
+        )
+        return func
+
+    return decorator

--- a/slime/utils/arguments.py
+++ b/slime/utils/arguments.py
@@ -1,4 +1,5 @@
 import os
+from typing import Any, Dict
 
 from transformers import AutoConfig
 
@@ -92,6 +93,11 @@ def get_slime_extra_args_provider(add_custom_arguments=None):
                     "so you only need to provide a huggingface checkpoint that has the same architecture as the model you want to train. "
                     "It doesn't necessary need to contain the most up-to-date parameters."
                 ),
+            )
+            parser.add_argument(
+                "--use-hf-config-for-megatron",
+                action="store_true",
+                help="Whether to use HF config for Megatron core to define the model architecture.",
             )
             parser.add_argument(
                 "--model-name",
@@ -879,6 +885,12 @@ def parse_args(add_custom_arguments=None):
         args = megatron_parse_args(extra_args_provider=add_slime_arguments)
         if getattr(args, "hf_checkpoint", None):
             hf_config = AutoConfig.from_pretrained(args.hf_checkpoint, trust_remote_code=True)
+            if args.use_hf_config_for_megatron:
+                from slime.backends.megatron_utils.config_mapping import get_mapper
+
+                megatron_config_from_hf = get_mapper(hf_config.model_type)(hf_config)
+                _validate_and_update_megatron_args_from_hf(args, megatron_config_from_hf.transformer_config)
+                _validate_and_update_megatron_args_from_hf(args, megatron_config_from_hf.gpt_model_args)
             hf_validate_args(args, hf_config)
 
         args.rank = 0
@@ -1056,3 +1068,12 @@ def hf_validate_args(args, hf_config):
                 f"{hf_config_name} in hf config {getattr(hf_config, hf_config_name)} is not equal to "
                 f"{megatron_config_name} {getattr(args, megatron_config_name)}, please check the config."
             )
+
+
+def _validate_and_update_megatron_args_from_hf(args, args_from_hf_config: Dict[str, Any]):
+    for key, value in args_from_hf_config.items():
+        if hasattr(args, key) and getattr(args, key) != value:
+            raise ValueError(
+                f"Argument {key} is not consistent. {key} in args is {getattr(args, key)}, but from HF config is {value}."
+            )
+        setattr(args, key, value)


### PR DESCRIPTION
I like the way of initializing megatron in #50. Here's an implementation of it.

Currently only `Qwen2`, `Qwen3`, `Qwen3Moe` and `GLM4Moe` are added as predefined model types but it's easy to add more in the future. Could you please take a review of the design? @zhuzilin 