### PR TITLE
[Feature] add tensorboard support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ sglang
 torch
 transformers
 wandb
+tensorboard

--- a/slime/backends/megatron_utils/model.py
+++ b/slime/backends/megatron_utils/model.py
@@ -18,6 +18,7 @@ from megatron.training.global_vars import get_args
 from megatron.training.training import get_model
 
 import wandb
+from slime.utils.logger_utils import log_metric
 from slime.utils.memory_utils import clear_memory
 
 from .checkpoint import load_checkpoint, save_checkpoint
@@ -463,9 +464,9 @@ def train(rollout_id, model, optimizer, opt_param_scheduler, data_iterator, num_
             for param_group_id, param_group in enumerate(optimizer.param_groups):
                 log_dict[f"train/lr-pg_{param_group_id}"] = opt_param_scheduler.get_lr(param_group)
 
-            if args.use_wandb:
+            if args.use_wandb or getattr(args, 'use_tensorboard', False):
                 log_dict["train/step"] = accumulated_step_id
-                wandb.log(log_dict)
+                log_metric(log_dict)
 
             if args.ci_test:
                 if step_id == 0 and "train/ppo_kl" in log_dict and "train/pg_clipfrac" in log_dict:

--- a/slime/utils/arguments.py
+++ b/slime/utils/arguments.py
@@ -605,10 +605,16 @@ def get_slime_extra_args_provider(add_custom_arguments=None):
             )
             return parser
 
-        # wandb
+        # wandb and tensorboard
         def add_wandb_arguments(parser):
             # wandb parameters
             parser.add_argument("--use-wandb", action="store_true", default=False)
+            
+            # tensorboard parameters
+            parser.add_argument("--use-tensorboard", action="store_true", default=False, 
+                              help="Enable tensorboard logging")
+            parser.add_argument("--tensorboard-log-dir", type=str, default=None,
+                              help="Directory to store tensorboard logs. Default is ./runs")
             parser.add_argument(
                 "--wandb-mode",
                 type=str,

--- a/slime/utils/logger_utils.py
+++ b/slime/utils/logger_utils.py
@@ -1,0 +1,97 @@
+import os
+from typing import Dict, Any, Optional
+import wandb
+
+
+class UnifiedLogger:
+    """Unified logging interface that supports both wandb and tensorboard."""
+    
+    def __init__(self, use_wandb: bool = False, use_tensorboard: bool = False, 
+                 tensorboard_log_dir: Optional[str] = None):
+        self.use_wandb = use_wandb
+        self.use_tensorboard = use_tensorboard
+        self.writer = None
+        
+        # Initialize tensorboard if requested
+        if self.use_tensorboard:
+            try:
+                from torch.utils.tensorboard import SummaryWriter
+                self.writer = SummaryWriter(log_dir=tensorboard_log_dir)
+            except ImportError:
+                print("Warning: torch.utils.tensorboard not available. Tensorboard logging disabled.")
+                self.use_tensorboard = False
+    
+    def log_metric(self, metrics: Dict[str, Any], step: Optional[int] = None):
+        """
+        Log metrics to both wandb and tensorboard if enabled.
+        
+        Args:
+            metrics: Dictionary of metric names and values
+            step: Optional step number for tensorboard
+        """
+        # Log to wandb (existing behavior)
+        if self.use_wandb:
+            wandb.log(metrics)
+        
+        # Log to tensorboard
+        if self.use_tensorboard and self.writer is not None:
+            for key, value in metrics.items():
+                # Handle different metric types
+                if isinstance(value, (int, float)):
+                    # Extract step from metrics if not provided
+                    if step is None:
+                        # Try to find step in the metrics
+                        if "train/step" in metrics:
+                            step = metrics["train/step"]
+                        elif "rollout/step" in metrics:
+                            step = metrics["rollout/step"]
+                        elif "eval/step" in metrics:
+                            step = metrics["eval/step"]
+                        else:
+                            step = 0  # Default step
+                    
+                    self.writer.add_scalar(key, value, step)
+    
+    def close(self):
+        """Close the tensorboard writer if it exists."""
+        if self.writer is not None:
+            self.writer.close()
+
+
+# Global logger instance
+_global_logger: Optional[UnifiedLogger] = None
+
+
+def init_logger(use_wandb: bool = False, use_tensorboard: bool = False, 
+                tensorboard_log_dir: Optional[str] = None):
+    """Initialize the global logger instance."""
+    global _global_logger
+    _global_logger = UnifiedLogger(
+        use_wandb=use_wandb, 
+        use_tensorboard=use_tensorboard,
+        tensorboard_log_dir=tensorboard_log_dir
+    )
+
+
+def log_metric(metrics: Dict[str, Any], step: Optional[int] = None):
+    """
+    Log metrics using the global logger instance.
+    
+    Args:
+        metrics: Dictionary of metric names and values
+        step: Optional step number for tensorboard
+    """
+    if _global_logger is not None:
+        _global_logger.log_metric(metrics, step)
+    else:
+        # Fallback to wandb if global logger not initialized
+        if wandb.run is not None:
+            wandb.log(metrics)
+
+
+def close_logger():
+    """Close the global logger."""
+    global _global_logger
+    if _global_logger is not None:
+        _global_logger.close()
+        _global_logger = None

--- a/slime/utils/wandb_utils.py
+++ b/slime/utils/wandb_utils.py
@@ -1,5 +1,6 @@
 import os
 import wandb
+from slime.utils.logger_utils import init_logger
 
 
 def _is_offline_mode(args) -> bool:
@@ -68,6 +69,13 @@ def init_wandb_primary(args):
     wandb.init(**init_kwargs)
 
     _init_wandb_common()
+    
+    # Initialize unified logger
+    init_logger(
+        use_wandb=args.use_wandb,
+        use_tensorboard=getattr(args, 'use_tensorboard', False),
+        tensorboard_log_dir=getattr(args, 'tensorboard_log_dir', None)
+    )
 
     return wandb.run.id
 
@@ -113,6 +121,13 @@ def init_wandb_secondary(args, wandb_run_id):
     wandb.init(**init_kwargs)
 
     _init_wandb_common()
+    
+    # Initialize unified logger for secondary processes
+    init_logger(
+        use_wandb=args.use_wandb,
+        use_tensorboard=getattr(args, 'use_tensorboard', False),
+        tensorboard_log_dir=getattr(args, 'tensorboard_log_dir', None)
+    )
 
 
 def _init_wandb_common():

--- a/tests/test_unified_logging.py
+++ b/tests/test_unified_logging.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Test script for unified logging interface."""
+
+import os
+import tempfile
+import shutil
+from unittest.mock import Mock
+
+# Mock wandb to avoid requiring actual wandb setup
+import sys
+wandb_mock = Mock()
+wandb_mock.run = None
+wandb_mock.log = Mock()
+sys.modules['wandb'] = wandb_mock
+
+from slime.utils.logger_utils import UnifiedLogger, init_logger, log_metric
+
+
+def test_wandb_only():
+    """Test logging with wandb only."""
+    print("Testing wandb-only logging...")
+    logger = UnifiedLogger(use_wandb=True, use_tensorboard=False)
+    
+    test_metrics = {
+        "train/loss": 0.5,
+        "train/step": 100,
+        "eval/accuracy": 0.9
+    }
+    
+    logger.log_metric(test_metrics)
+    wandb_mock.log.assert_called_with(test_metrics)
+    print("✓ Wandb logging works")
+
+
+def test_tensorboard_only():
+    """Test logging with tensorboard only."""
+    print("Testing tensorboard-only logging...")
+    with tempfile.TemporaryDirectory() as temp_dir:
+        logger = UnifiedLogger(use_wandb=False, use_tensorboard=True, 
+                              tensorboard_log_dir=temp_dir)
+        
+        test_metrics = {
+            "train/loss": 0.3,
+            "train/step": 200,
+            "eval/accuracy": 0.95
+        }
+        
+        logger.log_metric(test_metrics)
+        logger.close()
+        
+        # Check if tensorboard files were created
+        files = os.listdir(temp_dir)
+        assert any(f.startswith('events.out.tfevents') for f in files), "Tensorboard files not created"
+        print("✓ Tensorboard logging works")
+
+
+def test_unified_logging():
+    """Test logging with both wandb and tensorboard."""
+    print("Testing unified logging...")
+    with tempfile.TemporaryDirectory() as temp_dir:
+        logger = UnifiedLogger(use_wandb=True, use_tensorboard=True,
+                              tensorboard_log_dir=temp_dir)
+        
+        test_metrics = {
+            "train/loss": 0.2,
+            "train/step": 300,
+            "eval/accuracy": 0.98
+        }
+        
+        logger.log_metric(test_metrics)
+        logger.close()
+        
+        # Check wandb was called
+        wandb_mock.log.assert_called_with(test_metrics)
+        
+        # Check tensorboard files were created
+        files = os.listdir(temp_dir)
+        assert any(f.startswith('events.out.tfevents') for f in files), "Tensorboard files not created"
+        print("✓ Unified logging works")
+
+
+def test_global_logger():
+    """Test global logger interface."""
+    print("Testing global logger interface...")
+    with tempfile.TemporaryDirectory() as temp_dir:
+        # Initialize global logger
+        init_logger(use_wandb=True, use_tensorboard=True, 
+                   tensorboard_log_dir=temp_dir)
+        
+        test_metrics = {
+            "train/loss": 0.1,
+            "train/step": 400,
+            "eval/accuracy": 0.99
+        }
+        
+        # Use global logging function
+        log_metric(test_metrics)
+        
+        # Check wandb was called
+        wandb_mock.log.assert_called_with(test_metrics)
+        print("✓ Global logger interface works")
+
+
+def main():
+    """Run all tests."""
+    print("Running unified logging tests...\n")
+    
+    try:
+        test_wandb_only()
+        test_tensorboard_only()
+        test_unified_logging()
+        test_global_logger()
+        
+        print("\n🎉 All tests passed! The unified logging interface is working correctly.")
+        print("\nUsage examples:")
+        print("1. Enable both: --use-wandb --use-tensorboard --tensorboard-log-dir ./tb_logs")
+        print("2. Wandb only: --use-wandb")
+        print("3. Tensorboard only: --use-tensorboard --tensorboard-log-dir ./tb_logs")
+        
+    except Exception as e:
+        print(f"\n❌ Test failed: {e}")
+        return 1
+    
+    return 0
+
+
+if __name__ == "__main__":
+    exit(main())


### PR DESCRIPTION
# Add TensorBoard Support to Slime

## 🎯 Overview

This PR adds comprehensive TensorBoard support to Slime alongside the existing Weights & Biases (wandb) integration, providing users with more flexibility in choosing their preferred logging and visualization tools for training monitoring.

## ✨ Key Features

### 🔧 Unified Logging Interface
- **New unified logger**: Introduces `slime.utils.logger_utils.UnifiedLogger` that seamlessly supports both wandb and TensorBoard
- **Backward compatibility**: All existing wandb functionality remains unchanged
- **Minimal code changes**: Uses a single `log_metric()` function for both logging backends
- **Clean separation**: TensorBoard and wandb can be used independently or together

### 🎛️ Command Line Arguments
Added new arguments for TensorBoard configuration:
```bash
--use-tensorboard              # Enable TensorBoard logging
--tensorboard-log-dir PATH     # Directory for TensorBoard logs (default: ./runs)
```

### 📊 Comprehensive Metric Logging
TensorBoard integration captures all the same metrics as wandb:
- **Training metrics**: loss, learning rate, gradient norms, KL divergence, etc.
- **Rollout metrics**: rewards, response lengths, generation performance
- **Evaluation metrics**: accuracy, pass rates, multi-turn conversation metrics
- **Performance metrics**: throughput, memory usage, timing information

## 🔄 Changes Made

### Core Infrastructure
- **`slime/utils/logger_utils.py`** (NEW): Unified logging interface with TensorBoard support
- **`slime/utils/arguments.py`**: Added TensorBoard command-line arguments
- **`slime/utils/wandb_utils.py`**: Integrated unified logger initialization
- **`requirements.txt`**: Added `tensorboard` dependency

### Updated Logging Calls
Replaced `wandb.log()` calls with unified `log_metric()` across:
- **`slime/ray/buffer.py`**: Evaluation and performance logging
- **`slime/backends/megatron_utils/model.py`**: Training step logging
- **`slime/backends/megatron_utils/data.py`**: Rollout data and performance logging
- **`slime/backends/fsdp_utils/actor.py`**: FSDP training and rollout logging


## 🚀 Usage Examples

### TensorBoard Only
```bash
python train.py \
    --use-tensorboard \
    --tensorboard-log-dir ./tensorboard_logs \
    [other training arguments]
```

### Both TensorBoard and Wandb
```bash
python train.py \
    --use-wandb \
    --use-tensorboard \
    --tensorboard-log-dir ./tensorboard_logs \
    [other training arguments]
```

### Wandb Only (unchanged)
```bash
python train.py \
    --use-wandb \
    [other training arguments]
```
