### PR TITLE
[rm_hub] fix ground_truth type error in grade_answer_verl

### DIFF
--- a/slime/rollout/rm_hub/math_utils.py
+++ b/slime/rollout/rm_hub/math_utils.py
@@ -485,6 +485,7 @@ def extract_answer(passage: str) -> str:
 def grade_answer_verl(solution_str, ground_truth):
     if not ground_truth:
         return False
+    ground_truth = str(ground_truth)
     if "\\boxed" in ground_truth:
         ground_truth = extract_answer(ground_truth)
     given_answer = extract_answer(solution_str)


### PR DESCRIPTION
Summary

force convert `ground_truth` to str in grade_answer_verl

Problem

grade_answer_verl required ground_truth as a string.