### PR TITLE
Do not read ip if env is provided

### DIFF
--- a/slime/utils/http_utils.py
+++ b/slime/utils/http_utils.py
@@ -37,10 +37,10 @@ def is_port_available(port):
 def get_host_info():
     hostname = socket.gethostname()
 
-    local_ip = socket.gethostbyname(hostname)
-
-    if SLIME_HOST_IP_ENV in os.environ:
-        local_ip = os.environ[SLIME_HOST_IP_ENV]
+    if env_overwrite_local_ip := os.getenv(SLIME_HOST_IP_ENV, None):
+        local_ip = env_overwrite_local_ip
+    else:
+        local_ip = socket.gethostbyname(hostname)
 
     return hostname, local_ip
 


### PR DESCRIPTION
I was trying slime and encounter the issue that `socket.gethostbyname(hostname)` failed. It seems like a basic config issue, I didn't dig into it and trying to use `SLIME_HOST_IP` as a workaround. The current version does not look like the expected behavior.
This PR skips trying to read ip if env provided.