### PR TITLE
Added back --rollout-num-gpus-per-node for backward compatibility

### DIFF
--- a/slime/utils/arguments.py
+++ b/slime/utils/arguments.py
@@ -57,7 +57,7 @@ def get_slime_extra_args_provider(add_custom_arguments=None):
             )
             parser.add_argument(
                 "--num-gpus-per-node",
-                "--rollout-num-gpus-per-node", # deprecated, for backward compatibility
+                "--rollout-num-gpus-per-node", # Note: Added back as alias, for backward compatibility
                 type=int,
                 default=8,
                 help=(


### PR DESCRIPTION
Added back the flag since this broke my old training scripts. Feel like it makes sense to keep it as an alias as it is pretty clear that it indicates the num of gpus for rollout.