### PR TITLE
Enable loss mask for sft

### DIFF
--- a/docs/en/get_started/usage.md
+++ b/docs/en/get_started/usage.md
@@ -150,7 +150,8 @@ Currently, slime only supports loading files in `.jsonl` format, where each line
   "prompt": [
     {
       "content": "Solve the following math problem step by step. The last line of your response should be of the form Answer: \\boxed{$Answer} where $Answer is the answer to the problem.\n\nIn triangle $ABC$, $\\sin \\angle A = \\frac{4}{5}$ and $\\angle A < 90^\\circ$. Let $D$ be a point outside triangle $ABC$ such that $\\angle BAD = \\angle DAC$ and $\\angle BDC = 90^\\circ$. Suppose that $AD = 1$ and that $\\frac{BD}{CD} = \\frac{3}{2}$. If $AB + AC$ can be expressed in the form $\\frac{a\\sqrt{b}}{c}$ where $a, b, c$ are pairwise relatively prime integers, find $a + b + c$.\n\nRemember to put your answer on its own line after \"Answer:\".",
-      "role": "user","loss": 1, // Whether to count the turn when calculating loss
+      "role": "user",
+      "step_loss_mask": 1,
     }
   ],
   "label": "34"
@@ -165,7 +166,7 @@ This corresponds to the following configuration:
   --apply-chat-template
 ```
 
-Please note that the `loss` (default=1) here is for SFT phase. If it is set to 0, the turn will not contibute to the final loss; if it is set to 1, slime will use the normal `loss_mask`.
+Please note that the `step_loss_mask` (default=1) here is for SFT phase. If it is set to 0, the turn will not contibute to the final loss; if it is set to 1, slime will use the normal `loss_mask`.
 Additionally, we provide a `metadata_key`, which defaults to `"metadata"`. When read, slime will load the metadata from the data, which can be helpful for custom data generation or creating custom reward models.
 
 ### Hyperparameters for RL Training

--- a/docs/en/get_started/usage.md
+++ b/docs/en/get_started/usage.md
@@ -150,7 +150,7 @@ Currently, slime only supports loading files in `.jsonl` format, where each line
   "prompt": [
     {
       "content": "Solve the following math problem step by step. The last line of your response should be of the form Answer: \\boxed{$Answer} where $Answer is the answer to the problem.\n\nIn triangle $ABC$, $\\sin \\angle A = \\frac{4}{5}$ and $\\angle A < 90^\\circ$. Let $D$ be a point outside triangle $ABC$ such that $\\angle BAD = \\angle DAC$ and $\\angle BDC = 90^\\circ$. Suppose that $AD = 1$ and that $\\frac{BD}{CD} = \\frac{3}{2}$. If $AB + AC$ can be expressed in the form $\\frac{a\\sqrt{b}}{c}$ where $a, b, c$ are pairwise relatively prime integers, find $a + b + c$.\n\nRemember to put your answer on its own line after \"Answer:\".",
-      "role": "user"
+      "role": "user","loss": 1, // Whether to count the turn when calculating loss
     }
   ],
   "label": "34"
@@ -165,6 +165,7 @@ This corresponds to the following configuration:
   --apply-chat-template
 ```
 
+Please note that the `loss` (default=1) here is for SFT phase. If it is set to 0, the turn will not contibute to the final loss; if it is set to 1, slime will use the normal `loss_mask`.
 Additionally, we provide a `metadata_key`, which defaults to `"metadata"`. When read, slime will load the metadata from the data, which can be helpful for custom data generation or creating custom reward models.
 
 ### Hyperparameters for RL Training

--- a/docs/zh/get_started/usage.md
+++ b/docs/zh/get_started/usage.md
@@ -155,7 +155,7 @@ sglang 的加载非常简单，只需要：
     {
       "content": "Solve the following math problem step by step. The last line of your response should be of the form Answer: \\boxed{$Answer} where $Answer is the answer to the problem.\n\nIn triangle $ABC$, $\\sin \\angle A = \\frac{4}{5}$ and $\\angle A < 90^\\circ$. Let $D$ be a point outside triangle $ABC$ such that $\\angle BAD = \\angle DAC$ and $\\angle BDC = 90^\\circ$. Suppose that $AD = 1$ and that $\\frac{BD}{CD} = \\frac{3}{2}$. If $AB + AC$ can be expressed in the form $\\frac{a\\sqrt{b}}{c}$ where $a, b, c$ are pairwise relatively prime integers, find $a + b + c$.\n\nRemember to put your answer on its own line after \"Answer:\".",
       "role": "user",
-      "loss": 1, // 是否将此轮计入最终 loss
+      "step_loss_mask": 1,
     }
   ],
   "label": "34"
@@ -170,7 +170,7 @@ sglang 的加载非常简单，只需要：
   --apply-chat-template
 ```
 
-请注意，这里的 `loss`（默认值为 1）字段为 SFT 阶段提供，若设置为 0，则会将该轮 `loss_mask` 设置为 0；若设置为 1，则使用正常 `loss_mask`。
+请注意，这里的 `step_loss_mask`（默认值为 1）字段为 SFT 阶段提供，若设置为 0，则会将该轮 `loss_mask` 设置为 0；若设置为 1，则使用正常 `loss_mask`。
 另外我们还提供了一个 metadata_key，默认为 `"metadata"`，读取后我们会把数据中的 metadata 加载进 slime，可能会对自定义数据生成或者自定义 reward model 有帮助。
 
 ### RL 训练需要的超参

--- a/docs/zh/get_started/usage.md
+++ b/docs/zh/get_started/usage.md
@@ -154,7 +154,8 @@ sglang 的加载非常简单，只需要：
   "prompt": [
     {
       "content": "Solve the following math problem step by step. The last line of your response should be of the form Answer: \\boxed{$Answer} where $Answer is the answer to the problem.\n\nIn triangle $ABC$, $\\sin \\angle A = \\frac{4}{5}$ and $\\angle A < 90^\\circ$. Let $D$ be a point outside triangle $ABC$ such that $\\angle BAD = \\angle DAC$ and $\\angle BDC = 90^\\circ$. Suppose that $AD = 1$ and that $\\frac{BD}{CD} = \\frac{3}{2}$. If $AB + AC$ can be expressed in the form $\\frac{a\\sqrt{b}}{c}$ where $a, b, c$ are pairwise relatively prime integers, find $a + b + c$.\n\nRemember to put your answer on its own line after \"Answer:\".",
-      "role": "user"
+      "role": "user",
+      "loss": 1, // 是否将此轮计入最终 loss
     }
   ],
   "label": "34"
@@ -169,6 +170,7 @@ sglang 的加载非常简单，只需要：
   --apply-chat-template
 ```
 
+请注意，这里的 `loss`（默认值为 1）字段为 SFT 阶段提供，若设置为 0，则会将该轮 `loss_mask` 设置为 0；若设置为 1，则使用正常 `loss_mask`。
 另外我们还提供了一个 metadata_key，默认为 `"metadata"`，读取后我们会把数据中的 metadata 加载进 slime，可能会对自定义数据生成或者自定义 reward model 有帮助。
 
 ### RL 训练需要的超参

--- a/slime/utils/mask_utils.py
+++ b/slime/utils/mask_utils.py
@@ -57,7 +57,7 @@ class MultiTurnLossMaskGenerator:
             else:
                 loss_mask = [0] * len(message_ids)
 
-            if message.get("loss", 1) != 1:
+            if message.get("step_loss_mask", 1) != 1:
                 loss_mask = [0] * len(message_ids)
 
             all_loss_masks.extend(loss_mask)
@@ -84,7 +84,7 @@ class MultiTurnLossMaskGenerator:
             else:
                 loss_mask = [0] * len(message_ids)
 
-            if message.get("loss", 1) != 1:
+            if message.get("step_loss_mask", 1) != 1:
                 loss_mask = [0] * len(message_ids)
 
             all_loss_masks.extend(loss_mask)
@@ -102,7 +102,7 @@ class MultiTurnLossMaskGenerator:
         token_ids = prompt_tokens + response_tokens
         loss_mask = [0] * len(prompt_tokens) + [1] * response_length
 
-        if messages[-1].get("loss", 1) != 1:
+        if messages[-1].get("step_loss_mask", 1) != 1:
             loss_mask = [0] * len(token_ids)
         return token_ids, loss_mask
 

--- a/slime/utils/mask_utils.py
+++ b/slime/utils/mask_utils.py
@@ -57,6 +57,9 @@ class MultiTurnLossMaskGenerator:
             else:
                 loss_mask = [0] * len(message_ids)
 
+            if message.get("loss", 1) != 1:
+                loss_mask = [0] * len(message_ids)
+
             all_loss_masks.extend(loss_mask)
             all_token_ids.extend(message_ids)
 
@@ -81,6 +84,9 @@ class MultiTurnLossMaskGenerator:
             else:
                 loss_mask = [0] * len(message_ids)
 
+            if message.get("loss", 1) != 1:
+                loss_mask = [0] * len(message_ids)
+
             all_loss_masks.extend(loss_mask)
             all_token_ids.extend(message_ids)
 
@@ -95,6 +101,9 @@ class MultiTurnLossMaskGenerator:
         response_length = len(response_tokens)
         token_ids = prompt_tokens + response_tokens
         loss_mask = [0] * len(prompt_tokens) + [1] * response_length
+
+        if messages[-1].get("loss", 1) != 1:
+            loss_mask = [0] * len(token_ids)
         return token_ids, loss_mask
 
     def get_loss_mask(self, messages: List[Dict]) -> List[int]:


### PR DESCRIPTION
In this PR, I add a feature for manually set the loss mask of some turns to be all zero.

To do so, just add a `loss` column to the message. For example,

```
[
  {"role": "user", "content": "xxx"},
  {"role": "assistant", "content": "xxx", "loss": 0}
]
```

By default, the `loss` column is 1 which means consistency with original loss_mask. If `loss` is set to 0, then the loss mask of the turn will be all 0.