### PR TITLE
[FSDP][Feature] TIS implementation

### DIFF
--- a/slime/backends/fsdp_utils/actor.py
+++ b/slime/backends/fsdp_utils/actor.py
@@ -220,6 +220,7 @@ class FSDPTrainRayActor(TrainRayActor):
                     rollout_data["response_lengths"][start:end],
                     rollout_data["advantages"][start:end],
                     rollout_data["returns"][start:end],
+                    rollout_log_probs=rollout_data["rollout_log_probs"][start:end] if "rollout_log_probs" in rollout_data else None,
                     num_packs=mbs_size,
                 )
             )
@@ -316,13 +317,35 @@ class FSDPTrainRayActor(TrainRayActor):
             ppo_kl = old_log_probs.to(device=log_probs.device) - log_probs
             advantages = advantages.to(device=ppo_kl.device)
             pg_loss, pg_clipfrac = compute_policy_loss(ppo_kl, advantages, self.args.eps_clip, self.args.eps_clip_high)
+            
+            # Initialize TIS variables
+            tis = None
+            tis_clipfrac = None
+            
+            # Apply TIS before sample mean calculation
+            if self.args.use_tis:
+                # Apply TIS off-policy correction using importance sampling
+                assert all(
+                    "rollout_log_probs" in batch and 
+                    isinstance(batch["rollout_log_probs"], torch.Tensor) and 
+                    batch["rollout_log_probs"].numel() > 0
+                    for batch in unpacked_batches
+                ), "rollout_log_probs must be provided as non-empty torch.Tensor for TIS"
+                
+                rollout_log_probs = torch.cat([batch["rollout_log_probs"] for batch in unpacked_batches], dim=0)
+                rollout_log_probs = rollout_log_probs.to(device=log_probs.device)
+                
+                tis = torch.exp(old_log_probs - rollout_log_probs)
+                tis_clip = torch.clamp(tis, min=getattr(self.args, 'tis_clip_low', 0.1), max=getattr(self.args, 'tis_clip', 5.0))
+                tis_clipfrac = tis_clip != tis
+                
+                pg_loss = pg_loss * tis_clip
+            
             pg_loss = sum_of_sample_mean(pg_loss, response_lengths, loss_masks)
             pg_clipfrac = sum_of_sample_mean(pg_clipfrac, response_lengths, loss_masks)
             ppo_kl = sum_of_sample_mean(ppo_kl.abs(), response_lengths, loss_masks)
 
             loss = pg_loss
-            if self.args.use_tis:
-                raise NotImplementedError("implement TIS")
 
             if self.args.entropy_coef != 0:
                 raise NotImplementedError("implement entropy bonus")
@@ -349,6 +372,10 @@ class FSDPTrainRayActor(TrainRayActor):
 
             if self.args.use_kl_loss:
                 reported["kl_loss"] = kl_loss.detach()
+                
+            if self.args.use_tis and tis is not None:
+                reported["tis"] = sum_of_sample_mean(tis, response_lengths, loss_masks).detach()
+                reported["tis_clipfrac"] = sum_of_sample_mean(tis_clipfrac.float(), response_lengths, loss_masks).detach()
 
             # Scale loss for gradient accumulation
             loss = loss * dist.get_world_size() / self.args.global_batch_size


### PR DESCRIPTION
This pull request adds support for Token-level Importance Sampling (TIS) to the FSDP actor training loop, which implements #298. The main changes include updating data packing/unpacking to handle the new `rollout_log_probs` field, integrating TIS logic into the policy loss calculation, and reporting relevant TIS metrics. These updates enable off-policy correction using importance sampling during training.

**TIS integration and policy loss calculation:**

* Added TIS logic to the `train` method in `actor.py`, including calculation of importance weights (`tis`), clipping, and adjustment of the policy loss when `use_tis` is enabled.
* Reported TIS metrics (`tis`, `tis_clipfrac`) in the training output when TIS is used.

**Data packing and unpacking updates:**

* Updated the `pack_sequences` function in `data_packing.py` to accept and pack `rollout_log_probs` alongside other rollout data. 
* Modified the `unpack_sequences` function to correctly unpack and slice `rollout_log_probs` for each instance.

Tested with slime/tests/test_fsdp.sh. 