### PR TITLE
Fix Pipeline Parallelism deadlock in distributed_masked_whiten

### DIFF
--- a/slime/backends/megatron_utils/loss.py
+++ b/slime/backends/megatron_utils/loss.py
@@ -242,8 +242,14 @@ def compute_advantages_and_returns(args, rollout_data):
             assert (
                 all_advs.size() == all_masks.size()
             ), f"Shape mismatch before whitening: advantages {all_advs.size()}, masks {all_masks.size()}"
+            dp_group = mpu.get_data_parallel_group()
 
-            whitened_advs_flat = distributed_masked_whiten(all_advs, all_masks, shift_mean=True)
+            whitened_advs_flat = distributed_masked_whiten(
+                all_advs,
+                all_masks,
+                process_group=dp_group,
+                shift_mean=True,
+            )
             chunk_lengths = [chunk.size(0) for chunk in advantages]
             advantages = list(torch.split(whitened_advs_flat, chunk_lengths))
 


### PR DESCRIPTION
## Problem

When using Pipeline Parallelism (PP), the training process hangs indefinitely during advantage normalization. The root cause is that `distributed_masked_whiten` uses the default WORLD process group for `all_reduce` operations, but in PP mode:
- Only the last pipeline stage executes `compute_advantages_and_returns` 
- Other pipeline stages skip this function (they don't have log_probs/values)
- This creates a deadlock as `all_reduce` waits for all ranks in WORLD group

Fixes #391

## Solution

Modified `distributed_masked_whiten` to accept an optional `process_group` parameter and pass the Data Parallel (DP) group instead of using the WORLD group. This ensures communication only happens between ranks that actually execute the function.

## Changes

1. **`./slime/utils/distributed_utils.py`**:
   - Added optional `process_group` parameter to `distributed_masked_whiten`
   - Updated `dist.all_reduce` to use the specified process group

2. **`./slime/backends/megatron_utils/loss.py`**:
   - Pass `process_group=dp_group` to `distributed_masked_whiten`