### PR TITLE
Fix GRPO ignoring KL penalty configuration

### DIFF
--- a/slime/backends/megatron_utils/loss.py
+++ b/slime/backends/megatron_utils/loss.py
@@ -153,7 +153,7 @@ def compute_advantages_and_returns(args, rollout_data):
 
     if args.advantage_estimator in ["grpo", "gspo"]:
         rewards = torch.tensor(rewards, dtype=torch.float32, device=kl[0].device)
-        returns = get_grpo_returns(rewards, kl)
+        returns = get_grpo_returns(rewards, kl, args.kl_coef)
         # TODO: is the copy necessary?
         advantages = [r for r in returns]
 

--- a/slime/utils/ppo_utils.py
+++ b/slime/utils/ppo_utils.py
@@ -124,10 +124,11 @@ def compute_entropy_from_logits(logits: torch.Tensor, process_group) -> torch.Te
 def get_grpo_returns(
     rewards: torch.Tensor,
     kl: list[torch.Tensor],
+    kl_coeff: float,
 ):
     returns = []
     for i in range(len(rewards)):
-        returns.append(torch.ones_like(kl[i]) * rewards[i])
+        returns.append(torch.ones_like(kl[i]) * rewards[i] - kl_coeff * kl[i])
     return returns
 
 


### PR DESCRIPTION
### **Description**

This PR addresses a bug in the Group Relative Policy Optimization (GRPO) implementation where the `kl_coef` was not being applied to the reward calculation. The KL divergence was calculated but then ignored when computing the advantages and returns for the GRPO advantage estimator.

### **Context**

The GRPO algorithm, as described in the relevant literature, uses a KL divergence penalty to regularize the policy updates and ensure training stability. This penalty prevents the policy from deviating too drastically from a reference policy.

In the previous implementation, the `get_grpo_returns` function did not use the calculated KL divergence, effectively ignoring the `kl_coef` parameter. This resulted in an incomplete and potentially unstable implementation of the GRPO algorithm. This fix ensures that the KL penalty is correctly applied, which should lead to more stable and effective training when using the GRPO advantage estimator.

### **Changes Made**

1.  **`slime/utils/ppo_utils.py`**:
    * The `get_grpo_returns` function signature was updated to accept a `kl_coef` argument.
    * The function logic was modified to subtract the scaled KL penalty (`kl_coef * kl`) from the broadcasted reward when calculating the returns.

2.  **`slime/backends/megatron_utils/loss.py`**:
    * The call to `get_grpo_returns` within the `compute_advantages_and_returns` function was updated to pass `args.kl_coef`.

