### PR TITLE
[FSDP] [feature]Support save/load checkpointing

### DIFF
--- a/slime/backends/fsdp_utils/arguments.py
+++ b/slime/backends/fsdp_utils/arguments.py
@@ -31,6 +31,12 @@ class FSDPArgs:
     wandb_project: str = "slime-fsdp"
     wandb_run_name: Optional[str] = None
 
+    # Checkpoint
+    save: Optional[str] = None
+    load: Optional[str] = None
+    save_safe_serialization: bool = True
+    overwrite_checkpoints: bool = False
+
     # Precision
     gradient_checkpointing: bool = False
 

--- a/slime/backends/fsdp_utils/checkpoint.py
+++ b/slime/backends/fsdp_utils/checkpoint.py
@@ -1,0 +1,75 @@
+import os
+import torch
+import torch.distributed as dist
+from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
+from torch.distributed.fsdp import StateDictType
+
+
+def save_checkpoint(args, iteration, model, optimizer, tokenizer, global_step):
+    """Save a checkpoint."""
+    if dist.get_rank() == 0:
+        checkpoint_dir = os.path.join(args.save, str(iteration))
+
+        if os.path.exists(checkpoint_dir):
+            if not args.overwrite_checkpoints:
+                print(
+                    f"WARNING: Checkpoint directory {checkpoint_dir} already exists and --overwrite-checkpoints is not set. "
+                    "Skipping saving."
+                )
+                return
+            else:
+                print(f"WARNING: Overwriting existing checkpoint directory {checkpoint_dir}.")
+
+        print(f"Saving checkpoint at iteration {iteration} to {checkpoint_dir}")
+        os.makedirs(checkpoint_dir, exist_ok=True)
+
+        with FSDP.state_dict_type(model, StateDictType.FULL_STATE_DICT):
+            state_dict = model.state_dict()
+
+        model.save_pretrained(
+            checkpoint_dir,
+            state_dict=state_dict,
+            safe_serialization=args.save_safe_serialization,
+        )
+        tokenizer.save_pretrained(checkpoint_dir)
+
+        torch.save(optimizer.state_dict(), os.path.join(checkpoint_dir, "optimizer.pt"))
+
+        training_state = {
+            "iteration": iteration,
+            "global_step": global_step,
+        }
+        torch.save(training_state, os.path.join(checkpoint_dir, "training_state.pt"))
+        print(f"Checkpoint saved to {checkpoint_dir}")
+
+    dist.barrier()
+
+
+def load_checkpoint(args, model, optimizer):
+    """Load a checkpoint into the provided model and optimizer."""
+    loaded_rollout_id = -1
+    global_step = 0
+    checkpoint_path = args.load
+    if not checkpoint_path:
+        return loaded_rollout_id, global_step
+
+    print(f"Loading checkpoint from {checkpoint_path}")
+
+    optimizer_path = os.path.join(checkpoint_path, "optimizer.pt")
+    if os.path.exists(optimizer_path):
+        optimizer_state = torch.load(optimizer_path, map_location="cpu")
+        optimizer.load_state_dict(optimizer_state)
+        print("Loaded optimizer state.")
+    else:
+        print("Optimizer state not found, skipping.")
+
+    training_state_path = os.path.join(checkpoint_path, "training_state.pt")
+    if os.path.exists(training_state_path):
+        training_state = torch.load(training_state_path)
+        loaded_rollout_id = training_state.get("iteration", -1)
+        global_step = training_state.get("global_step", 0)
+        print(f"Loaded training state: iteration={loaded_rollout_id}, global_step={global_step}")
+    else:
+        print("Training state not found, skipping.")
+
+    return loaded_rollout_id, global_step


### PR DESCRIPTION


Hi everyone,

This pr add load/save feature in FSDP and also closes #402 

Here are the main changes I've made:

* **Checkpointing Logic**: I added all the logic for saving and loading into a new file, `slime/backends/fsdp_utils/checkpoint.py`, to keep things organized. This handles saving the model, tokenizer, and optimizer state.

* **Actor Integration**: I updated the `FSDPTrainRayActor` in `slime/backends/fsdp_utils/actor.py` to use the new functions. It now correctly loads the state from a checkpoint at the start of a run and saves progress when `save_model` is called.

* **New Arguments**: To control this, I added a few command-line arguments to `slime/backends/fsdp_utils/arguments.py`: `--save`, `--load`, `--save-safe-serialization` and a safety flag `--overwrite-checkpoints` so you don't accidentally overwrite your work.

* **Bug Fixes**: While building this, I also fixed a couple of bugs in the `init` process to prevent the model from being loaded twice and to make sure the `global_step` counter is restored correctly.

Please check it out and let me know if any changes are needed. I'm happy to make them! Thanks for taking a look.