### PR TITLE
fix sft error and update training arguments

### DIFF
--- a/examples/retool/retool_qwen3_4b_sft.sh
+++ b/examples/retool/retool_qwen3_4b_sft.sh
@@ -73,7 +73,6 @@ OPTIMIZER_ARGS=(
    --lr-warmup-iters 128
    --lr-decay-style cosine
    --min-lr 1e-6
-   --lr-warmup-fraction 0.9
    --weight-decay 0.1
    --adam-beta1 0.9
    --adam-beta2 0.95

--- a/slime/utils/arguments.py
+++ b/slime/utils/arguments.py
@@ -42,7 +42,7 @@ def get_slime_extra_args_provider(add_custom_arguments=None):
             parser.add_argument(
                 "--rollout-num-gpus",
                 type=int,
-                default=None,
+                default=8,
                 help=(
                     "Number of GPUs for inference. Note that when using --colocate, "
                     "i.e. the training and the inference engines are on the same gpus, this param will be ignored and will be set as "

--- a/train_async.py
+++ b/train_async.py
@@ -1,6 +1,6 @@
 import ray
 
-from slime.ray.placement_group import create_placement_groups, create_rollout_manager, create_train_models
+from slime.ray.placement_group import create_placement_groups, create_rollout_manager, create_training_models
 from slime.utils.arguments import parse_args
 from slime.utils.wandb_utils import init_wandb_primary
 
@@ -11,11 +11,11 @@ def train(args):
     pgs = create_placement_groups(args)
     wandb_run_id = init_wandb_primary(args)
 
-    # create the actor and critic models
-    actor_model, critic_model = create_train_models(args, pgs, wandb_run_id=wandb_run_id)
-
     # create the rollout manager, with sglang engines inside.
     rollout_manager, num_rollout_per_epoch = create_rollout_manager(args, pgs["rollout"], wandb_run_id=wandb_run_id)
+
+    # create the actor and critic models
+    actor_model, critic_model = create_training_models(args, pgs, wandb_run_id=wandb_run_id)
 
     actor_model.set_rollout_manager(rollout_manager)
 


### PR DESCRIPTION
# Fix SFT Error and Update Training Arguments

This PR fixes sft related error, including resolving a critical TypeError in the rollout manager initialization.


### 1. Fixed Training Script Import Issue (`train_async.py`)
- changed `create_train_models` to `create_training_models`
- moved model creation after rollout manager setup for better initialization sequence

### 2. Updated Training Arguments Configuration (`slime/utils/arguments.py`)
- set default GPU count: Changed --rollout-num-gpus default from None to 8 as a workaround to keep current SFT running.
- fix the following error 
```
ray.exceptions.ActorDiedError: The actor died because of an error raised in its creation task, ray::RolloutManager.__init__() (pid=918378, ip=10.209.8.134, actor_id=27f2e294e954e7ea6e151f1c02000000, repr=<slime.ray.rollout.RolloutManager object at 0x7141f04f4260>)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/shared/shared_experiments/xth/workspace/slime/slime/ray/rollout.py", line 37, in __init__
    init_http_client(args)
  File "/shared/shared_experiments/xth/workspace/slime/slime/utils/http_utils.py", line 124, in init_http_client
    _client_concurrency = args.sglang_server_concurrency * args.rollout_num_gpus // args.rollout_num_gpus_per_engine
                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~
TypeError: unsupported operand type(s) for *: 'int' and 'NoneType'
```

### 3. Optimized Learning Rate Schedule (`examples/retool/retool_qwen3_4b_sft.sh`)
- remove`--lr-warmup-fraction 0.9`
