### PR TITLE
fix the sft arguments' default value

### DIFF
--- a/slime/utils/arguments.py
+++ b/slime/utils/arguments.py
@@ -42,7 +42,7 @@ def get_slime_extra_args_provider(add_custom_arguments=None):
             parser.add_argument(
                 "--rollout-num-gpus",
                 type=int,
-                default=None,
+                default=8,
                 help=(
                     "Number of GPUs for inference. Note that when using --colocate, "
                     "i.e. the training and the inference engines are on the same gpus, this param will be ignored and will be set as "
@@ -332,7 +332,7 @@ def get_slime_extra_args_provider(add_custom_arguments=None):
             parser.add_argument(
                 "--num-rollout",
                 type=int,
-                default=None,
+                default=1,
                 help="Number of rollout steps. Currently, we don't support passing num_epoch and calculate num_rollout from data size.",
             )
             parser.add_argument(


### PR DESCRIPTION
When initializing actors, num-rollouts and rollout-num-gpus are used but is set to None by default in SFT setting, leading to illegal operation. I change the default value of rollout-num-gpus to 8 and num-rollouts to 1 which addresses the issue