### PR TITLE
Fix hostname resolution when DNS/hosts missing

### DIFF
--- a/slime/utils/http_utils.py
+++ b/slime/utils/http_utils.py
@@ -41,7 +41,12 @@ def get_host_info():
     if env_overwrite_local_ip := os.getenv(SLIME_HOST_IP_ENV, None):
         local_ip = env_overwrite_local_ip
     else:
-        local_ip = socket.gethostbyname(hostname)
+        try:
+            local_ip = socket.gethostbyname(hostname)
+        except socket.gaierror:
+            with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as udp_sock:
+                udp_sock.connect(("8.8.8.8", 80))  # Google DNS
+                local_ip = udp_sock.getsockname()[0]
 
     return hostname, local_ip
 


### PR DESCRIPTION
Some systems have hostnames that cannot be resolved via DNS or /etc/hosts, causing `socket.gethostbyname(hostname)` to raise `socket.gaierror` and break local IP detection.

This commit adds a fallback mechanism: when hostname resolution fails, the code creates a temporary UDP socket to a known public IP (Google DNS: 8.8.8.8) to determine the outbound interface and retrieve its IP address. This method does not rely on DNS and works in most network environments.

Changes:
- Wrapped `socket.gethostbyname(hostname)` in try/except to catch `socket.gaierror`.
- Added UDP fallback via `with socket.socket(...)` for cleaner socket closing.
- Removed dependency on DNS resolution for local IP detection in edge cases.

Impact:
- Prevents crashes when hostname does not exist in DNS or /etc/hosts.
- Ensures local IP is correctly detected in containerized or isolated networks.