### PR TITLE
fix: Correctly display sglang_tensor_parallel_size in startup logs

### DIFF
--- a/slime/utils/arguments.py
+++ b/slime/utils/arguments.py
@@ -961,14 +961,14 @@ def get_slime_extra_args_provider(add_custom_arguments=None):
                 default=None,
             )
             return parser
-        
+
         def add_sglang_tp_size():
             temp_parser = argparse.ArgumentParser(add_help=False)
             temp_parser.add_argument("--rollout-num-gpus-per-engine", type=int, default=1)
             temp_args, _ = temp_parser.parse_known_args()
             sglang_tp_size = temp_args.rollout_num_gpus_per_engine
             return sglang_tp_size
-        
+
         # Add custom arguments in front to prevent overwritten some slime arguments.
         if add_custom_arguments is not None:
             parser = add_custom_arguments(parser)
@@ -989,7 +989,7 @@ def get_slime_extra_args_provider(add_custom_arguments=None):
         parser = add_rollout_buffer_arguments(parser)
         parser = add_ci_arguments(parser)
         parser.set_defaults(sglang_tensor_parallel_size=add_sglang_tp_size())
-        
+
         # For megatron
         parser = add_custom_megatron_plugins_arguments(parser)
         try:


### PR DESCRIPTION
This PR fixes an issue where the sglang_tensor_parallel_size was incorrectly logged as 1 at startup logs, even when a different value was effectively being used via --rollout-num-gpus-per-engine. This misleading log could cause confusion during debug.
For example, if we set the :
SGLANG_ARGS=(
   --rollout-num-gpus-per-engine 8
   --sglang-mem-fraction-static 0.7
   --sglang-cuda-graph-bs 1 2 4 8 $(seq 16 8 256)
)

Before fix, the startup log is：
<img width="804" height="214" alt="image" src="https://github.com/user-attachments/assets/8bed02a3-ffdb-4332-8c3a-c305f9c0e1b5" />
<img width="790" height="92" alt="image" src="https://github.com/user-attachments/assets/ce4ee87d-19cc-473b-b4a0-d6ddae121759" />
which is very confusion when we try different sglang tpsize config through setting rollout-num-gpus-per-engine, it all displays 1.

After fix, the startup log is right:
<img width="796" height="170" alt="image" src="https://github.com/user-attachments/assets/8e208553-f182-49c1-9067-090f16149765" />
<img width="782" height="94" alt="image" src="https://github.com/user-attachments/assets/bf4c3488-f02b-463e-95b4-67496910b407" />

