### PR TITLE
[Feat] Support retool multi-turn partial rollout

### DIFF
--- a/examples/retool/retool_qwen3_4b_rl.sh
+++ b/examples/retool/retool_qwen3_4b_rl.sh
@@ -45,6 +45,7 @@ ROLLOUT_ARGS=(
    --num-rollout 3000
    --rollout-batch-size 32
    --n-samples-per-prompt 8
+   --rollout-max-context-len 262144
    --rollout-max-response-len 8192
    --rollout-temperature 0.8
 

--- a/examples/retool/retool_qwen3_4b_rl_amd.sh
+++ b/examples/retool/retool_qwen3_4b_rl_amd.sh
@@ -50,6 +50,7 @@ ROLLOUT_ARGS=(
    --num-rollout 3000
    --rollout-batch-size 32
    --n-samples-per-prompt 8
+   --rollout-max-context-len 262144
    --rollout-max-response-len 8192
    --rollout-temperature 0.8
 


### PR DESCRIPTION
Adding partial rollout support for retool example.

Summary of the changes:
- Added reconstruct_loss_masks(response, tokenizer):
  - Rebuilds loss masks from a saved response when resuming partial rollout
  - Marks <interpreter> blocks as non-trainable (0), model output as trainable (1)
  - Used when resuming without saved metadata or when the response length and the loss mask lengths dont match (this rarely happens in training when resuming partial rollout)
- Added count_tool_turns(response) - this just counts completed tool calls by counting </interpreter> tags (helpful to know which turn we are in when resuming partial rollout if not already in metadata)
- Add a check to make sure we don't sample outside model's max context length (args.rollout_max_context_len and a SAFETY_MARGIN to keep track of how much context we have left to generate)
- Some metadata to track the formatted prompt, loss_masks, response so far etc for partial rollout resumption

Tests:
<img width="463" height="119" alt="image" src="https://github.com/user-attachments/assets/676dbbf6-13ee-42e9-8f2a-d2d8de303bb0" />
<img width="465" height="122" alt="image" src="https://github.com/user-attachments/assets/5ac0f629-d4a9-4921-8ed0-e7f01fb02381" />

- Unfortunately both non partial rollout example already provided and the partial rollout support ive added have both bad training results. I have tested both of these runs in AMD MI325x and might need to also test on nvidia gpus and potentially needs a hyperparameter tune to get better results.

- I've manually verified the partial rollout rollouts and all stages + resumption seems fine.

@yushengsu-thu @zyzshishui Can you guys review this and let me know what we can do to make it better?

Thanks

