### PR TITLE
fix: prevent OOM when converting DeepSeek-V3 models by enabling memory-efficient loading

### DIFF
--- a/tools/convert_hf_to_torch_dist.py
+++ b/tools/convert_hf_to_torch_dist.py
@@ -86,7 +86,7 @@ def main():
     # Load model
     hf_model_path = args.hf_checkpoint
     bridge = AutoBridge.from_pretrained(hf_model_path, trust_remote_code=True)
-    bridge.load_weights(model, hf_model_path)
+    bridge.load_weights(model, hf_model_path, memory_efficient=True)
     print(f"Model loaded: {hf_model_path}")
 
     save_checkpoint(1, model, None, None, 0)


### PR DESCRIPTION
During model conversion for DeepSeek, the process could run out of GPU memory because weights were fully loaded into memory at once. This commit introduces a 'memory_efficient=True` option when calling bridge.load_weights()`, which avoids full in-memory loading.

This change significantly reduces memory usage during `convert_hf_to_torch_dist` for large DeepSeek models, preventing OOM errors.