### PR TITLE
fix load data label type

### DIFF
--- a/slime/utils/data.py
+++ b/slime/utils/data.py
@@ -15,7 +15,7 @@ __all__ = ["Dataset"]
 # TODO: don't read the whole file into memory.
 def read_file(path):
     if path.endswith(".jsonl"):
-        df = pd.read_json(path, lines=True)
+        df = pd.read_json(path, lines=True, dtype={'label': str})
     elif path.endswith(".parquet"):
         df = pd.read_parquet(path, dtype_backend="pyarrow")
     else:


### PR DESCRIPTION
### Fix: Ensure 'label' column is loaded as string from JSONL files

#### What this PR does

This pull request modifies our data loading logic for `.jsonl` files to explicitly cast the `label` column as a string. By adding the `dtype={'label': str}` parameter to the `pd.read_json` function, we prevent pandas from automatically inferring the data type, which previously caused issues with labels formatted like numbers (e.g., "1.0").

#### Why it's needed

In our JSONL data, some labels are strings that resemble numeric values, such as `"1.0"`, `"2"`, or `"1.2"`. The previous implementation did not specify a data type for the `label` column, so pandas' type inference would automatically convert these string labels into float or integer types.

This unintended type conversion is problematic because it alters the original data format, which can lead to inconsistencies and errors in downstream processes that expect the `label` field to always be a string.

#### Example of the issue

Consider the following `test.jsonl` file:
```json
{"feature": "some_feature_1", "label": "1.0"}
{"feature": "some_feature_2", "label": "1.2"}
{"feature": "some_feature_4", "label": "2"}
```

##### Before this change
The code `df = pd.read_json("test.jsonl", lines=True)` would produce a DataFrame where the `label` column has a `float64` dtype, and the values would be `1.0`, `1.2`, and `2.0`.

**Code:**
```python
# Previous behavior
df_before = pd.read_json("test.jsonl", lines=True)
print(df_before)
print(f"\nColumn 'label' dtype is: {df_before['label'].dtype}")
```

**Output:**
```console
       feature  label
0  some_feature_1    1.0
1  some_feature_2    1.2
2  some_feature_4    2.0

Column 'label' dtype is: float64
```

##### After this change
By adding `dtype={'label': str}`, we ensure the `label` column is correctly interpreted as strings, preserving the original data.

**Code:**
```python
# New behavior
df_after = pd.read_json("test.jsonl", lines=True, dtype={'label': str})
print(df_after)
print(f"\nColumn 'label' dtype is: {df_after['label'].dtype}")
```

**Output:**
```console
       feature label
0  some_feature_1   1.0
1  some_feature_2   1.2
2  some_feature_4     2

Column 'label' dtype is: object
```

This simple fix ensures data integrity and makes our data handling more robust and predictable.