### PR TITLE
Fix non thinking model deepscaler score bug 

### DIFF
--- a/slime/rollout/rm_hub/deepscaler.py
+++ b/slime/rollout/rm_hub/deepscaler.py
@@ -7,7 +7,7 @@ def get_deepscaler_rule_based_reward(response, label):
     elif "###Response" in response:
         model_solution = response.split("###Response")[1]
     else:
-        return 0
+        model_solution = response
 
     model_answer = extract_answer(model_solution)
     if model_answer is None:


### PR DESCRIPTION
When rollout non-thinking model, like Qwen-4B-2507., the score is always 0.
This is because the response does not have `<think>` prefix or `###Response` prefix.