### PR TITLE
Small fix on --num-rollout and --num-epoch

### DIFF
--- a/slime/utils/arguments.py
+++ b/slime/utils/arguments.py
@@ -394,7 +394,7 @@ def get_slime_extra_args_provider(add_custom_arguments=None):
                 "--num-rollout",
                 type=int,
                 default=None,
-                help="Number of rollout steps. Currently, we don't support passing num_epoch and calculate num_rollout from data size.",
+                help="Number of rollout steps. If not set, we will calculate the number of rollout steps from the dataset size.",
             )
             parser.add_argument(
                 "--num-epoch",
@@ -404,6 +404,7 @@ def get_slime_extra_args_provider(add_custom_arguments=None):
                     "Number of epochs for the training. "
                     "This is used to calculate the number of rollout steps from the dataset size. "
                     "If set, we will calculate the number of rollout steps as `num_rollout = num_epoch * dataset_size // rollout_batch_size`."
+                    "If both `--num-epoch` and `--num-rollout` are set, `--num-epoch` will be ignored."
                 ),
             )
 


### PR DESCRIPTION
as titled, a small fix for `--num-rollout` and `--num-epoch`, currently we have supported calculating `num-rollout = num_epoch * dataset_size // rollout_batch_size`.

### What changed
modify the help description of the arguments to avoid misunderstanding
