### PR TITLE
refactor(slime_plugins): replace dist.nn.all_gather with dist.all_gather

### DIFF
--- a/slime_plugins/models/hf_attention.py
+++ b/slime_plugins/models/hf_attention.py
@@ -63,7 +63,7 @@ class HuggingfaceAttention(MegatronModule, ABC):
             hidden_states_list = [
                 torch.empty_like(hidden_states) for _ in range(mpu.get_context_parallel_world_size())
             ]
-            dist.nn.all_gather(
+            dist.all_gather(
                 hidden_states_list,
                 hidden_states,
                 group=mpu.get_context_parallel_group(),


### PR DESCRIPTION
## What problem does this solve?

In `slime_plugins/models/hf_attention.py`, within the `HuggingfaceAttention` class, the call to `all_gather` uses an incorrect path: `dist.nn.all_gather`.

This causes the following `TypeError` at runtime:

```
TypeError: all_gather() got multiple values for argument 'group'
```

## Why did this error occur?

This error indicates that the `group` argument was passed twice.

When calling `dist.nn.all_gather(hidden_states_list, hidden_states, group=...)`:

1.  `hidden_states_list` is passed as the first positional argument.
2.  `hidden_states` is passed as the second positional argument, which the function signature likely maps to the `group` parameter.
3.  `group=mpu.get_context_parallel_group()` then provides the `group` argument again via a keyword.

## How was it fixed?

This PR corrects the function call from `dist.nn.all_gather` to `dist.all_gather`.

The correct function, `dist.all_gather` (i.e., `torch.distributed.all_gather`), has the expected signature `all_gather(tensor_list, tensor, group=...)`:

1.  `hidden_states_list` maps to `tensor_list`.
2.  `hidden_states` maps to `tensor`.
3.  `group=...` maps to `group`.

This resolves the argument conflict and the `TypeError`.