### PR TITLE
Add qwen3‑4B‑instruct‑2507.sh model args script for Qwen3‑4B‑Instruct‑2507

### DIFF
--- a/scripts/models/qwen3-4B-instruct-2507.sh
+++ b/scripts/models/qwen3-4B-instruct-2507.sh
@@ -1,0 +1,17 @@
+MODEL_ARGS=(
+   --swiglu
+   --num-layers 36
+   --hidden-size 2560
+   --ffn-hidden-size 9728
+   --num-attention-heads 32
+   --group-query-attention
+   --num-query-groups 8
+   --use-rotary-position-embeddings
+   --disable-bias-linear
+   --normalization "RMSNorm"
+   --norm-epsilon 1e-6
+   --rotary-base 5000000
+   --vocab-size 151936
+   --kv-channels 128
+   --qk-layernorm
+)


### PR DESCRIPTION
**Description:**
While using the Qwen3‑4B‑Instruct‑2507 model, I noticed that no `model_args` entry exists in the Slime framework for this variant. Furthermore, the existing `model_args` for Qwen3‑4B cannot be applied directly because the `rotary_base` parameter differs:

* Qwen3‑4B uses `rotary_base = 1 000 000`
* Qwen3‑4B‑Instruct‑2507 uses `rotary_base = 5 000 000`

To address this, I created a new script at `scripts/models/qwen3‑4B‑instruct‑2507.sh` that defines the correct model args for this variant.
