### PR TITLE
Tiny remove non-effective tis to avoid confusion

### DIFF
--- a/examples/true_on_policy/run_simple.py
+++ b/examples/true_on_policy/run_simple.py
@@ -61,8 +61,6 @@ def execute():
         "--entropy-coef 0.00 "
         "--eps-clip 0.2 "
         "--eps-clip-high 0.28 "
-        # mainly to look at its metric
-        "--use-tis "
     )
 
     optimizer_args = (


### PR DESCRIPTION
tis surely is no-op here since train inference mismatch is 0.0

originally wanted to see metrics but no need since long ago