### PR TITLE
Support rollout routing replay

### DIFF
--- a/docker/patch/latest/sglang.patch
+++ b/docker/patch/latest/sglang.patch
@@ -1,5 +1,25 @@
+diff --git a/python/sglang/srt/entrypoints/engine.py b/python/sglang/srt/entrypoints/engine.py
+index ebab42a8f..05b2cb466 100644
+--- a/python/sglang/srt/entrypoints/engine.py
++++ b/python/sglang/srt/entrypoints/engine.py
+@@ -179,6 +179,7 @@ class Engine(EngineBase):
+         lora_path: Optional[List[Optional[str]]] = None,
+         custom_logit_processor: Optional[Union[List[str], str]] = None,
+         return_hidden_states: bool = False,
++        return_routed_experts: bool = False,
+         stream: bool = False,
+         bootstrap_host: Optional[Union[List[str], str]] = None,
+         bootstrap_port: Optional[Union[List[int], int]] = None,
+@@ -213,6 +214,7 @@ class Engine(EngineBase):
+             lora_path=lora_path,
+             custom_logit_processor=custom_logit_processor,
+             return_hidden_states=return_hidden_states,
++            return_routed_experts=return_routed_experts,
+             stream=stream,
+             bootstrap_host=bootstrap_host,
+             bootstrap_port=bootstrap_port,
 diff --git a/python/sglang/srt/entrypoints/http_server.py b/python/sglang/srt/entrypoints/http_server.py
-index 289db654c..9af349bfe 100644
+index 76e999498..c098f1d37 100644
 --- a/python/sglang/srt/entrypoints/http_server.py
 +++ b/python/sglang/srt/entrypoints/http_server.py
 @@ -403,6 +403,10 @@ async def validate_json_request(raw_request: Request):
@@ -13,8 +33,501 @@ index 289db654c..9af349bfe 100644
  @app.get("/health_generate")
  async def health_generate(request: Request) -> Response:
      """
+diff --git a/python/sglang/srt/layers/moe/routed_experts_capturer.py b/python/sglang/srt/layers/moe/routed_experts_capturer.py
+new file mode 100644
+index 000000000..a15b73501
+--- /dev/null
++++ b/python/sglang/srt/layers/moe/routed_experts_capturer.py
+@@ -0,0 +1,206 @@
++import logging
++from abc import ABC
++from typing import Optional
++
++import numpy as np
++import torch
++
++from sglang.srt.configs.model_config import ModelConfig
++from sglang.srt.mem_cache.memory_pool import ReqToTokenPool
++from sglang.srt.server_args import get_global_server_args
++
++logger = logging.getLogger(__name__)
++
++_GB = 1024 * 1024 * 1024
++_MB = 1024 * 1024
++
++
++def get_tensor_size_bytes(t: torch.Tensor):
++    return np.prod(t.shape) * t.dtype.itemsize
++
++
++class _RoutedExpertsDeviceCache:
++    def __init__(
++        self, model_config: ModelConfig, max_running_requests: int, device: str
++    ) -> None:
++        self.buffer = torch.zeros(
++            (
++                max(
++                    get_global_server_args().chunked_prefill_size, max_running_requests
++                ),
++                model_config.hf_text_config.num_hidden_layers,
++                model_config.hf_text_config.num_experts_per_tok,
++            ),
++            dtype=torch.int32,
++            device=device,
++        )
++        self._finalize_allocation_log()
++
++    def get_buffer_size_bytes(self):
++        assert hasattr(self, "buffer")
++        return get_tensor_size_bytes(self.buffer)
++
++    def capture_fwd_routed_experts(self, layer_id: int, topk_ids: torch.Tensor):
++        assert layer_id is not None, "capturing routing experts but get layer_id None"
++        batch, _ = topk_ids.shape
++        self.buffer[:batch, layer_id, :] = topk_ids
++
++    def _finalize_allocation_log(self):
++        """Common logging and memory usage computation for captured experts buffers."""
++        buffer_size_MB = self.get_buffer_size_bytes() / _MB
++        logger.info(
++            f"Routing experts device buffer allocated. #shape: {tuple(self.buffer.shape)}, size: {buffer_size_MB:.2f} MB"
++        )
++
++
++class _RoutedExpertsHostCache:
++    def __init__(
++        self,
++        model_config: ModelConfig,
++        num_tokens: int,
++    ) -> None:
++        self.num_tokens = num_tokens
++        self.buffer = torch.zeros(
++            (
++                num_tokens,
++                model_config.hf_text_config.num_hidden_layers,
++                model_config.hf_text_config.num_experts_per_tok,
++            ),
++            dtype=torch.int32,
++            device="cpu",
++        )
++        self._finalize_allocation_log()
++
++    def get_buffer_size_bytes(self):
++        assert hasattr(self, "buffer")
++        return get_tensor_size_bytes(self.buffer)
++
++    def set_experts_buffer(self, layer_id: int, loc: torch.Tensor, top_k: torch.Tensor):
++        self.buffer[layer_id, loc, :] = top_k.cpu()
++
++    def _finalize_allocation_log(self):
++        """Common logging and memory usage computation for captured experts buffers."""
++        buffer_size_GB = self.get_buffer_size_bytes() / _GB
++        logger.info(
++            f"Routing experts host buffer allocated. #tokens: {self.num_tokens}, size: {buffer_size_GB:.2f} GB"
++        )
++
++
++class RoutedExpertsCapturer(ABC):
++    @staticmethod
++    def create(
++        enable: bool,
++        model_config: ModelConfig,
++        num_tokens: int,
++        max_running_requests: int,
++        device: str,
++    ):
++        if enable:
++            return _RoutedExpertsCapturerReal(
++                model_config,
++                num_tokens=num_tokens,
++                max_running_requests=max_running_requests,
++                device=device,
++            )
++        else:
++            return _RoutedExpertsCapturerNoop()
++
++    def capture(self, layer_id: int, topk_ids: torch.Tensor):
++        raise NotImplementedError
++
++    def get_routed_experts(
++        self,
++        req_pool_idx: int,
++        seqlen: int,
++        req_to_token_pool: ReqToTokenPool,
++    ):
++        raise NotImplementedError
++
++    def sync_fwd_experts_buffer_DtoH(self, batch: int, loc: torch.Tensor):
++        raise NotImplementedError
++
++    def get_host_cache(self):
++        raise NotImplementedError
++
++    def get_device_cache(self):
++        raise NotImplementedError
++
++
++class _RoutedExpertsCapturerReal(RoutedExpertsCapturer):
++    """Capturer for routed experts with host buffer"""
++
++    def __init__(
++        self,
++        model_config: ModelConfig,
++        num_tokens: int,
++        max_running_requests: int,
++        device: str,
++    ):
++
++        self.host_cache = _RoutedExpertsHostCache(model_config, num_tokens)
++
++        self.device_cache = _RoutedExpertsDeviceCache(
++            model_config, max_running_requests, device
++        )
++
++    def capture(self, layer_id: int, topk_ids: torch.Tensor):
++        self.device_cache.capture_fwd_routed_experts(layer_id, topk_ids)
++
++    def sync_fwd_experts_buffer_DtoH(self, loc: torch.Tensor):
++        batch = loc.shape[0]
++        self.host_cache.buffer[loc] = self.device_cache.buffer[:batch].cpu()
++
++    def get_routed_experts(
++        self,
++        req_pool_idx: int,
++        seqlen: int,
++        req_to_token_pool: ReqToTokenPool,
++    ):
++        cache_pool_idx = (
++            req_to_token_pool.req_to_token[req_pool_idx][:seqlen].cpu().clone()
++        )
++
++        return self.get_host_cache().buffer[cache_pool_idx].tolist()
++
++    def get_host_cache(self):
++        return self.host_cache
++
++    def get_device_cache(self):
++        return self.device_cache
++
++
++class _RoutedExpertsCapturerNoop(RoutedExpertsCapturer):
++    def __init__(self):
++        pass
++
++    def capture(self, layer_id: int, topk_ids: torch.Tensor):
++        pass
++
++    def get_routed_experts(
++        self,
++        req_pool_idx: int,
++        seqlen: int,
++        req_to_token_pool: ReqToTokenPool,
++    ):
++        pass
++
++    def sync_fwd_experts_buffer_DtoH(self, loc: torch.Tensor):
++        pass
++
++    def get_host_cache(self):
++        pass
++
++    def get_device_cache(self):
++        pass
++
++
++_global_expert_capturer: Optional[RoutedExpertsCapturer] = _RoutedExpertsCapturerNoop()
++
++
++def get_global_experts_capturer():
++    return _global_expert_capturer
++
++
++def set_global_experts_capturer(capturer: RoutedExpertsCapturer):
++    global _global_expert_capturer
++    _global_expert_capturer = capturer
+diff --git a/python/sglang/srt/layers/moe/topk.py b/python/sglang/srt/layers/moe/topk.py
+index 203cd5f41..dad8515f5 100644
+--- a/python/sglang/srt/layers/moe/topk.py
++++ b/python/sglang/srt/layers/moe/topk.py
+@@ -44,6 +44,7 @@ from sglang.srt.eplb.expert_location_dispatch import (
+ )
+ from sglang.srt.layers.dp_attention import is_allocation_symmetric
+ from sglang.srt.layers.moe import get_moe_runner_backend
++from sglang.srt.layers.moe.routed_experts_capturer import get_global_experts_capturer
+ from sglang.srt.utils import (
+     cpu_has_amx_support,
+     get_bool_env_var,
+@@ -195,6 +196,7 @@ class TopK(CustomOp):
+         self,
+         top_k: int,
+         *,
++        layer_id: Optional[int] = None,
+         use_grouped_topk: bool = False,
+         topk_group: Optional[int] = None,
+         num_expert_group: Optional[int] = None,
+@@ -215,6 +217,7 @@ class TopK(CustomOp):
+         if use_grouped_topk:
+             assert num_expert_group is not None and topk_group is not None
+ 
++        self.layer_id = layer_id
+         self.topk_config = TopKConfig(
+             top_k=top_k,
+             use_grouped_topk=use_grouped_topk,
+@@ -240,6 +243,7 @@ class TopK(CustomOp):
+         self.topk_config.torch_native = True
+         return select_experts(
+             hidden_states=hidden_states,
++            layer_id=self.layer_id,
+             router_logits=router_logits,
+             topk_config=self.topk_config,
+             num_token_non_padded=num_token_non_padded,
+@@ -289,6 +293,7 @@ class TopK(CustomOp):
+             ):
+                 topk_output = select_experts(
+                     hidden_states=hidden_states,
++                    layer_id=self.layer_id,
+                     router_logits=router_logits,
+                     topk_config=self.topk_config,
+                     num_token_non_padded=num_token_non_padded,
+@@ -306,6 +311,7 @@ class TopK(CustomOp):
+     ) -> TopKOutput:
+         return select_experts(
+             hidden_states=hidden_states,
++            layer_id=self.layer_id,
+             router_logits=router_logits,
+             topk_config=self.topk_config,
+             num_token_non_padded=num_token_non_padded,
+@@ -387,6 +393,7 @@ class TopK(CustomOp):
+             self.topk_config.torch_native = True
+             return select_experts(
+                 hidden_states=hidden_states,
++                layer_id=self.layer_id,
+                 router_logits=router_logits,
+                 topk_config=self.topk_config,
+                 num_token_non_padded=num_token_non_padded,
+@@ -823,6 +830,7 @@ def select_experts(
+     router_logits: torch.Tensor,
+     topk_config: TopKConfig,
+     *,
++    layer_id: Optional[int] = None,
+     num_token_non_padded: Optional[torch.Tensor] = None,
+     expert_location_dispatch_info: Optional[ExpertLocationDispatchInfo] = None,
+ ) -> StandardTopKOutput:
+@@ -920,7 +928,10 @@ def select_experts(
+         )
+ 
+     get_global_expert_distribution_recorder().on_select_experts(topk_ids=topk_ids)
+-
++    get_global_experts_capturer().capture(
++        layer_id=layer_id,
++        topk_ids=topk_ids,
++    )
+     return StandardTopKOutput(topk_weights, topk_ids, router_logits)
+ 
+ 
+diff --git a/python/sglang/srt/managers/detokenizer_manager.py b/python/sglang/srt/managers/detokenizer_manager.py
+index 9399bbbea..91fbf80ab 100644
+--- a/python/sglang/srt/managers/detokenizer_manager.py
++++ b/python/sglang/srt/managers/detokenizer_manager.py
+@@ -273,6 +273,7 @@ class DetokenizerManager(MultiHttpWorkerDetokenizerMixin):
+             output_token_ids_logprobs_idx=recv_obj.output_token_ids_logprobs_idx,
+             output_token_entropy_val=recv_obj.output_token_entropy_val,
+             output_hidden_states=recv_obj.output_hidden_states,
++            output_routed_experts=recv_obj.output_routed_experts,
+             placeholder_tokens_idx=None,
+             placeholder_tokens_val=None,
+             retraction_counts=recv_obj.retraction_counts,
+diff --git a/python/sglang/srt/managers/io_struct.py b/python/sglang/srt/managers/io_struct.py
+index b22f98fbd..3513a9f14 100644
+--- a/python/sglang/srt/managers/io_struct.py
++++ b/python/sglang/srt/managers/io_struct.py
+@@ -175,6 +175,8 @@ class GenerateReqInput(BaseReq):
+     log_metrics: bool = True
+     # Whether to return hidden states
+     return_hidden_states: Union[List[bool], bool] = False
++    # Whether to return captured routed experts
++    return_routed_experts: bool = False
+ 
+     # The modalities of the image data [image, multi-images, video]
+     modalities: Optional[List[str]] = None
+@@ -592,6 +594,7 @@ class GenerateReqInput(BaseReq):
+                 if isinstance(self.return_hidden_states, list)
+                 else self.return_hidden_states
+             ),
++            return_routed_experts=self.return_routed_experts,
+             modalities=self.modalities[i] if self.modalities else None,
+             session_params=self.session_params,
+             lora_path=self.lora_path[i] if self.lora_path is not None else None,
+@@ -655,6 +658,9 @@ class TokenizedGenerateReqInput(BaseReq):
+     # Whether to return hidden states
+     return_hidden_states: bool = False
+ 
++    # Whether to return captured routed experts
++    return_routed_experts: bool = False
++
+     # The input embeds
+     input_embeds: Optional[Union[List[List[List[float]]], List[List[float]]]] = None
+ 
+@@ -910,6 +916,9 @@ class BatchTokenIDOutput(
+     # Hidden states
+     output_hidden_states: List[List[float]]
+ 
++    # The routed experts for each output token
++    output_routed_experts: List[List[int]]
++
+     # The information of placeholder tokens (e.g., image token)
+     # idx is the index of the token in the prompt after expansion.
+     # val is the length of padded tokens after expansion.
+@@ -989,6 +998,9 @@ class BatchStrOutput(
+     # Hidden states
+     output_hidden_states: List[List[float]]
+ 
++    # The routed experts for each output token
++    output_routed_experts: List[List[int]]
++
+     # The information of placeholder tokens (e.g., image token)
+     # idx is the index of the token in the prompt after expansion.
+     # val is the length of padded tokens after expansion.
+diff --git a/python/sglang/srt/managers/schedule_batch.py b/python/sglang/srt/managers/schedule_batch.py
+index 326b010b2..b7e24cfcf 100644
+--- a/python/sglang/srt/managers/schedule_batch.py
++++ b/python/sglang/srt/managers/schedule_batch.py
+@@ -451,6 +451,7 @@ class Req:
+         session_id: Optional[str] = None,
+         custom_logit_processor: Optional[str] = None,
+         return_hidden_states: bool = False,
++        return_routed_experts: bool = False,
+         eos_token_ids: Optional[Set[int]] = None,
+         bootstrap_host: Optional[str] = None,
+         bootstrap_port: Optional[int] = None,
+@@ -628,6 +629,10 @@ class Req:
+         self.output_topk_p = None
+         self.output_topk_index = None
+ 
++        # capture routed experts
++        self.return_routed_experts = return_routed_experts
++        self.routed_experts = []
++
+         # Embedding (return values)
+         self.embedding = None
+ 
+@@ -943,6 +948,7 @@ class Req:
+         self.retraction_count += 1
+ 
+         self.prefix_indices = torch.empty((0,), dtype=torch.int64)
++        self.routed_experts = []
+         self.last_node = None
+         self.swa_uuid_for_lock = None
+         self.extend_input_len = 0
+@@ -1112,6 +1118,9 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
+     # Whether to return hidden states
+     return_hidden_states: bool = False
+ 
++    # Whether to return captured experts
++    return_routed_experts: bool = False
++
+     # Whether this batch is prefill-only (no token generation needed)
+     is_prefill_only: bool = False
+ 
+@@ -1155,6 +1164,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
+             device=req_to_token_pool.device,
+             spec_algorithm=spec_algorithm,
+             return_hidden_states=any(req.return_hidden_states for req in reqs),
++            return_routed_experts=any(req.return_routed_experts for req in reqs),
+             is_prefill_only=all(req.is_prefill_only for req in reqs),
+             chunked_req=chunked_req,
+         )
+@@ -1900,7 +1910,8 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
+     def __str__(self):
+         return (
+             f"ScheduleBatch(forward_mode={self.forward_mode.name if self.forward_mode else 'None'}, "
+-            f"#req={(len(self.reqs))})"
++            f"#req={(len(self.reqs))}), "
++            f"#out_cache_loc={self.out_cache_loc})"
+         )
+ 
+ 
+diff --git a/python/sglang/srt/managers/scheduler.py b/python/sglang/srt/managers/scheduler.py
+index 719e93691..dd9f613da 100644
+--- a/python/sglang/srt/managers/scheduler.py
++++ b/python/sglang/srt/managers/scheduler.py
+@@ -1250,6 +1250,7 @@ class Scheduler(
+                 input_embeds=recv_req.input_embeds,
+                 custom_logit_processor=recv_req.custom_logit_processor,
+                 return_hidden_states=recv_req.return_hidden_states,
++                return_routed_experts=recv_req.return_routed_experts,
+                 eos_token_ids=self.model_config.hf_eos_token_id,
+                 bootstrap_host=recv_req.bootstrap_host,
+                 bootstrap_port=recv_req.bootstrap_port,
+diff --git a/python/sglang/srt/managers/scheduler_output_processor_mixin.py b/python/sglang/srt/managers/scheduler_output_processor_mixin.py
+index 5f5467c4f..186216c73 100644
+--- a/python/sglang/srt/managers/scheduler_output_processor_mixin.py
++++ b/python/sglang/srt/managers/scheduler_output_processor_mixin.py
+@@ -9,6 +9,7 @@ import torch
+ from sglang.srt.disaggregation.utils import DisaggregationMode
+ from sglang.srt.environ import envs
+ from sglang.srt.layers.logits_processor import LogitsProcessorOutput
++from sglang.srt.layers.moe.routed_experts_capturer import get_global_experts_capturer
+ from sglang.srt.managers.io_struct import (
+     AbortReq,
+     BatchEmbeddingOutput,
+@@ -112,6 +113,14 @@ class SchedulerOutputProcessorMixin:
+                     req.check_finished()
+ 
+                     if req.finished():
++                        req.routed_experts = (
++                            get_global_experts_capturer().get_routed_experts(
++                                req_pool_idx=req.req_pool_idx,
++                                seqlen=req.seqlen,
++                                req_to_token_pool=self.req_to_token_pool,
++                            )
++                        )
++
+                         release_kv_cache(req, self.tree_cache)
+                         req.time_stats.completion_time = time.perf_counter()
+                     elif not batch.decoding_reqs or req not in batch.decoding_reqs:
+@@ -333,6 +342,12 @@ class SchedulerOutputProcessorMixin:
+             req.check_finished(new_accepted_len)
+ 
+             if req.finished():
++                req.routed_experts = get_global_experts_capturer().get_routed_experts(
++                    req_pool_idx=req.req_pool_idx,
++                    seqlen=req.seqlen,
++                    req_to_token_pool=self.req_to_token_pool,
++                )
++
+                 if self.server_args.disaggregation_decode_enable_offload_kvcache:
+                     # Asynchronously offload KV cache; release_kv_cache will be called after Device->Host transfer completes
+                     if not self.decode_offload_manager.offload_kv_cache(req):
+@@ -721,6 +736,7 @@ class SchedulerOutputProcessorMixin:
+         spec_accepted_tokens = []
+         retraction_counts = []
+         output_hidden_states = None
++        output_routed_experts = None
+ 
+         queue_times = []
+         forward_entry_times = []
+@@ -925,6 +941,10 @@ class SchedulerOutputProcessorMixin:
+                     if output_hidden_states is None:
+                         output_hidden_states = []
+                     output_hidden_states.append(req.hidden_states)
++                if req.return_routed_experts:
++                    if output_routed_experts is None:
++                        output_routed_experts = []
++                    output_routed_experts.append(req.routed_experts)
+ 
+             if (
+                 req.finished()
+@@ -971,6 +991,7 @@ class SchedulerOutputProcessorMixin:
+                     output_token_ids_logprobs_idx=output_token_ids_logprobs_idx,
+                     output_token_entropy_val=None,
+                     output_hidden_states=output_hidden_states,
++                    output_routed_experts=output_routed_experts,
+                     rids=rids,
+                     http_worker_ipcs=http_worker_ipcs,
+                     placeholder_tokens_idx=None,
 diff --git a/python/sglang/srt/managers/scheduler_runtime_checker_mixin.py b/python/sglang/srt/managers/scheduler_runtime_checker_mixin.py
-index 87418daae..0a2a23bf9 100644
+index e6f59e5b0..c199b987b 100644
 --- a/python/sglang/srt/managers/scheduler_runtime_checker_mixin.py
 +++ b/python/sglang/srt/managers/scheduler_runtime_checker_mixin.py
 @@ -138,7 +138,7 @@ class SchedulerRuntimeCheckerMixin:
@@ -52,10 +565,18 @@ index 9bed7030d..f83b7e736 100644
          if success:
              if recv_req.flush_cache:
 diff --git a/python/sglang/srt/managers/tokenizer_manager.py b/python/sglang/srt/managers/tokenizer_manager.py
-index 25c1bb3f7..5ba08cfe8 100644
+index c5a2e35ed..403cfcd9b 100644
 --- a/python/sglang/srt/managers/tokenizer_manager.py
 +++ b/python/sglang/srt/managers/tokenizer_manager.py
-@@ -1158,6 +1158,9 @@ class TokenizerManager(TokenizerCommunicatorMixin):
+@@ -802,6 +802,7 @@ class TokenizerManager(TokenizerCommunicatorMixin):
+                 session_params=session_params,
+                 custom_logit_processor=obj.custom_logit_processor,
+                 return_hidden_states=obj.return_hidden_states,
++                return_routed_experts=obj.return_routed_experts,
+                 data_parallel_rank=obj.data_parallel_rank,
+                 priority=obj.priority,
+                 extra_key=obj.extra_key,
+@@ -1169,6 +1170,9 @@ class TokenizerManager(TokenizerCommunicatorMixin):
          async with self.is_pause_cond:
              self.is_pause = True
              self.abort_request(abort_all=True)
@@ -65,7 +586,17 @@ index 25c1bb3f7..5ba08cfe8 100644
  
      async def continue_generation(self):
          async with self.is_pause_cond:
-@@ -1605,12 +1608,13 @@ class TokenizerManager(TokenizerCommunicatorMixin):
+@@ -1490,6 +1494,9 @@ class TokenizerManager(TokenizerCommunicatorMixin):
+             if getattr(recv_obj, "output_hidden_states", None):
+                 meta_info["hidden_states"] = recv_obj.output_hidden_states[i]
+ 
++            if getattr(recv_obj, "output_routed_experts", None):
++                meta_info["routed_experts"] = recv_obj.output_routed_experts[i]
++
+             if isinstance(recv_obj, BatchStrOutput):
+                 state.text += recv_obj.output_strs[i]
+                 if state.obj.stream:
+@@ -1616,12 +1623,13 @@ class TokenizerManager(TokenizerCommunicatorMixin):
              return
  
          if len(recv_obj.input_token_logprobs_val) > 0:
@@ -85,7 +616,7 @@ index 25c1bb3f7..5ba08cfe8 100644
          state.output_token_logprobs_val.extend(
              recv_obj.output_token_logprobs_val[recv_obj_index]
          )
-@@ -1728,6 +1732,9 @@ class TokenizerManager(TokenizerCommunicatorMixin):
+@@ -1739,6 +1747,9 @@ class TokenizerManager(TokenizerCommunicatorMixin):
                  meta_info["spec_accept_length"] = (
                      recv_obj.completion_tokens[i] / recv_obj.spec_verify_ct[i]
                  )
@@ -96,10 +627,10 @@ index 25c1bb3f7..5ba08cfe8 100644
      def _calculate_timing_metrics(
          self,
 diff --git a/python/sglang/srt/mem_cache/memory_pool.py b/python/sglang/srt/mem_cache/memory_pool.py
-index e222ae0f5..3fc80a9f5 100644
+index 739e28943..af3c78144 100644
 --- a/python/sglang/srt/mem_cache/memory_pool.py
 +++ b/python/sglang/srt/mem_cache/memory_pool.py
-@@ -868,6 +868,7 @@ class HybridLinearKVPool(KVCache):
+@@ -848,6 +848,7 @@ class HybridLinearKVPool(KVCache):
          enable_kvcache_transpose: bool,
          device: str,
          mamba_pool: MambaPool,
@@ -107,7 +638,7 @@ index e222ae0f5..3fc80a9f5 100644
          # TODO: refactor mla related args
          use_mla: bool = False,
          kv_lora_rank: int = None,
-@@ -899,7 +900,7 @@ class HybridLinearKVPool(KVCache):
+@@ -879,7 +880,7 @@ class HybridLinearKVPool(KVCache):
                  head_dim=head_dim,
                  layer_num=self.full_layer_nums,
                  device=device,
@@ -116,7 +647,7 @@ index e222ae0f5..3fc80a9f5 100644
              )
          else:
              TokenToKVPoolClass = MLATokenToKVPool
-@@ -911,7 +912,7 @@ class HybridLinearKVPool(KVCache):
+@@ -891,7 +892,7 @@ class HybridLinearKVPool(KVCache):
                  device=device,
                  kv_lora_rank=kv_lora_rank,
                  qk_rope_head_dim=qk_rope_head_dim,
@@ -126,19 +657,85 @@ index e222ae0f5..3fc80a9f5 100644
          self.full_attention_layer_id_mapping = {
              id: i for i, id in enumerate(full_attention_layer_ids)
 diff --git a/python/sglang/srt/model_executor/model_runner.py b/python/sglang/srt/model_executor/model_runner.py
-index 963e2cd81..c2d450a01 100644
+index 19e029d60..8c1be2535 100644
 --- a/python/sglang/srt/model_executor/model_runner.py
 +++ b/python/sglang/srt/model_executor/model_runner.py
-@@ -747,7 +747,7 @@ class ModelRunner:
+@@ -86,6 +86,10 @@ from sglang.srt.layers.dp_attention import (
+     initialize_dp_attention,
+ )
+ from sglang.srt.layers.logits_processor import LogitsProcessorOutput
++from sglang.srt.layers.moe.routed_experts_capturer import (
++    RoutedExpertsCapturer,
++    set_global_experts_capturer,
++)
+ from sglang.srt.layers.sampler import Sampler
+ from sglang.srt.layers.torchao_utils import apply_torchao_config_to_model
+ from sglang.srt.lora.lora_manager import LoRAManager
+@@ -155,6 +159,7 @@ from sglang.srt.utils.offloader import (
+     set_offloader,
+ )
+ from sglang.srt.utils.patch_torch import monkey_patch_torch_reductions
++from sglang.srt.layers.moe.routed_experts_capturer import get_global_experts_capturer
+ from sglang.srt.utils.torch_memory_saver_adapter import TorchMemorySaverAdapter
+ from sglang.srt.weight_sync.tensor_bucket import (
+     FlattenedTensorBucket,
+@@ -484,6 +489,10 @@ class ModelRunner:
+             server_args.max_running_requests,
+             server_args.max_total_tokens,
+         )
++
++        # Init routed experts capturer
++        self.init_routed_experts_capturer()
++
+         if self.device == "cuda":
+             self.init_cublas()
+             self.init_attention_backend()
+@@ -519,6 +528,31 @@ class ModelRunner:
+ 
+             self.model.set_eagle3_layers_to_capture(eagle_aux_hidden_state_layer_ids)
+ 
++    def init_routed_experts_capturer(self):
++        # TODO: the redundant logic with TpModelWorker
++        max_running_requests = min(
++            (
++                self.max_total_num_tokens // 2
++                if self.server_args.max_running_requests is None
++                else self.server_args.max_running_requests
++                // (
++                    self.server_args.dp_size
++                    if self.server_args.enable_dp_attention
++                    else 1
++                )
++            ),
++            self.req_to_token_pool.size,
++        )
++        set_global_experts_capturer(
++            RoutedExpertsCapturer.create(
++                enable=get_global_server_args().enable_return_routed_experts,
++                model_config=self.model_config,
++                num_tokens=self.max_total_num_tokens + self.page_size,
++                max_running_requests=max_running_requests,
++                device=self.device,
++            )
++        )
++
+     def model_specific_adjustment(self):
+         server_args = self.server_args
+ 
+@@ -758,7 +792,11 @@ class ModelRunner:
  
          with self.memory_saver_adapter.region(
              GPU_MEMORY_TYPE_WEIGHTS,
 -            enable_cpu_backup=self.server_args.enable_weights_cpu_backup,
-+            enable_cpu_backup=self.server_args.enable_weights_cpu_backup if not self.is_draft_worker else True,
++            enable_cpu_backup=(
++                self.server_args.enable_weights_cpu_backup
++                if not self.is_draft_worker
++                else True
++            ),
          ):
              self.model = get_model(
                  model_config=self.model_config,
-@@ -1799,6 +1799,7 @@ class ModelRunner:
+@@ -1810,6 +1848,7 @@ class ModelRunner:
                      enable_kvcache_transpose=False,
                      device=self.device,
                      mamba_pool=self.req_to_token_pool.mamba_pool,
@@ -146,60 +743,217 @@ index 963e2cd81..c2d450a01 100644
                      use_mla=self.use_mla_backend,
                      **extra_args,
                  )
+@@ -2164,6 +2203,10 @@ class ModelRunner:
+                 reinit_attn_backend,
+                 split_forward_count,
+             )
++            # Copy cached routing experts' buffers back to CPU cache
++            get_global_experts_capturer().sync_fwd_experts_buffer_DtoH(
++                forward_batch.out_cache_loc
++            )
+ 
+         if self.eplb_manager is not None:
+             self.eplb_manager.on_forward_pass_end()
+diff --git a/python/sglang/srt/models/deepseek_v2.py b/python/sglang/srt/models/deepseek_v2.py
+index 895b69105..4209a3ea6 100644
+--- a/python/sglang/srt/models/deepseek_v2.py
++++ b/python/sglang/srt/models/deepseek_v2.py
+@@ -641,6 +641,7 @@ class DeepseekV2MoE(nn.Module):
+ 
+         self.topk = TopK(
+             top_k=config.num_experts_per_tok + self.num_fused_shared_experts,
++            layer_id=self.layer_id,
+             renormalize=config.norm_topk_prob,
+             use_grouped_topk=True,
+             num_expert_group=config.n_group,
+diff --git a/python/sglang/srt/models/ernie4.py b/python/sglang/srt/models/ernie4.py
+index ab1b6576b..dffd8f09a 100644
+--- a/python/sglang/srt/models/ernie4.py
++++ b/python/sglang/srt/models/ernie4.py
+@@ -87,6 +87,7 @@ class Ernie4Moe(nn.Module):
+ 
+         self.topk = TopK(
+             top_k=config.moe_k,
++            layer_id=layer_id,
+             renormalize=True,
+             use_grouped_topk=False,
+             correction_bias=self.gate.e_score_correction_bias,
+diff --git a/python/sglang/srt/models/glm4_moe.py b/python/sglang/srt/models/glm4_moe.py
+index 3b04422b1..3b810843e 100644
+--- a/python/sglang/srt/models/glm4_moe.py
++++ b/python/sglang/srt/models/glm4_moe.py
+@@ -374,6 +374,7 @@ class Glm4MoeSparseMoeBlock(nn.Module):
+ 
+         self.topk = TopK(
+             top_k=self.top_k,
++            layer_id=self.layer_id,
+             renormalize=config.norm_topk_prob,
+             use_grouped_topk=True,
+             num_expert_group=config.n_group,
+diff --git a/python/sglang/srt/models/gpt_oss.py b/python/sglang/srt/models/gpt_oss.py
+index 9474700c4..398d622ff 100644
+--- a/python/sglang/srt/models/gpt_oss.py
++++ b/python/sglang/srt/models/gpt_oss.py
+@@ -113,6 +113,7 @@ class GptOssSparseMoeBlock(nn.Module):
+         self.topk = TopK(
+             top_k=config.num_experts_per_tok,
+             renormalize=True,
++            layer_id=layer_id,
+         )
+ 
+         self.top_k = config.num_experts_per_tok
+diff --git a/python/sglang/srt/models/grok.py b/python/sglang/srt/models/grok.py
+index 1f4a3b443..4eb23cca8 100644
+--- a/python/sglang/srt/models/grok.py
++++ b/python/sglang/srt/models/grok.py
+@@ -167,6 +167,7 @@ class Grok1MoE(nn.Module):
+         self.topk = TopK(
+             top_k=top_k,
+             renormalize=False,
++            layer_id=layer_id,
+             custom_routing_function=custom_routing_function,
+         )
+ 
+diff --git a/python/sglang/srt/models/hunyuan.py b/python/sglang/srt/models/hunyuan.py
+index 7c6fd9e48..b20d28544 100644
+--- a/python/sglang/srt/models/hunyuan.py
++++ b/python/sglang/srt/models/hunyuan.py
+@@ -150,6 +150,7 @@ class HunYuanSparseMoeBlock(nn.Module):
+ 
+         self.topk = TopK(
+             top_k=top_k,
++            layer_id=layer_id,
+             renormalize=True if top_k > 1 else False,
+         )
+ 
+diff --git a/python/sglang/srt/models/longcat_flash.py b/python/sglang/srt/models/longcat_flash.py
+index 84aeb8b30..19637b20c 100644
+--- a/python/sglang/srt/models/longcat_flash.py
++++ b/python/sglang/srt/models/longcat_flash.py
+@@ -241,6 +241,7 @@ class LongcatFlashMoE(nn.Module):
+             renormalize=False,
+             use_grouped_topk=False,
+             correction_bias=self.router.e_score_correction_bias.data,
++            layer_id=layer_id,
+         )
+         self.topk.forward = self.topk.forward_native
+ 
+diff --git a/python/sglang/srt/models/qwen2_moe.py b/python/sglang/srt/models/qwen2_moe.py
+index 051095e61..4857b775e 100644
+--- a/python/sglang/srt/models/qwen2_moe.py
++++ b/python/sglang/srt/models/qwen2_moe.py
+@@ -151,6 +151,7 @@ class Qwen2MoeSparseMoeBlock(nn.Module):
+         self.topk = TopK(
+             top_k=config.num_experts_per_tok,
+             renormalize=config.norm_topk_prob,
++            layer_id=layer_id,
+         )
+ 
+         self.experts = get_moe_impl_class(quant_config)(
+diff --git a/python/sglang/srt/models/qwen3_moe.py b/python/sglang/srt/models/qwen3_moe.py
+index d3acc629b..5aaae8523 100644
+--- a/python/sglang/srt/models/qwen3_moe.py
++++ b/python/sglang/srt/models/qwen3_moe.py
+@@ -100,6 +100,7 @@ class Qwen3MoeSparseMoeBlock(nn.Module):
+             top_k=config.num_experts_per_tok,
+             renormalize=config.norm_topk_prob,
+             use_grouped_topk=False,
++            layer_id=layer_id,
+         )
+ 
+         self.experts = get_moe_impl_class(quant_config)(
+diff --git a/python/sglang/srt/models/step3_vl.py b/python/sglang/srt/models/step3_vl.py
+index 5a9e74ab6..07a06351f 100644
+--- a/python/sglang/srt/models/step3_vl.py
++++ b/python/sglang/srt/models/step3_vl.py
+@@ -129,6 +129,7 @@ class Step3TextMoEMLP(nn.Module):
+             top_k=config.moe_top_k,
+             renormalize=config.norm_expert_weight,
+             use_grouped_topk=False,
++            layer_id=layer_id,
+         )
+ 
+         self.experts = get_moe_impl_class(quant_config)(
+diff --git a/python/sglang/srt/server_args.py b/python/sglang/srt/server_args.py
+index 5b9a520b9..da24facf4 100644
+--- a/python/sglang/srt/server_args.py
++++ b/python/sglang/srt/server_args.py
+@@ -515,6 +515,7 @@ class ServerArgs:
+     disable_fast_image_processor: bool = False
+     keep_mm_feature_on_device: bool = False
+     enable_return_hidden_states: bool = False
++    enable_return_routed_experts: bool = False
+     scheduler_recv_interval: int = 1
+     numa_node: Optional[List[int]] = None
+     enable_deterministic_inference: bool = False
+@@ -3384,6 +3385,11 @@ class ServerArgs:
+             action="store_true",
+             help="Enable returning hidden states with responses.",
+         )
++        parser.add_argument(
++            "--enable-return-routed-experts",
++            action="store_true",
++            help="Enable returning routed experts of each layer with responses.",
++        )
+         parser.add_argument(
+             "--scheduler-recv-interval",
+             type=int,
 diff --git a/python/sglang/srt/speculative/eagle_info.py b/python/sglang/srt/speculative/eagle_info.py
-index d8cd18c4e..aed601dae 100644
+index a2d72dc48..c18f37f1c 100644
 --- a/python/sglang/srt/speculative/eagle_info.py
 +++ b/python/sglang/srt/speculative/eagle_info.py
-@@ -742,6 +742,10 @@ class EagleDraftInput(SpecInput, EagleDraftInputV2Mixin):
+@@ -750,6 +750,10 @@ class EagleDraftInput(SpecInput, EagleDraftInputV2Mixin):
              self.topk_index = self.topk_index[: len(new_indices)]
              self.hidden_states = self.hidden_states[: len(new_indices)]
              self.verified_id = self.verified_id[: len(new_indices)]
 +            if self.accept_length is not None:
 +                self.accept_length = self.accept_length[: len(new_indices)]
 +            if self.accept_length_cpu is not None:
-+                self.accept_length_cpu = self.accept_length_cpu[:len(new_indices)]
++                self.accept_length_cpu = self.accept_length_cpu[: len(new_indices)]
          else:
              # in some cases(e.g draft_extend), we have not filtered the batch by `unfinished_index`
              self.topk_p = self.topk_p[new_indices]
-@@ -776,6 +780,17 @@ class EagleDraftInput(SpecInput, EagleDraftInputV2Mixin):
+@@ -784,6 +788,27 @@ class EagleDraftInput(SpecInput, EagleDraftInputV2Mixin):
          self.verified_id = torch.cat([self.verified_id, spec_info.verified_id], axis=0)
          self.topk_p = torch.cat([self.topk_p, spec_info.topk_p])
          self.topk_index = torch.cat([self.topk_index, spec_info.topk_index])
 +        if self.accept_length is not None and spec_info.accept_length is not None:
-+            self.accept_length = torch.cat([self.accept_length, spec_info.accept_length])
++            self.accept_length = torch.cat(
++                [self.accept_length, spec_info.accept_length]
++            )
 +            self.accept_length_cpu = self.accept_length.tolist()
 +        elif self.accept_length is not None:
-+            zeros = torch.zeros([spec_info.verified_id.shape[0]],dtype=self.accept_length.dtype,device=self.accept_length.device)
++            zeros = torch.zeros(
++                [spec_info.verified_id.shape[0]],
++                dtype=self.accept_length.dtype,
++                device=self.accept_length.device,
++            )
 +            self.accept_length = torch.cat([self.accept_length, zeros])
 +            self.accept_length_cpu = self.accept_length.tolist()
 +        elif spec_info.accept_length is not None:
-+            zeros = torch.zeros([self.verified_id.shape[0]],dtype=self.accept_length.dtype,device=self.accept_length.device)
++            zeros = torch.zeros(
++                [self.verified_id.shape[0]],
++                dtype=self.accept_length.dtype,
++                device=self.accept_length.device,
++            )
 +            self.accept_length = torch.cat([zeros, spec_info.accept_length])
 +            self.accept_length_cpu = self.accept_length.tolist()
  
  
  @dataclass
 diff --git a/python/sglang/srt/speculative/eagle_worker.py b/python/sglang/srt/speculative/eagle_worker.py
-index 26386d913..74dd6a32c 100644
+index 08e6516bc..37b4c3f85 100644
 --- a/python/sglang/srt/speculative/eagle_worker.py
 +++ b/python/sglang/srt/speculative/eagle_worker.py
-@@ -11,6 +11,7 @@ from sglang.srt.layers.moe.utils import speculative_moe_backend_context
+@@ -9,6 +9,7 @@ from sglang.srt.layers.dp_attention import get_attention_tp_group
+ from sglang.srt.layers.logits_processor import LogitsProcessorOutput
+ from sglang.srt.layers.moe.utils import speculative_moe_backend_context
  from sglang.srt.layers.sampler import get_token_ids_logprobs, get_top_logprobs
++from sglang.srt.managers.io_struct import UpdateWeightsFromTensorReqInput
  from sglang.srt.managers.schedule_batch import ScheduleBatch
  from sglang.srt.managers.scheduler import GenerationBatchResult
-+from sglang.srt.managers.io_struct import UpdateWeightsFromTensorReqInput
  from sglang.srt.managers.tp_worker import TpModelWorker
- from sglang.srt.mem_cache.common import (
-     alloc_paged_token_slots_extend,
-@@ -22,6 +23,7 @@ from sglang.srt.model_executor.forward_batch_info import (
-     ForwardBatch,
-     ForwardMode,
- )
-+from sglang.srt.utils.patch_torch import monkey_patch_torch_reductions
- from sglang.srt.server_args import ServerArgs
- from sglang.srt.speculative.draft_utils import DraftBackendFactory
- from sglang.srt.speculative.eagle_draft_cuda_graph_runner import (
-@@ -50,6 +52,7 @@ from sglang.srt.speculative.spec_utils import (
+@@ -50,6 +51,7 @@ from sglang.srt.speculative.spec_utils import (
      select_top_k_tokens,
  )
  from sglang.srt.utils import (
@@ -207,7 +961,15 @@ index 26386d913..74dd6a32c 100644
      empty_context,
      get_available_gpu_memory,
      get_bool_env_var,
-@@ -982,6 +985,25 @@ class EAGLEWorker(TpModelWorker):
+@@ -57,6 +59,7 @@ from sglang.srt.utils import (
+     is_npu,
+     next_power_of_2,
+ )
++from sglang.srt.utils.patch_torch import monkey_patch_torch_reductions
+ 
+ _is_npu = is_npu()
+ 
+@@ -984,6 +987,26 @@ class EAGLEWorker(TpModelWorker):
          draft_input.topk_p, draft_input.topk_index = fast_topk(probs, self.topk, dim=-1)
          draft_input.hidden_states = logits_output.hidden_states
  
@@ -230,6 +992,7 @@ index 26386d913..74dd6a32c 100644
 +        )
 +
 +        return success, message
++
  
  @torch.compile(dynamic=True, disable=_is_npu)
  def get_last_loc_large_page_size_top_k_1(

--- a/slime/backends/megatron_utils/cp_utils.py
+++ b/slime/backends/megatron_utils/cp_utils.py
@@ -165,7 +165,9 @@ def slice_with_cp(tokens: torch.Tensor, pad_value: int) -> torch.Tensor:
     # pad
     chunk_size = (len(tokens) + 2 * cp_size - 1) // (2 * cp_size)
     pad = 2 * cp_size * chunk_size - len(tokens)
-    tokens = F.pad(tokens, (0, pad), value=pad_value)
+    # pad on the first dimension
+    pad_tuple = (0, 0) * (tokens.dim() - 1) + (0, pad)
+    tokens = F.pad(tokens, pad_tuple, value=pad_value)
     # get 2 chunk for thd cp
     start_1, end_1 = chunk_size * cp_rank, chunk_size * (cp_rank + 1)
     start_2, end_2 = chunk_size * (2 * cp_size - cp_rank - 1), chunk_size * (2 * cp_size - cp_rank)

--- a/slime/backends/megatron_utils/data.py
+++ b/slime/backends/megatron_utils/data.py
@@ -315,7 +315,12 @@ def log_rollout_data(rollout_id: int, args: Namespace, rollout_data: RolloutBatc
         total_lengths = rollout_data["total_lengths"]
 
         for key, val in rollout_data.items():
-            if key == "tokens" or key == "loss_masks" or key == "sample_indices":
+            if key in [
+                "tokens",
+                "loss_masks",
+                "sample_indices",
+                "rollout_routed_experts",
+            ]:
                 continue
             # Upload per sample mean for each rollout value
             # There are the following assumptions:

--- a/slime/backends/sglang_utils/arguments.py
+++ b/slime/backends/sglang_utils/arguments.py
@@ -55,6 +55,7 @@ def add_sglang_arguments(parser):
         "base_gpu_id",
         "nccl_port",
         "skip_server_warmup",
+        "enable_return_routed_experts",
     ]
 
     def new_add_argument_wrapper(*name_or_flags, **kwargs):

--- a/slime/backends/sglang_utils/sglang_engine.py
+++ b/slime/backends/sglang_utils/sglang_engine.py
@@ -353,6 +353,7 @@ def _compute_server_args(args, rank, dist_init_addr, nccl_port, host, port):
         "ep_size": args.sglang_ep_size,
         # always skip warmup to prevent warmup timeout.
         "skip_server_warmup": True,
+        "enable_return_routed_experts": args.use_rollout_routing_replay,
     }
     if args.fp16:
         kwargs["dtype"] = "float16"

--- a/slime/ray/rollout.py
+++ b/slime/ray/rollout.py
@@ -246,6 +246,9 @@ class RolloutManager:
         if samples[0].rollout_log_probs is not None:
             train_data["rollout_log_probs"] = [sample.rollout_log_probs for sample in samples]
 
+        if samples[0].rollout_routed_experts is not None:
+            train_data["rollout_routed_experts"] = [sample.rollout_routed_experts for sample in samples]
+
         if samples[0].train_metadata is not None:
             train_data["metadata"] = [sample.train_metadata for sample in samples]
 

--- a/slime/utils/arguments.py
+++ b/slime/utils/arguments.py
@@ -764,6 +764,13 @@ def get_slime_extra_args_provider(add_custom_arguments=None):
                 "--use-routing-replay",
                 action="store_true",
                 default=False,
+                help="The routing replay technique from https://arxiv.org/abs/2507.18071",
+            )
+            parser.add_argument(
+                "--use-rollout-routing-replay",
+                action="store_true",
+                default=False,
+                help="The rollout routing replay technique from https://arxiv.org/abs/2510.11370",
             )
             return parser
 
@@ -1409,6 +1416,9 @@ def slime_validate_args(args):
 
     if args.enable_mtp_training:
         assert args.mtp_num_layers, "mtp_num_layers must be set when enable_mtp_training is set"
+
+    if args.use_rollout_routing_replay:
+        args.use_routing_replay = True
 
     if args.custom_config_path:
         with open(args.custom_config_path, "r") as f:

--- a/slime/utils/data.py
+++ b/slime/utils/data.py
@@ -210,6 +210,7 @@ def process_rollout_data(args, rollout_data_ref, dp_rank, dp_size):
         "round_number",
         "sample_indices",
         "rollout_log_probs",
+        "rollout_routed_experts",
         "prompt",
     ]:
         if key not in data:

--- a/slime/utils/routing_replay.py
+++ b/slime/utils/routing_replay.py
@@ -40,10 +40,18 @@ class RoutingReplay:
         self.backward_index = 0
         self.top_indices_list = []
 
+    def clear_forward(self):
+        self.forward_index = 0
+
     @staticmethod
     def clear_all():
         for replay in RoutingReplay.all_routing_replays:
             replay.clear()
+
+    @staticmethod
+    def clear_all_forward():
+        for replay in RoutingReplay.all_routing_replays:
+            replay.clear_forward()
 
 
 def get_routing_replay_compute_topk(old_compute_topk):
@@ -59,7 +67,7 @@ def get_routing_replay_compute_topk(old_compute_topk):
                 top_indices = ROUTING_REPLAY.pop_forward()
                 assert (
                     top_indices.shape[0] == scores.shape[0] and top_indices.shape[1] == topk
-                ), f"top_indices shape {top_indices.shape} does not match scores shape {scores.shape} and topk {topk}"
+                ), f"[{torch.distributed.get_rank()}] top_indices shape {top_indices.shape} does not match scores shape {scores.shape} and topk {topk}"
                 probs = scores.gather(1, top_indices)
             elif routing_replay_stage == "replay_backward":
                 top_indices = ROUTING_REPLAY.pop_backward()

--- a/slime/utils/types.py
+++ b/slime/utils/types.py
@@ -22,6 +22,7 @@ class Sample:
     loss_mask: Optional[list[int]] = None
     weight_versions: list[str] = field(default_factory=list)
     rollout_log_probs: Optional[list[float]] = None  # Log probabilities from rollout engine
+    rollout_routed_experts: Optional[list[list[int]]] = None  # Routed experts from rollout engine
 
     class Status(Enum):
         PENDING = "pending"


### PR DESCRIPTION
Huge thanks to @ocss884 for the return routed experts support in sglang: https://github.com/sgl-project/sglang/pull/12162
And current commit contains the patch of the referenced sglang pr. We will update the patch when the sglang pr got merged. 

The enable rollout routing replay, one need to use `--use-rollout-routing-replay` and `--use-slime-router` (need the latter to pass `"return_routed_experts": True` to sglang).

<img width="356" height="315" alt="image" src="https://github.com/user-attachments/assets/7fc7920d-34a2-44fb-a6ae-306d84128e9e" />

- currently the sglang pr does not support dp attention.
