### PR TITLE
Fix: make raw_reward optional in process_rollout_data

### DIFF
--- a/slime/utils/data.py
+++ b/slime/utils/data.py
@@ -156,8 +156,9 @@ def process_rollout_data(args, rollout_data_ref, dp_rank, dp_size):
         dist.broadcast_object_list(data, src=0)
         data = data[0]
 
-    # save the unprocessed reward for logging
-    rollout_data["raw_reward"] = data["raw_reward"]
+    # save the unprocessed reward for logging (optional for forward-only passes)
+    if "raw_reward" in data:
+        rollout_data["raw_reward"] = data["raw_reward"]
 
     if "prompt" in data:
         rollout_data["prompt"] = data["prompt"]


### PR DESCRIPTION
## Problem

`process_rollout_data()` unconditionally requires `raw_reward` field, causing crashes when processing forward-only passes that should not have rewards:

```python
# slime/utils/data.py:135
rollout_data["raw_reward"] = data["raw_reward"]  # ❌ KeyError on forward-only passes
```

**Error when running DPO or any forward-only workflow:**
```
KeyError: 'raw_reward'
File "slime/utils/data.py", line 135, in process_rollout_data
    rollout_data["raw_reward"] = data["raw_reward"]
```

In commit (678f361), optional RL training fields were correctly added using the `if key not in data: continue` pattern (lines 190-200):

```python
for key in [
    "tokens",
    # ... other fields ...
    # Additional RL training fields for forward_backward_only API
    "advantages",      # ✅ Optional - added in 678f361
    "returns",         # ✅ Optional - added in 678f361
    "log_probs",       # ✅ Optional - added in 678f361
    "ref_log_probs",   # ✅ Optional - added in 678f361
    "values",          # ✅ Optional - added in 678f361
]:
    if key not in data:
        continue  # ✅ Correctly handles missing fields
    val = get_partition(data[key])
    rollout_data[key] = val
```

**But just 50 lines above, `raw_reward` was left unconditional:**

```python
# Line 135 - added in commit 32d55a6, NOT updated in 678f361
rollout_data["raw_reward"] = data["raw_reward"]  # ❌ Still unconditional!
```

This shows the fix was **known**.

## Why `raw_reward` Should Be Optional

Forward-only passes legitimately don't provide rewards because:

1. **DPO reference model forward pass**: Only needs logprobs for custom DPO loss computation - no rewards
2. **Logprob-only inference**: `compute_log_prob()` and `forward_only()` functions exist for this purpose
3. **Preference learning workflows**: Compute losses client-side after getting model outputs

Since Slime already supports `forward_only()` (model.py:154) and has optional RL training fields (advantages, returns, values), **`raw_reward` should also be optional**.

## Solution

Move `raw_reward` into the optional fields loop, matching the pattern from commit `678f361`:

```python
# Before (line 135):
rollout_data["raw_reward"] = data["raw_reward"]  # ❌ Unconditional

# After (line 135-137):
# save the unprocessed reward for logging (optional for forward-only passes)
if "raw_reward" in data:
    rollout_data["raw_reward"] = data["raw_reward"]  # ✅ Optional
```

## Files Changed

- `slime/utils/data.py`: Lines 134-136 (make `raw_reward` optional)

