### PR TITLE
[FSDP] fix the rollout/raw_reward metrics calculation

### DIFF
--- a/slime/backends/fsdp_utils/actor.py
+++ b/slime/backends/fsdp_utils/actor.py
@@ -442,7 +442,12 @@ class FSDPTrainRayActor(TrainRayActor):
 
         self.compute_log_prob("actor", packed_batches)
 
-        for metric_key in ["log_probs", "ref_log_probs", "advantages", "returns", "raw_reward"]:
+        if "raw_reward" in rollout_data and dist.get_rank() == 0:
+            raw_reward_list = rollout_data["raw_reward"]
+            if raw_reward_list:
+                log_dict["rollout/raw_reward"] = sum(raw_reward_list) / len(raw_reward_list)
+
+        for metric_key in ["log_probs", "ref_log_probs", "advantages", "returns"]:
             if metric_key not in packed_batches[0]:
                 continue
             val = torch.tensor([0.0], device=torch.cuda.current_device())


### PR DESCRIPTION
solve the raw_reward report bug in FSDP. 
now, we calculate the means of `rolloout_data["raw_reward"]` at rank 0, check https://github.com/THUDM/slime/pull/788#issuecomment-3543774375 for wandb curve