### PR TITLE
Fix: logger.info receives multiple positional arguments causing incorrect logging

### DIFF
--- a/slime/rollout/sglang_rollout.py
+++ b/slime/rollout/sglang_rollout.py
@@ -581,9 +581,9 @@ async def eval_rollout_single_dataset(
         sample = await coro
         if do_print:
             logger.info(
-                "eval_rollout_single_dataset example data:",
-                [str(sample.prompt) + sample.response],
-                f"reward={sample.reward}",
+                "eval_rollout_single_dataset example data: %s, reward=%s",
+                str(sample.prompt) + sample.response,
+                sample.reward,
             )
             do_print = False
         if isinstance(sample, list):


### PR DESCRIPTION
### **Description**

This PR fixes a bug where `logger.info()` is called with multiple positional arguments, which is not supported by Python's standard logging module. As a result, only the first argument is logged, and example rollout data is not printed correctly.

Below is the full error:

```text
(RolloutManager pid=996715) --- Logging error ---
Traceback (most recent call last):
  File "/root/.local/share/uv/python/cpython-3.12.11-linux-x86_64-gnu/lib/python3.12/logging/__init__.py", line 1160, in emit
    msg = self.format(record)
  File "/root/.local/share/uv/python/cpython-3.12.11-linux-x86_64-gnu/lib/python3.12/logging/__init__.py", line 999, in format
    return fmt.format(record)
  File "/root/.local/share/uv/python/cpython-3.12.11-linux-x86_64-gnu/lib/python3.12/logging/__init__.py", line 703, in format
    record.message = record.getMessage()
  File "/root/.local/share/uv/python/cpython-3.12.11-linux-x86_64-gnu/lib/python3.12/logging/__init__.py", line 392, in getMessage
    msg = msg % self.args
TypeError: not all arguments converted during string formatting

Call stack:
  File "/root/.local/share/uv/python/cpython-3.12.11-linux-x86_64-gnu/lib/python3.12/threading.py", line 1032, in _bootstrap
    self._bootstrap_inner()
  File "/root/.local/share/uv/python/cpython-3.12.11-linux-x86_64-gnu/lib/python3.12/threading.py", line 1075, in _bootstrap_inner
    self.run()
  File "/root/.local/share/uv/python/cpython-3.12.11-linux-x86_64-gnu/lib/python3.12/threading.py", line 1012, in run
    self._target(*self._args, **self._kwargs)
  File "/root/projects/slime_total/slime/slime/utils/async_utils.py", line 16, in _start_loop
    self.loop.run_forever()
  File "/root/projects/slime_total/slime/slime/rollout/sglang_rollout.py", line 453, in eval_rollout
    results.update(await eval_rollout_single_dataset(args, rollout_id, dataset_cfg))
  File "/root/projects/slime_total/slime/slime/rollout/sglang_rollout.py", line 582, in eval_rollout_single_dataset
    logger.info(
Message: 'eval_rollout_single_dataset example data:'
```