### PR TITLE
Refactor Retool recipe with `rollout_log_probs` recorded

### DIFF
--- a/examples/retool/generate_with_retool.py
+++ b/examples/retool/generate_with_retool.py
@@ -290,7 +290,7 @@ async def generate(args, sample: Sample, sampling_params) -> Sample:
             break
 
         # Count tool calls (when we get interpreter output, it means a tool
-        # was called)    
+        # was called)
         if "<interpreter>" in next_obs:
             tool_call_count += 1
 


### PR DESCRIPTION

when running current retool recipe, it has the following issue:
```
(MegatronTrainRayActor pid=197478) [2025-11-17 23:38:42] memory_utils.py:39 - [Rank 1] Memory-Usage after wake_up model: [repeated 7x across cluster]
(MegatronTrainRayActor pid=197171) [2025-11-17 23:38:54] timer.py:24 - Timer log_probs start
(MegatronTrainRayActor pid=197171) [2025-11-17 23:38:59] timer.py:32 - Timer log_probs end (elapsed: 4.5s)
(MegatronTrainRayActor pid=197171) [2025-11-17 23:38:59] data.py:119 - rollout 0: {'rollout/raw_reward': -0.10908203125000002, 'rollout/total_lengths': 2948.859375, 'rollout/response_lengths': 2601.3125, 'rollout/rewards': -3.157765604555607e-08, 'rollout/truncated': 0.052734375, 'rollout/ref_log_probs': -0.12787111476063728, 'rollout/log_probs': -0.12787111476063728, 'rollout/advantages': -2.991873770952225e-08, 'rollout/returns': -2.991873770952225e-08}
(MegatronTrainRayActor pid=197171) [2025-11-17 23:38:59] timer.py:24 - Timer actor_train start
Traceback (most recent call last):
  File "/home/data/workgroup/zhuohao/project/github/slime/train.py", line 119, in <module>
    train(args)
  File "/home/data/workgroup/zhuohao/project/github/slime/train.py", line 80, in train
    ray.get(actor_model.async_train(rollout_id, rollout_data_ref))
  File "/usr/local/lib/python3.12/dist-packages/ray/_private/auto_init_hook.py", line 22, in auto_init_wrapper
    return fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/ray/_private/client_mode_hook.py", line 104, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/ray/_private/worker.py", line 2962, in get
    values, debugger_breakpoint = worker.get_objects(
                                  ^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/ray/_private/worker.py", line 1026, in get_objects
    raise value.as_instanceof_cause()
ray.exceptions.RayTaskError(TypeError): ray::MegatronTrainRayActor.train() (pid=197483, ip=mlflow-training-7a8pku-296548-n3-master-0, actor_id=bfffc844f8ef2fec034fc62902000000, repr=<slime.backends.megatron_utils.actor.MegatronTrainRayActor object at 0x7f3651002e10>)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/data/workgroup/zhuohao/project/github/slime/slime/backends/megatron_utils/actor.py", line 276, in train
    return self.train_actor(rollout_id, rollout_data)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/data/workgroup/zhuohao/project/github/slime/slime/backends/megatron_utils/actor.py", line 368, in train_actor
    train(
  File "/home/data/workgroup/zhuohao/project/github/slime/slime/backends/megatron_utils/model.py", line 583, in train
    loss_dict, grad_norm = train_one_step(
                           ^^^^^^^^^^^^^^^
  File "/home/data/workgroup/zhuohao/project/github/slime/slime/backends/megatron_utils/model.py", line 443, in train_one_step
    losses_reduced = forward_backward_func(
                     ^^^^^^^^^^^^^^^^^^^^^^
  File "/root/Megatron-LM/megatron/core/pipeline_parallel/schedules.py", line 600, in forward_backward_no_pipelining
    output_tensor, num_tokens = forward_step(
                                ^^^^^^^^^^^^^
  File "/root/Megatron-LM/megatron/core/pipeline_parallel/schedules.py", line 405, in forward_step
    output_tensor, num_tokens = forward_step_calc_loss(
                                ^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/Megatron-LM/megatron/core/pipeline_parallel/schedules.py", line 235, in forward_step_calc_loss
    outputs = loss_func(output_tensor)
              ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/data/workgroup/zhuohao/project/github/slime/slime/backends/megatron_utils/loss.py", line 699, in loss_function
    loss, log = policy_loss_function(**loss_function_kwargs)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/data/workgroup/zhuohao/project/github/slime/slime/backends/megatron_utils/loss.py", line 517, in policy_loss_function
    rollout_log_probs = torch.cat(batch["rollout_log_probs"], dim=0)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: cat() received an invalid combination of arguments - got (NoneType, dim=int), but expected one of:
 * (tuple of Tensors tensors, int dim = 0, *, Tensor out = None)
 * (tuple of Tensors tensors, name dim, *, Tensor out = None)
Traceback (most recent call last):
  File "/home/data/workgroup/zhuohao/project/github/slime/train.py", line 119, in <module>
    train(args)
  File "/home/data/workgroup/zhuohao/project/github/slime/train.py", line 80, in train
    ray.get(actor_model.async_train(rollout_id, rollout_data_ref))
  File "/usr/local/lib/python3.12/dist-packages/ray/_private/auto_init_hook.py", line 22, in auto_init_wrapper
    return fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/ray/_private/client_mode_hook.py", line 104, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/ray/_private/worker.py", line 2962, in get
    values, debugger_breakpoint = worker.get_objects(
                                  ^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/ray/_private/worker.py", line 1026, in get_objects
    raise value.as_instanceof_cause()
ray.exceptions.RayTaskError(TypeError): ray::MegatronTrainRayActor.train() (pid=197483, ip=mlflow-training-7a8pku-296548-n3-master-0, actor_id=bfffc844f8ef2fec034fc62902000000, repr=<slime.backends.megatron_utils.actor.MegatronTrainRayActor object at 0x7f3651002e10>)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/data/workgroup/zhuohao/project/github/slime/slime/backends/megatron_utils/actor.py", line 276, in train
    return self.train_actor(rollout_id, rollout_data)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/data/workgroup/zhuohao/project/github/slime/slime/backends/megatron_utils/actor.py", line 368, in train_actor
    train(
  File "/home/data/workgroup/zhuohao/project/github/slime/slime/backends/megatron_utils/model.py", line 583, in train
    loss_dict, grad_norm = train_one_step(
                           ^^^^^^^^^^^^^^^
  File "/home/data/workgroup/zhuohao/project/github/slime/slime/backends/megatron_utils/model.py", line 443, in train_one_step
    losses_reduced = forward_backward_func(
                     ^^^^^^^^^^^^^^^^^^^^^^
  File "/root/Megatron-LM/megatron/core/pipeline_parallel/schedules.py", line 600, in forward_backward_no_pipelining
    output_tensor, num_tokens = forward_step(
                                ^^^^^^^^^^^^^
  File "/root/Megatron-LM/megatron/core/pipeline_parallel/schedules.py", line 405, in forward_step
    output_tensor, num_tokens = forward_step_calc_loss(
                                ^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/Megatron-LM/megatron/core/pipeline_parallel/schedules.py", line 235, in forward_step_calc_loss
    outputs = loss_func(output_tensor)
              ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/data/workgroup/zhuohao/project/github/slime/slime/backends/megatron_utils/loss.py", line 699, in loss_function
    loss, log = policy_loss_function(**loss_function_kwargs)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/data/workgroup/zhuohao/project/github/slime/slime/backends/megatron_utils/loss.py", line 517, in policy_loss_function
    rollout_log_probs = torch.cat(batch["rollout_log_probs"], dim=0)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: cat() received an invalid combination of arguments - got (NoneType, dim=int), but expected one of:
 * (tuple of Tensors tensors, int dim = 0, *, Tensor out = None)
 * (tuple of Tensors tensors, name dim, *, Tensor out = None)
```

this is because the current forward step requires to check `rollout_log_probs` https://github.com/THUDM/slime/blob/695a68c9abab8ccb1279a7933784c7d64aa3abd8/slime/backends/megatron_utils/model.py#L353

this PR refactor the `generate_with_retool` function by adding `rollout_log_probs` as the current main branch traces

After tests, this resolve the previous issue in Retool recipe.