### PR TITLE
Support IPV6 env 

### DIFF
--- a/slime/backends/sglang_utils/arguments.py
+++ b/slime/backends/sglang_utils/arguments.py
@@ -1,6 +1,7 @@
 import sglang
 from packaging.version import parse
 from sglang.srt.server_args import ServerArgs
+from slime.utils.http_utils import _wrap_ipv6
 
 
 # TODO: use all sglang router arguments with `--sglang-router` prefix
@@ -124,3 +125,6 @@ def validate_args(args):
 
     if args.sglang_dp_size > 1:
         assert args.sglang_enable_dp_attention
+
+    if getattr(args, "sglang_router_ip", None):
+        args.sglang_router_ip = _wrap_ipv6(args.sglang_router_ip)

--- a/slime/backends/sglang_utils/sglang_engine.py
+++ b/slime/backends/sglang_utils/sglang_engine.py
@@ -32,6 +32,7 @@ def get_base_gpu_id(args, rank):
 
 
 def launch_server_process(server_args: ServerArgs) -> multiprocessing.Process:
+    server_args.host = server_args.host.strip("[]")
     p = multiprocessing.Process(target=launch_server, args=(server_args,))
     p.start()
 
@@ -93,6 +94,20 @@ class SGLangEngine(RayActor):
         self.router_port = self.args.sglang_router_port
 
         host = host or get_host_info()[1]
+
+        # support ipv6 address
+        if ":" in host and not host.startswith("["):
+            host = f"[{host}]"
+        if ":" in dist_init_addr and not dist_init_addr.startswith("["):
+            # dist_init_addr may be 2605:...:10163, should split port
+            try:
+                *addr_parts, port_str = dist_init_addr.split(":")
+                ipv6_addr = ":".join(addr_parts)
+                dist_init_addr = f"[{ipv6_addr}]:{port_str}"
+            except Exception:
+                # fallback
+                dist_init_addr = f"[{dist_init_addr}]"
+
         server_args_dict, external_engine_need_check_fields = _compute_server_args(
             self.args, self.rank, dist_init_addr, nccl_port, host, port
         )

--- a/slime/ray/rollout.py
+++ b/slime/ray/rollout.py
@@ -15,7 +15,7 @@ from slime.ray.rollout_data_source import RolloutDataSourceWithBuffer
 from slime.rollout.base_types import call_rollout_fn
 from slime.utils import tracking_utils
 from slime.utils.health_monitor import RolloutHealthMonitor
-from slime.utils.http_utils import find_available_port, get_host_info, init_http_client
+from slime.utils.http_utils import _wrap_ipv6, find_available_port, get_host_info, init_http_client
 from slime.utils.iter_utils import group_by
 from slime.utils.logging_utils import configure_logger
 from slime.utils.metric_checker import MetricChecker
@@ -416,7 +416,7 @@ def _start_router(args):
     if args.sglang_router_ip is not None:
         return
 
-    args.sglang_router_ip = get_host_info()[1]
+    args.sglang_router_ip = _wrap_ipv6(get_host_info()[1])
     if args.sglang_router_port is None:
         args.sglang_router_port = find_available_port(random.randint(3000, 4000))
 


### PR DESCRIPTION
Fixes #706 

As discussed in issue #706, the current environment did not support IPv6-only setups. I have updated the networking logic to support IPv6.

I have verified this in my IPv6-only environment.

The training job started successfully and communication between nodes worked as expected.