### PR TITLE
token-in-token-out and rollout log prob for fully async rl

### DIFF
--- a/slime_plugins/rollout_buffer/buffer.py
+++ b/slime_plugins/rollout_buffer/buffer.py
@@ -5,7 +5,7 @@ import json
 import pathlib
 import threading
 import time
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Optional, List
 
 import uvicorn
 from fastapi import BackgroundTasks, FastAPI, HTTPException, Request
@@ -334,7 +334,6 @@ if __name__ == "__main__":
         app,
         host="0.0.0.0",
         port=8889,
-        limit_concurrency=1000,  # Connection concurrency limit
-        # limit_max_requests=1000000,  # Maximum request limit
+        limit_concurrency=8192,  # Connection concurrency limit
         timeout_keep_alive=5,  # Keep-alive timeout,
     )

--- a/slime_plugins/rollout_buffer/generator/__init__.py
+++ b/slime_plugins/rollout_buffer/generator/__init__.py
@@ -1,6 +1,6 @@
-from .base_generator import BaseGenerator, query_single_turn
+from .base_generator import BaseGenerator, math_rollout_func
 
 __all__ = [
     "BaseGenerator",
-    "query_single_turn",
+    "math_rollout_func",
 ]

--- a/slime_plugins/rollout_buffer/generator/base_generator.py
+++ b/slime_plugins/rollout_buffer/generator/base_generator.py
@@ -1,143 +1,167 @@
 import copy
 import json
-import random
 import time
 import uuid
 from functools import partial
 from multiprocessing import Process, Queue
-from time import sleep
+from types import SimpleNamespace
 from typing import List, Optional
-
 import requests
-from openai import OpenAI
+
+from pebble import ThreadPool
 from tqdm import tqdm
+from transformers import AutoTokenizer
+
+
+from slime.utils.types import Sample
+from slime.utils.data import Dataset
 from slime.rollout.rm_hub import get_deepscaler_rule_based_reward
 
 TASK_TYPE = "math"
 
-SAMPLING_PARAMS = {
-    "top_p": 1,
-}
+
+def post_sync(url, payload, timeout=6000):
+    """同步版本的 post，替换原来的 async post"""
+    # 这里只是保留参数接口，use_http2 在 requests 中无效，因为它只支持 HTTP/1.1
+    try:
+        resp = requests.post(url, json=payload, timeout=timeout)
+        resp.raise_for_status()
+        output = resp.json()
+        return output  # 成功直接返回
+    except Exception as e:
+        # print(f"[post_sync] Error: {e}, retrying... ({retry_count}/{max_retries})", flush=True)
+        # time.sleep(30)  # 同步等待
+        return None
 
 
 def get_rule_based_math_reward(item):
-    messages = item["messages"]
-    label = item["label"]
-    assert messages[-1]["role"] == "assistant", "last message must be assistant, but got {}".format(
-        messages[-1]["role"]
-    )
-
-    response = messages[-1]["content"]
+    response, label = item["response"], item["label"]    
     if response is None or len(response) == 0:
         return 0
-
     reward = get_deepscaler_rule_based_reward(response, label)
     return reward
 
 
-def query_single_turn(client, messages, sampling_params, tools=None):
-    base_payload = {
-        "messages": messages,
-        **sampling_params,
-        "model": "custom",
-        "stream": False,
-        "seed": random.randint(1, 10000000),
-        "tools": tools,
-    }
+def math_rollout_func(remote_engine_url, item, sampling_params, data_dict: dict):
+    instance_id = item.pop("instance_id")
+    sample = Sample.from_dict(item)
 
-    text = None
-    accumulated_tokens = 0
-    finish_reason = "stop"
+    url = f"{remote_engine_url}/generate"
+    abort_count = 0
+    abort_sleep_time = data_dict.get("abort_sleep_time", 30)
 
-    for attempt in range(6):
-        try:
-            # Create a fresh payload for each attempt
-            current_payload = copy.deepcopy(base_payload)
-
-            if text is not None:
-                # Update messages with current progress
-                current_messages = copy.deepcopy(messages)
-                current_messages.append({"role": "assistant", "content": text})
-                current_payload["messages"] = current_messages
-
-                # Adjust max_tokens based on accumulated tokens
-                if "max_tokens" in sampling_params:
-                    current_payload["max_tokens"] = max(0, sampling_params["max_tokens"] - accumulated_tokens)
-
-                # Add continue flag for partial rollouts
-                current_payload["extra_body"] = {"continue_final_message": True}
-            if current_payload["max_tokens"] == 0:
-                break
-            response = client.chat.completions.create(**current_payload)
-
-            if len(response.choices) > 0:
-                finish_reason = response.choices[0].finish_reason
-                if finish_reason == "abort":
-                    print(
-                        f"query failed, reason: {response.choices[0].finish_reason}, currently generated: {response.usage.completion_tokens}"
-                    )
-
-                    accumulated_tokens += response.usage.completion_tokens
-
-                    if text is None:
-                        text = response.choices[0].message.content
-                    else:
-                        text += response.choices[0].message.content
-
-                    sleep(10)
-                    continue
-                if text is None:
-                    text = response.choices[0].message.content
-                elif response.choices[0].message.content is not None:
-                    text += response.choices[0].message.content
-                break
-            else:
-                print(f"Error in query, status code: {response.status_code}")
-                continue
-        except Exception as e:
-            print(f"query failed in single turn, error: {e}")
-            continue
-
-    # Update final messages
-    if len(messages) > 0 and messages[-1]["role"] == "assistant":
-        messages = messages[:-1]
-    messages.append({"role": "assistant", "content": text})
-
-    return messages, finish_reason
-
-
-def worker_process(task_queue, done_queue, rollout_func, reward_func, client, sampling_params):
-
-    for line in iter(task_queue.get, "STOP"):
-        if isinstance(line, str):
-            item = json.loads(line)
-        else:
-            item = line
-
-        # try:
-        messages, finish_reason = rollout_func(client, item["prompt"], sampling_params)
-
-        item["uid"] = str(uuid.uuid4())
-        item["messages"] = messages
-        reward = reward_func(item)
-        item["rollout_index"] = 1
-        item["reward"] = reward
-        item["extra_info"] = {}
-        item.update(sampling_params)
-        item["timestamp"] = str(time.time())
-        item["round_number"] = len([_ for _ in item["messages"] if _["role"] == "assistant"])
-        item["finish_reason"] = finish_reason
-
-        output_item = {
-            "uid": item.pop("uid"),
-            "messages": messages,
-            "reward": reward,
-            "instance_id": item.pop("instance_id"),
-            "extra_info": item,
+    for attempt in range(8):
+        payload = {
+            "input_ids": sample.tokens,
+            "sampling_params": sampling_params,
+            "return_logprob": True,
         }
 
-        done_queue.put(output_item)
+        output = post_sync(url, payload)
+        finish_type = "timeout" if output is None else output["meta_info"]["finish_reason"]["type"]
 
+        if finish_type == "abort":
+            abort_count += 1
+            sample.status = Sample.Status.ABORTED
+            print(f"[math_rollout_func] Abort detected in {attempt} attempt, waiting {abort_sleep_time}s before retry ({attempt}/{abort_count})...")
+            time.sleep(abort_sleep_time)
+            continue
+        elif finish_type == "timeout":
+            print(f"[math_rollout_func] timeout detected in {attempt} attempt, waiting {abort_sleep_time}s before attempt {attempt} ...")
+            time.sleep(abort_sleep_time)
+            continue
+
+        # 如果不是 abort，就更新 sample 的输出信息
+        if "output_token_logprobs" in output["meta_info"]:
+            new_response_tokens = [tok[1] for tok in output["meta_info"]["output_token_logprobs"]]
+            new_response_log_probs = [tok[0] for tok in output["meta_info"]["output_token_logprobs"]]
+        else:
+            new_response_tokens = []
+            new_response_log_probs = []
+
+        sample.tokens.extend(new_response_tokens)
+        sample.response += output.get("text", "")
+        sample.response_length += len(new_response_tokens)
+        if sample.rollout_log_probs is None:
+            sample.rollout_log_probs = []
+        sample.rollout_log_probs.extend(new_response_log_probs)
+
+        # 设置状态并直接返回
+        match finish_type:
+            case "length":
+                sample.status = Sample.Status.TRUNCATED
+            case "stop":
+                sample.status = Sample.Status.COMPLETED
+            case _:
+                # 未知类型也直接返回
+                sample.status = Sample.Status.COMPLETED
+
+        return sample.to_dict(), instance_id
+
+    return sample.to_dict(), instance_id
+
+def worker_process(task_queue, done_queue, rollout_func, reward_func, remote_engine_url=None, sampling_params=None, data_dict=None):
+    """极简版 - 无序输出版本"""
+
+    def _process_single_task(data, rollout_func, reward_func, remote_engine_url=None, sampling_params=None, data_dict=None):
+        """处理单个任务"""
+        if isinstance(data, str):
+            item = json.loads(data)
+        else:
+            item = data
+        
+        sample_dict, instance_id = rollout_func(remote_engine_url, item, sampling_params, data_dict)
+        reward = reward_func(sample_dict)
+        sample_dict["reward"] = reward
+        sample_dict["instance_id"] = instance_id
+        sample_dict["metadata"] = {"timestamp": str(time.time())}
+        
+        return sample_dict
+    
+    with ThreadPool(max_workers=data_dict.get("num_repeat_per_sample", 32) * 8) as pool:
+        active_futures = set()
+        
+        # 初始化：提交初始任务
+        for _ in range(data_dict.get("num_repeat_per_sample", 32) * 8):
+            data = task_queue.get()
+            if data == "STOP":
+                break
+            future = pool.schedule(
+                _process_single_task, 
+                args=(data, rollout_func, reward_func, remote_engine_url, sampling_params, data_dict)
+            )
+            active_futures.add(future)
+        
+        # 持续处理：任意任务完成就输出，并补充新任务
+        while active_futures:
+            # 检查所有活跃任务
+            completed = {f for f in active_futures if f.done()}
+            
+            if completed:
+                # 处理所有已完成的任务
+                for future in completed:
+                    try:
+                        done_queue.put(future.result())
+                    except Exception as e:
+                        print(f"Error: {e}")
+                    
+                    active_futures.remove(future)
+                
+                # 补充新任务（补充与完成数量相同的任务）
+                for _ in range(len(completed)):
+                    data = task_queue.get()
+                    if data == "STOP":
+                        break
+                    
+                    future = pool.schedule(
+                        _process_single_task, 
+                        args=(data, rollout_func, reward_func, remote_engine_url, sampling_params, data_dict)
+                    )
+                    active_futures.add(future)
+            else:
+                # 没有任务完成，短暂休眠避免忙等待
+                time.sleep(0.1)
+    
     done_queue.put("COMPLETE")
 
 
@@ -146,14 +170,16 @@ class BaseGenerator:
         self,
         remote_engine_url,
         remote_buffer_url,
+        args: Optional[SimpleNamespace] = None,
         num_repeat_per_sample=1,
-        queue_size=1000000,
+        queue_size=1024000,
         num_process=10,
         task_type="math",
         max_tokens=4096,
-        num_repeats=10,
+        num_epochs=10,
         skip_instance_ids: Optional[List[str]] = None,
     ):
+        self.args = args
         self.queue_size = queue_size
         self.num_process = num_process
         self.remote_engine_url = remote_engine_url
@@ -161,7 +187,8 @@ class BaseGenerator:
         self.num_repeat_per_sample = num_repeat_per_sample
         self.task_type = task_type
         self.max_tokens = max_tokens
-        self.num_repeats = num_repeats
+        self.num_epochs = num_epochs
+        
         # Ensure skip_instance_ids is a mutable list (copy to avoid modifying original)
         self.skip_instance_ids = list(skip_instance_ids) if skip_instance_ids is not None else None
 
@@ -169,16 +196,37 @@ class BaseGenerator:
             print(f"BaseGenerator initialized with {len(self.skip_instance_ids)} instance_ids to skip")
             self.skip_instance_ids = self.skip_instance_ids * self.num_repeat_per_sample
 
-        if "/v1" in remote_engine_url:
-            self.client = OpenAI(api_key="test", base_url=remote_engine_url)
-        else:
-            remote_engine_url = remote_engine_url.strip("/") + "/v1"
-            self.client = OpenAI(api_key="test", base_url=remote_engine_url)
+        # init dataset using slime utils data
+        self.tokenizer = AutoTokenizer.from_pretrained(args.hf_checkpoint, trust_remote_code=True)
+        self.dataset = Dataset(
+            args.prompt_data,
+            tokenizer=self.tokenizer,
+            max_length=args.rollout_max_prompt_len,
+            prompt_key=args.input_key,
+            label_key=args.label_key,
+            metadata_key=args.metadata_key,
+            tool_key=args.tool_key,
+            apply_chat_template=args.apply_chat_template,
+            apply_chat_template_kwargs={},
+            seed=args.rollout_seed,
+        )
+        self.sampling_params = dict(
+            temperature=args.rollout_temperature,
+            top_p=args.rollout_top_p,
+            top_k=args.rollout_top_k,
+            max_new_tokens=args.rollout_max_response_len,
+            stop=args.rollout_stop,
+            stop_token_ids=args.rollout_stop_token_ids,
+            skip_special_tokens=args.rollout_skip_special_tokens,
+            no_stop_trim=True,
+            spaces_between_special_tokens=False,
+        )
+
 
     def send_data_to_buffer(self, data):
         remote_buffer_url = self.remote_buffer_url.rstrip("/") + "/buffer/write"
 
-        for _ in range(2):
+        for _ in range(3):
             try:
                 response = requests.post(remote_buffer_url, json=data)
                 if response.status_code == 200:
@@ -190,66 +238,43 @@ class BaseGenerator:
                 print(f"send data to buffer failed, error: {e}")
                 continue
 
-    def run(self, input_file, rollout_func, reward_func):
+    def run(self, data_dict, rollout_func, reward_func):
         task_queue, done_queue = Queue(maxsize=self.queue_size), Queue(maxsize=self.queue_size)
-
         def read_data_into_queue():
-            cnt = 0
-            items = []
-            skipped_count = 0
-            with open(input_file, "r") as f:
-                for i, line in enumerate(f):
-                    item = json.loads(line)
-                    if "instance_id" not in item:
-                        item["instance_id"] = i
-                    items.append(item)
-            random.shuffle(items)
+            # read all data into queue
+            for epoch_id in range(self.num_epochs):
+                # shuffle data in each epoch
+                self.dataset.shuffle(epoch_id)
 
-            for _ in range(self.num_repeats):
+                for sample in self.dataset:
+                    # token in token out
+                    sample.tokens = self.tokenizer(sample.prompt, add_special_tokens=False)["input_ids"]
+                    item = sample.to_dict()
+                    item["instance_id"] = str(uuid.uuid4())
 
-                for item in items:
+                    # put num_repeat_per_sample samples into queue
                     for _ in range(self.num_repeat_per_sample):
                         item_repeat = copy.deepcopy(item)
-
-                        if "uid" not in item_repeat:
-                            item_repeat["uid"] = str(uuid.uuid4())
-
-                        # Check if instance_id should be skipped
-                        if self.skip_instance_ids is not None and item_repeat["instance_id"] in self.skip_instance_ids:
-                            print(f"Skipping instance_id: {item_repeat['instance_id']}")
-                            # Remove from skip list to handle potential duplicates in multiple epochs
-                            self.skip_instance_ids.remove(item_repeat["instance_id"])
-                            skipped_count += 1
-                            continue
-
                         task_queue.put(item_repeat)
-                    cnt += 1
-                time.sleep(300)
 
-            if skipped_count > 0:
-                remaining_skip_count = len(self.skip_instance_ids) if self.skip_instance_ids is not None else 0
-                print(
-                    f"Rollout summary: skipped {skipped_count} instance_ids, {remaining_skip_count} still in skip list"
-                )
+                time.sleep(600)
 
-            for _ in range(self.num_process):
+            for _ in range(self.num_process*self.num_process*self.num_repeat_per_sample):
                 task_queue.put("STOP")
 
         processes = []
-        SAMPLING_PARAMS["max_tokens"] = self.max_tokens
-
         for _ in range(self.num_process):
             process = Process(
-                target=partial(worker_process, client=self.client, sampling_params=SAMPLING_PARAMS),
+                target=partial(worker_process, remote_engine_url=self.remote_engine_url, sampling_params=self.sampling_params.copy(), data_dict=data_dict),
                 args=(task_queue, done_queue, rollout_func, reward_func),
             )
             process.start()
             processes.append(process)
 
-        process = Process(target=read_data_into_queue)
-        process.start()
+        producer = Process(target=read_data_into_queue)
+        producer.start()        
 
-        progress_bar = tqdm()
+        # progress_bar = tqdm()
         num_finished = 0
         while num_finished < self.num_process:
             item = done_queue.get()
@@ -259,73 +284,35 @@ class BaseGenerator:
                 assert "reward" in item, f"reward not in item: {item}"
                 assert "instance_id" in item, f"instance_id not in item: {item}"
                 self.send_data_to_buffer(item)
-                progress_bar.update(1)
+                # progress_bar.update(1)
 
-        progress_bar.close()
-
+        # progress_bar.close()
         return "finished"
 
-    def entry(self, input_file, rollout_func, reward_func, num_epoch=1):
-        for _ in range(num_epoch):
-            status = self.run(input_file, rollout_func, reward_func)
+
+    def entry(self, data, rollout_func, reward_func):
+        _ = self.run(data, rollout_func, reward_func)
 
 
 def run_rollout(data: dict):
-
     print(f"Starting math rollout with data: {data}")
 
-    rollout_func = query_single_turn
-    reward_func = get_rule_based_math_reward
-
-    print(f"Waiting for 10 seconds for buffer server to start")
-    time.sleep(10)
-    global SAMPLING_PARAMS
-    for k, v in data["sampling_params"].items():
-        SAMPLING_PARAMS[k] = v
-        print(f"Set {k} to {v}", type(v))
+    args_dict = data["args"]
+    args = SimpleNamespace(**args_dict)
 
     generator = BaseGenerator(
         data["remote_engine_url"],
         data["remote_buffer_url"],
-        num_repeat_per_sample=int(data["num_repeat_per_sample"]),
-        queue_size=1000000,
-        max_tokens=int(data["sampling_params"]["max_tokens"]),
+        args=args,
+        queue_size=8192000,
         num_process=int(data.get("num_process", 100)),
         task_type=data["task_type"],
+        num_epochs=int(data.get("num_epochs", 128)),
+        num_repeat_per_sample=data.get("num_repeat_per_sample", 32),
         skip_instance_ids=data.get("skip_instance_ids", None),
     )
 
-    generator.entry(data["input_file"], rollout_func, reward_func, int(data.get("num_epoch", 1)))
-
-
-def normalize_group_data(group, epsilon=1e-8, algo="grpo"):
-    print(f"Using math-specific normalization for group {group[0]}")
-
-    assert algo == "grpo", "Only 'grpo' is supported for now."
-
-    instance_id = group[0]
-    data = group[1]
-    rewards = [item["reward"] for item in data]
-
-    valid_rewards = [r for r in rewards if 1 >= r >= 0]
-
-    if set(valid_rewards) == {0}:
-        normalized_rewards = rewards
-    else:
-        mean_reward = sum(valid_rewards) / len(valid_rewards)
-        std_reward = (sum((r - mean_reward) ** 2 for r in valid_rewards) / len(valid_rewards)) ** 0.5
-
-        if std_reward < epsilon:
-            print(f"[Math Info] Zero variance in group {instance_id}, setting all to 0.")
-            normalized_rewards = [0.0 if 1 >= r >= 0 else r for r in rewards]
-        else:
-            normalized_rewards = [(r - mean_reward) / (std_reward + epsilon) if 1 >= r >= 0 else r for r in rewards]
-
-    for i, item in enumerate(data):
-        item["reward"] = normalized_rewards[i]
-        item["raw_reward"] = rewards[i]
-
-    return (instance_id, data)
+    generator.entry(data, math_rollout_func, get_rule_based_math_reward)
 
 
 def is_valid_group(group, min_valid_group_size, task_type="math"):
@@ -338,7 +325,7 @@ def is_valid_group(group, min_valid_group_size, task_type="math"):
     # Count valid items (non-empty responses)
     valid_indices = []
     for i, item in enumerate(items):
-        if item["messages"][-1]["content"].strip():
+        if len(item["response"].strip()) > 0:
             valid_indices.append(i)
 
     group_size = len(items)


### PR DESCRIPTION
# Summary: Token-in/Token-out Rollout with Logprobs

This PR overhauls the rollout pipeline to support **token-level generation**, **logprob capture**, and **zero-redundant-tokenization** by serializing full `Sample` objects through the buffer.

### Critical Code Changes

1. **Replace message-based rollout with token-based rollout**  
   ```python
   # Old (text-in/text-out)
   messages, finish_reason = rollout_func(client, item["prompt"], sampling_params)

   # New (token-in/token-out)
   payload = {"input_ids": sample.tokens, "sampling_params": sampling_params, ...}
   output = post_sync(url, payload)
   sample.tokens.extend([tok[1] for tok in output["meta_info"]["output_token_logprobs"]])
   sample.response += output.get("text", "")
   ```

2. **Capture and store rollout log probabilities**  
   ```python
   new_response_log_probs = [tok[0] for tok in output["meta_info"]["output_token_logprobs"]]
   sample.rollout_log_probs.extend(new_response_log_probs)
   ```

3. **Eliminate re-tokenization in consumer**  
   - Buffer now stores full `Sample` objects (via `Sample.to_dict()` / `Sample.from_dict()`)
   - Removed `MultiTurnLossMaskGenerator` and tokenizer calls in `generate_rollout_async`
   - Consumer directly uses `Sample.from_dict(record)` instead of re-parsing messages

4. **Drop OpenAI client; use direct HTTP to engine**  
   ```python
   def post_sync(url, payload, timeout=6000):
       resp = requests.post(url, json=payload, timeout=timeout)
       return resp.json()
   ```

5. **Refactor data loading with `slime.utils.data.Dataset`**  
   Tokenization now happens once during dataset init:
   ```python
   sample.tokens = self.tokenizer(sample.prompt, add_special_tokens=False)["input_ids"]
   ```

These changes enable Trajectory Importance Sampling (TIS) and ensure consistent, efficient token handling across the RL pipeline.