### PR TITLE
[FSDP] Optimize FSDP2 Model Loading with Rank-0 Broadcast

### DIFF
--- a/slime/backends/fsdp_utils/actor.py
+++ b/slime/backends/fsdp_utils/actor.py
@@ -324,13 +324,10 @@ class FSDPTrainRayActor(TrainRayActor):
         # Select which model to use
         if model_tag == "ref" and self.ref_model is not None:
             if not self.fsdp_cpu_offload:
-                logger.info("[Rank {}] Offloading actor model to CPU".format(dist.get_rank()))
                 self.model.cpu()
                 torch.cuda.empty_cache()
                 dist.barrier(group=get_gloo_group())
 
-            # Ref model uses FSDP2 CPUOffloadPolicy - don't manually move to GPU
-            logger.info("[Rank {}] Using ref model with FSDP2 CPUOffloadPolicy".format(dist.get_rank()))
             active_model = self.ref_model
             active_model.eval()
         else:


### PR DESCRIPTION
1. **Efficient model initialization**: Only rank 0 loads checkpoint weights from disk; other ranks use meta device (via `init_empty_weights` context manager) to avoid redundant I/O and memory allocation. Weights broadcast via `set_model_state_dict` with `broadcast_from_rank0=True` option.

2. **Resolves cpu_offload/train_offload conflict**: Clarifies that `fsdp_cpu_offload` (FSDP2's CPUOffloadPolicy) and `offload_train` are separate mechanisms. Prevents conflicts by disabling `offload_train` when FSDP CPU offload is enabled.

3. **Reference model optimization**: Always uses FSDP2 CPUOffloadPolicy for reference models regardless of actor settings. This approach is cleaner and faster than manual `.cpu()` calls while ensuring memory efficiency.

4. **Handles tied embeddings**: Detects `tie_word_embeddings` config and falls back to CPU initialization on all ranks when needed (meta tensors cause hangs).



Implementation inspired by and references [veRL's](https://github.com/volcengine/verl) fsdp_utils.py approach for efficient distributed model initialization.