### PR TITLE
Add logger.warning for destroy_process_groups().

### DIFF
--- a/slime/utils/reloadable_process_group.py
+++ b/slime/utils/reloadable_process_group.py
@@ -137,7 +137,10 @@ class ReloadableProcessGroup(torch.distributed.ProcessGroup):
             try:
                 dist.destroy_process_group(reloadable_group.group)
             except ValueError:
-                pass
+                logger.warning(
+                    "Process group already invalid/destroyed; skipping cleanup",
+                    exc_info=True,
+                )
 
             del reloadable_group.group
             reloadable_group.group = None


### PR DESCRIPTION
Added a logger for the previous PR #909, following the [recommendation](https://github.com/THUDM/slime/pull/910#issuecomment-3573375315) from fzyzcjy