### PR TITLE
Add logger.warning for destroy_process_groups().

### DIFF
--- a/slime/utils/reloadable_process_group.py
+++ b/slime/utils/reloadable_process_group.py
@@ -136,8 +136,11 @@ class ReloadableProcessGroup(torch.distributed.ProcessGroup):
                 continue
             try:
                 dist.destroy_process_group(reloadable_group.group)
-            except ValueError:
-                pass
+            except ValueError as e:
+                logger.warning(
+                    f"Process group already invalid/destroyed; skipping cleanup. Exception: {e}",
+                    exc_info=True,
+                )
 
             del reloadable_group.group
             reloadable_group.group = None


### PR DESCRIPTION
Added a logger for the previous PR #909, following the [recommendation](https://github.com/THUDM/slime/pull/910#issuecomment-3573375315) from fzyzcjy