### PR TITLE
[scripts] remove --sglang-disable-radix-cache in scripts

### DIFF
--- a/docs/en/examples/deepseek-r1.md
+++ b/docs/en/examples/deepseek-r1.md
@@ -184,7 +184,6 @@ SGLANG_ARGS=(
    --sglang-dp-size 8
    --sglang-moe-dense-tp-size 1
    --sglang-enable-dp-lm-head
-   --sglang-disable-radix-cache
 
    # enable deepep for sglang
    --sglang-enable-deepep-moe

--- a/docs/en/examples/glm4.5-355B-A32B.md
+++ b/docs/en/examples/glm4.5-355B-A32B.md
@@ -183,7 +183,6 @@ SGLANG_ARGS=(
    --sglang-moe-dense-tp-size 1
    --sglang-enable-dp-lm-head
    --sglang-cuda-graph-bs 1 2 4 8 $(seq 16 8 128)
-   --sglang-disable-radix-cache
 
    --sglang-moe-a2a-backend deepep
    --sglang-deepep-mode auto

--- a/docs/zh/examples/deepseek-r1.md
+++ b/docs/zh/examples/deepseek-r1.md
@@ -184,7 +184,6 @@ SGLANG_ARGS=(
    --sglang-dp-size 8
    --sglang-moe-dense-tp-size 1
    --sglang-enable-dp-lm-head
-   --sglang-disable-radix-cache
 
    # enable deepep for sglang
    --sglang-enable-deepep-moe

--- a/docs/zh/examples/glm4.5-355B-A32B.md
+++ b/docs/zh/examples/glm4.5-355B-A32B.md
@@ -183,7 +183,6 @@ SGLANG_ARGS=(
    --sglang-moe-dense-tp-size 1
    --sglang-enable-dp-lm-head
    --sglang-cuda-graph-bs 1 2 4 8 $(seq 16 8 128)
-   --sglang-disable-radix-cache
 
    --sglang-moe-a2a-backend deepep
    --sglang-deepep-mode auto

--- a/scripts/run-deepseek-r1.sh
+++ b/scripts/run-deepseek-r1.sh
@@ -120,7 +120,6 @@ SGLANG_ARGS=(
    --sglang-dp-size 8
    --sglang-moe-dense-tp-size 1
    --sglang-enable-dp-lm-head
-   --sglang-disable-radix-cache
 
    # enable deepep for sglang
    --sglang-enable-deepep-moe

--- a/scripts/run-kimi-k2-Instruct.sh
+++ b/scripts/run-kimi-k2-Instruct.sh
@@ -124,7 +124,6 @@ SGLANG_ARGS=(
    --sglang-dp-size 8
    --sglang-moe-dense-tp-size 1
    --sglang-enable-dp-lm-head
-   --sglang-disable-radix-cache
 
    --sglang-ep-size 16
 

--- a/scripts/run-kimi-k2-Thinking.sh
+++ b/scripts/run-kimi-k2-Thinking.sh
@@ -126,7 +126,6 @@ SGLANG_ARGS=(
    --sglang-dp-size 8
    --sglang-moe-dense-tp-size 1
    --sglang-enable-dp-lm-head
-   --sglang-disable-radix-cache
 
    --sglang-ep-size 16
 

--- a/scripts/run-qwen3-235B-A22B.sh
+++ b/scripts/run-qwen3-235B-A22B.sh
@@ -126,7 +126,6 @@ SGLANG_ARGS=(
    --sglang-ep-size 32
    --sglang-enable-dp-lm-head
    --sglang-cuda-graph-bs 1 2 4 8 $(seq 16 8 256)
-   --sglang-disable-radix-cache
 
    --sglang-moe-a2a-backend deepep
    --sglang-deepep-mode auto

--- a/scripts/run_deepseek.py
+++ b/scripts/run_deepseek.py
@@ -247,7 +247,6 @@ def train(args: ScriptArgs):
         f"--sglang-dp-size {sglang_attn_dp_size} "
         "--sglang-moe-dense-tp-size 1 "
         "--sglang-enable-dp-lm-head "
-        "--sglang-disable-radix-cache "
         # enable deepep for sglang
         "--sglang-moe-a2a-backend deepep "
         "--sglang-deepep-mode low_latency "

--- a/scripts/run_glm45_355b_a32b.py
+++ b/scripts/run_glm45_355b_a32b.py
@@ -236,8 +236,6 @@ def train(args: ScriptArgs):
         # f"--sglang-dp-size {sglang_attn_dp_size} "
         # "--sglang-moe-dense-tp-size 1 "
         # "--sglang-enable-dp-lm-head "
-        # TODO why disable?
-        # "--sglang-disable-radix-cache "
         # enable deepep for sglang
         # "--sglang-moe-a2a-backend deepep "
         # "--sglang-deepep-mode low_latency "

--- a/tests/test_qwen3_30B_A3B.py
+++ b/tests/test_qwen3_30B_A3B.py
@@ -92,7 +92,6 @@ def execute():
         "--sglang-moe-a2a-backend deepep "
         "--sglang-deepep-mode auto "
         "--sglang-max-running-requests 512 "
-        "--sglang-disable-radix-cache "
         "--sglang-enable-metrics "
     )
 

--- a/tests/test_qwen3_4B_ppo.py
+++ b/tests/test_qwen3_4B_ppo.py
@@ -86,7 +86,6 @@ def execute():
         "--rollout-num-gpus 8 "
         "--sglang-mem-fraction-static 0.8 "
         "--sglang-max-running-requests 512 "
-        "--sglang-disable-radix-cache "
         "--sglang-enable-metrics "
     )
 


### PR DESCRIPTION
We set this because in old sglang, the radix cache may trigger crash for multi-node serving. And the issue seems to be disappear in the latter version of sglang.