### PR TITLE
[WIP] Add quantization config -- make DSv3 torch_dist -> hf conversion work

### DIFF
--- a/tools/convert_torch_dist_to_hf.py
+++ b/tools/convert_torch_dist_to_hf.py
@@ -109,6 +109,12 @@ def save_tensors(args, model_name, state_dict, output_dir, chunk_size, vocab_siz
 
     print(f"start saving to {output_dir}")
     os.makedirs(output_dir, exist_ok=True)
+
+    hf_config = AutoConfig.from_pretrained(
+        hf_model_configs_only_path, trust_remote_code=True
+    )
+    quantization_config = getattr(hf_config, "quantization_config", None)
+    
     # 2GB
     current_size = 0
     total_size = 0
@@ -116,7 +122,7 @@ def save_tensors(args, model_name, state_dict, output_dir, chunk_size, vocab_siz
     for name, param in get_named_params(args, state_dict):
         if vocab_size:
             param = remove_padding(name, param, vocab_size)
-        converted_named_tensors = convert_to_hf(args, model_name, name, param)
+        converted_named_tensors = convert_to_hf(args, model_name, name, param, quantization_config)
         for converted_name, converted_param in converted_named_tensors:
             tensor_size = converted_param.numel() * converted_param.element_size()
             if tensor_size + current_size > chunk_size:


### PR DESCRIPTION
Added support for quantization configuration for DSv3 conversion. 

Without it, the converted checkpoints would still be in bf16, which conflicts with the default quantization config. It completely breaks `vllm serve` I think, making it to output gibeerish. 