### PR TITLE
Fix: resolve variable shadowing bug in setup_model_and_optimizer

### DIFF
--- a/slime/backends/megatron_utils/model.py
+++ b/slime/backends/megatron_utils/model.py
@@ -127,10 +127,10 @@ def setup_model_and_optimizer(
         use_gloo_process_groups=args.enable_gloo_process_groups,
     )
     opt_param_scheduler = get_optimizer_param_scheduler(args, optimizer)
-    for optimizer in optimizer.chained_optimizers:
-        if not getattr(optimizer, "init_state_fn", None):
+    for sub_optimizer in optimizer.chained_optimizers:
+        if not getattr(sub_optimizer, "init_state_fn", None):
             continue
-        optimizer.init_state_fn(optimizer.optimizer, optimizer.config)
+        sub_optimizer.init_state_fn(sub_optimizer.optimizer, sub_optimizer.config)
 
     return model, optimizer, opt_param_scheduler
 


### PR DESCRIPTION
What this PR does / why we need it:
This PR fixes a critical bug in setup_model_and_optimizer where the loop variable optimizer shadowed the outer optimizer object (the ChainedOptimizer instance).

The Bug:
Previously, the code used:
`for optimizer in optimizer.chained_optimizers:
    # ...`

This caused the optimizer variable to be overwritten by the last sub-optimizer in the list. As a result, the function returned a single sub-optimizer (usually the MoE expert optimizer) instead of the full ChainedOptimizer. This leads to Dense parameters not being updated during training and incomplete checkpoint states.
The Fix:
Renamed the loop variable from optimizer to sub_optimizer to avoid variable shadowing.