### PR TITLE
Fixed bug in checking max_length for SFT #997

### DIFF
--- a/slime/utils/data.py
+++ b/slime/utils/data.py
@@ -98,11 +98,11 @@ class Dataset:
                 prompt = prompt_content
 
             # TODO: this is slow.
-            if max_length is not None:
+            # Only check token length for string prompts, skip for multimodal and message lists (SFT)
+            if max_length is not None and not multimodal_keys and isinstance(prompt, str):
                 raw_prompt_ids = tokenizer.encode(prompt, add_special_tokens=False)
-                if not multimodal_keys:
-                    if len(raw_prompt_ids) > max_length:
-                        continue
+                if len(raw_prompt_ids) > max_length:
+                    continue
 
             self.origin_samples.append(
                 Sample(


### PR DESCRIPTION
## Summary

Add `isinstance(prompt, str)` check to skip token-level length filtering for list prompts (SFT messages).

## Changes

```python
# Before
if max_length is not None:
    raw_prompt_ids = tokenizer.encode(prompt, ...)
    if not multimodal_keys:
        ...

# After
if max_length is not None and not multimodal_keys and isinstance(prompt, str):
    raw_prompt_ids = tokenizer.encode(prompt, ...)
    ...
```

Fixes #997 