### PR TITLE
fix: update deprecated import path in mcore2hf script

### DIFF
--- a/tools/convert_torch_dist_to_hf.py
+++ b/tools/convert_torch_dist_to_hf.py
@@ -13,7 +13,7 @@ import torch.distributed.checkpoint as dist_cp
 from transformers import AutoConfig
 from typing_extensions import override
 
-from slime.backends.megatron_utils.update_weight_utils import convert_to_hf, remove_padding
+from slime.backends.megatron_utils.megatron_to_hf import convert_to_hf, remove_padding
 
 
 class UnpicklerWrapper(pickle.Unpickler):


### PR DESCRIPTION
It appears that `slime.backends.megatron_utils.update_weight_utils` has been discarded or deprecated. 

This change updates the import path to use `slime.backends.megatron_utils.megatron_to_hf` instead, where `convert_to_hf` and `remove_padding` are currently located.