### PR TITLE
fix: FSDP runnable for Qwen3-30b-a3b

### DIFF
--- a/slime/backends/fsdp_utils/actor.py
+++ b/slime/backends/fsdp_utils/actor.py
@@ -156,6 +156,10 @@ class FSDPTrainRayActor(TrainRayActor):
             )
 
             apply_true_on_policy_patch_for_qwen3_moe()
+        else:
+            from .models.qwen3_moe_hf import apply_fsdp_moe_patch
+
+            apply_fsdp_moe_patch()
 
     def _setup_device_mesh(self) -> None:
         """Setup device mesh for parallelism (always called, handles both CP and non-CP cases).

--- a/slime/backends/fsdp_utils/models/qwen3_moe_hf.py
+++ b/slime/backends/fsdp_utils/models/qwen3_moe_hf.py
@@ -1,0 +1,44 @@
+import torch
+import torch.nn.functional as F
+
+
+def apply_fsdp_moe_patch():
+
+    from transformers.models.qwen3_moe import modeling_qwen3_moe
+
+    def _forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        batch_size, sequence_length, hidden_dim = hidden_states.shape
+        hidden_states = hidden_states.view(-1, hidden_dim)
+        router_logits = self.gate(hidden_states)
+
+        routing_weights = F.softmax(router_logits, dim=1, dtype=torch.float)
+        routing_weights, selected_experts = torch.topk(routing_weights, self.top_k, dim=-1)
+        if self.norm_topk_prob:
+            routing_weights /= routing_weights.sum(dim=-1, keepdim=True)
+        routing_weights = routing_weights.to(hidden_states.dtype)
+
+        final_hidden_states = torch.zeros(
+            (batch_size * sequence_length, hidden_dim), dtype=hidden_states.dtype, device=hidden_states.device
+        )
+
+        expert_mask = torch.nn.functional.one_hot(selected_experts, num_classes=self.num_experts).permute(2, 1, 0)
+
+        # Loop over all experts
+        for expert_idx in range(self.num_experts):
+            expert_layer = self.experts[expert_idx]
+            idx, top_x = torch.where(expert_mask[expert_idx])
+
+            if top_x.numel() > 0:
+                current_state = hidden_states[None, top_x].reshape(-1, hidden_dim)
+                current_hidden_states = expert_layer(current_state) * routing_weights[top_x, idx, None]
+                final_hidden_states.index_add_(0, top_x, current_hidden_states.to(hidden_states.dtype))
+            else:
+                # force experts to participate in computation graph
+                dummy_output = expert_layer(hidden_states[:1]) * 0.0
+                final_hidden_states[:1] = final_hidden_states[:1] + dummy_output
+
+        final_hidden_states = final_hidden_states.reshape(batch_size, sequence_length, hidden_dim)
+        return final_hidden_states, router_logits
+
+    modeling_qwen3_moe.Qwen3MoeSparseMoeBlock.forward = _forward
+


### PR DESCRIPTION
Patch the huggingface model and hack the NCCL hanging issue for FSDP compatibility on MoE models with separate expert parameters (e.g. Qwen 30b a3b).

In the previous implementation, the training will hang at the reduced scatter in the backward of FSDP. The reason is that only partial experts are activated per rank, so only some of them can be involved in the computational graph, which makes the communication ranks not match in NCCL. So they may enter a deadlock.

Theoretically, FSDP does not allow partially activated parameters when `use_orig_params=False`... (`use_orig_params=True` will no longer flatter the tensors - which is intuitively slow. So doing this hack.)

> FSDP has some constraints when freezing parameters. For use_orig_params=False, each FSDP instance must manage parameters that are all frozen or all non-frozen. For use_orig_params=True, FSDP supports mixing frozen and non-frozen parameters, but it’s recommended to avoid doing so to prevent higher than expected gradient memory usage.

(Note: This bug does not apply to MoE models with a single, combined experts tensor - e.g. GPT-OSS)