### PR TITLE
refactor: expose compute_metrics_from_samples as public

### DIFF
--- a/slime/ray/rollout.py
+++ b/slime/ray/rollout.py
@@ -490,7 +490,7 @@ def _log_eval_rollout_data(rollout_id, args, data, extra_metrics: dict[str, Any]
         rewards = data[key]["rewards"]
         log_dict[f"eval/{key}"] = sum(rewards) / len(rewards)
         if (samples := data[key].get("samples")) is not None:
-            log_dict |= dict_add_prefix(_compute_metrics_from_samples(args, samples), f"eval/{key}/")
+            log_dict |= dict_add_prefix(compute_metrics_from_samples(args, samples), f"eval/{key}/")
         if "truncated" in data[key]:
             truncated = data[key]["truncated"]
             log_dict[f"eval/{key}-truncated_ratio"] = sum(truncated) / len(truncated)
@@ -522,14 +522,14 @@ def _log_rollout_data(rollout_id, args, samples, rollout_extra_metrics, rollout_
     if args.rollout_num_gpus:
         log_dict["perf/tokens_per_gpu_per_sec"] = sum(response_lengths) / rollout_time / args.rollout_num_gpus
     log_dict["perf/longest_sample_tokens_per_sec"] = max(response_lengths) / rollout_time
-    log_dict |= dict_add_prefix(_compute_metrics_from_samples(args, samples), "rollout/")
+    log_dict |= dict_add_prefix(compute_metrics_from_samples(args, samples), "rollout/")
     logger.info(f"perf {rollout_id}: {log_dict}")
     step = compute_rollout_step(args, rollout_id)
     log_dict["rollout/step"] = step
     tracking_utils.log(args, log_dict, step_key="rollout/step")
 
 
-def _compute_metrics_from_samples(args, samples):
+def compute_metrics_from_samples(args, samples):
     response_lengths = [sample.effective_response_length for sample in samples]
 
     log_dict = {}

--- a/slime/utils/debug_utils/display_debug_rollout_data.py
+++ b/slime/utils/debug_utils/display_debug_rollout_data.py
@@ -6,7 +6,7 @@ from typing import Annotated
 import torch
 import typer
 
-from slime.ray.rollout import _compute_metrics_from_samples
+from slime.ray.rollout import compute_metrics_from_samples
 from slime.utils.types import Sample
 
 _WHITELIST_KEYS = [
@@ -47,8 +47,7 @@ def main(
                 log_reward_category=None,
             )
             sample_objects = [Sample.from_dict(s) for s in sample_dicts]
-            # TODO make the function public
-            metrics = _compute_metrics_from_samples(args, sample_objects)
+            metrics = compute_metrics_from_samples(args, sample_objects)
             print("metrics", metrics)
 
         if show_samples:


### PR DESCRIPTION
### Summary
Renamed `_compute_metrics_from_samples` to `compute_metrics_from_samples` to make it a public API, addressing the TODO in `display_debug_rollout_data.py`.

### Changes
- **slime/ray/rollout.py**: Renamed method from `_compute_metrics_from_samples` to `compute_metrics_from_samples`
- **slime/utils/debug_utils/display_debug_rollout_data.py**: Updated import and usage, removed TODO comment



