### PR TITLE
[rollout] Truncate last token for rollout routing replay

### DIFF
--- a/slime/backends/megatron_utils/actor.py
+++ b/slime/backends/megatron_utils/actor.py
@@ -236,7 +236,7 @@ class MegatronTrainRayActor(TrainRayActor):
             tokens = batch["tokens"]
             assert len(rollout_routed_experts) == len(tokens)
             for a, b in zip(rollout_routed_experts, tokens, strict=False):
-                assert a.shape[0] == b.shape[0], f"{a.shape}, {b.shape}"
+                assert a.shape[0] == b.shape[0] - 1, f"{a.shape}, {b.shape}"
 
             # TODO: maybe extract a common process function for here and get_batch?
             rollout_routed_experts = [slice_with_cp(r, pad_func) for r in rollout_routed_experts]

--- a/slime/rollout/sglang_rollout.py
+++ b/slime/rollout/sglang_rollout.py
@@ -185,7 +185,7 @@ async def generate(args: Namespace, sample: Sample, sampling_params: dict[str, A
         sample.weight_versions.append(output["meta_info"]["weight_version"])
 
     if "routed_experts" in output["meta_info"]:
-        assert len(output["meta_info"]["routed_experts"]) == len(sample.tokens)
+        assert len(output["meta_info"]["routed_experts"]) == len(sample.tokens) - 1
         sample.rollout_routed_experts = np.array(output["meta_info"]["routed_experts"])
 
     match output["meta_info"]["finish_reason"]["type"]:


### PR DESCRIPTION
- Add a script
- Fix assertion to match SGLang return. The last toke is not used.