### PR TITLE
fix(examples): correct quotes and comment out ray cleanup commands in Qwen3-30B-A3B FP8 script

### DIFF
--- a/examples/low_precision/run-qwen3-30b-a3b-fp8-two-nodes.sh
+++ b/examples/low_precision/run-qwen3-30b-a3b-fp8-two-nodes.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
 
 # for rerun the task
-pkill -9 sglang
-sleep 3
-ray stop --force
-pkill -9 ray
-pkill -9 python
-sleep 3
-pkill -9 ray
-pkill -9 python
-pkill -9 redis
+# pkill -9 sglang
+# sleep 3
+# ray stop --force
+# pkill -9 ray
+# pkill -9 python
+# sleep 3
+# pkill -9 ray
+# pkill -9 python
+# pkill -9 redis
 
 set -ex
 
@@ -31,15 +31,15 @@ source "${SCRIPT_DIR}/../../scripts/models/qwen3-30B-A3B.sh"
 BASE_DIR="/root" 
 
 CKPT_ARGS=(
-   --hf-checkpoint “${BASE_DIR}/Qwen3-30B-A3B-FP8/”
-   --ref-load “${BASE_DIR}/Qwen3-30B-A3B_torch_dist/”
-   --load “${BASE_DIR}/Qwen3-30B-A3B_slime/”
-   --save “${BASE_DIR}/Qwen3-30B-A3B_slime/”
+   --hf-checkpoint "${BASE_DIR}/Qwen3-30B-A3B-FP8/"
+   --ref-load "${BASE_DIR}/Qwen3-30B-A3B_torch_dist/"
+   --load "${BASE_DIR}/Qwen3-30B-A3B_slime/"
+   --save "${BASE_DIR}/Qwen3-30B-A3B_slime/"
    --save-interval 20
 )
 
 ROLLOUT_ARGS=(
-   --prompt-data “${BASE_DIR}/dapo-math-17k.jsonl”
+   --prompt-data "${BASE_DIR}/dapo-math-17k.jsonl"
    --input-key prompt
    --label-key label
    --apply-chat-template
@@ -57,7 +57,7 @@ ROLLOUT_ARGS=(
 
 EVAL_ARGS=(
    --eval-interval 20
-   --eval-prompt-data aime “${BASE_DIR}/aime-2024.jsonl”
+   --eval-prompt-data aime "${BASE_DIR}/aime-2024.jsonl"
    --n-samples-per-eval-prompt 16
    --eval-max-response-len 16384
    --eval-top-p 0.7


### PR DESCRIPTION
This PR fixes syntax errors and logic issues in `examples/low_precision/run-qwen3-30b-a3b-fp8-two-nodes.sh`.

### Changes
- **Fix Syntax:** Replaced smart quotes (e.g., `“path”`) with standard ASCII double quotes (`"path"`) in `CKPT_ARGS`, `ROLLOUT_ARGS`, and `EVAL_ARGS`. This ensures arguments are parsed correctly by bash.
- **Preserve Cluster:** Commented out the aggressive cleanup commands (`pkill`, `ray stop`) at the start of the script. This allows the script to be used for submitting jobs to an existing Ray cluster without killing it first, which is better suited for the "two-nodes" configuration where a cluster is expected to be running.