### PR TITLE
feat: support Qwen3 Moe BackEnd Kernel

### DIFF
--- a/slime/backends/fsdp_utils/kernels/fused_experts.py
+++ b/slime/backends/fsdp_utils/kernels/fused_experts.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import torch
 import triton.language as tl
 from sglang.srt.layers.moe.fused_moe_triton.fused_moe import (
@@ -6,6 +8,8 @@ from sglang.srt.layers.moe.fused_moe_triton.fused_moe import (
     moe_sum_reduce,
     silu_and_mul,
 )
+
+from .fused_moe_triton_backward_kernels import invoke_fused_moe_backward_kernel
 
 
 class GateUpProjFunction(torch.autograd.Function):
@@ -81,14 +85,89 @@ class GateUpProjFunction(torch.autograd.Function):
                 filter_expert=True,
             )
 
-        ctx.save_for_backward(hidden_states, w1, topk_weights)
+        ctx.save_for_backward(hidden_states, w1, topk_weights, topk_ids)
+        ctx.config = config
+        ctx.num_tokens = num_tokens
+        ctx.topk = topk
 
         return intermediate_cache1
 
     @staticmethod
     def backward(ctx, grad_output):
-        hidden_states, w1, topk_weights = ctx.saved_tensors
-        return torch.zeros_like(hidden_states), torch.zeros_like(w1), torch.zeros_like(topk_weights), None
+        """
+        Backward pass for GateUpProjFunction using Triton kernels.
+
+        Args:
+            grad_output: shape (num_tokens * topk, N)
+
+        Returns:
+            (grad_hidden_states, grad_w1, grad_topk_weights, None)
+        """
+
+        hidden_states, w1, topk_weights, topk_ids = ctx.saved_tensors
+        config = ctx.config
+        num_tokens = ctx.num_tokens
+        topk = ctx.topk
+
+        E, N, D_in = w1.shape
+        CHUNK_SIZE = 64 * 1024
+
+        # Initialize gradient tensors
+        grad_hidden_states = torch.zeros_like(hidden_states)
+        grad_w1 = torch.zeros_like(w1)
+        # GateUpProj stage doesn't need topk_weights gradient
+        grad_topk_weights = torch.zeros_like(topk_weights)
+
+        # Process in chunks to match forward pass
+        for chunk in range((num_tokens // CHUNK_SIZE) + 1):
+            begin_chunk_idx, end_chunk_idx = (
+                chunk * CHUNK_SIZE,
+                min((chunk + 1) * CHUNK_SIZE, num_tokens),
+            )
+
+            curr_num_tokens = end_chunk_idx - begin_chunk_idx
+            if curr_num_tokens == 0:
+                continue
+
+            curr_hidden_states = hidden_states[begin_chunk_idx:end_chunk_idx]
+            curr_topk_ids = topk_ids[begin_chunk_idx:end_chunk_idx]
+            curr_topk_weights = topk_weights[begin_chunk_idx:end_chunk_idx]
+            curr_grad_output = grad_output[begin_chunk_idx * topk : end_chunk_idx * topk]
+
+            # Get aligned metadata
+            sorted_token_ids, expert_ids, num_tokens_post_padded = moe_align_block_size(
+                curr_topk_ids, config["BLOCK_SIZE_M"], E
+            )
+
+            # Prepare gradient buffer for this chunk
+            curr_grad_hidden_states = torch.zeros_like(curr_hidden_states)
+            curr_grad_w1 = torch.zeros_like(w1)
+
+            # Call Triton backward kernel with MUL_ROUTED_WEIGHT=False
+            # Use chunk of hidden_states to match sorted_token_ids indices
+            invoke_fused_moe_backward_kernel(
+                grad_output=curr_grad_output,
+                input=curr_hidden_states,  # Use chunk of hidden_states to match sorted_token_ids
+                weight=w1,
+                grad_input=curr_grad_hidden_states,
+                grad_weight=curr_grad_w1,
+                grad_topk_weights=None,  # Not needed for GateUpProj
+                topk_weights=curr_topk_weights,
+                topk_ids=curr_topk_ids,
+                sorted_token_ids=sorted_token_ids,
+                expert_ids=expert_ids,
+                num_tokens_post_padded=num_tokens_post_padded,
+                mul_routed_weight=False,
+                top_k=topk,
+                config=config,
+                compute_type=tl.bfloat16,
+            )
+
+            # Accumulate gradients
+            grad_hidden_states[begin_chunk_idx:end_chunk_idx] += curr_grad_hidden_states
+            grad_w1 += curr_grad_w1
+
+        return grad_hidden_states, grad_w1, grad_topk_weights, None
 
 
 class SiluAndMulFunction(torch.autograd.Function):
@@ -193,15 +272,89 @@ class DownProjFunction(torch.autograd.Function):
                 b_use_tma=False,
             )
 
-        ctx.save_for_backward(intermediate_cache2, w2, topk_weights)
+        ctx.save_for_backward(intermediate_cache2, w2, topk_weights, topk_ids)
+        ctx.config = config
+        ctx.num_tokens = num_tokens
+        ctx.topk = topk
 
         return intermediate_cache3
 
     @staticmethod
     def backward(ctx, grad_output):
-        intermediate_cache2, w2, topk_weights = ctx.saved_tensors
+        """
+        Backward pass for DownProjFunction using Triton kernels.
 
-        return torch.zeros_like(intermediate_cache2), torch.zeros_like(w2), torch.zeros_like(topk_weights), None
+        Args:
+            grad_output: shape (num_tokens, topk, hidden_size)
+
+        Returns:
+            (grad_intermediate_cache2, grad_w2, grad_topk_weights, None)
+        """
+        intermediate_cache2, w2, topk_weights, topk_ids = ctx.saved_tensors
+        config = ctx.config
+        num_tokens = ctx.num_tokens
+        topk = ctx.topk
+
+        E, hidden_size, intermediate_size = w2.shape
+        CHUNK_SIZE = 64 * 1024
+
+        # Initialize gradient tensors
+        grad_intermediate_cache2 = torch.zeros_like(intermediate_cache2)
+        grad_w2 = torch.zeros_like(w2)
+        grad_topk_weights = torch.zeros_like(topk_weights)
+
+        # Process in chunks to match forward pass
+        for chunk in range((num_tokens // CHUNK_SIZE) + 1):
+            begin_chunk_idx, end_chunk_idx = (
+                chunk * CHUNK_SIZE,
+                min((chunk + 1) * CHUNK_SIZE, num_tokens),
+            )
+
+            curr_num_tokens = end_chunk_idx - begin_chunk_idx
+            if curr_num_tokens == 0:
+                continue
+
+            curr_intermediate_cache2 = intermediate_cache2[begin_chunk_idx * topk : end_chunk_idx * topk]
+            curr_topk_ids = topk_ids[begin_chunk_idx:end_chunk_idx]
+            curr_topk_weights = topk_weights[begin_chunk_idx:end_chunk_idx]
+            curr_grad_output = grad_output[begin_chunk_idx:end_chunk_idx]
+
+            # Get aligned metadata
+            sorted_token_ids, expert_ids, num_tokens_post_padded = moe_align_block_size(
+                curr_topk_ids, config["BLOCK_SIZE_M"], E
+            )
+
+            # Prepare gradient buffers for this chunk
+            curr_grad_intermediate_cache2 = torch.zeros_like(curr_intermediate_cache2)
+            curr_grad_w2 = torch.zeros_like(w2)
+            curr_grad_topk_weights = torch.zeros_like(curr_topk_weights)
+
+            # Call Triton backward kernel with MUL_ROUTED_WEIGHT=True
+            # Note: Use top_k=1 to match forward pass indexing
+            invoke_fused_moe_backward_kernel(
+                grad_output=curr_grad_output,
+                input=curr_intermediate_cache2,
+                weight=w2,
+                grad_input=curr_grad_intermediate_cache2,
+                grad_weight=curr_grad_w2,
+                grad_topk_weights=curr_grad_topk_weights,
+                topk_weights=curr_topk_weights,
+                topk_ids=curr_topk_ids,
+                sorted_token_ids=sorted_token_ids,
+                expert_ids=expert_ids,
+                num_tokens_post_padded=num_tokens_post_padded,
+                mul_routed_weight=True,
+                top_k=1,
+                config=config,
+                compute_type=tl.bfloat16,
+            )
+
+            # Accumulate gradients
+            grad_intermediate_cache2[begin_chunk_idx * topk : end_chunk_idx * topk] = curr_grad_intermediate_cache2
+            grad_w2 += curr_grad_w2
+            grad_topk_weights[begin_chunk_idx:end_chunk_idx] = curr_grad_topk_weights
+
+        return grad_intermediate_cache2, grad_w2, grad_topk_weights, None
 
 
 class MoeSumReduceFunction(torch.autograd.Function):

--- a/slime/backends/fsdp_utils/kernels/fused_moe_triton_backward_kernels.py
+++ b/slime/backends/fsdp_utils/kernels/fused_moe_triton_backward_kernels.py
@@ -1,0 +1,540 @@
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def fused_moe_backward_input_kernel(
+    # Pointers to matrices
+    grad_output_ptr,
+    weight_ptr,
+    grad_input_ptr,
+    grad_topk_weights_ptr,
+    topk_weights_ptr,
+    sorted_token_ids_ptr,
+    expert_ids_ptr,
+    num_tokens_post_padded_ptr,
+    # Matrix dimensions
+    N,
+    K,
+    EM,
+    num_valid_tokens,
+    # Strides
+    stride_gom,
+    stride_gon,
+    stride_we,
+    stride_wn,
+    stride_wk,
+    stride_gim,
+    stride_gik,
+    # Meta-parameters
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    MUL_ROUTED_WEIGHT: tl.constexpr,
+    top_k: tl.constexpr,
+    compute_type: tl.constexpr,
+):
+    """
+    Backward kernel for computing grad_input.
+
+    Forward: output = input @ weight.T (optionally multiplied by topk_weights)
+    Backward: grad_input = grad_output @ weight (optionally multiplied by topk_weights)
+
+    This kernel computes: grad_input[token] = sum_over_N(grad_output[token, n] * weight[expert, n, :])
+    If MUL_ROUTED_WEIGHT: grad_input[token] *= topk_weights[token]
+
+    Parallelization: Similar to forward, parallel over M and N dimensions, loop over K.
+    """
+    # Map program ids to blocks (parallel over M and N, similar to forward)
+    pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(EM, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+    group_id = pid // num_pid_in_group
+    first_pid_m = group_id * GROUP_SIZE_M
+    group_size_m = min(num_pid_m - first_pid_m, GROUP_SIZE_M)
+    pid_m = first_pid_m + ((pid % num_pid_in_group) % group_size_m)
+    pid_n = (pid % num_pid_in_group) // group_size_m
+
+    # Check bounds
+    num_tokens_post_padded = tl.load(num_tokens_post_padded_ptr)
+
+    # Only process if this block is valid
+    if pid_m * BLOCK_SIZE_M < num_tokens_post_padded:
+        # Load token information
+        offs_token_id = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M).to(tl.int64)
+        offs_token = tl.load(sorted_token_ids_ptr + offs_token_id)
+        offs_token = offs_token.to(tl.int64)
+        token_mask = offs_token < num_valid_tokens
+
+        # Get expert ID for this block
+        off_experts = tl.load(expert_ids_ptr + pid_m).to(tl.int64)
+
+        # Only process if expert is valid
+        if off_experts != -1:
+            # Initialize offsets for N dimension (current block)
+            offs_n = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N).to(tl.int64)
+            offs_k = tl.arange(0, BLOCK_SIZE_K)
+
+            # Load grad_output block: shape (BLOCK_SIZE_M, BLOCK_SIZE_N)
+            grad_output_ptrs = grad_output_ptr + (offs_token[:, None] * stride_gom + offs_n[None, :] * stride_gon)
+            grad_out = tl.load(
+                grad_output_ptrs,
+                mask=token_mask[:, None] & (offs_n[None, :] < N),
+                other=0.0,
+            )
+
+            # Apply topk_weights to grad_output if needed
+            if MUL_ROUTED_WEIGHT:
+                moe_weight = tl.load(topk_weights_ptr + offs_token, mask=token_mask, other=0)
+                grad_out = grad_out * moe_weight[:, None]
+
+            # Iterate over K dimension
+            for k in range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+                # Current K offsets
+                curr_offs_k = k * BLOCK_SIZE_K + offs_k
+
+                # Load weight block: shape (BLOCK_SIZE_N, BLOCK_SIZE_K)
+                # weight: shape (E, N, K)
+                weight_ptrs = (
+                    weight_ptr
+                    + off_experts * stride_we
+                    + offs_n[:, None] * stride_wn
+                    + curr_offs_k[None, :] * stride_wk
+                )
+                w = tl.load(
+                    weight_ptrs,
+                    mask=(offs_n[:, None] < N) & (curr_offs_k[None, :] < K),
+                    other=0.0,
+                )
+
+                # Compute contribution: grad_out @ weight
+                # grad_out: (BLOCK_SIZE_M, BLOCK_SIZE_N)
+                # w: (BLOCK_SIZE_N, BLOCK_SIZE_K)
+                # result: (BLOCK_SIZE_M, BLOCK_SIZE_K)
+                contribution = tl.dot(grad_out, w)
+
+                # Atomic add to grad_input because different N blocks contribute to same K
+                grad_input_ptrs = grad_input_ptr + (
+                    (offs_token[:, None] // top_k) * stride_gim + curr_offs_k[None, :] * stride_gik
+                )
+                grad_input_mask = token_mask[:, None] & (curr_offs_k[None, :] < K)
+                tl.atomic_add(grad_input_ptrs, contribution.to(compute_type), mask=grad_input_mask)
+
+
+@triton.jit
+def fused_moe_backward_weight_kernel(
+    # Pointers to matrices
+    grad_output_ptr,
+    input_ptr,
+    grad_weight_ptr,
+    topk_weights_ptr,
+    sorted_token_ids_ptr,
+    expert_ids_ptr,
+    num_tokens_post_padded_ptr,
+    # Matrix dimensions
+    N,
+    K,
+    EM,
+    num_valid_tokens,
+    # Strides
+    stride_gom,
+    stride_gon,
+    stride_im,
+    stride_ik,
+    stride_gwe,
+    stride_gwn,
+    stride_gwk,
+    # Meta-parameters
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    MUL_ROUTED_WEIGHT: tl.constexpr,
+    top_k: tl.constexpr,
+    compute_type: tl.constexpr,
+):
+    """
+    Backward kernel for computing grad_weight.
+
+    Forward: output = input @ weight.T (optionally multiplied by topk_weights)
+    Backward: grad_weight = input.T @ grad_output (optionally multiplied by topk_weights)
+
+    This kernel computes: grad_weight[expert, n, k] = sum_over_tokens(input[token, k] * grad_output[token, n])
+    If MUL_ROUTED_WEIGHT: the accumulation is weighted by topk_weights[token]
+
+    Parallelization: Parallel over M and N dimensions with grouping, loop over K.
+    """
+    # Map program ids to blocks (parallel over M and N with grouping, similar to forward and backward_input)
+    pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(EM, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+    group_id = pid // num_pid_in_group
+    first_pid_m = group_id * GROUP_SIZE_M
+    group_size_m = min(num_pid_m - first_pid_m, GROUP_SIZE_M)
+    pid_m = first_pid_m + ((pid % num_pid_in_group) % group_size_m)
+    pid_n = (pid % num_pid_in_group) // group_size_m
+
+    # Check bounds
+    num_tokens_post_padded = tl.load(num_tokens_post_padded_ptr)
+
+    # Only process if this block is valid
+    if pid_m * BLOCK_SIZE_M >= num_tokens_post_padded:
+        return
+
+    # Get expert ID for this M block
+    expert_id = tl.load(expert_ids_ptr + pid_m).to(tl.int64)
+
+    # Only process if expert is valid
+    if expert_id == -1:
+        return
+
+    # Load token information for this M block
+    offs_m = tl.arange(0, BLOCK_SIZE_M)
+    offs_token_id = pid_m * BLOCK_SIZE_M + offs_m.to(tl.int64)
+    offs_token = tl.load(
+        sorted_token_ids_ptr + offs_token_id, mask=offs_token_id < num_tokens_post_padded, other=num_valid_tokens
+    )
+    offs_token = offs_token.to(tl.int64)
+    token_mask = (offs_token_id < num_tokens_post_padded) & (offs_token < num_valid_tokens)
+
+    # Clamp offs_token to valid range
+    offs_token_clamped = tl.where(token_mask, offs_token, 0)
+
+    # Determine input token indices based on MUL_ROUTED_WEIGHT
+    if MUL_ROUTED_WEIGHT:
+        input_token_idx = offs_token_clamped
+        input_mask = token_mask
+    else:
+        input_token_idx = offs_token_clamped // top_k
+        num_input_tokens = num_valid_tokens // top_k
+        input_mask = token_mask & (input_token_idx < num_input_tokens)
+
+    # Load topk_weights if needed
+    if MUL_ROUTED_WEIGHT:
+        moe_weight = tl.load(topk_weights_ptr + offs_token_clamped, mask=token_mask, other=0.0)
+
+    # Current N offset for this program
+    offs_n = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N).to(tl.int64)
+
+    # Load grad_output for this N block: shape (M, BLOCK_SIZE_N)
+    # grad_output is always indexed by sorted_token_ids (offs_token_clamped)
+    # because it has shape (num_tokens * topk, N)
+    grad_output_ptrs = grad_output_ptr + (offs_token_clamped[:, None] * stride_gom + offs_n[None, :] * stride_gon)
+    grad_out = tl.load(
+        grad_output_ptrs,
+        mask=token_mask[:, None] & (offs_n[None, :] < N),
+        other=0.0,
+    )
+
+    # Apply topk_weights if needed
+    if MUL_ROUTED_WEIGHT:
+        grad_out = grad_out * moe_weight[:, None]
+
+    # Zero out padding tokens
+    token_mask_col = token_mask[:, None]
+    grad_out = grad_out * token_mask_col
+
+    # Iterate over K blocks and accumulate
+    for k_block in range(tl.cdiv(K, BLOCK_SIZE_K)):
+        offs_k = k_block * BLOCK_SIZE_K + tl.arange(0, BLOCK_SIZE_K).to(tl.int64)
+
+        # Load input for this K block
+        input_ptrs = input_ptr + (input_token_idx[:, None] * stride_im + offs_k[None, :] * stride_ik)
+        inp = tl.load(
+            input_ptrs,
+            mask=input_mask[:, None] & (offs_k[None, :] < K),
+            other=0.0,
+        )
+
+        # Zero out padding tokens - use input_mask for input, token_mask for grad_output
+        input_mask_col = input_mask[:, None]
+        inp = inp * input_mask_col
+
+        # Compute grad_weight contribution: grad_out.T @ inp
+        grad_w_contribution = tl.dot(grad_out.T, inp)
+
+        # Write back using atomic add
+        grad_weight_ptrs = (
+            grad_weight_ptr + expert_id * stride_gwe + offs_n[:, None] * stride_gwn + offs_k[None, :] * stride_gwk
+        )
+        grad_weight_mask = (offs_n[:, None] < N) & (offs_k[None, :] < K)
+        tl.atomic_add(grad_weight_ptrs, grad_w_contribution.to(compute_type), mask=grad_weight_mask)
+
+
+@triton.jit
+def fused_moe_backward_topk_weights_kernel(
+    # Pointers to matrices
+    grad_output_ptr,
+    input_ptr,
+    weight_ptr,
+    grad_topk_weights_ptr,
+    sorted_token_ids_ptr,
+    expert_ids_ptr,
+    num_tokens_post_padded_ptr,
+    # Matrix dimensions
+    N,
+    K,
+    EM,
+    num_valid_tokens,
+    # Strides
+    stride_gom,
+    stride_gon,
+    stride_im,
+    stride_ik,
+    stride_we,
+    stride_wn,
+    stride_wk,
+    # Meta-parameters
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    top_k: tl.constexpr,
+    compute_type: tl.constexpr,
+):
+    """
+    Backward kernel for computing grad_topk_weights.
+
+    Forward: output = topk_weights * (input @ weight.T)
+    Backward: grad_topk_weights = sum(grad_output * (input @ weight.T))
+
+    This kernel computes the gradient of topk_weights by computing the dot product
+    of grad_output with the forward output before weight multiplication.
+    """
+    # Map program id to token block
+    pid = tl.program_id(axis=0)
+
+    # Check bounds
+    num_tokens_post_padded = tl.load(num_tokens_post_padded_ptr)
+
+    # Only process if this block is valid
+    if pid * BLOCK_SIZE_M < num_tokens_post_padded:
+        # Load token information
+        offs_token_id = pid * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M).to(tl.int64)
+        offs_token = tl.load(
+            sorted_token_ids_ptr + offs_token_id, mask=offs_token_id < num_tokens_post_padded, other=num_valid_tokens
+        )
+        offs_token = offs_token.to(tl.int64)
+        token_mask = (offs_token_id < num_tokens_post_padded) & (offs_token < num_valid_tokens)
+
+        # Clamp offs_token to valid range for safe pointer arithmetic
+        offs_token_clamped = tl.where(token_mask, offs_token, 0)
+
+        # Get expert ID for this block
+        off_experts = tl.load(expert_ids_ptr + pid).to(tl.int64)
+
+        # Only process if expert is valid
+        if off_experts != -1:
+            # Initialize offsets
+            offs_n = tl.arange(0, BLOCK_SIZE_N)
+            offs_k = tl.arange(0, BLOCK_SIZE_K)
+
+            # Accumulator for grad_topk_weights
+            accumulator = tl.zeros((BLOCK_SIZE_M,), dtype=tl.float32)
+
+            # Iterate over N and K dimensions to compute forward output and gradient
+            for n in range(0, tl.cdiv(N, BLOCK_SIZE_N)):
+                # Current N offset
+                curr_offs_n = n * BLOCK_SIZE_N + offs_n
+
+                # Load grad_output block: (M, N)
+                grad_output_ptrs = grad_output_ptr + (
+                    offs_token_clamped[:, None] * stride_gom + curr_offs_n[None, :] * stride_gon
+                )
+                grad_out = tl.load(
+                    grad_output_ptrs,
+                    mask=token_mask[:, None] & (curr_offs_n[None, :] < N),
+                    other=0.0,
+                )
+
+                # Compute forward output for this N block: input @ weight[:, n, :].T
+                forward_output_n = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+                for k in range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+                    # Current K offset
+                    curr_offs_k = k * BLOCK_SIZE_K + offs_k
+
+                    # Load input block: (M, K)
+                    input_ptrs = input_ptr + (
+                        (offs_token_clamped[:, None] // top_k) * stride_im + curr_offs_k[None, :] * stride_ik
+                    )
+                    inp = tl.load(
+                        input_ptrs,
+                        mask=token_mask[:, None] & (curr_offs_k[None, :] < K),
+                        other=0.0,
+                    )
+
+                    # Load weight block: (N, K)
+                    weight_ptrs = (
+                        weight_ptr
+                        + off_experts * stride_we
+                        + curr_offs_n[:, None] * stride_wn
+                        + curr_offs_k[None, :] * stride_wk
+                    )
+                    w = tl.load(
+                        weight_ptrs,
+                        mask=(curr_offs_n[:, None] < N) & (curr_offs_k[None, :] < K),
+                        other=0.0,
+                    )
+
+                    # Accumulate forward output: input @ weight.T
+                    # inp: (M, K), w.T: (K, N) -> (M, N)
+                    forward_output_n += tl.dot(inp, w.T)
+
+                # Compute contribution to grad_topk_weights: sum(grad_out * forward_output)
+                # Sum over N dimension
+                accumulator += tl.sum(grad_out * forward_output_n, axis=1)
+
+            # Write back grad_topk_weights using atomic add with clamped token indices
+            tl.atomic_add(grad_topk_weights_ptr + offs_token_clamped, accumulator.to(compute_type), mask=token_mask)
+
+
+def invoke_fused_moe_backward_kernel(
+    grad_output: torch.Tensor,
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    grad_input: torch.Tensor,
+    grad_weight: torch.Tensor,
+    grad_topk_weights: torch.Tensor | None,
+    topk_weights: torch.Tensor,
+    topk_ids: torch.Tensor,
+    sorted_token_ids: torch.Tensor,
+    expert_ids: torch.Tensor,
+    num_tokens_post_padded: torch.Tensor,
+    mul_routed_weight: bool,
+    top_k: int,
+    config: dict[str, Any],
+    compute_type: tl.dtype,
+) -> None:
+    """
+    Invoke the fused MOE backward kernels to compute gradients.
+
+    Args:
+        grad_output: Gradient of output, shape (num_tokens * topk, N) or (num_tokens, topk, N)
+        input: Input tensor, shape (num_tokens, K)
+        weight: Weight tensor, shape (E, N, K)
+        grad_input: Output gradient for input, shape (num_tokens, K)
+        grad_weight: Output gradient for weight, shape (E, N, K)
+        grad_topk_weights: Output gradient for topk_weights, shape (num_tokens, topk) or None
+        topk_weights: Top-K routing weights, shape (num_tokens, topk)
+        topk_ids: Top-K expert IDs, shape (num_tokens, topk)
+        sorted_token_ids: Sorted token IDs
+        expert_ids: Expert IDs for each block
+        num_tokens_post_padded: Number of tokens after padding
+        mul_routed_weight: Whether to multiply by routing weights
+        top_k: Number of experts per token
+        config: Kernel configuration
+        compute_type: Computation data type
+    """
+    assert topk_weights.stride(1) == 1
+    assert sorted_token_ids.stride(0) == 1
+
+    # Flatten grad_output if needed
+    # Before: (num_tokens, topk, hidden_size)
+    # After: (num_tokens * topk, hidden_size)
+    if grad_output.ndim == 3:
+        grad_output = grad_output.reshape(-1, grad_output.shape[-1])
+
+    E, N, K = weight.shape
+
+    # ===================== Compute grad_input =====================
+    def grid_input(META):
+        return (triton.cdiv(sorted_token_ids.shape[0], META["BLOCK_SIZE_M"]) * triton.cdiv(N, META["BLOCK_SIZE_N"]),)
+
+    fused_moe_backward_input_kernel[grid_input](
+        grad_output,
+        weight,
+        grad_input,
+        grad_topk_weights if grad_topk_weights is not None else grad_input,  # dummy pointer
+        topk_weights,
+        sorted_token_ids,
+        expert_ids,
+        num_tokens_post_padded,
+        N,
+        K,
+        sorted_token_ids.shape[0],
+        grad_output.shape[0],
+        grad_output.stride(0),
+        grad_output.stride(1),
+        weight.stride(0),
+        weight.stride(1),
+        weight.stride(2),
+        grad_input.stride(0),
+        grad_input.stride(1),
+        MUL_ROUTED_WEIGHT=mul_routed_weight,
+        top_k=top_k,
+        compute_type=compute_type,
+        **config,
+    )
+
+    # ===================== Compute grad_weight =====================
+    # Initialize grad_weight to zero
+    grad_weight.zero_()
+
+    # Use same grid configuration as forward kernel: encode both M and N dimensions
+    def grid_weight(META):
+        return (triton.cdiv(sorted_token_ids.shape[0], META["BLOCK_SIZE_M"]) * triton.cdiv(N, META["BLOCK_SIZE_N"]),)
+
+    fused_moe_backward_weight_kernel[grid_weight](
+        grad_output,
+        input,
+        grad_weight,
+        topk_weights,
+        sorted_token_ids,
+        expert_ids,
+        num_tokens_post_padded,
+        N,
+        K,
+        sorted_token_ids.shape[0],
+        grad_output.shape[0],
+        grad_output.stride(0),
+        grad_output.stride(1),
+        input.stride(0),
+        input.stride(1),
+        grad_weight.stride(0),
+        grad_weight.stride(1),
+        grad_weight.stride(2),
+        MUL_ROUTED_WEIGHT=mul_routed_weight,
+        top_k=top_k,
+        compute_type=compute_type,
+        **config,
+    )
+
+    # ===================== Compute grad_topk_weights (if needed) =====================
+    if mul_routed_weight and grad_topk_weights is not None:
+
+        def grid_topk(META):
+            return (triton.cdiv(sorted_token_ids.shape[0], META["BLOCK_SIZE_M"]),)
+
+        fused_moe_backward_topk_weights_kernel[grid_topk](
+            grad_output,
+            input,
+            weight,
+            grad_topk_weights.view(-1),
+            sorted_token_ids,
+            expert_ids,
+            num_tokens_post_padded,
+            N,
+            K,
+            sorted_token_ids.shape[0],
+            grad_output.shape[0],
+            grad_output.stride(0),
+            grad_output.stride(1),
+            input.stride(0),
+            input.stride(1),
+            weight.stride(0),
+            weight.stride(1),
+            weight.stride(2),
+            top_k=top_k,
+            compute_type=compute_type,
+            BLOCK_SIZE_M=config["BLOCK_SIZE_M"],
+            BLOCK_SIZE_N=config["BLOCK_SIZE_N"],
+            BLOCK_SIZE_K=config["BLOCK_SIZE_K"],
+        )

--- a/tests/test_fused_experts_backward.py
+++ b/tests/test_fused_experts_backward.py
@@ -1,0 +1,593 @@
+"""
+Test script to compare Triton backward implementation with Python backward implementation.
+
+This test compares:
+1. Triton implementation (from fused_experts.py) - uses invoke_fused_moe_backward_kernel
+2. Python reference implementation (defined in this file) - uses pure PyTorch operations
+"""
+
+import pytest
+import torch
+
+# ============================================================================
+# Python Reference Implementation (Pure PyTorch)
+# ============================================================================
+
+
+class GateUpProjFunctionPython(torch.autograd.Function):
+    @staticmethod
+    def forward(
+        ctx,
+        hidden_states: torch.Tensor,
+        w1: torch.Tensor,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+    ):
+        num_tokens, D_in = hidden_states.shape
+        E, N, K = w1.shape
+        assert D_in == K, f"hidden_states dim {D_in} != w1 dim {K}"
+
+        topk = topk_ids.shape[1]
+
+        # Output: (num_tokens * topk, N)
+        intermediate_cache1 = torch.empty(
+            (num_tokens * topk, N),
+            device=hidden_states.device,
+            dtype=hidden_states.dtype,
+        )
+
+        # Python implementation: iterate over tokens and their topk experts
+        # For each token t and expert k:
+        #   intermediate_cache1[t*topk + k] = hidden_states[t] @ w1[expert_id].T
+        for t in range(num_tokens):
+            for k in range(topk):
+                expert_id = topk_ids[t, k].item()
+                x_t = hidden_states[t]  # shape: (D_in,)
+                W1_e = w1[expert_id]  # shape: (N, K)
+                intermediate_cache1[t * topk + k] = x_t @ W1_e.T
+
+        ctx.save_for_backward(hidden_states, w1, topk_weights, topk_ids)
+        ctx.num_tokens = num_tokens
+        ctx.topk = topk
+
+        return intermediate_cache1
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        """
+        Backward pass for GateUpProjFunction - Pure Python implementation.
+
+        Forward: output = input @ w1 (without topk_weight multiplication)
+        Backward:
+            - grad_hidden_states = grad_output @ w1
+            - grad_w1 = grad_output.T @ input (note: transposed)
+            - grad_topk_weights = zeros (not needed in this stage)
+
+        Args:
+            grad_output: shape (num_tokens * topk, N)
+
+        Returns:
+            (grad_hidden_states, grad_w1, grad_topk_weights, None)
+        """
+        hidden_states, w1, topk_weights, topk_ids = ctx.saved_tensors
+        topk = ctx.topk
+
+        num_tokens, D_in = hidden_states.shape
+        E, N, _ = w1.shape
+        CHUNK_SIZE = 64 * 1024
+
+        # Initialize gradient tensors
+        grad_hidden_states = torch.zeros_like(hidden_states)
+        # Use float32 for grad_w1 accumulation to avoid bfloat16 precision loss
+        grad_w1 = torch.zeros(w1.shape, dtype=torch.float32, device=w1.device)
+        # GateUpProj stage doesn't compute topk_weights gradient
+        grad_topk_weights = torch.zeros_like(topk_weights)
+
+        # Process in chunks to match forward pass
+        for chunk in range((num_tokens // CHUNK_SIZE) + 1):
+            begin_chunk_idx, end_chunk_idx = (
+                chunk * CHUNK_SIZE,
+                min((chunk + 1) * CHUNK_SIZE, num_tokens),
+            )
+
+            curr_num_tokens = end_chunk_idx - begin_chunk_idx
+            if curr_num_tokens == 0:
+                continue
+
+            curr_hidden_states = hidden_states[begin_chunk_idx:end_chunk_idx]
+            curr_topk_ids = topk_ids[begin_chunk_idx:end_chunk_idx]
+            curr_grad_output = grad_output[begin_chunk_idx * topk : end_chunk_idx * topk]
+
+            # 1. Calculate grad_hidden_states: grad_output @ w1
+            # For each token t and expert k:
+            #   grad_hidden_states[t] += grad_output[t*topk+k] @ w1[expert_id]
+            for t in range(curr_num_tokens):
+                for k in range(topk):
+                    expert_id = curr_topk_ids[t, k].item()
+                    grad_y_tk = curr_grad_output[t * topk + k]  # shape: (N,)
+                    W1_e = w1[expert_id]  # shape: (N, D_in)
+                    # grad_x: (N,) @ (N, D_in) -> (D_in,)
+                    grad_hidden_states[begin_chunk_idx + t] += grad_y_tk @ W1_e
+
+            # 2. Calculate grad_w1: input.T @ grad_output
+            # For each token t and expert k:
+            #   grad_w1[expert_id] += input[t].T @ grad_output[t*topk+k]
+            # Which is: grad_w1[expert_id] += outer(grad_output[t*topk+k], input[t])
+            for t in range(curr_num_tokens):
+                for k in range(topk):
+                    expert_id = curr_topk_ids[t, k].item()
+                    x_t = curr_hidden_states[t]  # shape: (D_in,)
+                    grad_y_tk = curr_grad_output[t * topk + k]  # shape: (N,)
+                    # grad_W1: outer(grad_y_tk, x_t) -> (N, D_in)
+                    # Accumulate in float32
+                    grad_w1[expert_id] += torch.outer(grad_y_tk, x_t).to(torch.float32)
+
+        # Convert grad_w1 back to original dtype (bfloat16)
+        grad_w1 = grad_w1.to(hidden_states.dtype)
+
+        return grad_hidden_states, grad_w1, grad_topk_weights, None
+
+
+class DownProjFunctionPython(torch.autograd.Function):
+    @staticmethod
+    def forward(
+        ctx,
+        intermediate_cache2: torch.Tensor,
+        w2: torch.Tensor,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+    ):
+        total_tokens, intermediate_size = intermediate_cache2.shape
+        topk = topk_ids.shape[1]
+        num_tokens = total_tokens // topk
+        E, hidden_size, K = w2.shape
+        assert intermediate_size == K, f"intermediate_cache2 dim {intermediate_size} != w2 dim {K}"
+
+        # Output: (num_tokens, topk, hidden_size)
+        intermediate_cache3 = torch.empty(
+            (num_tokens, topk, hidden_size),
+            device=intermediate_cache2.device,
+            dtype=intermediate_cache2.dtype,
+        )
+
+        # Python implementation: iterate over tokens and their topk experts
+        # For each token t and expert k:
+        #   intermediate_cache3[t, k] = topk_weights[t, k] * (intermediate_cache2[t*topk+k] @ w2[expert_id].T)
+        for t in range(num_tokens):
+            for k in range(topk):
+                expert_id = topk_ids[t, k].item()
+                x_tk = intermediate_cache2[t * topk + k]  # shape: (intermediate_size,)
+                W2_e = w2[expert_id]  # shape: (hidden_size, intermediate_size)
+                weight_tk = topk_weights[t, k]  # scalar
+
+                intermediate_cache3[t, k] = weight_tk * (x_tk @ W2_e.T)
+
+        ctx.save_for_backward(intermediate_cache2, w2, topk_weights, topk_ids)
+        ctx.num_tokens = num_tokens
+        ctx.topk = topk
+
+        return intermediate_cache3
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        """
+        Backward pass for DownProjFunction - Pure Python implementation.
+
+        Forward: output = topk_weights * (input @ w2) (with topk_weight multiplication)
+        Backward:
+            - grad_intermediate_cache2 = topk_weights * (grad_output @ w2)
+            - grad_w2 = topk_weights * (grad_output.T @ intermediate_cache2)
+            - grad_topk_weights = dot(grad_output, forward_output_before_weighting)
+
+        Args:
+            grad_output: shape (num_tokens, topk, hidden_size)
+
+        Returns:
+            (grad_intermediate_cache2, grad_w2, grad_topk_weights, None)
+        """
+        intermediate_cache2, w2, topk_weights, topk_ids = ctx.saved_tensors
+        num_tokens = ctx.num_tokens
+        topk = ctx.topk
+
+        E, hidden_size, intermediate_size = w2.shape
+        CHUNK_SIZE = 64 * 1024
+
+        # Initialize gradient tensors
+        grad_intermediate_cache2 = torch.zeros_like(intermediate_cache2)
+        # Use float32 for grad_w2 accumulation to avoid bfloat16 precision loss
+        grad_w2 = torch.zeros(w2.shape, dtype=torch.float32, device=w2.device)
+        # Compute grad_topk_weights in DownProjFunction backward
+        grad_topk_weights = torch.zeros_like(topk_weights)
+
+        # Process in chunks to match forward pass
+        for chunk in range((num_tokens // CHUNK_SIZE) + 1):
+            begin_chunk_idx, end_chunk_idx = (
+                chunk * CHUNK_SIZE,
+                min((chunk + 1) * CHUNK_SIZE, num_tokens),
+            )
+
+            curr_num_tokens = end_chunk_idx - begin_chunk_idx
+            if curr_num_tokens == 0:
+                continue
+
+            curr_intermediate_cache2 = intermediate_cache2[begin_chunk_idx * topk : end_chunk_idx * topk]
+            curr_topk_ids = topk_ids[begin_chunk_idx:end_chunk_idx]
+            curr_grad_output = grad_output[begin_chunk_idx:end_chunk_idx]
+            curr_topk_weights = topk_weights[begin_chunk_idx:end_chunk_idx]
+
+            # 1. Calculate grad_intermediate_cache2: topk_weights * (grad_output @ w2)
+            for t in range(curr_num_tokens):
+                for k in range(topk):
+                    expert_id = curr_topk_ids[t, k].item()
+                    grad_y_tk = curr_grad_output[t, k]  # shape: (hidden_size,)
+                    W2_e = w2[expert_id]  # shape: (hidden_size, intermediate_size)
+                    weight_tk = curr_topk_weights[t, k]  # scalar
+
+                    grad_intermediate_cache2[(begin_chunk_idx + t) * topk + k] = weight_tk * (grad_y_tk @ W2_e)
+
+            # 2. Calculate grad_w2: topk_weights * (grad_output.T @ intermediate_cache2)
+            for t in range(curr_num_tokens):
+                for k in range(topk):
+                    expert_id = curr_topk_ids[t, k].item()
+                    grad_y_tk = curr_grad_output[t, k]  # shape: (hidden_size,)
+                    x_tk = curr_intermediate_cache2[t * topk + k]  # shape: (intermediate_size,)
+                    weight_tk = curr_topk_weights[t, k]  # scalar
+
+                    # Accumulate in float32
+                    grad_w2[expert_id] += (weight_tk * torch.outer(grad_y_tk, x_tk)).to(torch.float32)
+
+            # 3. Calculate grad_topk_weights: dot(grad_output, forward_output_before_weighting)
+            for t in range(curr_num_tokens):
+                for k in range(topk):
+                    expert_id = curr_topk_ids[t, k].item()
+                    grad_y_tk = curr_grad_output[t, k]  # shape: (hidden_size,)
+                    x_tk = curr_intermediate_cache2[t * topk + k]  # shape: (intermediate_size,)
+                    W2_e = w2[expert_id]  # shape: (hidden_size, intermediate_size)
+
+                    # Compute forward output before weighting
+                    forward_output_unweighted = x_tk @ W2_e.T  # shape: (hidden_size,)
+
+                    # grad_topk_weights: dot product
+                    grad_topk_weights[begin_chunk_idx + t, k] += torch.sum(grad_y_tk * forward_output_unweighted)
+
+        # Convert grad_w2 back to original dtype (bfloat16)
+        grad_w2 = grad_w2.to(intermediate_cache2.dtype)
+
+        return grad_intermediate_cache2, grad_w2, grad_topk_weights, None
+
+
+# ============================================================================
+# Import Triton Implementation
+# ============================================================================
+
+from slime.backends.fsdp_utils.kernels.fused_experts import DownProjFunction as DownProjFunctionTriton
+from slime.backends.fsdp_utils.kernels.fused_experts import GateUpProjFunction as GateUpProjFunctionTriton
+
+# ============================================================================
+# Test Fixtures and Utilities
+# ============================================================================
+
+
+@pytest.fixture
+def setup_moe_params():
+    """Setup MOE parameters for testing."""
+    torch.manual_seed(42)
+
+    # Small parameters for easier debugging
+    num_tokens = 64
+    hidden_size = 128
+    intermediate_size = 256
+    num_experts = 4
+    topk = 2
+
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    dtype = torch.bfloat16
+
+    # Create input tensors with random values for better testing
+    hidden_states = torch.randn(num_tokens, hidden_size, device=device, dtype=dtype)
+
+    # Create expert weights
+    w1 = torch.randn(num_experts, intermediate_size * 2, hidden_size, device=device, dtype=dtype)
+    w2 = torch.randn(num_experts, hidden_size, intermediate_size, device=device, dtype=dtype)
+
+    # Create router outputs
+    topk_weights = torch.rand(num_tokens, topk, device=device, dtype=dtype)
+    topk_weights = topk_weights / topk_weights.sum(dim=-1, keepdim=True)  # normalize
+
+    # Random expert selection
+    topk_ids = torch.stack([torch.randperm(num_experts, device=device)[:topk] for _ in range(num_tokens)], dim=0).to(
+        torch.int32
+    )
+
+    return {
+        "hidden_states": hidden_states,
+        "w1": w1,
+        "w2": w2,
+        "topk_weights": topk_weights,
+        "topk_ids": topk_ids,
+        "device": device,
+        "dtype": dtype,
+    }
+
+
+# ============================================================================
+# Test Cases
+# ============================================================================
+
+
+class TestGateUpProjBackward:
+    """Test GateUpProjFunction backward pass comparison."""
+
+    def test_forward_consistency(self, setup_moe_params):
+        """Test that Triton and Python implementations produce same forward output."""
+        params = setup_moe_params
+
+        # Python implementation
+        out_python = GateUpProjFunctionPython.apply(
+            params["hidden_states"].clone(),
+            params["w1"].clone(),
+            params["topk_weights"].clone(),
+            params["topk_ids"].clone(),
+        )
+
+        # Triton implementation
+        out_triton = GateUpProjFunctionTriton.apply(
+            params["hidden_states"].clone(),
+            params["w1"].clone(),
+            params["topk_weights"].clone(),
+            params["topk_ids"].clone(),
+        )
+
+        # Check outputs are close
+        torch.testing.assert_close(out_python, out_triton, rtol=1, atol=1)
+        print("✓ GateUpProjFunction forward test passed")
+
+    def test_backward_consistency(self, setup_moe_params):
+        """Test that Triton and Python implementations produce same gradients."""
+        params = setup_moe_params
+
+        # Prepare inputs with requires_grad
+        hidden_states_python = params["hidden_states"].clone().requires_grad_(True)
+        w1_python = params["w1"].clone().requires_grad_(True)
+        topk_weights_python = params["topk_weights"].clone().requires_grad_(True)
+        topk_ids_python = params["topk_ids"].clone()
+
+        hidden_states_triton = params["hidden_states"].clone().requires_grad_(True)
+        w1_triton = params["w1"].clone().requires_grad_(True)
+        topk_weights_triton = params["topk_weights"].clone().requires_grad_(True)
+        topk_ids_triton = params["topk_ids"].clone()
+
+        # Python implementation
+        out_python = GateUpProjFunctionPython.apply(
+            hidden_states_python,
+            w1_python,
+            topk_weights_python,
+            topk_ids_python,
+        )
+
+        # Triton implementation
+        out_triton = GateUpProjFunctionTriton.apply(
+            hidden_states_triton,
+            w1_triton,
+            topk_weights_triton,
+            topk_ids_triton,
+        )
+
+        # Create gradient for backward
+        grad_output = torch.randn_like(out_python)
+
+        # Backward pass
+        out_python.backward(grad_output.clone())
+        out_triton.backward(grad_output.clone())
+
+        # Check hidden_states gradients
+        print("\n" + "=" * 80)
+        print("GateUpProjFunction Backward - hidden_states gradients:")
+        print("=" * 80)
+        if hidden_states_python.grad is not None and hidden_states_triton.grad is not None:
+            diff = hidden_states_python.grad - hidden_states_triton.grad
+            max_diff = torch.max(torch.abs(diff))
+            print(f"Max absolute difference: {max_diff:.6f}")
+            torch.testing.assert_close(hidden_states_python.grad, hidden_states_triton.grad, rtol=1, atol=1)
+            print("✓ hidden_states gradient matches")
+        print("=" * 80 + "\n")
+
+        # Check w1 gradients
+        print("\n" + "=" * 80)
+        print("GateUpProjFunction Backward - w1 gradients:")
+        print("=" * 80)
+        if w1_python.grad is not None and w1_triton.grad is not None:
+            diff = w1_python.grad - w1_triton.grad
+            max_diff = torch.max(torch.abs(diff))
+            print(f"Max absolute difference: {max_diff:.6f}")
+            torch.testing.assert_close(w1_python.grad, w1_triton.grad, rtol=1, atol=1)
+            print("✓ w1 gradient matches")
+        print("=" * 80 + "\n")
+
+        print("✓ GateUpProjFunction backward test passed")
+
+
+class TestDownProjBackward:
+    """Test DownProjFunction backward pass comparison."""
+
+    def test_forward_consistency(self, setup_moe_params):
+        """Test that Triton and Python implementations produce same forward output."""
+        params = setup_moe_params
+
+        # Create intermediate input (after SiluAndMul)
+        num_tokens = params["hidden_states"].shape[0]
+        topk = params["topk_ids"].shape[1]
+        intermediate_size = params["w2"].shape[2]
+        intermediate_cache2 = torch.randn(
+            num_tokens * topk, intermediate_size, device=params["device"], dtype=params["dtype"]
+        )
+
+        # Python implementation
+        out_python = DownProjFunctionPython.apply(
+            intermediate_cache2.clone(),
+            params["w2"].clone(),
+            params["topk_weights"].clone(),
+            params["topk_ids"].clone(),
+        )
+
+        # Triton implementation
+        out_triton = DownProjFunctionTriton.apply(
+            intermediate_cache2.clone(),
+            params["w2"].clone(),
+            params["topk_weights"].clone(),
+            params["topk_ids"].clone(),
+        )
+
+        # Check outputs are close
+        torch.testing.assert_close(out_python, out_triton, rtol=1, atol=1)
+        print("✓ DownProjFunction forward test passed")
+
+    def test_backward_consistency(self, setup_moe_params):
+        """Test that Triton and Python implementations produce same gradients."""
+        params = setup_moe_params
+
+        # Create intermediate input
+        num_tokens = params["hidden_states"].shape[0]
+        topk = params["topk_ids"].shape[1]
+        intermediate_size = params["w2"].shape[2]
+
+        intermediate_cache2_base = torch.randn(
+            num_tokens * topk, intermediate_size, device=params["device"], dtype=params["dtype"]
+        )
+
+        intermediate_cache2_python = intermediate_cache2_base.clone().requires_grad_(True)
+        intermediate_cache2_triton = intermediate_cache2_base.clone().requires_grad_(True)
+
+        w2_python = params["w2"].clone().requires_grad_(True)
+        w2_triton = params["w2"].clone().requires_grad_(True)
+
+        topk_weights_python = params["topk_weights"].clone().requires_grad_(True)
+        topk_weights_triton = params["topk_weights"].clone().requires_grad_(True)
+
+        # Python implementation
+        out_python = DownProjFunctionPython.apply(
+            intermediate_cache2_python,
+            w2_python,
+            topk_weights_python,
+            params["topk_ids"],
+        )
+
+        # Triton implementation
+        out_triton = DownProjFunctionTriton.apply(
+            intermediate_cache2_triton,
+            w2_triton,
+            topk_weights_triton,
+            params["topk_ids"],
+        )
+
+        # Create gradient for backward
+        grad_output = torch.randn_like(out_python)
+
+        # Backward pass
+        out_python.backward(grad_output.clone())
+        out_triton.backward(grad_output.clone())
+
+        # Check intermediate_cache2 gradients
+        print("\n" + "=" * 80)
+        print("DownProjFunction Backward - intermediate_cache2 gradients:")
+        print("=" * 80)
+        if intermediate_cache2_python.grad is not None and intermediate_cache2_triton.grad is not None:
+            diff = intermediate_cache2_python.grad - intermediate_cache2_triton.grad
+            max_diff = torch.max(torch.abs(diff))
+            print(f"Max absolute difference: {max_diff:.6f}")
+            torch.testing.assert_close(
+                intermediate_cache2_python.grad, intermediate_cache2_triton.grad, rtol=1, atol=1
+            )
+            print("✓ intermediate_cache2 gradient matches")
+        print("=" * 80 + "\n")
+
+        # Check topk_weights gradients
+        print("\n" + "=" * 80)
+        print("DownProjFunction Backward - topk_weights gradients:")
+        print("=" * 80)
+        if topk_weights_python.grad is not None and topk_weights_triton.grad is not None:
+            diff = topk_weights_python.grad - topk_weights_triton.grad
+            max_diff = torch.max(torch.abs(diff))
+            print(f"Max absolute difference: {max_diff:.6f}")
+            torch.testing.assert_close(topk_weights_python.grad, topk_weights_triton.grad, rtol=1, atol=1)
+            print("✓ topk_weights gradient matches")
+        print("=" * 80 + "\n")
+
+        # Check w2 gradients
+        print("\n" + "=" * 80)
+        print("DownProjFunction Backward - w2 gradients:")
+        print("=" * 80)
+        if w2_python.grad is not None and w2_triton.grad is not None:
+            diff = w2_python.grad - w2_triton.grad
+            max_diff = torch.max(torch.abs(diff))
+            print(f"Max absolute difference: {max_diff:.6f}")
+            torch.testing.assert_close(w2_python.grad, w2_triton.grad, rtol=1, atol=1)
+            print("✓ w2 gradient matches")
+        print("=" * 80 + "\n")
+
+        print("✓ DownProjFunction backward test passed")
+
+
+# ============================================================================
+# Main Test Runner
+# ============================================================================
+
+
+def run_all_tests():
+    """Run all tests."""
+    print("=" * 80)
+    print("Running Fused Experts Backward Tests")
+    print("Testing: Triton Implementation vs Python Reference")
+    print("=" * 80)
+
+    if not torch.cuda.is_available():
+        print("WARNING: CUDA not available, skipping tests")
+        return
+
+    # Setup parameters
+    torch.manual_seed(42)
+    params_dict = {}
+
+    # Small parameters for testing
+    num_tokens = 64
+    hidden_size = 128
+    intermediate_size = 256
+    num_experts = 4
+    topk = 2
+
+    device = "cuda"
+    dtype = torch.bfloat16
+
+    # Create input tensors
+    params_dict["hidden_states"] = torch.randn(num_tokens, hidden_size, device=device, dtype=dtype)
+    params_dict["w1"] = torch.randn(num_experts, intermediate_size * 2, hidden_size, device=device, dtype=dtype)
+    params_dict["w2"] = torch.randn(num_experts, hidden_size, intermediate_size, device=device, dtype=dtype)
+    params_dict["topk_weights"] = torch.rand(num_tokens, topk, device=device, dtype=dtype)
+    params_dict["topk_weights"] = params_dict["topk_weights"] / params_dict["topk_weights"].sum(dim=-1, keepdim=True)
+    params_dict["topk_ids"] = torch.stack(
+        [torch.randperm(num_experts, device=device)[:topk] for _ in range(num_tokens)], dim=0
+    ).to(torch.int32)
+    params_dict["device"] = device
+    params_dict["dtype"] = dtype
+
+    print("\n" + "=" * 80)
+    print("Testing GateUpProjFunction Backward")
+    print("=" * 80)
+    test_gate_up = TestGateUpProjBackward()
+    test_gate_up.test_forward_consistency(params_dict)
+    test_gate_up.test_backward_consistency(params_dict)
+
+    print("\n" + "=" * 80)
+    print("Testing DownProjFunction Backward")
+    print("=" * 80)
+    test_down = TestDownProjBackward()
+    test_down.test_forward_consistency(params_dict)
+    test_down.test_backward_consistency(params_dict)
+
+    print("\n" + "=" * 80)
+    print("All Backward Tests Passed! ✓")
+    print("=" * 80)
+
+
+if __name__ == "__main__":
+    run_all_tests()


### PR DESCRIPTION
公式有一点问题，可以看原始markdown文件

[MoeKernel.md](https://github.com/user-attachments/files/24142104/MoeKernel.md)


# **测试结果**

## PerformanceTest
  
HuggingFace Native: 1.63s

Triton Backward Kernel: 0.5s

# **公式推导**
# GateUpProj

## forward

| 变量名 | 维度 | 含义                                                                          |
|--------|------|-----------------------------------------------------------------------------|
| `hidden_states` | `(num_tokens, D_in)` | 输入的隐藏状态，D_in 为输入维度                                                          |
| `w1` | `(E, N, D_in)` | Gate-Up 投影权重矩阵，E 为专家数量，N 为中间层维度. 一般来说N = intermedia_size * 2，因为融合了gate和up操作 |
| `topk_ids` | `(num_tokens, topk)` | Top-K 路由索引，每个 token 对应 topk 个专家的 ID                                         |

$$
intermediate\_cache1[t \times topk + k] = hidden\_states[t] \times W_1^{(expert\_id)}
$$

即 `(D_in,) @ (N, D_in).T = (N,)`

($W_1^{(expert\_id)}$ 的形状为 `(N, D_in)`)

输出结果`intermediate_cache1` 的形状为 `(num_tokens * topk, N)`


## backward

输入grad_output的维度为 $(num_token \times topk, N)$ 
 
- grad_hidden_states (∂L/∂x)

$$
\frac{\partial L}{\partial x[t]} = \sum_{k=0}^{topk-1} grad_y[t \cdot topk + k] \cdot W_1^{(expert\_id)}
$$

**维度：** `(N,) @ (N, D_in) = (D_in,)`

代码实现为

```python
for t in range(curr_num_tokens):
    for k in range(topk):
        expert_id = curr_topk_ids[t, k].item()
        grad_y_tk = curr_grad_output[t * topk + k]  # shape: (N,)
        W1_e = w1[expert_id]  # shape: (N, D_in)
        # grad_x: (N,) @ (N, D_in) -> (D_in,)
        grad_hidden_states[begin_chunk_idx + t] += grad_y_tk @ W1_e
```

---

- grad_w1 (∂L/∂W1)

$$
\frac{\partial L}{\partial W_1^{(e)}} = \sum_{(t,k): expert\_id[t,k]=e} grad_y[t \cdot topk + k] \otimes x[t]
$$

**维度：** `outer((N,), (D_in,)) = (N, D_in)`

代码实现为

```python
for t in range(curr_num_tokens):
    for k in range(topk):
        expert_id = curr_topk_ids[t, k].item()
        x_t = curr_hidden_states[t]  # shape: (D_in,)
        grad_y_tk = curr_grad_output[t * topk + k]  # shape: (N,)
        # grad_W1: outer(grad_y_tk, x_t) -> (N, D_in)
        # Convert to float32 for accumulation to avoid bfloat16 precision loss
        grad_w1[expert_id] = torch.outer(grad_y_tk, x_t).to(torch.float32)
```
---


# DownProjFunction

## forward

| 变量名 | 维度 | 含义                                               |
|--------|------|--------------------------------------------------|
| `intermediate_cache2` | `(num_tokens * topk, N//2)` | 经过 SiLU 激活和乘法后的中间结果，这里的N/2实际上就是immediate_size的大小 |
| `w2` | `(E, hidden_size, N//2)` | Down 投影权重矩阵，E 为专家数量                              |
| `topk_weights` | `(num_tokens, topk)` | Top-K 路由权重                                       |
| `topk_ids` | `(num_tokens, topk)` | Top-K 路由索引                                       |

- forward计算公式

$$
intermediate_cache3[t, k] = topk\_weights[t, k] \times (intermediate\_cache2[t \times topk + k] \times W_2^{(expert\_id)})
$$

`intermediate_cache3` 的形状为 `(num_tokens, topk, hidden_size)`

其中：
- $W_2^{(expert\_id)}$ 的形状为 `(hidden_size, N//2)`
- 矩阵乘法：`(N//2,) @ (hidden_size, N//2).T = (hidden_size,)`

**关键特性：**
- 该阶段 **会乘以** `topk_weights`
- 输出维度从 `(num_tokens * topk, N//2)` 重组为 `(num_tokens, topk, hidden_size)`，便于后续的聚合操作



## backward

- input: grad_output
- **维度**: `(num_tokens, topk, hidden_size)`
- **含义**: 损失函数对输出的梯度

#### 1 grad_intermediate_cache2 (∂L/∂x)
- **维度**: `(num_tokens * topk, intermediate_size)`
- **计算公式**:
$$
\frac{\partial L}{\partial x[t \cdot topk + k]} = w[t,k] \cdot \left(\frac{\partial L}{\partial y[t,k]} @ W_2^{(expert\_id)}\right)
$$

**维度分析**: 
- `grad_y[t,k]`: `(hidden_size,)`
- `W2[expert_id]`: `(hidden_size, intermediate_size)`
- `grad_y @ W2`: `(intermediate_size,)`
- 乘以标量 `topk_weight`：`(intermediate_size,)` 

- python实现

```python
for t in range(curr_num_tokens):
    for k in range(topk):
        expert_id = curr_topk_ids[t, k].item()
        grad_y_tk = curr_grad_output[t, k]  # shape: (hidden_size,)
        W2_e = w2[expert_id]  # shape: (hidden_size, intermediate_size)
        weight_tk = curr_topk_weights[t, k]  # scalar

        grad_intermediate_cache2[(begin_chunk_idx + t) * topk + k] = weight_tk * (grad_y_tk @ W2_e)

```

#### 2 grad_w2 (∂L/∂W2)
- **计算公式**:
$$
\frac{\partial L}{\partial W_2^{(e)}} = \sum_{t,k: expert\_id[t,k]=e} w[t,k] \cdot outer\left(\frac{\partial L}{\partial y[t,k]}, x[t \cdot topk + k]\right)
$$

**维度分析**: 
- `outer(grad_y, x)`: `outer((hidden_size,), (intermediate_size,)) = (hidden_size, intermediate_size)`
- 乘以标量 `topk_weight`: `(hidden_size, intermediate_size)` 
- 输出维度: `(E, hidden_size, intermediate_size)`


- python实现

```python
for t in range(curr_num_tokens):
    for k in range(topk):
        expert_id = curr_topk_ids[t, k].item()
        grad_y_tk = curr_grad_output[t, k]  # shape: (hidden_size,)
        x_tk = curr_intermediate_cache2[t * topk + k]  # shape: (intermediate_size,)
        weight_tk = curr_topk_weights[t, k]  # scalar

        grad_w2[expert_id] += (weight_tk * torch.outer(grad_y_tk, x_tk)).to(torch.float32)
```

#### 3 grad_topk_weights (∂L/∂w)

- **计算公式**:
$$
\frac{\partial L}{\partial w[t,k]} = \frac{\partial L}{\partial y[t,k]} \cdot (x[t \cdot topk + k] @ W_2^{(expert\_id)}{}^T)
$$

**解释**: 前向公式为 $y = w \cdot (x @ W^T)$，对 $w$ 求导得到 $\frac{\partial y}{\partial w} = x @ W^T$

**维度分析**:
- `x @ W2.T`: `(intermediate_size,) @ (intermediate_size, hidden_size) = (hidden_size,)`
- `dot(grad_y, forward_unweighted)`: `sum((hidden_size,) * (hidden_size,)) = scalar` 
- 输出维度：`(num_tokens, topk)`

- python实现

```python
for t in range(curr_num_tokens):
    for k in range(topk):
        expert_id = curr_topk_ids[t, k].item()
        grad_y_tk = curr_grad_output[t, k]  # shape: (hidden_size,)
        x_tk = curr_intermediate_cache2[t * topk + k]  # shape: (intermediate_size,)
        W2_e = w2[expert_id]  # shape: (hidden_size, intermediate_size)

        # Compute forward output before weighting: x @ w2.T
        forward_output_unweighted = x_tk @ W2_e.T  # shape: (hidden_size,)

        # grad_topk_weights: dot product
        grad_topk_weights[begin_chunk_idx + t, k] += grad_y_tk @ forward_output_unweighted
```


## Nsys Performance

由于Backward阶段需要atomic add，因此性能会有一定下降

- GetUpProj-Forward

<img width="788" height="934" alt="image" src="https://github.com/user-attachments/assets/80c3beee-9413-44fa-87c9-18a8c9d3a636" />

- DownProj-Forward

<img width="658" height="928" alt="image" src="https://github.com/user-attachments/assets/4210070f-98d7-49f1-bac7-cbabc072be62" />

- GateUpProj-Backward


<img width="616" height="1162" alt="image" src="https://github.com/user-attachments/assets/c1aa706c-591f-410c-8d4d-d6ef7389916e" />
