### PR TITLE
fix: resolve size mismatch error during training (fixes #1076)

### DIFF
--- a/slime/backends/megatron_utils/loss.py
+++ b/slime/backends/megatron_utils/loss.py
@@ -286,15 +286,15 @@ def compute_advantages_and_returns(args: Namespace, rollout_data: RolloutBatch) 
         student_log_probs = log_probs
         teacher_log_probs = rollout_data.get("teacher_log_probs")
         response_lengths = rollout_data.get("response_lengths")
+
         device = student_log_probs[0].device
-        teacher_log_probs = [t_log_prob.to(device=device) for t_log_prob in teacher_log_probs]
-        teacher_log_probs = [
-            t_log_prob[-response_length:]
-            for t_log_prob, response_length in zip(teacher_log_probs, response_lengths, strict=False)
-        ]
+        teacher_log_probs = [t.to(device=device) for t in teacher_log_probs]
+
         advantages = [
-            teacher_log_prob - student_log_prob
-            for teacher_log_prob, student_log_prob in zip(teacher_log_probs, student_log_probs, strict=False)
+            t_log_prob[-response_length:] - s_log_prob[-response_length:]
+            for t_log_prob, s_log_prob, response_length in zip(
+                teacher_log_probs, student_log_probs, response_lengths, strict=False
+            )
         ]
         returns = advantages
 


### PR DESCRIPTION
### Description
This PR fixes the `RuntimeError: size not match` (e.g., 6236 vs 8192) that occurs in `on_policy_distillation` when `use_rollout_logprobs=True`.

Resolves #1076

### Root Cause Analysis
When `use_rollout_logprobs=True` and `cp_size=1` (standard setup):
1. **Student Logprobs:** Derived directly from the rollout buffer without slicing. It retains the full buffer size (e.g., 8192) including Padding.
2. **Teacher Logprobs:** Might be sliced based on logic or tensor mismatch depending on the previous steps.
3. **The Mismatch:** Subtracting the student tensor (8192) from the teacher tensor (e.g., 6236) causes a RuntimeError.

The issue stems from the fact that `slice_log_prob_with_cp` in `rollout.py` returns the raw buffer (with padding) when `cp_size=1`, but the loss calculation expects pure response data.

### The Fix
Apply symmetric slicing `[-response_length:]` to both the student and teacher tensors in `loss.py`.

```python
# Before
advantages = [t - s for t, s in zip(teacher, student)] # student is 8192, teacher is 6236

# After
advantages = [
    t[-r_len:] - s[-r_len:] 
    for t, s, r_len in zip(teacher, student, response_lengths)
]


Verification
Left Padding: Slime uses decoder-only models which inherently use Left Padding for generation. The valid response is always at the end of the sequence. Using [-response_length:] correctly extracts the valid data.
Idempotency:
If the input is raw (8192), it slices it to valid length (6236).
If the input is already processed/sliced (e.g., when cp_size > 1), slicing the last N elements of an N-length tensor is a no-op (safe).
Consistency: This ensures that both student and teacher tensors are strictly aligned to the response_length before subtraction.