### PR TITLE
[FSDP][1/n] Support LoRA training for FSDP backend.

### DIFF
--- a/slime/backends/fsdp_utils/actor.py
+++ b/slime/backends/fsdp_utils/actor.py
@@ -141,10 +141,11 @@ class FSDPTrainRayActor(TrainRayActor):
         if with_ref:
             self.ref_model = self._create_ref_model(args.ref_load)
 
-        if self.args.colocate:
-            self.weight_updater = UpdateWeightFromTensor(self.args, self.model)
-        else:
-            self.weight_updater = UpdateWeightFromDistributed(self.args, self.model)
+        self.weight_updater = (
+            UpdateWeightFromTensor(self.args, self.model)
+            if self.args.colocate
+            else UpdateWeightFromDistributed(self.args, self.model)
+        )
 
         checkpoint.finalize_load(self, checkpoint_payload)
 

--- a/slime/backends/fsdp_utils/actor.py
+++ b/slime/backends/fsdp_utils/actor.py
@@ -29,6 +29,7 @@ from ...utils import tracking_utils
 from ...utils.profile_utils import TrainProfiler
 from . import checkpoint
 from .data_packing import pack_sequences, pad_packed_sequence_with_cp, unpack_sequences
+from .lora_utils import apply_lora_to_model, is_lora_model
 from .lr_scheduler import get_lr_scheduler
 from .update_weight_utils import UpdateWeightFromDistributed, UpdateWeightFromTensor
 
@@ -95,6 +96,9 @@ class FSDPTrainRayActor(TrainRayActor):
                 attn_implementation=self.args.attn_implementation,
             )
 
+        if self.args.lora_rank > 0 or self.args.lora_adapter_path:
+            model = apply_lora_to_model(model, self.args)
+
         model.train()
 
         full_state = model.state_dict()
@@ -108,11 +112,14 @@ class FSDPTrainRayActor(TrainRayActor):
         self.model = model
 
         if args.gradient_checkpointing:
-            self.model.gradient_checkpointing_enable()
+            # Avoid "does not require grad" error
+            gc_kwargs = {"use_reentrant": False} if is_lora_model(self.model) else {}
+            self.model.gradient_checkpointing_enable(gradient_checkpointing_kwargs=gc_kwargs)
 
         if args.optimizer == "adam":
+            trainable_params = [p for p in self.model.parameters() if p.requires_grad]
             self.optimizer = torch.optim.AdamW(
-                self.model.parameters(),
+                trainable_params,
                 lr=args.lr,
                 betas=(args.adam_beta1, args.adam_beta2),
                 eps=args.adam_eps,
@@ -134,11 +141,10 @@ class FSDPTrainRayActor(TrainRayActor):
         if with_ref:
             self.ref_model = self._create_ref_model(args.ref_load)
 
-        self.weight_updater = (
-            UpdateWeightFromTensor(self.args, self.model)
-            if self.args.colocate
-            else UpdateWeightFromDistributed(self.args, self.model)
-        )
+        if self.args.colocate:
+            self.weight_updater = UpdateWeightFromTensor(self.args, self.model)
+        else:
+            self.weight_updater = UpdateWeightFromDistributed(self.args, self.model)
 
         checkpoint.finalize_load(self, checkpoint_payload)
 

--- a/slime/backends/fsdp_utils/arguments.py
+++ b/slime/backends/fsdp_utils/arguments.py
@@ -60,6 +60,13 @@ class FSDPArgs:
     # YAML bookkeeping
     config: str | None = None
 
+    # LoRA configuration
+    lora_rank: int = 0
+    lora_alpha: int = 16
+    target_modules: str = "all-linear"
+    exclude_modules: str | None = None
+    lora_adapter_path: str | None = None
+
 
 def parse_fsdp_cli(extra_args_provider=None):
     parser = argparse.ArgumentParser("FSDP SFT Training (slime)")

--- a/slime/backends/fsdp_utils/checkpoint.py
+++ b/slime/backends/fsdp_utils/checkpoint.py
@@ -145,6 +145,8 @@ def load(actor: Any) -> dict[str, Any] | None:
     elif hasattr(actor, "lr_scheduler"):
         logger.info(f"[FSDP] LR scheduler checkpoint not found at {lr_scheduler_dir}, skipping LR scheduler load.")
 
+    # TODO: Load LoRA adapter (optional)
+
     rng_state = None
     rng_path = checkpoint_dir / "rng.pt"
     if rng_path.exists():
@@ -225,6 +227,8 @@ def save(actor: Any, iteration: int) -> None:
         lr_scheduler_state = LRSchedulerState(actor.lr_scheduler)
         lr_scheduler_state_dict = {"lr_scheduler_state": lr_scheduler_state}
         dcp.save(lr_scheduler_state_dict, checkpoint_id=str(lr_scheduler_dir))
+
+    # TODO: Save LoRA adapter
 
     if dist.get_rank() == 0:
         rng_state = {"torch": torch.get_rng_state()}

--- a/slime/backends/fsdp_utils/lora_utils.py
+++ b/slime/backends/fsdp_utils/lora_utils.py
@@ -54,13 +54,6 @@ def save_lora_to_disk(module: nn.Module, save_dir: str) -> str:
     full_state_dict = get_model_state_dict(module, options=options)
 
     state_dict = {name: param for name, param in full_state_dict.items() if "lora_" in name}
-    if dist.get_rank() == 0:
-        logger.info(f"Filtered {len(state_dict)} LoRA weight tensors from {len(full_state_dict)} total")
-
-    # TODO: check if this is needed
-    for name in list(state_dict.keys()):
-        key = name.replace(".default.weight", ".weight").replace("base_model.model.", "")
-        state_dict[key] = state_dict.pop(name)
 
     if dist.get_rank() == 0:
         save_path = Path(save_dir)
@@ -68,7 +61,6 @@ def save_lora_to_disk(module: nn.Module, save_dir: str) -> str:
 
         module.save_pretrained(str(save_path), state_dict=state_dict)
 
-        # Sync to ensure all adapter files are written to disk
         # TODO: check if file lock is needed or better way to do it
         os.sync()
 

--- a/slime/backends/fsdp_utils/lora_utils.py
+++ b/slime/backends/fsdp_utils/lora_utils.py
@@ -1,0 +1,84 @@
+import logging
+import os
+import shutil
+from pathlib import Path
+
+import torch.distributed as dist
+import torch.nn as nn
+from torch.distributed.checkpoint.state_dict import StateDictOptions, get_model_state_dict
+
+try:
+    from peft import LoraConfig, PeftModel, TaskType, get_peft_model
+except ImportError as err:
+    raise ImportError("peft library required for LoRA. Install with: pip install peft") from err
+
+logger = logging.getLogger(__name__)
+
+LORA_READY_MARKER = ".lora_ready"
+LORA_ADAPTER_NAME = "slime_lora"
+LORA_SUBDIR = "tmp_lora"
+
+
+def apply_lora_to_model(model: nn.Module, args) -> nn.Module:
+    if args.lora_adapter_path:
+        logger.info(f"Loading LoRA adapter from {args.lora_adapter_path}")
+        model = PeftModel.from_pretrained(model, args.lora_adapter_path, is_trainable=True)
+        peft_config = model.peft_config["default"]
+        if isinstance(peft_config.task_type, str):
+            peft_config.task_type = TaskType.CAUSAL_LM
+        model.print_trainable_parameters()
+        return model
+
+    lora_config = LoraConfig(
+        task_type=TaskType.CAUSAL_LM,
+        r=args.lora_rank,
+        lora_alpha=args.lora_alpha,
+        target_modules=args.target_modules,
+        bias="none",
+    )
+
+    model = get_peft_model(model, lora_config)  # autocast_adapter_dtype=False)
+    model.print_trainable_parameters()
+    logger.info(f"Applied LoRA: rank={args.lora_rank}, alpha={args.lora_alpha}")
+    return model
+
+
+def is_lora_model(module: nn.Module) -> bool:
+    unwrapped = getattr(module, "_fsdp_wrapped_module", module)
+    return hasattr(unwrapped, "peft_config")
+
+
+def save_lora_to_disk(module: nn.Module, save_dir: str) -> str:
+    """Save LoRA adapter to disk with file lock mechanism."""
+    options = StateDictOptions(full_state_dict=True, cpu_offload=True)
+    full_state_dict = get_model_state_dict(module, options=options)
+
+    state_dict = {name: param for name, param in full_state_dict.items() if "lora_" in name}
+    if dist.get_rank() == 0:
+        logger.info(f"Filtered {len(state_dict)} LoRA weight tensors from {len(full_state_dict)} total")
+
+    # TODO: check if this is needed
+    for name in list(state_dict.keys()):
+        key = name.replace(".default.weight", ".weight").replace("base_model.model.", "")
+        state_dict[key] = state_dict.pop(name)
+
+    if dist.get_rank() == 0:
+        save_path = Path(save_dir)
+        save_path.mkdir(parents=True, exist_ok=True)
+
+        module.save_pretrained(str(save_path), state_dict=state_dict)
+
+        # Sync to ensure all adapter files are written to disk
+        # TODO: check if file lock is needed or better way to do it
+        os.sync()
+
+        logger.info(f"Saved LoRA adapter to {save_path}")
+    return save_dir
+
+
+def delete_lora_from_disk(save_dir: str) -> None:
+    """Delete LoRA adapter files from disk."""
+    save_path = Path(save_dir)
+    if save_path.exists():
+        shutil.rmtree(save_path)
+        logger.info(f"Deleted LoRA adapter from {save_path}")

--- a/slime/backends/fsdp_utils/update_weight_utils.py
+++ b/slime/backends/fsdp_utils/update_weight_utils.py
@@ -1,5 +1,6 @@
 import abc
 import logging
+import os
 import socket
 from argparse import Namespace
 from collections.abc import Sequence
@@ -19,12 +20,12 @@ from sglang.srt.utils import MultiprocessingSerializer
 
 from slime.utils.distributed_utils import init_process_group
 
-
 try:
     from sglang.srt.weight_sync.tensor_bucket import FlattenedTensorBucket  # type: ignore[import]
 except ImportError:
     from sglang.srt.model_executor.model_runner import FlattenedTensorBucket  # type: ignore[import]
 
+from .lora_utils import LORA_ADAPTER_NAME, LORA_SUBDIR, delete_lora_from_disk, is_lora_model, save_lora_to_disk
 
 logger = logging.getLogger(__name__)
 
@@ -34,6 +35,8 @@ class UpdateWeight(abc.ABC):
         self.args = args
         self.model = model
         self.weight_version = 0
+        self._lora_loaded = False
+        self._base_sync_done = False
 
     @abc.abstractmethod
     def connect_rollout_engines(
@@ -45,31 +48,73 @@ class UpdateWeight(abc.ABC):
 
     def update_weights(self) -> None:
         self.weight_version += 1
-        bucket = []
-        bucket_size = 0
-        for name, param in self.model.state_dict().items():
-            param_size = param.numel() * param.element_size()
-            if bucket and bucket_size + param_size >= self.args.update_weight_buffer_size:
-                self.wait_and_update_bucket_weights(bucket)
-                del bucket
-                bucket = []
-                bucket_size = 0
 
-            param = param.cuda()
-            if isinstance(param, DTensor):
-                # async version of param.full_tensor
-                param = param.redistribute(
-                    placements=[Replicate()] * param.device_mesh.ndim,
-                    async_op=True,
-                ).to_local()
-            bucket.append((name, param))
-            bucket_size += param_size
-
-        if bucket:
-            self.wait_and_update_bucket_weights(bucket)
-            del bucket
+        # Update base model if needed
+        # Level 1: only sync base once for LoRA models, then just LoRA
+        # Level 2: always sync base + LoRA
+        if not (is_lora_model(self.model) and self._base_sync_done and self.args.offload_rollout_level == 1):
             bucket = []
             bucket_size = 0
+            for name, param in self.model.state_dict().items():
+                if any(x in name for x in ["_flat_param", "lora_"]):
+                    continue
+                name = name.replace("base_model.model.", "").replace(".base_layer", "")
+                param_size = param.numel() * param.element_size()
+                if bucket and bucket_size + param_size >= self.args.update_weight_buffer_size:
+                    self.wait_and_update_bucket_weights(bucket)
+                    del bucket
+                    bucket = []
+                    bucket_size = 0
+
+                param = param.cuda()
+                if isinstance(param, DTensor):
+                    # async version of param.full_tensor
+                    param = param.redistribute(
+                        placements=[Replicate()] * param.device_mesh.ndim,
+                        async_op=True,
+                    ).to_local()
+                bucket.append((name, param))
+                bucket_size += param_size
+
+            if bucket:
+                self.wait_and_update_bucket_weights(bucket)
+                del bucket
+
+            self._base_sync_done = True
+
+        # Update lora weights if needed
+        if is_lora_model(self.model):
+            self._update_lora_via_file()
+
+    def _update_lora_via_file(self) -> None:
+        """Push LoRA weights to rollout engines using disk files."""
+        self._lora_save_dir = os.path.join(self.args.save, LORA_SUBDIR)
+        if dist.get_rank() == 0:
+            if os.path.exists(self._lora_save_dir):
+                delete_lora_from_disk(self._lora_save_dir)
+
+        dist.barrier()
+
+        save_lora_to_disk(self.model, self._lora_save_dir)
+
+        dist.barrier()
+
+        if dist.get_rank() == 0:
+            if self._lora_loaded:
+                refs = [engine.unload_lora_adapter.remote(LORA_ADAPTER_NAME) for engine in self.rollout_engines]
+                ray.get(refs)
+
+            refs = [
+                engine.load_lora_adapter.remote(LORA_ADAPTER_NAME, self._lora_save_dir)
+                for engine in self.rollout_engines
+            ]
+            ray.get(refs)
+
+            refs = [engine.flush_cache.remote() for engine in self.rollout_engines]
+            ray.get(refs)
+
+            self._lora_loaded = True
+        dist.barrier()
 
     def wait_and_update_bucket_weights(self, bucket):
         bucket = [(name, param.wait()) if hasattr(param, "wait") else (name, param) for name, param in bucket]

--- a/slime/backends/fsdp_utils/update_weight_utils.py
+++ b/slime/backends/fsdp_utils/update_weight_utils.py
@@ -104,6 +104,9 @@ class UpdateWeight(abc.ABC):
                 refs = [engine.unload_lora_adapter.remote(LORA_ADAPTER_NAME) for engine in self.rollout_engines]
                 ray.get(refs)
 
+            refs = [engine.flush_cache.remote() for engine in self.rollout_engines]
+            ray.get(refs)
+
             refs = [
                 engine.load_lora_adapter.remote(LORA_ADAPTER_NAME, self._lora_save_dir)
                 for engine in self.rollout_engines
@@ -114,6 +117,7 @@ class UpdateWeight(abc.ABC):
             ray.get(refs)
 
             self._lora_loaded = True
+
         dist.barrier()
 
     def wait_and_update_bucket_weights(self, bucket):

--- a/slime/ray/rollout.py
+++ b/slime/ray/rollout.py
@@ -125,8 +125,8 @@ class RolloutManager:
     def load(self, rollout_id=None):
         self.data_source.load(rollout_id)
 
-    def offload(self):
-        return ray.get([engine.release_memory_occupation.remote() for engine in self.rollout_engines])
+    def offload(self, tags: list[str] = None):
+        return ray.get([engine.release_memory_occupation.remote(tags=tags) for engine in self.rollout_engines])
 
     def onload(self, tags: list[str] = None):
         return ray.get([engine.resume_memory_occupation.remote(tags=tags) for engine in self.rollout_engines])

--- a/slime/rollout/sglang_rollout.py
+++ b/slime/rollout/sglang_rollout.py
@@ -12,6 +12,7 @@ import sglang_router
 from packaging.version import parse
 from tqdm import tqdm
 
+from slime.backends.fsdp_utils.lora_utils import LORA_ADAPTER_NAME
 from slime.rollout.base_types import RolloutFnEvalOutput, RolloutFnTrainOutput
 from slime.rollout.filter_hub.base_types import DynamicFilterOutput
 from slime.utils.async_utils import run
@@ -125,6 +126,10 @@ async def generate(args: Namespace, sample: Sample, sampling_params: dict[str, A
         "sampling_params": sampling_params,
         "return_logprob": True,
     }
+
+    # Use LoRA adapter when LoRA is enabled
+    if args.lora_rank > 0 or args.lora_adapter_path is not None:
+        payload["lora_path"] = LORA_ADAPTER_NAME
 
     if args.use_rollout_routing_replay:
         payload["return_routed_experts"] = True

--- a/slime/utils/arguments.py
+++ b/slime/utils/arguments.py
@@ -104,6 +104,15 @@ def get_slime_extra_args_provider(add_custom_arguments=None):
                     "This will always be true when --colocate is set."
                 ),
             )
+            parser.add_argument(
+                "--offload-rollout-level",
+                type=int,
+                default=2,
+                help=(
+                    "The offload level for rollout when offload-rollout is set. "
+                    "1 means only offload kv cache, 2 means offload kv cache and weights."
+                ),
+            )
 
             reset_arg(parser, "--distributed-backend", type=str, default="nccl")
             reset_arg(parser, "--distributed-timeout-minutes", type=int, default=10)
@@ -1416,6 +1425,27 @@ def slime_validate_args(args):
 
     if args.save_interval is not None:
         assert args.save is not None, "'--save' is required when save_interval is set."
+
+    if args.lora_rank > 0:
+        # assert args.save is not None, "'--save' is required when LoRA is enabled."
+        assert args.target_modules is not None, "'--target-modules' is required when LoRA is enabled."
+
+        if args.target_modules == "all-linear":
+            modules = ["q_proj", "k_proj", "v_proj", "o_proj", "gate_proj", "up_proj", "down_proj"]
+        elif "," in args.target_modules:
+            modules = [m.strip() for m in args.target_modules.split(",")]
+        else:
+            modules = [args.target_modules]
+
+        if args.exclude_modules:
+            exclude_set = (
+                set(m.strip() for m in args.exclude_modules.split(","))
+                if "," in args.exclude_modules
+                else {args.exclude_modules}
+            )
+            modules = [m for m in modules if m not in exclude_set]
+
+        args.target_modules = modules
 
     assert not (args.kl_coef != 0 and args.kl_loss_coef != 0), "Only one of kl_coef and kl_loss_coef can be set"
 


### PR DESCRIPTION
Approaches Considered:

1. Merge/Unmerge: Merge LoRA to base -> send merged weights -> unmerge for training.
2. File-based (Current): Save adapter to disk -> rollout engine loads via load_lora_adapter (e.g., AReal).
3. Direct Tensor: Send tensors via memory (e.g., verl).

Current Implementation: Implemented Option 2 using UpdateWeightFromDisk.

Limitation: When rollout engine offloading is enabled, the base model should be re-transmitted in each update (though overhead is manageable).

Status:
✅ Train Qwen3-4B with LoRA on single A100 40G (Full param triggers OOM).
🚧 Reward curve pending.

TODO:
- [ ] Implement Options 1 & 3 for comparison.

## Update
> Current Status:
> 
> * Add '--offload-rollout-level' argument, level 1: offload kv cache/cuda graph only, level 2: offload weights + kv cache/cuda graph. When the rollout engine  does not release the base model weights, we only need to sync LoRA weights.
> * I modified `UpdateWeight` base class (this should be invasive) to support LoRA update alongside base model weight update.
> * Current LoRA weight update logic works for both colocated and disaggregated modes.
> * Fixed nits you mentioned before. But I can not remove _lora_loaded because unload_lora_adapter will throw error if LoRA is not loaded.
> 
> More TODOs: 
- [ ] Save/Load logic. 
- [ ] Efficient layer summon for LoRA weight update. 
- [ ] Option 3: Send LoRA tensors rather than files.

Discussion Feedback on the trade-offs of these approaches is welcome!