### PR TITLE
Fix optimizer schedule resume

### DIFF
--- a/slime/backends/megatron_utils/model.py
+++ b/slime/backends/megatron_utils/model.py
@@ -748,4 +748,6 @@ def initialize_model_and_optimizer(
     )
     clear_memory()
 
+    opt_param_scheduler.step(increment=iteration * args.global_batch_size)
+
     return model, optimizer, opt_param_scheduler, iteration


### PR DESCRIPTION
训练 SFT 的时候如果 --load 重启训练的话，lr 会重启到初始位置导致训练不连续，因此加了一个 opt_param_scheduler 的 .step() 功能（训 RL 如果 learning_rate 不变的话则没有影响）