### PR TITLE
Avoids repeated work.

### DIFF
--- a/slime/backends/megatron_utils/loss.py
+++ b/slime/backends/megatron_utils/loss.py
@@ -247,12 +247,12 @@ def compute_advantages_and_returns(args: Namespace, rollout_data: RolloutBatch) 
         advantages = [r for r in returns]
 
     elif args.advantage_estimator == "ppo":
-        # TODO: optimize this
         old_rewards = rewards
         rewards = []
+        kl_coef = -args.kl_coef
+        cp_rank = mpu.get_context_parallel_rank()
         for reward, k in zip(old_rewards, kl, strict=False):
-            k *= -args.kl_coef
-            cp_rank = mpu.get_context_parallel_rank()
+            k *= kl_coef
             if cp_rank == 0:
                 k[-1] += reward
             rewards.append(k)


### PR DESCRIPTION
Avoids repeated work: mpu.get_context_parallel_rank() and -args.kl_coef are computed once outside the loop.