### PR TITLE
Lazily import AutoBridge only in bridge mode

### DIFF
--- a/slime/backends/megatron_utils/actor.py
+++ b/slime/backends/megatron_utils/actor.py
@@ -8,7 +8,6 @@ from contextlib import nullcontext
 import ray
 import torch
 import torch.distributed as dist
-from megatron.bridge import AutoBridge
 from megatron.core import mpu
 from ray.actor import ActorHandle
 from torch_memory_saver import torch_memory_saver
@@ -68,6 +67,7 @@ class MegatronTrainRayActor(TrainRayActor):
                 self.hf_config = AutoConfig.from_pretrained(args.hf_checkpoint, trust_remote_code=True)
                 self.tokenizer = AutoTokenizer.from_pretrained(self.args.hf_checkpoint, trust_remote_code=True)
                 if args.megatron_to_hf_mode == "bridge":
+                    from megatron.bridge import AutoBridge
                     args.bridge = AutoBridge.from_hf_pretrained(args.hf_checkpoint, trust_remote_code=True)
 
             dist.barrier(group=get_gloo_group())


### PR DESCRIPTION
This PR moves the megatron.bridge.AutoBridge import out of the module top-level and into the megatron_to_hf_mode == "bridge" code path, so non-bridge runs don’t require the bridge dependency at import time.

- Avoid unnecessary dependency loading and potential import failures in non-bridge scenarios.

- Keep startup/import path lighter when bridge functionality isn’t used.