### PR TITLE
Fix prompt type bug in generate_with_search within examples/search-r1

### DIFF
--- a/examples/search-r1/generate_with_search.py
+++ b/examples/search-r1/generate_with_search.py
@@ -242,7 +242,7 @@ async def generate(args, sample: Sample, sampling_params) -> Sample:
     sample.response_length = len(response_token_ids)
     sample.response = response
     sample.loss_mask = loss_mask
-    sample.prompt=prompt_text
+    sample.prompt = prompt_text
 
     # Store log probs if enabled
     if SEARCH_R1_CONFIGS["return_logprob"]:


### PR DESCRIPTION
After pulling the latest slimerl/slime:latest image and installing the latest version of slime, I encountered the following error when running the search-r1 example:

<img width="1642" height="312" alt="2ea5f66884e17de1b1100f20392ab26b" src="https://github.com/user-attachments/assets/983054d6-f8f8-42f7-bfdb-76e850122ca6" />

<img width="1540" height="184" alt="9af8c63b4f298663b45accd51438b17a" src="https://github.com/user-attachments/assets/c8651d83-b872-4b4f-b882-e9cb35ae859f" />


When using apply_chat_template, as shown in my screenshot above, the prompt type should be a numpy.ndarray instead of a list.
After calling apply_chat_template, the resulting prompt_text must be reassigned to sample.prompt. Otherwise, sample.prompt remains an OpenAI-style dict, which leads to the error.

After applying the fix, I have run the process for 1,200 steps without encountering any errors. The performance successfully reproduces the results of search-r1, as shown in the screenshot below.

<img width="1872" height="726" alt="401ef1b067d58dd16e8c422996a4e85b" src="https://github.com/user-attachments/assets/5d87c6ae-8ca5-4133-8904-a19df501ef09" />

<img width="1898" height="1590" alt="b808788864f0ca05491b7262e95b77f2" src="https://github.com/user-attachments/assets/7d12daf9-b847-429f-9030-0230d53d3e5d" />

