### PR TITLE
fix: replace blocking sleep with async sleep and fix file handle leak

### DIFF
--- a/slime/ray/rollout.py
+++ b/slime/ray/rollout.py
@@ -137,7 +137,7 @@ class RolloutManager:
     def _get_rollout_data(self, rollout_id):
         if self.args.load_debug_rollout_data:
             data = torch.load(
-                open(self.args.load_debug_rollout_data.format(rollout_id=rollout_id), "rb"),
+                self.args.load_debug_rollout_data.format(rollout_id=rollout_id),
                 weights_only=False,
             )["samples"]
             data = [Sample.from_dict(sample) for sample in data]

--- a/slime/router/middleware_hub/radix_tree_middleware.py
+++ b/slime/router/middleware_hub/radix_tree_middleware.py
@@ -1,5 +1,5 @@
+import asyncio
 import json
-from time import sleep
 
 from fastapi.responses import JSONResponse
 from starlette.middleware.base import BaseHTTPMiddleware
@@ -108,7 +108,7 @@ class RadixTreeMiddleware(BaseHTTPMiddleware):
             ):
                 break
             # await 30 seconds for aborted responses
-            sleep(30)
+            await asyncio.sleep(30)
 
         if isinstance(response_data, dict) and "text" in response_data and "output_ids" in response_data:
             generated_text = response_data["text"]


### PR DESCRIPTION
## Summary
- Async sleep fix (radix_tree_middleware.py): Replaced blocking time.sleep(30) with await asyncio.sleep(30) in the async dispatch method to prevent blocking the event loop.
- File handle leak fix (ray/rollout.py): Removed unnecessary open() call and pass path directly to torch.load(), which handles file I/O internally.