### PR TITLE
tiny fix for sft script after tokenizer improvement

### DIFF
--- a/scripts/run-qwen3-235B-A22B-sft.sh
+++ b/scripts/run-qwen3-235B-A22B-sft.sh
@@ -49,6 +49,7 @@ SFT_ARGS=(
    --rollout-function-path slime.rollout.sft_rollout.generate_rollout
    --prompt-data ${BASE_FOLDER}/openhermes2_5.parquet
    --input-key messages
+   --apply-chat-template
    --rollout-shuffle
    --num-epoch 3
    --rollout-batch-size 128

--- a/scripts/run-qwen3-4B-base-sft.sh
+++ b/scripts/run-qwen3-4B-base-sft.sh
@@ -38,6 +38,7 @@ SFT_ARGS=(
    --rollout-function-path slime.rollout.sft_rollout.generate_rollout
    --prompt-data /root/openhermes2_5.parquet
    --input-key messages
+   --apply-chat-template
    --rollout-shuffle
    --num-epoch 3
    --rollout-batch-size 128


### PR DESCRIPTION
[tiny fix]

due to https://github.com/THUDM/slime/pull/1113, now if `prompt_text` is a list, we have to make `apply_chat_template` to be true. https://github.com/THUDM/slime/blob/main/docs/en/examples/qwen3-4b-base-openhermes.md make data processing to make prompts structured, thus we should update current SFT script to align with it.