### PR TITLE
Improve AMD tutorial with complete model/data setup workflow

### DIFF
--- a/docs/en/platform_support/amd_tutorial.md
+++ b/docs/en/platform_support/amd_tutorial.md
@@ -50,13 +50,27 @@ docker run --rm -it \
   /bin/bash
 ```
 
-Then, download and install slime.
+Then, download and install slime:
 ```bash
 git clone https://github.com/THUDM/slime.git
 cd slime
 pip install -e .
 ```
 
+Download the model and data:
+
+```bash
+# hf checkpoint
+hf download Qwen/Qwen3-4B --local-dir /root/Qwen3-4B
+
+# train data
+hf download --repo-type dataset zhuzilin/dapo-math-17k \
+  --local-dir /root/dapo-math-17k
+
+# eval data
+hf download --repo-type dataset zhuzilin/aime-2024 \
+  --local-dir /root/aime-2024
+```
 
 ### Checkpoint Format Conversion
 
@@ -73,8 +87,8 @@ MEGATRON_LM_PATH=$(pip list | grep megatron-core | awk '{print $NF}')
 PYTHONPATH=${MEGATRON_LM_PATH} python tools/convert_hf_to_torch_dist.py \
     ${MODEL_ARGS[@]} \
     --no-gradient-accumulation-fusion \
-    --hf-checkpoint model/Qwen3-4B \
-    --save model/Qwen3-4B_torch_dist
+    --hf-checkpoint /root/Qwen3-4B \
+    --save /root/Qwen3-4B_torch_dist
 ```
 
 Note: We implemented a dedicated AMD conversion script that forces a CPU-only conversion workflow using the Gloo backend to bypass hardware-specific issues. A GPU-based script for ROCm is currently in development.
@@ -85,7 +99,14 @@ Note: We implemented a dedicated AMD conversion script that forces a CPU-only co
 ### Example: Qwen3-4B
 
 We provide examples to use [Qwen3-4B](https://huggingface.co/Qwen/Qwen3-4B), please refer to:
-- [Example: Qwen3-4B Model](https://github.com/THUDM/slime/blob/main/scripts/run-qwen3-4B-amd.sh): Just run `scripts/run-qwen3-4B-amd.sh`
+- [Example: Qwen3-4B Model](https://github.com/THUDM/slime/blob/main/scripts/run-qwen3-4B-amd.sh): Just run
+
+```bash
+SLIME_DIR=/root \
+MODEL_DIR=/root \
+DATA_DIR=/root \
+bash scripts/run-qwen3-4B-amd.sh
+``` 
 
 ⚠️ TODO: ROCM seems to not support `apex` yet. Thus, we need to disable gradient accumulation fusionby adding the `--no-gradient-accumulation-fusion` flag in the training script currently. We will continue investigating how to enable this.
 


### PR DESCRIPTION
This PR updates the AMD tutorial (docs/en/platform_support/amd_tutorial.md) to fill in missing steps and improve usability.

Changes:

- Added Download Instructions: Included specific hf download commands for the Qwen3-4B model and required datasets (dapo-math-17k, aime-2024).

- Updated Paths: Corrected file paths in the checkpoint conversion section to match the download location (using absolute paths for clarity).

- Refined Run Command: Updated the usage example for run-qwen3-4B-amd.sh to explicitly set necessary environment variables (SLIME_DIR, MODEL_DIR, DATA_DIR), making it easier for users to run out-of-the-box.

cc: @zhuzilin 