### PR TITLE
Add Qwen3-Coder-30B-A3B-Instruct model script

### DIFF
--- a/scripts/models/qwen3-30B-A3B.sh
+++ b/scripts/models/qwen3-30B-A3B.sh
@@ -32,7 +32,7 @@ MODEL_ARGS=(
    --untie-embeddings-and-output-weights
    --vocab-size 151936
 
-   --rotary-base 1000000
+   --rotary-base "${MODEL_ARGS_ROTARY_BASE:-1000000}"
 
    # moe
    --moe-ffn-hidden-size 768

--- a/scripts/models/qwen3-coder-30B-A3B-Instruct.sh
+++ b/scripts/models/qwen3-coder-30B-A3B-Instruct.sh
@@ -1,0 +1,1 @@
+MODEL_ARGS_ROTARY_BASE=10000000 source "$(dirname -- "${BASH_SOURCE[0]}")/qwen3-30B-A3B.sh"


### PR DESCRIPTION

Added `scripts/models/qwen3-coder-30B-A3B-Instruct.sh` by extending `scripts/models/qwen3-30B-A3B.sh`
Updated rotary-base from 1,000,000 to 10,000,000 to match theQwen/Qwen3-Coder-30B-A3B-Instruct configuration.