### PR TITLE
add new status

### DIFF
--- a/slime/utils/types.py
+++ b/slime/utils/types.py
@@ -31,6 +31,9 @@ class Sample:
         COMPLETED = "completed"
         TRUNCATED = "truncated"
         ABORTED = "aborted"
+        # Indicates a recoverable or non-critical failure during generation (e.g., tool call failure,
+        # external API error, parsing error). Unlike ABORTED, FAILED samples may still contain partial
+        # valid output and can be retried or handled gracefully.
         FAILED = "failed"
 
     status: Status = Status.PENDING


### PR DESCRIPTION
add `FAILED` status to indicate any failure during rollout(e.g. tool execution error). log will be using this for better/detailed logging