### PR TITLE
fix: remove duplicate Megatron-LM installation in build_conda.sh

### DIFF
--- a/build_conda.sh
+++ b/build_conda.sh
@@ -46,10 +46,6 @@ NVCC_APPEND_FLAGS="--threads 4" \
   --no-build-isolation \
   --config-settings "--build-option=--cpp_ext --cuda_ext --parallel 8" git+https://github.com/NVIDIA/apex.git@10417aceddd7d5d05d7cbf7b0fc2daad1105f8b4
 
-git clone https://github.com/NVIDIA/Megatron-LM.git --recursive && \
-    cd Megatron-LM && git checkout ${MEGATRON_COMMIT} && \
-    pip install -e .
-
 pip install git+https://github.com/fzyzcjy/torch_memory_saver.git@dc6876905830430b5054325fa4211ff302169c6b --no-cache-dir --force-reinstall
 pip install git+https://github.com/fzyzcjy/Megatron-Bridge.git@dev_rl --no-build-isolation
 pip install nvidia-modelopt[torch]>=0.37.0 --no-build-isolation


### PR DESCRIPTION
## Summary

- Removes duplicate Megatron-LM clone operation from `build_conda.sh`
- Fixes undefined `${MEGATRON_COMMIT}` variable reference
- Eliminates redundant installation that was never used

## Problem

The script was cloning Megatron-LM twice:

1. **First clone (lines 49-51, now removed):** Inside the sglang directory with undefined `${MEGATRON_COMMIT}` variable
2. **Second clone (lines 58-61, kept):** At `$BASE_DIR` with explicit `core_v0.14.0` tag

Only the second clone at `$BASE_DIR/Megatron-LM` was actually used by the patch operation (line 83).

## Changes

Removed the redundant 4-line block that:
- Cloned into the wrong directory (`$BASE_DIR/sglang/Megatron-LM`)
- Used an undefined variable `${MEGATRON_COMMIT}`
- Was never referenced by subsequent commands

## Benefits

- Faster build times (avoids duplicate clone + install)
- Reduced disk space usage
- Cleaner, more maintainable script
- Consistent with the Dockerfile approach

## Test plan

- [ ] Verify build_conda.sh executes without errors
- [ ] Confirm Megatron-LM is installed at `$BASE_DIR/Megatron-LM`
- [ ] Verify patches apply correctly

Fixes #1236

🤖 Generated with [Claude Code](https://claude.com/claude-code)