### PR TITLE
feat: add --custom-model-provider-path argument

### DIFF
--- a/slime/backends/megatron_utils/model_provider.py
+++ b/slime/backends/megatron_utils/model_provider.py
@@ -2,7 +2,7 @@
 import argparse
 import inspect
 from contextlib import nullcontext
-from typing import Literal
+from typing import Literal, Optional
 
 import torch
 from megatron.core import tensor_parallel
@@ -15,6 +15,8 @@ from megatron.core.models.gpt.gpt_layer_specs import (
 from megatron.core.transformer.spec_utils import import_module
 from megatron.core.transformer.transformer_config import TransformerConfig
 from megatron.training.arguments import core_transformer_config_from_args
+
+from slime.utils.misc import load_function
 
 
 # Adapt from https://github.com/volcengine/verl/blob/c3b20575d2bc815fcccd84bddb4c0401fc4b632b/verl/models/llama/megatron/layers/parallel_linear.py#L82
@@ -53,6 +55,28 @@ def get_model_provider_func(
     args: argparse.Namespace,
     role: Literal["actor", "critic"] = "actor",
 ):
+    # Support custom model provider path (similar to --custom-rm-path for reward models)
+    if getattr(args, "custom_model_provider_path", None):
+
+        def wrapped_model_provider(
+            pre_process: bool = True, post_process: bool = True, vp_stage: Optional[int] = None
+        ) -> GPTModel:
+            custom_model_provider = load_function(args.custom_model_provider_path)
+            # Check if the custom provider supports vp_stage parameter
+            has_vp_stage = "vp_stage" in inspect.signature(custom_model_provider).parameters
+            if has_vp_stage:
+                model = custom_model_provider(pre_process=pre_process, post_process=post_process, vp_stage=vp_stage)
+            else:
+                model = custom_model_provider(pre_process=pre_process, post_process=post_process)
+            # Apply critic output layer if needed
+            if post_process and role == "critic":
+                model.output_layer = LinearForLastLayer(
+                    input_size=model.config.hidden_size, output_size=1, config=model.config
+                )
+            return model
+
+        return wrapped_model_provider
+
     if args.megatron_to_hf_mode == "bridge":
         from megatron.bridge import AutoBridge
 

--- a/slime/utils/arguments.py
+++ b/slime/utils/arguments.py
@@ -148,6 +148,18 @@ def get_slime_extra_args_provider(add_custom_arguments=None):
                 help="The method to convert megatron weights to hugging face weights for SGLang.",
             )
             parser.add_argument(
+                "--custom-model-provider-path",
+                type=str,
+                default=None,
+                help=(
+                    "Path to a custom model provider function. "
+                    "If set, we will use this function instead of the default model provider. "
+                    "The function should have the signature "
+                    "`def custom_model_provider(pre_process: bool, post_process: bool, vp_stage: int | None = None) -> GPTModel`. "
+                    "Example: 'my_module.my_model_provider'."
+                ),
+            )
+            parser.add_argument(
                 "--recompute-loss-function",
                 action="store_true",
                 help="Whether to disable recompute loss function to save memory during training.",


### PR DESCRIPTION
## Summary

- Adds `--custom-model-provider-path` CLI argument for loading custom model providers
- Follows the same pattern as existing `--custom-rm-path` for reward models
- Enables dynamic model architecture customization without modifying core code

## Motivation

As requested in #1009, users need to integrate custom model provider implementations from external paths without modifying the SLIME codebase. This is analogous to how `--custom-rm-path` allows custom reward model functions.

## Changes

### `slime/utils/arguments.py`
- Added `--custom-model-provider-path` argument with documentation

### `slime/backends/megatron_utils/model_provider.py`
- Added import for `load_function` utility
- Added `Optional` type import
- Modified `get_model_provider_func` to:
  - Check for custom model provider path before default behavior
  - Load custom provider function dynamically using `load_function`
  - Inspect function signature to handle optional `vp_stage` parameter
  - Apply `LinearForLastLayer` output layer for critic role when `post_process=True`

## Usage

```bash
# Use a custom model provider
python train.py --custom-model-provider-path my_module.my_custom_provider ...
```

The custom function should have the signature:
```python
def my_custom_provider(
    pre_process: bool = True, 
    post_process: bool = True, 
    vp_stage: int | None = None
) -> GPTModel:
    # Custom model construction logic
    return model
```