### PR TITLE
fix: add HF config validation to convert_hf_to_torch_dist.py

### DIFF
--- a/tools/convert_hf_to_torch_dist.py
+++ b/tools/convert_hf_to_torch_dist.py
@@ -8,12 +8,14 @@ from megatron.core.enums import ModelType
 from megatron.training.arguments import parse_args, validate_args
 from megatron.training.checkpointing import get_checkpoint_name, get_checkpoint_tracker_filename, save_checkpoint
 from megatron.training.training import get_model
+from transformers import AutoConfig
 
 import slime_plugins.mbridge  # noqa: F401
 from mbridge import AutoBridge
 from slime.backends.megatron_utils.arguments import set_default_megatron_args
 from slime.backends.megatron_utils.initialize import init
 from slime.backends.megatron_utils.model_provider import get_model_provider_func
+from slime.utils.arguments import hf_validate_args
 from slime.utils.logging_utils import configure_logger
 from slime.utils.memory_utils import print_memory
 
@@ -105,11 +107,19 @@ def main():
         device_id=torch.device(f"cuda:{local_rank}"),
     )
     args = get_args()
+
+    # Validate HF config matches script config to catch silent configuration errors
+    # See: https://github.com/THUDM/slime/issues/1059
+    hf_model_path = args.hf_checkpoint
+    hf_config = AutoConfig.from_pretrained(hf_model_path, trust_remote_code=True)
+    hf_validate_args(args, hf_config)
+    if dist.get_rank() == 0:
+        print(f"HF config validation passed for: {hf_model_path}")
+
     init(args)
     model = get_model(get_model_provider_func(args), ModelType.encoder_or_decoder, wrap_with_ddp=False)
 
     # Load model
-    hf_model_path = args.hf_checkpoint
     bridge = AutoBridge.from_pretrained(hf_model_path, trust_remote_code=True)
     bridge.load_weights(model, hf_model_path, memory_efficient=True)
     print(f"Model loaded: {hf_model_path}")


### PR DESCRIPTION
## Summary

- Adds HuggingFace config validation to `convert_hf_to_torch_dist.py`
- Uses existing `hf_validate_args` function from `slime/utils/arguments.py`
- Catches configuration mismatches early, before silent training failures occur

## Problem

As noted in #1059, the conversion tool doesn't validate whether the HuggingFace config matches the script configuration in `scripts/models`. This can lead to:
- Silent training errors with no error messages
- Difficult debugging when failures occur
- Wasted compute time on misconfigured runs

## Solution

Integrate the existing `hf_validate_args` validation function (already present in the codebase) into the conversion tool workflow.

## Changes

### `tools/convert_hf_to_torch_dist.py`
- Import `AutoConfig` from `transformers`
- Import `hf_validate_args` from `slime.utils.arguments`
- Add validation call after parsing args, before model initialization
- Print confirmation message on successful validation (rank 0 only)

## Validated Parameters

The `hf_validate_args` function checks these critical parameters:

| HF Config | Megatron Config |
|-----------|-----------------|
| `hidden_size` | `hidden_size` |
| `num_attention_heads` | `num_attention_heads` |
| `num_hidden_layers` | `num_layers` |
| `intermediate_size` | `ffn_hidden_size` |
| `tie_word_embeddings` | `untie_embeddings_and_output_weights` (inverted) |
| `rms_norm_eps` | `norm_epsilon` |
| `rope_theta` | `rotary_base` |

## Example Output

On mismatch:
```
AssertionError: hf_validate_args failed: hidden_size in hf config 4096 is not equal to hidden_size 2048, please check the config.
```

On success:
```
HF config validation passed for: /path/to/model
```

## Test plan

- [ ] Verify validation passes with correctly configured model
- [ ] Verify validation fails with mismatched configs
- [ ] Ensure error message is clear and actionable

Closes #1059

🤖 Generated with [Claude Code](https://claude.com/claude-code)