### PR TITLE
fix: use format_score parameter in compute_score_em

### DIFF
--- a/examples/search-r1/qa_em_format.py
+++ b/examples/search-r1/qa_em_format.py
@@ -157,10 +157,9 @@ def compute_score_em(
     solution_str,
     ground_truth,
     method="strict",
-    structure_format_score=0,
+    format_score=0,
     final_format_score=0,
     retrieval_score=0,
-    format_score=0,
     score=1.0,
 ):
     """The scoring function for exact match (EM).
@@ -169,7 +168,9 @@ def compute_score_em(
         solution_str: the solution text
         ground_truth: the ground truth
         method: the method to extract the solution, choices are 'strict' and 'flexible'
-        format_score: the score for the format
+        format_score: the score for valid structure format (e.g., properly balanced tags)
+        final_format_score: the score when format is invalid but some answer exists
+        retrieval_score: the bonus score for correct retrieval
         score: the score for the correct answer
     """
     is_valid_format, _ = is_valid_sequence(solution_str)
@@ -188,21 +189,21 @@ def compute_score_em(
     if answer is None:
         if is_valid_format:
             if retrieval_correct:
-                return structure_format_score + retrieval_score  # 0.3
+                return format_score + retrieval_score
             else:
-                return structure_format_score  # 0.2
+                return format_score
         else:
             return 0
     else:
         if em_check(answer, ground_truth["target"]):
             if is_valid_format:
-                return score  # 1
+                return score
             else:
-                return score - structure_format_score  # 0.8
+                return score - format_score
         elif is_valid_format:
             if retrieval_correct:
-                return structure_format_score + retrieval_score  # 0.3
+                return format_score + retrieval_score
             else:
-                return structure_format_score  # 0.2
+                return format_score
         else:
-            return final_format_score  # 0.1
+            return final_format_score


### PR DESCRIPTION
## Summary

- Fixes unused `format_score` parameter in `compute_score_em` function
- Removes redundant `structure_format_score` parameter that was never passed by callers
- Updates docstring to properly document all parameters

## Problem

As noted in #705, the `format_score` parameter in `compute_score_em` was defined but never used:

```python
# Before: format_score passed but ignored
def compute_score_em(
    ...
    structure_format_score=0,  # Used in function, but never passed by callers
    format_score=0,            # Passed by callers, but never used!
):
```

The caller in `generate_with_search.py` passes:
```python
score = compute_score_em(
    ...
    format_score=SEARCH_R1_CONFIGS["format_score"],  # 0.2, but ignored!
)
```

This meant the user's `format_score` configuration was silently ignored.

## Solution

- Remove `structure_format_score` (never passed by callers)
- Use `format_score` parameter where `structure_format_score` was used
- Now the caller's configuration is actually applied

## Changes

| Before | After |
|--------|-------|
| `structure_format_score=0` used | `format_score` used |
| `format_score` ignored | `format_score` applied |
| Hardcoded comments `# 0.2` | Removed (values configurable) |

## Scoring Logic (unchanged)

| Condition | Score |
|-----------|-------|
| Correct answer + valid format | `score` (1.0) |
| Correct answer + invalid format | `score - format_score` |
| Wrong answer + valid format + retrieval correct | `format_score + retrieval_score` |
| Wrong answer + valid format | `format_score` |
| No answer + valid format + retrieval correct | `format_score + retrieval_score` |
| No answer + valid format | `format_score` |
| Invalid format with some answer | `final_format_score` |
| Invalid format, no answer | 0 |

## Test plan

- [ ] Verify compute_score_em returns expected scores with format_score=0.2
- [ ] Verify generate_with_search.py still works correctly
- [ ] Check that SEARCH_R1_CONFIGS["format_score"] is now applied

Fixes #705

🤖 Generated with [Claude Code](https://claude.com/claude-code)