### PR TITLE
docs: add GPU configuration warning to Qwen3-4B guide

### DIFF
--- a/docs/en/examples/qwen3-4B.md
+++ b/docs/en/examples/qwen3-4B.md
@@ -1,5 +1,21 @@
 # Qwen3-4B with 8xH100
 
+> ⚠️ **Important: GPU Configuration**
+>
+> This guide assumes **8 GPUs**. If you have a different number of GPUs (e.g., 4xH100), you **must** modify the following parameters in `scripts/run-qwen3-4B.sh`:
+>
+> 1. `ray start --num-gpus 8` → change `8` to your GPU count
+> 2. `--actor-num-gpus-per-node 8` → change `8` to your GPU count
+>
+> **Example for 4 GPUs:**
+> ```bash
+> ray start --head --node-ip-address ${MASTER_ADDR} --num-gpus 4 ...
+> ...
+> --actor-num-gpus-per-node 4 \
+> ```
+>
+> Failing to update these values will cause cryptic errors (e.g., `ModuleNotFoundError: No module named 'vllm'`) that don't indicate the actual GPU mismatch problem.
+
 ## Environment Setup
 
 After pulling the `slimerl/slime:latest` image, initialize the image environment as follows:

--- a/docs/zh/examples/qwen3-4B.md
+++ b/docs/zh/examples/qwen3-4B.md
@@ -1,5 +1,21 @@
 # 8xH100 训练 Qwen3-4B
 
+> ⚠️ **重要：GPU 配置**
+>
+> 本指南假设使用 **8 个 GPU**。如果您的 GPU 数量不同（例如 4xH100），**必须**修改 `scripts/run-qwen3-4B.sh` 中的以下参数：
+>
+> 1. `ray start --num-gpus 8` → 将 `8` 改为您的 GPU 数量
+> 2. `--actor-num-gpus-per-node 8` → 将 `8` 改为您的 GPU 数量
+>
+> **4 GPU 示例：**
+> ```bash
+> ray start --head --node-ip-address ${MASTER_ADDR} --num-gpus 4 ...
+> ...
+> --actor-num-gpus-per-node 4 \
+> ```
+>
+> 如果未更新这些值，将导致难以理解的错误（例如 `ModuleNotFoundError: No module named 'vllm'`），这些错误不会指出实际的 GPU 配置不匹配问题。
+
 ## 环境准备
 
 拉取 `slimerl/slime:latest` 镜像后，用如下方式初始化镜像环境：


### PR DESCRIPTION
## Summary

- Adds a prominent warning about GPU configuration at the top of Qwen3-4B documentation
- Updates both English and Chinese versions

## Problem

As reported in #148, users following the Qwen3-4B quickstart on machines with fewer than 8 GPUs encounter cryptic errors like:

```
ModuleNotFoundError: No module named 'vllm'
```

This error doesn't indicate the actual problem - a GPU configuration mismatch. Users waste time debugging import errors instead of the real issue.

## Solution

Add a visible warning box at the top of the documentation that:

1. **Clearly states** the guide assumes 8 GPUs
2. **Lists exactly which parameters** need to be modified:
   - `ray start --num-gpus 8`
   - `--actor-num-gpus-per-node 8`
3. **Provides a concrete example** for 4 GPU setup
4. **Warns about the cryptic error** users will see if they misconfigure

## Changes

| File | Change |
|------|--------|
| `docs/en/examples/qwen3-4B.md` | Added GPU configuration warning (EN) |
| `docs/zh/examples/qwen3-4B.md` | Added GPU configuration warning (ZH) |

## Preview

The warning appears like this:

> ⚠️ **Important: GPU Configuration**
>
> This guide assumes **8 GPUs**. If you have a different number of GPUs (e.g., 4xH100), you **must** modify the following parameters...

Fixes #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)