### PR TITLE
fix: preserve original messages for SFT with tool-key

### DIFF
--- a/slime/rollout/sft_rollout.py
+++ b/slime/rollout/sft_rollout.py
@@ -43,7 +43,10 @@ def generate_rollout(args, rollout_id, data_buffer, evaluation=False):
 
     for i, sample in enumerate(samples):
         (sample,) = sample
-        messages = sample.prompt
+        # Use original messages from metadata if available (when apply_chat_template was used),
+        # otherwise fall back to sample.prompt which should be list[dict]
+        # See: https://github.com/THUDM/slime/issues/289
+        messages = sample.metadata.get("messages", sample.prompt)
         tools = sample.metadata.get("tools", None)
 
         token_ids, loss_mask = MASK_GENERATOR.get_loss_mask(messages, tools=tools)

--- a/slime/utils/data.py
+++ b/slime/utils/data.py
@@ -157,6 +157,9 @@ class Dataset:
                     add_generation_prompt=True,
                     **(apply_chat_template_kwargs or {}),
                 )
+                # Store original messages for SFT loss mask generation
+                # See: https://github.com/THUDM/slime/issues/289
+                metadata["messages"] = prompt
             else:
                 formatted_prompt = prompt
 


### PR DESCRIPTION
## Summary

- Fixes type mismatch when using SFT with `--tool-key` and `--apply-chat-template`
- Preserves original messages in metadata for loss mask generation

## Problem

As reported in #289, when using SFT training with tool-key:

1. Data loading with `apply_chat_template=True` converts messages from `list[dict]` → `string`
2. `sft_rollout.py` passes this string to `get_loss_mask()`
3. `get_loss_mask()` expects `list[dict]` and iterates over messages
4. **Result:** Type error crashes training

```python
# Expected by get_loss_mask()
messages: list[dict] = [{"role": "user", "content": "..."}, ...]

# Actual after apply_chat_template
messages: str = "<|im_start|>user\n..."  # Crash!
```

## Solution

Store the original messages before chat template conversion:

### `slime/utils/data.py`
```python
if apply_chat_template:
    formatted_prompt = tokenizer.apply_chat_template(...)
    metadata["messages"] = prompt  # Store original list[dict]
```

### `slime/rollout/sft_rollout.py`
```python
# Prefer stored messages, fall back to prompt for backward compatibility
messages = sample.metadata.get("messages", sample.prompt)
```

## Changes

| File | Change |
|------|--------|
| `slime/utils/data.py` | Store original messages in metadata |
| `slime/rollout/sft_rollout.py` | Use stored messages for loss mask |

## Test plan

- [ ] Verify SFT training works with `--tool-key` + `--apply-chat-template`
- [ ] Verify SFT training still works without `--apply-chat-template`
- [ ] Verify loss masks are computed correctly

Fixes #289

🤖 Generated with [Claude Code](https://claude.com/claude-code)