### PR TITLE
fix: prevent double extraction for boxed_math rm_type

### DIFF
--- a/slime/rollout/rm_hub/__init__.py
+++ b/slime/rollout/rm_hub/__init__.py
@@ -37,8 +37,11 @@ async def async_rm(args, sample: Sample, **kwargs):
     response = sample.response
     label = sample.label
     if rm_type.startswith("boxed_"):
-        response = extract_boxed_answer(response) or ""
-        rm_type = rm_type[len("boxed_") :]
+        underlying_rm_type = rm_type[len("boxed_") :]
+        # Don't pre-extract for "math" as grade_answer_verl handles extraction internally
+        if underlying_rm_type != "math":
+            response = extract_boxed_answer(response) or ""
+        rm_type = underlying_rm_type
 
     # This function is intended for remote or time-consuming reward model evaluation.
     # Implement the actual logic as needed.


### PR DESCRIPTION
## Summary
- Fix incorrect scoring when using `rm_type="boxed_math"`
- Correct answers were being scored as 0 due to double extraction of `\boxed{}` wrapper

## Problem
When `rm_type="boxed_math"`:
1. Line 40: `extract_boxed_answer(response)` strips `\boxed{5}` → `5`
2. Line 41: `rm_type` becomes `"math"`
3. Line 52: `grade_answer_verl(response, label)` is called
4. Inside `grade_answer_verl`, `extract_answer()` looks for `\boxed{}` but it's already stripped
5. Returns `None`, so score = 0 for correct answers

## Solution
Skip pre-extraction when the underlying rm_type is `"math"` since `grade_answer_verl` already handles extraction internally via `extract_answer()`.

## Test plan
- [ ] Test with `rm_type="boxed_math"` and response ending in `\boxed{5}` with label `5` - should score 1
- [ ] Test with `rm_type="boxed_deepscaler"` still works (pre-extraction still happens)

Fixes #543

🤖 Generated with [Claude Code](https://claude.com/claude-code)