### PR TITLE
fix: apply kl_coef to GRPO/GSPO returns

### DIFF
--- a/slime/backends/megatron_utils/loss.py
+++ b/slime/backends/megatron_utils/loss.py
@@ -246,7 +246,7 @@ def compute_advantages_and_returns(args: Namespace, rollout_data: RolloutBatch) 
 
     if args.advantage_estimator in ["grpo", "gspo"]:
         rewards = torch.tensor(rewards, dtype=torch.float32, device=kl[0].device)
-        returns = get_grpo_returns(rewards, kl)
+        returns = get_grpo_returns(rewards, kl, kl_coef=args.kl_coef)
         # TODO: is the copy necessary?
         advantages = [r for r in returns]
 

--- a/slime/utils/ppo_utils.py
+++ b/slime/utils/ppo_utils.py
@@ -200,10 +200,12 @@ def compute_entropy_from_logits(logits: torch.Tensor, process_group) -> torch.Te
 def get_grpo_returns(
     rewards: torch.Tensor,
     kl: list[torch.Tensor],
+    kl_coef: float = 0.0,
 ):
     returns = []
     for i in range(len(rewards)):
-        returns.append(torch.ones_like(kl[i]) * rewards[i])
+        # Apply KL penalty to returns: reward - kl_coef * kl
+        returns.append(torch.ones_like(kl[i]) * rewards[i] - kl_coef * kl[i])
     return returns
 
 


### PR DESCRIPTION
## Summary
- Fix KL coefficient (`kl_coef`) not being applied when using GRPO/GSPO advantage estimator
- Now GRPO/GSPO returns include KL penalty: `reward - kl_coef * kl`

## Problem
When using GRPO/GSPO with a non-zero `kl_coef`, the KL penalty was computed but never applied to the returns:

```python
# Before: KL divergence was computed but ignored
def get_grpo_returns(rewards, kl):
    returns = []
    for i in range(len(rewards)):
        returns.append(torch.ones_like(kl[i]) * rewards[i])  # kl not used!
    return returns
```

For comparison, PPO applies `kl_coef`:
```python
kl_coef = -args.kl_coef
for reward, k in zip(old_rewards, kl):
    k *= kl_coef  # KL penalty applied
```

And REINFORCE++ also applies it:
```python
token_level_rewards = -kl_coef * full_kl_response
```

## Solution
Add `kl_coef` parameter to `get_grpo_returns()` and apply the KL penalty:
```python
def get_grpo_returns(rewards, kl, kl_coef=0.0):
    returns = []
    for i in range(len(rewards)):
        returns.append(torch.ones_like(kl[i]) * rewards[i] - kl_coef * kl[i])
    return returns
```

## Test plan
- [ ] Run GRPO training with `kl_coef > 0` and verify KL penalty affects training
- [ ] Verify `kl_coef = 0` still works as before (no change in behavior)

Fixes #397

🤖 Generated with [Claude Code](https://claude.com/claude-code)