### PR TITLE
fix: align EAGLE speculative decoding config in MIMO script

### DIFF
--- a/scripts/run-mimo-7B-rl-eagle.sh
+++ b/scripts/run-mimo-7B-rl-eagle.sh
@@ -111,8 +111,8 @@ SGLANG_ARGS=(
    # for speculative decoding
    --sglang-speculative-algorithm EAGLE
    --sglang-speculative-num-steps 3
-   --sglang-speculative-eagle-topk 1
-   --sglang-speculative-num-draft-tokens 4
+   --sglang-speculative-eagle-topk 2
+   --sglang-speculative-num-draft-tokens 5
 
    # sometimes flashinfer has IMA bugs. Use fa3 as instead
    --sglang-attention-backend fa3


### PR DESCRIPTION
## Summary
- Fix misaligned EAGLE speculative decoding configuration in `run-mimo-7B-rl-eagle.sh`
- Update `topk` from 1 to 2 and `num-draft-tokens` from 4 to 5

## Problem
The previous configuration had a mismatch:
```bash
--sglang-speculative-num-steps 3
--sglang-speculative-eagle-topk 1      # generates 3×1=3 draft tokens
--sglang-speculative-num-draft-tokens 4  # but verifies 4 tokens
```

This creates confusion as the verification capacity (4) exceeds what's generated (3).

## Solution
Updated to a more useful and aligned configuration:
```bash
--sglang-speculative-num-steps 3
--sglang-speculative-eagle-topk 2      # generates more candidates per step
--sglang-speculative-num-draft-tokens 5  # aligned verification capacity
```

## Test plan
- [ ] Run MIMO-7B training with EAGLE speculative decoding
- [ ] Verify speculative decoding metrics are reported correctly

Fixes #1017

🤖 Generated with [Claude Code](https://claude.com/claude-code)