### PR TITLE
fix: add weights_only=False to torch.load() for PyTorch 2.6 compatibility

### DIFF
--- a/examples/formal_math/single_round/prepare_data.py
+++ b/examples/formal_math/single_round/prepare_data.py
@@ -113,7 +113,7 @@ class _SolvableByRolloutDumpFilter:
     def _compute_df_samples(paths: str):
         print(f"compute_df_samples {paths=}")
         paths = paths.split(",")
-        df_samples = pl.concat([pl.DataFrame(torch.load(p)["samples"]) for p in paths], how="diagonal_relaxed")
+        df_samples = pl.concat([pl.DataFrame(torch.load(p, weights_only=False)["samples"]) for p in paths], how="diagonal_relaxed")
         print(f"{df_samples=}")
         return df_samples
 

--- a/slime/backends/fsdp_utils/checkpoint.py
+++ b/slime/backends/fsdp_utils/checkpoint.py
@@ -148,7 +148,7 @@ def load(actor: Any) -> dict[str, Any] | None:
     rng_state = None
     rng_path = checkpoint_dir / "rng.pt"
     if rng_path.exists():
-        rng_state = torch.load(rng_path, map_location="cpu")
+        rng_state = torch.load(rng_path, map_location="cpu", weights_only=False)
 
     metadata = _read_checkpoint_metadata(checkpoint_dir / "meta.json")
 

--- a/slime/backends/megatron_utils/model.py
+++ b/slime/backends/megatron_utils/model.py
@@ -648,7 +648,7 @@ def train(
                     rollout_id=rollout_id,
                     step_id=step_id,
                 )
-                expected_grad_norm = torch.load(ci_load_grad_norm_path)
+                expected_grad_norm = torch.load(ci_load_grad_norm_path, weights_only=False)
                 assert math.isclose(
                     grad_norm,
                     expected_grad_norm,

--- a/slime/rollout/data_source.py
+++ b/slime/rollout/data_source.py
@@ -143,7 +143,7 @@ class RolloutDataSource(DataSource):
 
         logger.info(f"load metadata from {path}")
         logger.info(f"load metadata: {self.metadata}")
-        state_dict = torch.load(path)
+        state_dict = torch.load(path, weights_only=False)
         self.sample_offset = state_dict.get("sample_offset", 0)
         self.epoch_id = state_dict.get("epoch_id", 0)
         self.sample_group_index = state_dict.get("sample_group_index", 0)

--- a/slime/utils/debug_utils/display_debug_rollout_data.py
+++ b/slime/utils/debug_utils/display_debug_rollout_data.py
@@ -36,7 +36,7 @@ def main(
         print(f"{rollout_id=} {path=}")
         print("-" * 80)
 
-        pack = torch.load(path)
+        pack = torch.load(path, weights_only=False)
         sample_dicts = pack["samples"]
 
         if show_metrics:

--- a/slime/utils/debug_utils/replay_reward_fn.py
+++ b/slime/utils/debug_utils/replay_reward_fn.py
@@ -26,7 +26,7 @@ def main(
     if not ray.is_initialized():
         ray.init()
 
-    pack = torch.load(rollout_data_path)
+    pack = torch.load(rollout_data_path, weights_only=False)
     samples = [Sample.from_dict(s) for s in pack["samples"]]
     asyncio.run(_main_async(samples=samples, custom_rm_path=custom_rm_path))
 


### PR DESCRIPTION
## Summary

- Fixes checkpoint loading failures in PyTorch 2.6+ due to the new default `weights_only=True` behavior
- Adds `weights_only=False` to all `torch.load()` calls that load checkpoints or rollout data

## Problem

PyTorch 2.6 changed the default behavior of `torch.load()` to use `weights_only=True` for security. This prevents loading checkpoints containing custom classes like `EvalDatasetConfig` without explicit allowlisting, resulting in `_pickle.UnpicklingError`.

## Solution

Add `weights_only=False` to all `torch.load()` calls in the SLIME codebase that load checkpoints or saved data. This is the recommended approach suggested in the issue discussion.

## Files Modified

- `slime/rollout/data_source.py` - Data source checkpoint loading
- `slime/backends/fsdp_utils/checkpoint.py` - FSDP RNG state loading  
- `slime/backends/megatron_utils/model.py` - CI grad norm loading
- `slime/utils/debug_utils/display_debug_rollout_data.py` - Debug rollout display
- `slime/utils/debug_utils/replay_reward_fn.py` - Reward function replay
- `examples/formal_math/single_round/prepare_data.py` - Formal math data preparation

## Test plan

- [x] Verify all `torch.load()` calls in the codebase are covered
- [ ] Test checkpoint loading with PyTorch 2.6+

Fixes #686

🤖 Generated with [Claude Code](https://claude.com/claude-code)