### PR TITLE
docs: add FAQ entry for gradient accumulation configuration

### DIFF
--- a/docs/en/get_started/qa.md
+++ b/docs/en/get_started/qa.md
@@ -66,3 +66,24 @@
 13. **Gradient becomes NaN or Inf during training.**
 
     You can try setting the `--no-check-for-nan-in-loss-and-grad` flag to skip the corresponding training steps.
+
+14. **How do I use gradient accumulation in training scripts?**
+
+    In SLIME, gradient accumulation is controlled through the combination of `--num-steps-per-rollout` and `--global-batch-size`. The relationship is:
+
+    ```
+    rollout_batch_size × n_samples_per_prompt = global_batch_size × num_steps_per_rollout
+    ```
+
+    For example, if you have:
+    - `--rollout-batch-size 128`
+    - `--n-samples-per-prompt 4`
+    - `--global-batch-size 128`
+
+    Then `num_steps_per_rollout` will be automatically computed as `(128 × 4) / 128 = 4`, meaning 4 gradient accumulation steps per rollout.
+
+    To explicitly control gradient accumulation:
+    1. Set `--num-steps-per-rollout N` where N > 1 for multiple accumulation steps
+    2. The effective micro-batch size is `global_batch_size / (dp_size × num_steps_per_rollout)`
+
+    Note: SLIME defaults to `--num-steps-per-rollout 1` for on-policy training. Increasing this value enables gradient accumulation but makes training more off-policy.

--- a/docs/zh/get_started/qa.md
+++ b/docs/zh/get_started/qa.md
@@ -66,3 +66,24 @@
 1. **训练出现 grad NaN 或者 Inf 的情况**
 
    可以通过设置 `--no-check-for-nan-in-loss-and-grad` 来尝试跳过对应的训练步。
+
+1. **如何在训练脚本中使用梯度累积？**
+
+   在 SLIME 中，梯度累积通过 `--num-steps-per-rollout` 和 `--global-batch-size` 的组合来控制。它们的关系是：
+
+   ```
+   rollout_batch_size × n_samples_per_prompt = global_batch_size × num_steps_per_rollout
+   ```
+
+   例如，如果你设置了：
+   - `--rollout-batch-size 128`
+   - `--n-samples-per-prompt 4`
+   - `--global-batch-size 128`
+
+   那么 `num_steps_per_rollout` 将自动计算为 `(128 × 4) / 128 = 4`，即每个 rollout 进行 4 次梯度累积步骤。
+
+   要显式控制梯度累积：
+   1. 设置 `--num-steps-per-rollout N`，其中 N > 1 表示多次累积步骤
+   2. 有效的 micro-batch 大小为 `global_batch_size / (dp_size × num_steps_per_rollout)`
+
+   注意：SLIME 默认使用 `--num-steps-per-rollout 1` 进行 on-policy 训练。增加此值可以启用梯度累积，但会使训练更偏向 off-policy。


### PR DESCRIPTION
## Summary

- Adds a new FAQ entry explaining how to configure gradient accumulation in SLIME training scripts

## Problem

Users have asked about how to use gradient accumulation in training scripts (issue #1126). While the documentation mentions `--num-steps-per-rollout`, the relationship between this and gradient accumulation wasn't clearly explained.

## Solution

Add a FAQ entry that explains:
1. The relationship between `rollout_batch_size`, `n_samples_per_prompt`, `global_batch_size`, and `num_steps_per_rollout`
2. The formula: `rollout_batch_size × n_samples_per_prompt = global_batch_size × num_steps_per_rollout`
3. A practical example showing how gradient accumulation steps are computed
4. How to explicitly control gradient accumulation
5. The trade-off between gradient accumulation and on-policy training

## Files Modified

- `docs/en/get_started/qa.md` - English FAQ
- `docs/zh/get_started/qa.md` - Chinese FAQ

## Test plan

- [x] Verify documentation renders correctly
- [x] Ensure both English and Chinese versions are consistent

Addresses #1126

🤖 Generated with [Claude Code](https://claude.com/claude-code)