### PR TITLE
fix: set default reward of 0.0 for aborted samples

### DIFF
--- a/slime/rollout/sglang_rollout.py
+++ b/slime/rollout/sglang_rollout.py
@@ -221,6 +221,8 @@ async def generate_and_rm(
     async with state.semaphore:
         if state.aborted:
             sample.status = Sample.Status.ABORTED
+            if sample.reward is None:
+                sample.reward = 0.0
             return sample
 
         if args.custom_generate_function_path is not None:
@@ -237,6 +239,9 @@ async def generate_and_rm(
     if isinstance(sample, list):
         samples = sample
         if any([sample.status == Sample.Status.ABORTED for sample in samples]):
+            for s in samples:
+                if s.reward is None:
+                    s.reward = 0.0
             return samples
 
         # for multi agent system, the reward of some sample is calculated during generation.
@@ -247,6 +252,8 @@ async def generate_and_rm(
         return samples
     else:
         if sample.status == Sample.Status.ABORTED:
+            if sample.reward is None:
+                sample.reward = 0.0
             return sample
         # for multi-turn environment, a reward could be assigned to the agent.
         if sample.reward is None:
@@ -261,6 +268,9 @@ async def generate_and_rm_group(
     state = GenerateState(args)
 
     if state.aborted:
+        for sample in group:
+            if sample.reward is None:
+                sample.reward = 0.0
         return group
 
     tasks = []


### PR DESCRIPTION
## Summary
- Fixes tensor conversion errors when samples are aborted during rollout
- Aborted samples now have a default reward of 0.0 instead of None
- Applied fix in four locations in `sglang_rollout.py`

## Problem
When a sample generation is aborted (via `--custom-generate-function-path` or other mechanisms), the `sample.reward` field remains `None`. This causes errors when the GRPO training backend attempts to convert rewards to PyTorch tensors:

```python
rewards = torch.tensor(rewards, dtype=torch.float32, device=kl[0].device)
```

The tensor conversion cannot handle None values, causing training to crash.

## Solution
Set `sample.reward = 0.0` for aborted samples that have `None` rewards in the following locations:
1. When `state.aborted` is True in `generate_and_rm`
2. When any sample in a list is aborted in `generate_and_rm`
3. When a single sample has `ABORTED` status in `generate_and_rm`
4. When `state.aborted` is True in `generate_and_rm_group`

## Test plan
- [ ] Verify that training with `--custom-generate-function-path` that aborts samples no longer crashes
- [ ] Verify that aborted samples have reward value of 0.0
- [ ] Verify normal training flow is unaffected

Fixes #200

🤖 Generated with [Claude Code](https://claude.com/claude-code)