### PR TITLE
fix: add Megatron-LM to PYTHONPATH in Docker image bashrc

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -51,7 +51,8 @@ RUN NVCC_APPEND_FLAGS="--threads 4" \
 
 RUN git clone https://github.com/NVIDIA/Megatron-LM.git --recursive && \
     cd Megatron-LM && git checkout ${MEGATRON_COMMIT} && \
-    pip install -e .
+    pip install -e . && \
+    echo 'export PYTHONPATH="${PYTHONPATH}:/root/Megatron-LM"' >> /root/.bashrc
 
 RUN pip install git+https://github.com/fzyzcjy/torch_memory_saver.git@dc6876905830430b5054325fa4211ff302169c6b --no-cache-dir --force-reinstall
 RUN pip install git+https://github.com/fzyzcjy/Megatron-Bridge.git@dev_rl --no-build-isolation


### PR DESCRIPTION
## Summary
- Adds explicit PYTHONPATH configuration for Megatron-LM in Docker image bashrc
- Ensures Megatron-LM is properly accessible in interactive shells

## Problem
When using the Docker image, users may encounter `No module named 'megatron.training'` errors because the editable pip installation doesn't always persist correctly in interactive shells.

## Solution
Add the following line to `/root/.bashrc` during Docker build:
```bash
export PYTHONPATH="${PYTHONPATH}:/root/Megatron-LM"
```

This supplements the existing `pip install -e .` by providing a fallback path configuration that survives shell restarts and works reliably in development scenarios.

## Test plan
- [ ] Build Docker image with the updated Dockerfile
- [ ] Verify `import megatron.training` works in a new shell session
- [ ] Verify training scripts work correctly

Fixes #288

🤖 Generated with [Claude Code](https://claude.com/claude-code)