### PR TITLE
docs: add TensorBoard usage FAQ entry

### DIFF
--- a/docs/en/get_started/qa.md
+++ b/docs/en/get_started/qa.md
@@ -66,3 +66,15 @@
 13. **Gradient becomes NaN or Inf during training.**
 
     You can try setting the `--no-check-for-nan-in-loss-and-grad` flag to skip the corresponding training steps.
+
+14. **How do I use TensorBoard for logging?**
+
+    slime supports TensorBoard for experiment tracking. To enable TensorBoard logging, add the following arguments to your training script:
+
+    ```bash
+    --use-tensorboard \
+    --tb-project-name your_project_name \
+    --tb-experiment-name your_experiment_name
+    ```
+
+    Logs will be saved to `tensorboard_log/{tb_project_name}/{tb_experiment_name}` by default. Alternatively, you can set the `TENSORBOARD_DIR` environment variable to specify a custom log directory.

--- a/docs/zh/get_started/qa.md
+++ b/docs/zh/get_started/qa.md
@@ -66,3 +66,15 @@
 1. **训练出现 grad NaN 或者 Inf 的情况**
 
    可以通过设置 `--no-check-for-nan-in-loss-and-grad` 来尝试跳过对应的训练步。
+
+1. **如何使用 TensorBoard 进行日志记录？**
+
+   slime 支持使用 TensorBoard 进行实验跟踪。要启用 TensorBoard 日志记录，请在训练脚本中添加以下参数：
+
+   ```bash
+   --use-tensorboard \
+   --tb-project-name 你的项目名称 \
+   --tb-experiment-name 你的实验名称
+   ```
+
+   日志默认保存到 `tensorboard_log/{tb_project_name}/{tb_experiment_name}` 目录。或者，你可以设置 `TENSORBOARD_DIR` 环境变量来指定自定义的日志目录。


### PR DESCRIPTION
## Summary
- Add FAQ entry #14 explaining how to use TensorBoard for experiment tracking in slime
- Document the `--use-tensorboard`, `--tb-project-name`, and `--tb-experiment-name` arguments
- Document the `TENSORBOARD_DIR` environment variable option
- Added to both English and Chinese FAQ documents

## Test plan
- [x] Verify the documented arguments match the actual implementation in `slime/utils/arguments.py`
- [x] Verify TensorBoard implementation exists in `slime/utils/tensorboard_utils.py`

Addresses #281

🤖 Generated with [Claude Code](https://claude.com/claude-code)