### PR TITLE
fix: remove duplicate Megatron-LM clone in build_conda.sh

### DIFF
--- a/build_conda.sh
+++ b/build_conda.sh
@@ -46,10 +46,6 @@ NVCC_APPEND_FLAGS="--threads 4" \
   --no-build-isolation \
   --config-settings "--build-option=--cpp_ext --cuda_ext --parallel 8" git+https://github.com/NVIDIA/apex.git@10417aceddd7d5d05d7cbf7b0fc2daad1105f8b4
 
-git clone https://github.com/NVIDIA/Megatron-LM.git --recursive && \
-    cd Megatron-LM && git checkout ${MEGATRON_COMMIT} && \
-    pip install -e .
-
 pip install git+https://github.com/fzyzcjy/torch_memory_saver.git@dc6876905830430b5054325fa4211ff302169c6b --no-cache-dir --force-reinstall
 pip install git+https://github.com/fzyzcjy/Megatron-Bridge.git@dev_rl --no-build-isolation
 pip install nvidia-modelopt[torch]>=0.37.0 --no-build-isolation


### PR DESCRIPTION
## Summary
Fixes #1236

Removed the redundant Megatron-LM installation from `build_conda.sh`.

## Problem
The script had two Megatron-LM clones:
1. **Lines 49-51** (removed): Cloned inside `sglang/` directory, used undefined `${MEGATRON_COMMIT}` variable
2. **Lines 54-57** (kept): Cloned in `$BASE_DIR`, uses `core_v0.14.0` tag

The first clone was:
- In the wrong location (`$BASE_DIR/sglang/Megatron-LM` instead of `$BASE_DIR/Megatron-LM`)
- Using an undefined variable `${MEGATRON_COMMIT}`
- Never actually used since the patch at line 80 targets `$BASE_DIR/Megatron-LM`

## Solution
Removed the duplicate clone, keeping only the correct installation that the megatron.patch depends on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)