### PR TITLE
fix: correct typo 'convertion' to 'conversion'

### DIFF
--- a/docs/en/get_started/quick_start.md
+++ b/docs/en/get_started/quick_start.md
@@ -106,7 +106,7 @@ PYTHONPATH=/root/Megatron-LM python tools/convert_torch_dist_to_hf.py \
   --origin-hf-dir /root/GLM-Z1-9B-0414
 ```
 
-Note that as Megatron will do padding to embedding for better performance, it may happen that the converted embedding is not correct. In that case, please manually set `--vocab-size` during convertion.
+Note that as Megatron will do padding to embedding for better performance, it may happen that the converted embedding is not correct. In that case, please manually set `--vocab-size` during conversion.
 
 For FSDP checkpoints (without `common.pt`), use the dedicated conversion script. Point `--input-dir` to the checkpoint directory (e.g. `iter_xxx` or `iter_xxx/model`) and provide the original Hugging Face directory:
 

--- a/tools/convert_hf_to_torch_dist.py
+++ b/tools/convert_hf_to_torch_dist.py
@@ -18,7 +18,7 @@ from slime.utils.logging_utils import configure_logger
 from slime.utils.memory_utils import print_memory
 
 
-def add_convertion_args(parser):
+def add_conversion_args(parser):
     """Add conversion arguments to the parser"""
     parser.add_argument("--hf-checkpoint", type=str, required=True, help="HuggingFace model path")
     parser.add_argument(
@@ -35,7 +35,7 @@ def add_convertion_args(parser):
 
 
 def get_args():
-    args = parse_args(add_convertion_args)
+    args = parse_args(add_conversion_args)
     args = set_default_megatron_args(args)
 
     # set to pass megatron validate_args


### PR DESCRIPTION
## Summary
Fixed spelling typo "convertion" → "conversion" in two locations:

## Changes
1. **tools/convert_hf_to_torch_dist.py**
   - Renamed function `add_convertion_args` → `add_conversion_args`
   - Updated the function reference in `get_args()`

2. **docs/en/get_started/quick_start.md**
   - Fixed typo in documentation: "during convertion" → "during conversion"

🤖 Generated with [Claude Code](https://claude.com/claude-code)