### PR TITLE
docs: add GPU configuration note to Qwen3-4B examples

### DIFF
--- a/docs/en/examples/qwen3-4B.md
+++ b/docs/en/examples/qwen3-4B.md
@@ -1,5 +1,13 @@
 # Qwen3-4B with 8xH100
 
+> **Note on GPU Configuration**: This example assumes 8 GPUs. If you have a different number of GPUs (e.g., 4 GPUs), you must adjust the following parameters:
+> - `ray start --num-gpus <your_gpu_count>`
+> - `--actor-num-gpus-per-node <your_gpu_count>`
+>
+> For 4-GPU setups, you can use the pre-configured script `scripts/run-qwen3-4B_4xgpu.sh` instead.
+>
+> Mismatched GPU configurations will cause the Ray job to hang or produce confusing error messages.
+
 ## Environment Setup
 
 After pulling the `slimerl/slime:latest` image, initialize the image environment as follows:

--- a/docs/zh/examples/qwen3-4B.md
+++ b/docs/zh/examples/qwen3-4B.md
@@ -1,5 +1,13 @@
 # 8xH100 训练 Qwen3-4B
 
+> **GPU 配置说明**：本示例假设使用 8 块 GPU。如果您的 GPU 数量不同（例如 4 块 GPU），必须调整以下参数：
+> - `ray start --num-gpus <您的GPU数量>`
+> - `--actor-num-gpus-per-node <您的GPU数量>`
+>
+> 对于 4 GPU 配置，可以直接使用预配置的脚本 `scripts/run-qwen3-4B_4xgpu.sh`。
+>
+> GPU 配置不匹配会导致 Ray 任务挂起或产生令人困惑的错误信息。
+
 ## 环境准备
 
 拉取 `slimerl/slime:latest` 镜像后，用如下方式初始化镜像环境：


### PR DESCRIPTION
## Summary
Addresses #148

Added a prominent note at the top of the Qwen3-4B documentation warning users about GPU configuration requirements when their hardware differs from the default 8-GPU setup.

## Problem
Users with different GPU counts (e.g., 4 GPUs instead of 8) would run the example scripts without adjusting configuration, causing:
- Ray jobs to hang indefinitely
- Confusing/misleading error messages that don't indicate the root cause

## Solution
Added a callout box to both English and Chinese Qwen3-4B documentation that:
1. Clearly states the example assumes 8 GPUs
2. Lists the specific parameters that need adjustment (`ray start --num-gpus`, `--actor-num-gpus-per-node`)
3. Points users to the pre-configured 4-GPU script (`scripts/run-qwen3-4B_4xgpu.sh`)
4. Warns that mismatched configs cause confusing errors

## Files Changed
- `docs/en/examples/qwen3-4B.md`
- `docs/zh/examples/qwen3-4B.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)