### PR TITLE
fix: move shebang to first line in run-mimo-7B-rl-eagle.sh

### DIFF
--- a/scripts/run-mimo-7B-rl-eagle.sh
+++ b/scripts/run-mimo-7B-rl-eagle.sh
@@ -1,4 +1,3 @@
-
 #!/bin/bash
 
 # for rerun the task


### PR DESCRIPTION
## Summary
Fixed the shebang position in `scripts/run-mimo-7B-rl-eagle.sh`.

## Problem
The script had an empty line before the shebang (`#!/bin/bash`). The shebang must be on the very first line of a script for the operating system to recognize it as an executable script interpreter directive.

With the empty line, running the script directly (`./run-mimo-7B-rl-eagle.sh`) would fail to use bash as the interpreter.

## Fix
Removed the empty first line so the shebang is now correctly on line 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)