### PR TITLE
fix: typos in --rollout-max-context-len help text

### DIFF
--- a/slime/utils/arguments.py
+++ b/slime/utils/arguments.py
@@ -214,7 +214,7 @@ def get_slime_extra_args_provider(add_custom_arguments=None):
                 default=None,
                 help=(
                     "The maximum context size for the inference engine during rollout."
-                    "It should no exceed the `max_position_embeddinds` in Huggingface model's `config.json`"
+                    "It should not exceed the `max_position_embeddings` in Hugging Face model's `config.json`"
                 ),
             )
             parser.add_argument(


### PR DESCRIPTION
## Summary
Fixed multiple typos in `slime/utils/arguments.py` line 217:
- "should no exceed" → "should not exceed"
- "max_position_embeddinds" → "max_position_embeddings"
- "Huggingface" → "Hugging Face"

## Test plan
- [x] Verify the typos are fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)