### PR TITLE
fix: typos in async_init docstring

### DIFF
--- a/slime/ray/actor_group.py
+++ b/slime/ray/actor_group.py
@@ -107,7 +107,7 @@ class RayTrainGroup:
 
     def async_init(self, args, role, with_ref=False):
         """
-        Allocate GPU resourced and initialize model, optimzier, local ckpt, etc.
+        Allocate GPU resources and initialize model, optimizer, local ckpt, etc.
         """
         self.args = args
         return [actor.init.remote(args, role, with_ref=with_ref) for actor in self._actor_handlers]


### PR DESCRIPTION
## Summary
Fixed typos in `slime/ray/actor_group.py` line 110:
- "resourced" → "resources"
- "optimzier" → "optimizer"

## Test plan
- [x] Verify the typos are fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)