### PR TITLE
fix: typo "requies" → "requires" in comment

### DIFF
--- a/slime/backends/megatron_utils/data.py
+++ b/slime/backends/megatron_utils/data.py
@@ -298,7 +298,7 @@ def get_data_iterator(
         dist.all_reduce(num_microbatches, op=dist.ReduceOp.MAX, group=dp_group)
 
         if vpp_size > 1:
-            # vpp requies the number of microbatches to be divisible by vpp_size
+            # vpp requires the number of microbatches to be divisible by vpp_size
             num_microbatches = torch.clamp(
                 num_microbatches // microbatch_group_size_per_vp_stage * microbatch_group_size_per_vp_stage,
                 min=1,


### PR DESCRIPTION
## Summary
Fixed typo "requies" → "requires" in `slime/backends/megatron_utils/data.py` line 301.

## Test plan
- [x] Verify the typo is fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)