### PR TITLE
fix: redundant "need to want to" in docstring

### DIFF
--- a/slime/backends/megatron_utils/model_provider.py
+++ b/slime/backends/megatron_utils/model_provider.py
@@ -74,7 +74,7 @@ def get_model_provider_func(
 
         Args:
             pre_process (bool, optional): Set to true if you need to compute embedings. Defaults to True.
-            post_process (bool, optional): Set to true if you need to want to compute output logits/loss. Defaults to True.
+            post_process (bool, optional): Set to true if you need to compute output logits/loss. Defaults to True.
 
 
         Returns:


### PR DESCRIPTION
## Summary
Fixed redundant wording in `slime/backends/megatron_utils/model_provider.py` line 77:
- "need to want to compute" → "need to compute"

This makes it consistent with the `pre_process` parameter description on line 76.

## Test plan
- [x] Verify the redundant wording is fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)