### PR TITLE
Fix "Pytorch" capitalization to "PyTorch"

### DIFF
--- a/slime/backends/megatron_utils/initialize.py
+++ b/slime/backends/megatron_utils/initialize.py
@@ -59,7 +59,7 @@ def init(args):
         logger.info("Enable megatron experimental")
         set_experimental_flag(True)
 
-    # Pytorch distributed.
+    # PyTorch distributed.
     _initialize_distributed(args)
 
     # https://github.com/NVIDIA/Megatron-LM/issues/1563


### PR DESCRIPTION
## Summary
- Fixed incorrect capitalization "Pytorch" to "PyTorch" in `slime/backends/megatron_utils/initialize.py`

The official branding is "PyTorch" with a capital T.

🤖 Generated with [Claude Code](https://claude.com/claude-code)