### PR TITLE
Fix missing space "failfrom" → "fail from"

### DIFF
--- a/docker/Dockerfile_20250810_c22f55b.rocm
+++ b/docker/Dockerfile_20250810_c22f55b.rocm
@@ -11,7 +11,7 @@
 # The Docker image built with this Dockerfile:
 # PR: commit ID 36711aa (Aug 22, 2025) dockerfile - Supports up to slime commit ID: 9a48ba0 (Aug 10, 2025)
 
-# Start to failfrom c22f55b (Aug 10, 2025) - Need to fix the bug from here
+# Start to fail from c22f55b (Aug 10, 2025) - Need to fix the bug from here
 
 # You can find the latest pre-built Docker image from here: https://hub.docker.com/r/rlsys/slime/tags
 # Current latest docker img: `rlsys/slime:slime_ubuntu22.04_rocm6.3.4-patch-numa-patch_sglang0.4.9_megatron-patch_ray2.47.1_apex_torch-memory-saver0.0.8-patch-vim` manually add the patch to mitigate checkpoint loading issue. (vim /workspace/Megatron-LM-amd_version/megatron/training/checkpointing.py. Line: 1449 ~ 1457 - comment out if becasue of dismatch number of dist checkpoints


### PR DESCRIPTION
## Summary
- Fixed missing space in `docker/Dockerfile_20250810_c22f55b.rocm`
- "failfrom" → "fail from"

🤖 Generated with [Claude Code](https://claude.com/claude-code)