### PR TITLE
Fix grammar "overwritten" → "overwriting"

### DIFF
--- a/slime/utils/arguments.py
+++ b/slime/utils/arguments.py
@@ -1292,7 +1292,7 @@ def get_slime_extra_args_provider(add_custom_arguments=None):
             sglang_tp_size = temp_args.rollout_num_gpus_per_engine
             return sglang_tp_size
 
-        # Add custom arguments in front to prevent overwritten some slime arguments.
+        # Add custom arguments in front to prevent overwriting some slime arguments.
         if add_custom_arguments is not None:
             parser = add_custom_arguments(parser)
 


### PR DESCRIPTION
## Summary
- Fixed grammatical error in `slime/utils/arguments.py`
- "to prevent overwritten" → "to prevent overwriting"

The gerund form "overwriting" is grammatically correct after "to prevent".

🤖 Generated with [Claude Code](https://claude.com/claude-code)