### PR TITLE
docs: fix ROCm capitalization and grammar in AMD tutorial

### DIFF
--- a/docs/en/platform_support/amd_tutorial.md
+++ b/docs/en/platform_support/amd_tutorial.md
@@ -5,7 +5,7 @@
 
 ## Introduction
 
-If you are running slime on AMD's Instinct, please refer to the following materials. This tutorial will explain how to set up the development environment (Docker), use the modified ROCm dependencies, and provide an example for running the experiments. The current rocm docker only support AMD's MI300 and MI325 GPUs.
+If you are running slime on AMD's Instinct, please refer to the following materials. This tutorial will explain how to set up the development environment (Docker), use the modified ROCm dependencies, and provide an example for running the experiments. The current ROCm Docker only supports AMD's MI300 and MI325 GPUs.
 
 
 <!-- First, you need to configure the slime runtime environment according to the [Readme](../../README.md) documentation and cd to the slime project directory. -->


### PR DESCRIPTION
## Summary
- Capitalize "rocm" to "ROCm" (proper brand name)
- Fix subject-verb agreement: "only support" → "only supports"

## Test plan
- [x] Verified the changes are documentation-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)