### PR TITLE
fix: typo "begining" → "beginning" in cp_utils.py

### DIFF
--- a/slime/backends/megatron_utils/cp_utils.py
+++ b/slime/backends/megatron_utils/cp_utils.py
@@ -11,7 +11,7 @@ def get_logits_and_tokens_offset_with_cp(
     response_length: int,
 ):
     """
-    All offsets start from the begining of the prompt.
+    All offsets start from the beginning of the prompt.
     """
     cp_rank = mpu.get_context_parallel_rank()
     cp_size = mpu.get_context_parallel_world_size()


### PR DESCRIPTION
## Summary
- Fix typo in docstring: "begining" → "beginning"

## Test plan
- [x] Verified the change is a comment-only fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)