### PR TITLE
docs: fix SGLang capitalization in Q&A

### DIFF
--- a/docs/en/get_started/qa.md
+++ b/docs/en/get_started/qa.md
@@ -55,7 +55,7 @@
 
     Please verify that the model corresponding to `--hf-checkpoint` has its stop tokens configured correctly. If not, you can set them using the `--rollout-stop` or `--rollout-stop-token-ids` arguments.
 
-11. **Sglang shows an `an illegal memory access was encountered` error.**
+11. **SGLang shows an `an illegal memory access was encountered` error.**
 
     According to the sglang documentation ([https://docs.sglang.ai/references/troubleshooting.html](https://docs.sglang.ai/references/troubleshooting.html)), this could be an OOM error. Consider reducing the value of `--sglang-mem-fraction-static`.
 


### PR DESCRIPTION
## Summary
- Capitalize "Sglang" to "SGLang" (proper brand name)

## Test plan
- [x] Verified the change is documentation-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)