### PR TITLE
fix: typos in --rollout-max-context-len help text

### DIFF
--- a/slime/utils/arguments.py
+++ b/slime/utils/arguments.py
@@ -214,7 +214,7 @@ def get_slime_extra_args_provider(add_custom_arguments=None):
                 default=None,
                 help=(
                     "The maximum context size for the inference engine during rollout."
-                    "It should no exceed the `max_position_embeddinds` in Huggingface model's `config.json`"
+                    "It should not exceed the `max_position_embeddings` in Hugging Face model's `config.json`"
                 ),
             )
             parser.add_argument(


### PR DESCRIPTION
## Summary
- Fix "no" → "not" (missing letter)
- Fix "embeddinds" → "embeddings" (typo)
- Fix "Huggingface" → "Hugging Face" (proper brand name)

## Test plan
- [x] Verified the change is a help text fix only

🤖 Generated with [Claude Code](https://claude.com/claude-code)