### PR TITLE
fix: typo "sgalng" → "sglang" in ROCm Dockerfiles

### DIFF
--- a/docker/Dockerfile_20250810_9a48ba0.rocm
+++ b/docker/Dockerfile_20250810_9a48ba0.rocm
@@ -82,7 +82,7 @@ RUN pip install setuptools==75.8.0
 
 
 ###########################################
-############build sgalng###################
+############build sglang###################
 ###########################################
 # Set environment variables
 ENV BASE_DIR=/workspace

--- a/docker/Dockerfile_20250810_c22f55b.rocm
+++ b/docker/Dockerfile_20250810_c22f55b.rocm
@@ -92,7 +92,7 @@ RUN pip install setuptools==75.8.0
 
 
 ###########################################
-############build sgalng###################
+############build sglang###################
 ###########################################
 # Set environment variables
 ENV BASE_DIR=/workspace


### PR DESCRIPTION
## Summary
- Fix typo in section header comments: "sgalng" → "sglang"
- Affects `Dockerfile_20250810_c22f55b.rocm` and `Dockerfile_20250810_9a48ba0.rocm`

## Test plan
- [x] Verified the changes are comment-only fixes