### PR TITLE
fix: remove invalid None default and fix misleading underscore variable naming

### DIFF
--- a/slime/utils/metric_utils.py
+++ b/slime/utils/metric_utils.py
@@ -105,7 +105,7 @@ def compression_ratio(
     return ratio, savings_pct
 
 
-def has_repetition(text: str = None):
+def has_repetition(text: str):
     if len(text) > 10000 and compression_ratio(text[-10000:])[0] > 10:
         return True
     else:

--- a/slime/utils/seqlen_balancing.py
+++ b/slime/utils/seqlen_balancing.py
@@ -165,11 +165,11 @@ def get_seqlen_balanced_partitions(seqlen_list: list[int], k_partitions: int, eq
         assert len(partitions) == k_partitions, f"{len(partitions)} != {k_partitions}"
         seen_idx = set()
         sorted_partitions = [None] * k_partitions
-        for _i, partition in enumerate(partitions):
-            assert len(partition) > 0, f"the {_i}-th partition is empty"
+        for i, partition in enumerate(partitions):
+            assert len(partition) > 0, f"the {i}-th partition is empty"
             for idx in partition:
                 seen_idx.add(idx)
-            sorted_partitions[_i] = sorted(partition)
+            sorted_partitions[i] = sorted(partition)
         assert seen_idx == set(range(len(seqlen_list)))
         return sorted_partitions
 


### PR DESCRIPTION
## Summary

Fix two minor code issues:

1. **`metric_utils.py`**: Remove invalid `None` default from `has_repetition(text: str = None)` which would cause `TypeError` when called without arguments
2. **`seqlen_balancing.py`**: Rename `_i` to `i` since the variable is used in the error message (underscore prefix convention implies unused)