### PR TITLE
[fix] conditionally pass kwargs for megatron-bridge VLM

### DIFF
--- a/slime/backends/megatron_utils/model.py
+++ b/slime/backends/megatron_utils/model.py
@@ -397,13 +397,13 @@ def train_one_step(
                 "packed_seq_params": batch["packed_seq_params"],
                 "loss_mask": batch["full_loss_masks"],
             }
-            
+
             if args.enable_mtp_training:
                 forward_kwargs["mtp_kwargs"] = {"mtp_labels": batch["tokens"]}
-            
+
             if batch["multimodal_train_inputs"] is not None:
                 forward_kwargs.update(batch["multimodal_train_inputs"])
-            
+
             output_tensor = model(**forward_kwargs)
 
         if os.environ.get("ENABLE_ROUTING_REPLAY", "0") == "1":


### PR DESCRIPTION
In `megatron_utils/model.py:390-400`, some patched kwargs like `mtp_kwargs` are passed unconditionally.

However, when using megatron-bridge to load some models (VLM), e.g., directly run script `examples/geo3k_vlm/run_geo3k_vlm.sh`, this will cause an `unexpected keyword argument 'mtp_kwargs'` error.

Fixed by conditionally passing those kwargs.