### PR TITLE
Set base_gpu_id for sglang from placement groups

### DIFF
--- a/slime/backends/sglang_utils/sglang_engine.py
+++ b/slime/backends/sglang_utils/sglang_engine.py
@@ -88,10 +88,11 @@ def _wait_server_healthy(base_url, api_key, is_process_alive):
 
 
 class SGLangEngine(RayActor):
-    def __init__(self, args, rank: int, worker_type: str = "regular"):
+    def __init__(self, args, rank: int, worker_type: str = "regular", base_gpu_id: int | None = None):
         self.args = args
         self.rank = rank
         self.worker_type = worker_type
+        self.base_gpu_id = base_gpu_id
 
     def init(self, dist_init_addr, port, nccl_port, host=None, disaggregation_bootstrap_port=None):
         self.router_ip = self.args.sglang_router_ip
@@ -122,6 +123,7 @@ class SGLangEngine(RayActor):
             port,
             self.worker_type,
             disaggregation_bootstrap_port,
+            base_gpu_id=self.base_gpu_id,
         )
 
         self.node_rank = server_args_dict["node_rank"]
@@ -424,6 +426,7 @@ def _compute_server_args(
     port,
     worker_type: str = "regular",
     disaggregation_bootstrap_port: int | None = None,
+    base_gpu_id: int | None = None,
 ):
     nnodes = max(1, args.rollout_num_gpus_per_engine // args.num_gpus_per_node)
     node_rank = rank % nnodes
@@ -441,7 +444,7 @@ def _compute_server_args(
         "node_rank": node_rank,
         "dist_init_addr": dist_init_addr,
         "gpu_id_step": 1,
-        "base_gpu_id": get_base_gpu_id(args, rank),
+        "base_gpu_id": base_gpu_id if base_gpu_id is not None else get_base_gpu_id(args, rank),
         # parallel
         "tp_size": args.rollout_num_gpus_per_engine,
         "dp_size": args.sglang_dp_size,

--- a/slime/ray/actor_group.py
+++ b/slime/ray/actor_group.py
@@ -31,7 +31,7 @@ class RayTrainGroup:
         args,
         num_nodes,
         num_gpus_per_node,
-        pg: tuple[PlacementGroup, list[int]],
+        pg: tuple[PlacementGroup, list[int], list[int]],
         num_gpus_per_actor: float = 1,
         role: str = "actor",
     ) -> None:
@@ -48,7 +48,7 @@ class RayTrainGroup:
 
         # Use placement group to lock resources for models of same type
         assert pg is not None
-        pg, reordered_bundle_indices = pg
+        pg, reordered_bundle_indices, _reordered_gpu_ids = pg
 
         env_vars = {
             # because sglang will always set NCCL_CUMEM_ENABLE to 0

--- a/slime/ray/placement_group.py
+++ b/slime/ray/placement_group.py
@@ -60,7 +60,11 @@ def _create_placement_group(num_gpus):
         ray.kill(actor)
 
     bundle_infos = [(i, gpu_ids[i][0], gpu_ids[i][1]) for i in range(num_bundles)]
-    pg_reordered_bundle_indices = [bundle_info[0] for bundle_info in sorted(bundle_infos, key=sort_key)]
+    sorted_bundle_infos = sorted(bundle_infos, key=sort_key)
+    pg_reordered_bundle_indices = [info[0] for info in sorted_bundle_infos]
+    # Map from logical index -> physical GPU ID
+    pg_reordered_gpu_ids = [gpu_ids[info[0]][1] for info in sorted_bundle_infos]
+
     for i in range(num_bundles):
         actual_bundle_index = pg_reordered_bundle_indices[i]
         logger.info(
@@ -68,7 +72,7 @@ def _create_placement_group(num_gpus):
             f"node: {gpu_ids[actual_bundle_index][0]}, gpu: {gpu_ids[actual_bundle_index][1]}"
         )
 
-    return pg, pg_reordered_bundle_indices
+    return pg, pg_reordered_bundle_indices, pg_reordered_gpu_ids
 
 
 def create_placement_groups(args):
@@ -99,16 +103,18 @@ def create_placement_groups(args):
             rollout_offset += args.critic_num_nodes * args.critic_num_gpus_per_node
 
     logger.info(f"Creating placement group with {num_gpus} GPUs...")
-    pg, actor_pg_reordered_bundle_indices = _create_placement_group(num_gpus)
+    pg, actor_pg_reordered_bundle_indices, actor_pg_reordered_gpu_ids = _create_placement_group(num_gpus)
 
     rollout_pg_reordered_bundle_indices = actor_pg_reordered_bundle_indices[rollout_offset:]
+    rollout_pg_reordered_gpu_ids = actor_pg_reordered_gpu_ids[rollout_offset:]
     if args.use_critic:
         critic_pg_reordered_bundle_indices = actor_pg_reordered_bundle_indices[critic_offset:]
+        critic_pg_reordered_gpu_ids = actor_pg_reordered_gpu_ids[critic_offset:]
 
     return {
-        "actor": (pg, actor_pg_reordered_bundle_indices),
-        "critic": (pg, critic_pg_reordered_bundle_indices) if args.use_critic else None,
-        "rollout": (pg, rollout_pg_reordered_bundle_indices),
+        "actor": (pg, actor_pg_reordered_bundle_indices, actor_pg_reordered_gpu_ids),
+        "critic": (pg, critic_pg_reordered_bundle_indices, critic_pg_reordered_gpu_ids) if args.use_critic else None,
+        "rollout": (pg, rollout_pg_reordered_bundle_indices, rollout_pg_reordered_gpu_ids),
     }
 
 


### PR DESCRIPTION
Current the SGLang base_gpu_id is recalculated without using the actual placement group gpu id. This makes slime not work with any other jobs on the same ray cluster if they are sharing the same node. This code keeps track of the gpu ids of the placement groups and pass it for sglang creation.