### PR TITLE
[Fix] Update deprecated sglang ep args in docs and scripts

### DIFF
--- a/docs/en/examples/deepseek-r1.md
+++ b/docs/en/examples/deepseek-r1.md
@@ -177,7 +177,7 @@ The final `--sglang-server-concurrency` is a parameter specific to slime. It is 
 SGLANG_ARGS=(
    --rollout-num-gpus-per-engine 64
    --sglang-mem-fraction-static 0.7
-   --sglang-enable-ep-moe
+   ----sglang-ep-size 64
 
    # dp attention
    --sglang-enable-dp-attention
@@ -186,7 +186,7 @@ SGLANG_ARGS=(
    --sglang-enable-dp-lm-head
 
    # enable deepep for sglang
-   --sglang-enable-deepep-moe
+   --sglang-moe-a2a-backend deepep
    --sglang-deepep-mode auto
 
    # make every dp rank have 128 concurrency

--- a/docs/en/examples/qwen3-30B-A3B.md
+++ b/docs/en/examples/qwen3-30B-A3B.md
@@ -62,7 +62,7 @@ Here, we will briefly introduce the MoE-related parts in the [run-qwen3-30B-A3B.
     SGLANG_ARGS=(
        --rollout-num-gpus-per-engine 8
        --sglang-mem-fraction-static 0.7
-       --sglang-enable-ep-moe
+       --sglang-ep-size 8
        --sglang-cuda-graph-bs 1 2 4 8 $(seq 16 8 256)
     )
     ```
@@ -109,7 +109,7 @@ In addition, you can make the following changes:
    SGLANG_ARGS=(
       --rollout-num-gpus-per-engine 24
       --sglang-mem-fraction-static 0.7
-      --sglang-enable-ep-moe
+      --sglang-ep-size 24
       --sglang-enable-dp-attention
       --sglang-dp-size 3
 

--- a/docs/en/get_started/usage.md
+++ b/docs/en/get_started/usage.md
@@ -280,7 +280,7 @@ slime incorporates almost all SGLang parameters by using SGLang's `ServerArgs.ad
 
   - In co-located training and inference, you often need to limit `--mem-fraction-static`. This parameter should be changed to `--sglang-mem-fraction-static`.
   - During training, if you want SGLang to infer beyond the maximum context length specified in the Hugging Face checkpoint's `config.json`, you need to use `--context-length`, which becomes `--sglang-context-length` in slime.
-  - For multi-node large EP inference, you might need `--enable-ep-moe`, `--enable-dp-attention`, `--dp-size`, `--enable-deepep-moe`, etc. These can be passed as `--sglang-enable-ep-moe`, `--sglang-enable-dp-attention`, `--sglang-dp-size`, and `--sglang-enable-deepep-moe` respectively.
+  - For multi-node large EP inference, you might need `--ep-size`, `--enable-dp-attention`, `--dp-size`, `--moe-a2a-backend deepep`, etc. These can be passed as `--sglang-ep-size`, `--sglang-enable-dp-attention`, `--sglang-dp-size`, and `--sglang-moe-a2a-backend deepep` respectively.
 
 Some parameters related to slime's resource scheduling are configured by slime itself, for example:
 

--- a/docs/zh/examples/deepseek-r1.md
+++ b/docs/zh/examples/deepseek-r1.md
@@ -177,7 +177,7 @@ sglang 所需的参数，这里 `--rollout-num-gpus-per-engine` 基本对应 sgl
 SGLANG_ARGS=(
    --rollout-num-gpus-per-engine 64
    --sglang-mem-fraction-static 0.7
-   --sglang-enable-ep-moe
+   --sglang-ep-size 64
 
    # dp attention
    --sglang-enable-dp-attention
@@ -186,7 +186,7 @@ SGLANG_ARGS=(
    --sglang-enable-dp-lm-head
 
    # enable deepep for sglang
-   --sglang-enable-deepep-moe
+   --sglang-moe-a2a-backend deepep
    --sglang-deepep-mode auto
 
    # make every dp rank has 128 concurrency

--- a/docs/zh/examples/qwen3-30B-A3B.md
+++ b/docs/zh/examples/qwen3-30B-A3B.md
@@ -61,7 +61,7 @@ bash scripts/run-qwen3-30B-A3B.sh
    SGLANG_ARGS=(
       --rollout-num-gpus-per-engine 8
       --sglang-mem-fraction-static 0.7
-      --sglang-enable-ep-moe
+      --sglang-ep-size 8
       --sglang-cuda-graph-bs 1 2 4 8 $(seq 16 8 256)
    )
    ```
@@ -107,7 +107,7 @@ hf download Qwen/Qwen3-30B-A3B-FP8 --local-dir /root/Qwen3-30B-A3B-FP8
    SGLANG_ARGS=(
       --rollout-num-gpus-per-engine 24
       --sglang-mem-fraction-static 0.7
-      --sglang-enable-ep-moe
+      --sglang-ep-size 24
       --sglang-enable-dp-attention
       --sglang-dp-size 3
 

--- a/docs/zh/get_started/usage.md
+++ b/docs/zh/get_started/usage.md
@@ -279,7 +279,7 @@ slime 通过引入 sglang 的 `ServerArgs.add_cli_args`，从而引入了几乎�
 
 - 在训推一体的训练时，往往需要限制 `--mem-fraction-static`，这个参数需要转变为 `--sglang-mem-fraction-static`；
 - 在训练中，希望 sglang 能推理超过 huggingface checkpoint 的 `config.json` 中标识的最长 context length，需要使用 `--context-length`，那么在 slime 中需要使用 `--sglang-context-length`；
-- 在进行多机大 ep 推理的时候，需要 `--enable-ep-moe`、`--enable-dp-attention`、`--dp-size`、`--enable-deepep-moe` 等，则可以对应地传入 `--sglang-enable-ep-moe`、`--sglang-enable-dp-attention`、`--sglang-dp-size`、`--sglang-enable-deepep-moe` 。
+- 在进行多机大 ep 推理的时候，需要 `--ep-size`、`--enable-dp-attention`、`--dp-size`、`--moe-a2a-backend deepep` 等，则可以对应地传入 `--sglang-ep-size`、`--sglang-enable-dp-attention`、`--sglang-dp-size`、`--sglang-moe-a2a-backend deepep` 。
 
 有部分参与和 slime 的资源调度相关，会由 slime 自行配置，例如：
 

--- a/scripts/run-deepseek-r1.sh
+++ b/scripts/run-deepseek-r1.sh
@@ -113,7 +113,7 @@ WANDB_ARGS=(
 SGLANG_ARGS=(
    --rollout-num-gpus-per-engine 64
    --sglang-mem-fraction-static 0.7
-   --sglang-enable-ep-moe
+   --sglang-ep-size 64
 
    # dp attention
    --sglang-enable-dp-attention
@@ -122,7 +122,7 @@ SGLANG_ARGS=(
    --sglang-enable-dp-lm-head
 
    # enable deepep for sglang
-   --sglang-enable-deepep-moe
+   --sglang-moe-a2a-backend deepep
    --sglang-deepep-mode auto
 
    # make every dp rank has 128 concurrency

--- a/scripts/run-kimi-k2-Instruct.sh
+++ b/scripts/run-kimi-k2-Instruct.sh
@@ -128,7 +128,7 @@ SGLANG_ARGS=(
    --sglang-ep-size 16
 
    # enable deepep for sglang
-#    --sglang-enable-deepep-moe
+#    --sglang-moe-a2a-backend deepep
 #    --sglang-deepep-mode auto
 
    # make every dp rank has 128 concurrency

--- a/scripts/run-kimi-k2-Thinking.sh
+++ b/scripts/run-kimi-k2-Thinking.sh
@@ -130,7 +130,7 @@ SGLANG_ARGS=(
    --sglang-ep-size 16
 
    # enable deepep for sglang
-   # --sglang-enable-deepep-moe
+   # --sglang-moe-a2a-backend deepep
    # --sglang-deepep-mode auto
 
    # make every dp rank has 128 concurrency

--- a/scripts/run-qwen3-32B.sh
+++ b/scripts/run-qwen3-32B.sh
@@ -110,7 +110,6 @@ SGLANG_ARGS=(
    --rollout-num-gpus-per-engine 8
    --sglang-mem-fraction-static 0.7
    --sglang-cuda-graph-bs 1 2 4 8 $(seq 16 8 256)
-   # --sglang-enable-ep-moe
 )
 
 MISC_ARGS=(


### PR DESCRIPTION
update `enable-ep-moe`, `enable-deepep-moe` to `ep-size`, `moe-a2a-backend deepep` in both docs and scripts