### PR TITLE
[On Policy Distillation] Fix on-policy distillation example readme issues

### DIFF
--- a/examples/on_policy_distillation/README.md
+++ b/examples/on_policy_distillation/README.md
@@ -22,12 +22,12 @@ hf download zhuzilin/dapo-math-17k --local-dir /root/dapo-math-17k
 
 2. Run the hf to mcore for student model conversion:
 ```bash
-source "${HOME_DIR}/slime/scripts/models/qwen3-8B.sh"
+source "${HOME}/slime/scripts/models/qwen3-8B.sh"
 
-PYTHONPATH=/root/Megatron-LM:${HOME_DIR}/slime python tools/convert_hf_to_torch_dist.py \
+PYTHONPATH=/root/Megatron-LM:${HOME}/slime python ${HOME}/slime/tools/convert_hf_to_torch_dist.py \
     ${MODEL_ARGS[@]} \
-    --hf-checkpoint ${HOME_DIR}/checkpoints/Qwen/Qwen3-8B \
-    --save ${HOME_DIR}/checkpoints/Qwen/Qwen3-8B_torch_dist
+    --hf-checkpoint ${HOME}/Qwen3-8B \
+    --save ${HOME}/Qwen3-8B_torch_dist
 ```
 3. run on-policy distillation:
 ```bash


### PR DESCRIPTION
Hi ~, Currently the instructions for the pre-training setup in the on-policy distillation example `README` are somewhat confusing. I’ve refined and clarified them so that the preparation commands can now be run sequentially without confusion. and align with the `run-qwen3-8B-opd.sh` script.