### PR TITLE
Docs: Add qqr to "Projects Built upon slime" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ slime has powered several novel research projects and production systems. Here a
 
 [**APRIL**](https://github.com/RLsys-Foundation/APRIL) introduces a system-level optimization that seamlessly integrates with slime to accelerate the rollout generation phase in RL training. By intelligently over-provisioning requests and actively managing partial completions, APRIL addresses the long-tail generation bottleneck that typically consumes over 90% of RL training time.
 
+### 🏟️ qqr: Scaling Open-Ended Agents with ArenaRL & MCP
+
+[**qqr**](https://github.com/Alibaba-NLP/qqr) (a.k.a. hilichurl) is a lightweight extension for slime designed to evolve open-ended agents. It implements the **ArenaRL** algorithm to tackle discriminative collapse through tournament-based relative ranking (**e.g., Seeded Single-Elimination, Round-Robin**) and seamlessly integrates the **Model Context Protocol (MCP)**. qqr leverages slime's high-throughput training capabilities to enable scalable, distributed evolution of agents in standardized, decoupled tool environments.
+
 These projects showcase slime's versatility—from training code-generation models to optimizing RL training systems—making it a powerful foundation for both research and production deployments.
 
 ## Arguments Walkthrough


### PR DESCRIPTION
**What this PR does:**

This PR adds [`qqr`](https://github.com/Alibaba-NLP/qqr) to the "Projects Built upon slime" section in the README.

`qqr` is an open-source project from Tongyi DeepResearch that implements the ArenaRL algorithm ([arXiv:2601.06487](https://huggingface.co/papers/2601.06487)). It is built directly on top of slime (tested with `v0.2.1`) to handle distributed rollouts and training for open-ended agents. We believe this serves as a good example of slime's capability in Agentic RL and MCP integration.
