### PR TITLE
[Fix] Return origin_samples instead of False in filter_long_prompt

### DIFF
--- a/slime/utils/data.py
+++ b/slime/utils/data.py
@@ -80,13 +80,13 @@ def _parse_generalized_path(s: str):
 
 def filter_long_prompt(origin_samples: list[Sample], tokenizer, processor, max_length: int | None) -> list[Sample]:
     if max_length is None:
-        return False
+        return origin_samples
 
     if not isinstance(origin_samples[0].prompt, str):
         logger.warning(
             "Skipping max_length check for list prompt. Set apply_chat_template=True to enable length filtering."
         )
-        return False
+        return origin_samples
 
     if processor:
         filtered_samples = []


### PR DESCRIPTION
  ## Summary

  Fix filter_long_prompt to return origin_samples instead of False when skipping length filtering. The function's return type is list[Sample], but it was returning a boolean in certain code paths.

  ## Problem

  The filter_long_prompt function had two code paths that returned False instead of the expected list[Sample]:

  1. When max_length is None: Returned False (though this branch is currently unreachable due to caller-side check)
  2. When prompt is not a string (e.g., pre-formatted chat template list): Returned False