### PR TITLE
[debug] fixed bug in sft_rollout

### DIFF
--- a/slime/rollout/sft_rollout.py
+++ b/slime/rollout/sft_rollout.py
@@ -12,6 +12,7 @@ TOKENIZER = None
 PROCESSOR = None
 MASK_GENERATOR = None
 SAMPLE_PRINTED = False
+TRUNCATION_WARNING_PRINTED = False
 
 
 def generate_rollout(args, rollout_id, data_buffer, evaluation=False):
@@ -29,7 +30,7 @@ def generate_rollout(args, rollout_id, data_buffer, evaluation=False):
     assert not evaluation
     assert args.rollout_global_dataset
 
-    global TOKENIZER, PROCESSOR, MASK_GENERATOR, SAMPLE_PRINTED
+    global TOKENIZER, PROCESSOR, MASK_GENERATOR, SAMPLE_PRINTED, TRUNCATION_WARNING_PRINTED
     if TOKENIZER is None:
         TOKENIZER = load_tokenizer(args.hf_checkpoint, trust_remote_code=True)
 
@@ -39,6 +40,9 @@ def generate_rollout(args, rollout_id, data_buffer, evaluation=False):
     if MASK_GENERATOR is None:
         MASK_GENERATOR = MultiTurnLossMaskGenerator(TOKENIZER, tokenizer_type=args.loss_mask_type)
 
+    # Get max context length for truncation
+    max_context_len = getattr(args, "rollout_max_context_len", None)
+
     samples = data_buffer.get_samples(args.rollout_batch_size)
 
     for i, sample in enumerate(samples):
@@ -47,6 +51,17 @@ def generate_rollout(args, rollout_id, data_buffer, evaluation=False):
         tools = sample.metadata.get("tools", None)
 
         token_ids, loss_mask = MASK_GENERATOR.get_loss_mask(messages, tools=tools)
+
+        # Truncate if exceeds max_context_len
+        if max_context_len is not None and len(token_ids) > max_context_len:
+            if not TRUNCATION_WARNING_PRINTED:
+                logger.warning(
+                    f"sft_rollout: Truncating sample from {len(token_ids)} to {max_context_len} tokens. "
+                    f"This warning will only be printed once."
+                )
+                TRUNCATION_WARNING_PRINTED = True
+            token_ids = token_ids[:max_context_len]
+            loss_mask = loss_mask[:max_context_len]
 
         response_length = MASK_GENERATOR.get_response_lengths([loss_mask])[0]
 


### PR DESCRIPTION
This PR fixes a critical **CUDA Out-of-Memory (OOM)** error encountered during Supervised Fine-Tuning (SFT) when using the Slime framework.

### The Problem

During the rollout phase of SFT, the system was crashing with a `torch.OutOfMemoryError` while trying to allocate a large chunk of memory (approx. 23.82 GiB).

Despite having explicit configuration flags set for context limits:

* `--rollout-max-context-len 8192`
* `--rollout-max-prompt-len 2048`
* `--rollout-max-response-len 6144`

The OOM persisted because the **SFT-specific rollout logic was ignoring these parameters.**

### Root Cause

The investigation revealed that in SFT mode, `apply_chat_template` is typically set to `False`. While standard RLHF rollouts might handle truncation elsewhere, the `generate_rollout` function in `slime/backends/megatron_utils/actor.py` (or specifically your SFT data loader) was taking raw `token_ids` from the `MASK_GENERATOR` and passing them directly to the model without checking their length.

If a dataset sample exceeded the 8192 token limit, the model attempted to process the full sequence, leading to the OOM on the training actor.

### The Fix

The PR implements **manual truncation** within the `generate_rollout` function to ensure that no sample exceeds the configured `rollout_max_context_len`.

**Key Changes:**

1. **Parameter Extraction:** Added logic to fetch `max_context_len` from `args.rollout_max_context_len`.
2. **Hard Truncation:** If the length of `token_ids` exceeds the limit, both `token_ids` and the `loss_mask` are sliced to the maximum allowed length.
3. **Dynamic Response Calculation:** The `response_length` is recalculated *after* truncation to ensure the `sample.loss_mask` remains aligned with the actual available tokens.
4. **Optimized Logging:** Introduced a `TRUNCATION_WARNING_PRINTED` flag to log a warning when truncation occurs without spamming the console (prints once per lifecycle).

### Verification

* **Memory Stability:** After applying the fix, the training process respects the 8192 limit, preventing the training actor from attempting massive allocations.
* **Data Integrity:** The loss mask is correctly sliced, ensuring that training still occurs on valid tokens within the truncated sequence.