### PR TITLE
fix: correct inverted condition for NaN check in loss and grad

### DIFF
--- a/slime/backends/megatron_utils/model.py
+++ b/slime/backends/megatron_utils/model.py
@@ -426,7 +426,7 @@ def train_one_step(
     )
 
     valid_step = True
-    if not getattr(args, "check_for_nan_in_loss_and_grad", True):
+    if getattr(args, "check_for_nan_in_loss_and_grad", True):
         found_inf_flag = optimizer.prepare_grads()
         if found_inf_flag:
             valid_step = False


### PR DESCRIPTION
The condition `check_for_nan_in_loss_and_grad` was incorrectly negated, causing the NaN check to be skipped when it should run and vice versa.