### PR TITLE
fix: remove enforced CPU initialization assertion for AMD GPUs

### DIFF
--- a/tools/convert_hf_to_torch_dist.py
+++ b/tools/convert_hf_to_torch_dist.py
@@ -107,10 +107,6 @@ def main():
     args = get_args()
     init(args)
 
-    # if using AMD gpus, we have to do the conversion in cpu
-    if hasattr(torch.version, "hip") and torch.version.hip is not None:
-        assert args.use_cpu_initialization, "AMD GPU requires --use_cpu_initialization=True"
-
     model = get_model(get_model_provider_func(args), ModelType.encoder_or_decoder, wrap_with_ddp=False)
 
     # Load model


### PR DESCRIPTION
Previously, the conversion script enforced `--use_cpu_initialization=True` when running on AMD GPUs. This assumption is not valid. We have verified that the conversion can run correctly on AMD MI300 GPUs without forcing CPU initialization.

This change removes the hard assertion to:
- Avoid blocking valid GPU-side conversion workflows on AMD hardware
- Align the behavior with actual runtime capabilities on modern AMD GPUs
- Reduce unnecessary constraints that are no longer required

No functional logic is changed beyond removing the enforced assertion.


cc @zhuzilin , thanks!