### PR TITLE
fix(rollout): raise error when buffer is insufficient without global dataset

### DIFF
--- a/slime/rollout/data_source.py
+++ b/slime/rollout/data_source.py
@@ -174,6 +174,12 @@ class RolloutDataSourceWithBuffer(RolloutDataSource):
         if num_samples == 0:
             return samples
 
+        if self.dataset is None:
+            raise RuntimeError(
+                f"Buffer only has {len(samples)} samples but {num_samples + len(samples)} were requested. "
+                "Either add more samples to the buffer or enable --rollout-global-dataset."
+            )
+
         samples += super().get_samples(num_samples=num_samples)
         return samples
 


### PR DESCRIPTION
For RolloutDataSourceWithBuffer.get_samples() method, when the buffer cannot provide enough samples and no global dataset is configured. Current behavior is to create empty Sample as placeholders [link1](https://github.com/THUDM/slime/blob/main/slime/rollout/data_source.py#L177) [link2](https://github.com/THUDM/slime/blob/main/slime/rollout/data_source.py#L99).

Shall we fail fast instead of silently proceeding in this circumstance? 