### PR TITLE
[Fix] Allow default TIS function usage when get_mismatch_metrics is set

### DIFF
--- a/slime/utils/arguments.py
+++ b/slime/utils/arguments.py
@@ -1672,9 +1672,10 @@ def slime_validate_args(args):
         assert not args.use_tis, "use_rollout_logprobs and use_tis cannot be set at the same time."
 
     if args.get_mismatch_metrics:
-        assert (
-            args.custom_tis_function_path is not None
-        ), "custom_tis_function_path must be set when get_mismatch_metrics is set"
+        if args.custom_tis_function_path is None:
+            logger.warning(
+                "get_mismatch_metrics is set but custom_tis_function_path is None. Using default vanilla_tis_function for metrics calculation."
+            )
 
         if args.use_rollout_logprobs:
             logger.info(


### PR DESCRIPTION
### Description
This PR addresses a logical conflict between `slime/utils/arguments.py` and `slime/backends/megatron_utils/loss.py`.

### Motivation
Previously, `slime_validate_args` enforced a strict assertion that `custom_tis_function_path` must be provided when `get_mismatch_metrics` is enabled. However, the backend logic in `loss.py` explicitly supports a fallback to `vanilla_tis_function` when no custom path is provided.

Since `vanilla_tis_function` correctly computes and returns metrics (e.g., `tis`, `tis_clipfrac`), the previous assertion unnecessarily prevented users from observing mismatch metrics using the default implementation.

### Modification
- Replaced the strict assertion in `slime/utils/arguments.py` with a **warning**.
- Now, if `get_mismatch_metrics` is set without a custom path, the system warns the user (for visibility) and correctly falls back to the default TIS function instead of raising an error.