### PR TITLE
Pass through correct Megatron model provider PP args

### DIFF
--- a/slime/backends/megatron_utils/model_provider.py
+++ b/slime/backends/megatron_utils/model_provider.py
@@ -90,6 +90,10 @@ def get_model_provider_func(
         provider.expert_model_parallel_size = args.expert_model_parallel_size
         provider.expert_tensor_parallel_size = args.expert_tensor_parallel_size
         provider.sequence_parallel = args.sequence_parallel
+        if getattr(args, "decoder_first_pipeline_num_layers", None) is not None:
+            provider.num_layers_in_first_pipeline_stage = args.decoder_first_pipeline_num_layers
+        if getattr(args, "decoder_last_pipeline_num_layers", None) is not None:
+            provider.num_layers_in_last_pipeline_stage = args.decoder_last_pipeline_num_layers
         provider.finalize()
         return provider.provide
 


### PR DESCRIPTION
Megatron provider has renamed the `decoder_*_pipeline_num_layers` to `num_layers_in_*_pipeline_stage`: https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/184e8858b9f2f11950be2a3c372c6e0f0e395097/src/megatron/bridge/models/model_provider.py#L458

I was running into issues using the Megatron bridge to load models into slime with uneven pipeline parallelism because these arguments were not correctly being passed to the bridge:
```
Megatron-LM/megatron/training/arguments.py", line 561, in validate_args
[rank14]:     assert num_layers % args.transformer_pipeline_model_parallel_size == 0, \
[rank14]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank14]: AssertionError: Number of layers should be divisible by the pipeline-model-parallel size
```