### PR TITLE
[FIX] model provider compatibility with Megatron-LM

### DIFF
--- a/slime/backends/megatron_utils/model_provider.py
+++ b/slime/backends/megatron_utils/model_provider.py
@@ -68,8 +68,6 @@ def get_model_provider_func(
             config: TransformerConfig | None = None,
             pg_collection: ProcessGroupCollection | None = None,
         ) -> GPTModel:
-            # Note: config and pg_collection are passed by Megatron-LM's get_model()
-            # but we build our own config from args. These parameters are accepted but not used.
             custom_model_provider = load_function(args.custom_model_provider_path)
             # Check if the custom provider supports vp_stage parameter
             sig_params = inspect.signature(custom_model_provider).parameters


### PR DESCRIPTION
### Issue
When using recent Megatron-LM versions (since Dec 10, 2025, [NVIDIA/Megatron-LM#2608](https://github.com/NVIDIA/Megatron-LM/pull/2608)), model initialization fails with `unexpected keyword argument 'pg_collection'` or `config` because the upstream megatron `get_model` interface now passes these arguments explicitly. This causes `convert_hf_to_torch_dist.py` to fail.

from megatron
```
def get_model(
    model_provider_func,
    model_type=ModelType.encoder_or_decoder,
    wrap_with_ddp=True,
    config=None, # <--- NEW PARAMETER
    pg_collection=None # <--- NEW PARAMETER
):
```


### Fix
*   **Custom Providers:** Updated `wrapped_model_provider` to dynamically inspect signatures and only pass `pg_collection`, `vp_stage`, or `config` if the custom function accepts them.
*   **Standard Provider:** Updated `model_provider` to accept `pg_collection` and `config` and forward `pg_collection` to `GPTModel` kwargs for correct distributed initialization.

### Related
*   Closes #1301