### PR TITLE
fix: support mtp for qwen3-next

### DIFF
--- a/scripts/models/qwen3-next-80B-A3B.sh
+++ b/scripts/models/qwen3-next-80B-A3B.sh
@@ -55,4 +55,7 @@ MODEL_ARGS=(
    # qwen3 specific
    --attention-output-gate
    --moe-shared-expert-gate
+
+   # mtp
+   --mtp-num-layers 1
 )

--- a/slime_plugins/mbridge/qwen3_next.py
+++ b/slime_plugins/mbridge/qwen3_next.py
@@ -1,4 +1,6 @@
 import torch
+from megatron.core.models.gpt.gpt_layer_specs import get_gpt_mtp_block_spec
+
 from mbridge.core import register_model
 from mbridge.models import Qwen2MoEBridge
 
@@ -38,6 +40,62 @@ class Qwen3NextBridge(Qwen2MoEBridge):
         }
     )
 
+    def _get_gptmodel_args(self) -> dict:
+        """Override to add MTP block spec if needed."""
+        ret = super()._get_gptmodel_args()
+        if getattr(self.config, "mtp_num_layers", None) is not None:
+            transformer_layer_spec = self.config
+            mtp_block_spec = get_gpt_mtp_block_spec(
+                self.config, transformer_layer_spec, use_transformer_engine=True
+            )
+            ret["mtp_block_spec"] = mtp_block_spec
+        return ret
+
+    def _weight_name_mapping_mcore_to_hf(self, mcore_weights_name: str) -> list[str]:
+        """Override to handle MTP layer mappings."""
+        if "mtp" in mcore_weights_name:
+            return self._convert_mtp_param(mcore_weights_name)
+        return super()._weight_name_mapping_mcore_to_hf(mcore_weights_name)
+
+    def _convert_mtp_param(self, name: str) -> list[str]:
+        """Convert MTP layer parameters from MCore to HF format."""
+        if "mtp.layers." not in name:
+            raise NotImplementedError(f"Invalid MTP parameter name: {name}")
+
+        parts = name.split(".")
+        mtp_layer_idx = parts[2]  # mtp.layers.{idx}
+
+        direct_name_mapping = {
+            f"mtp.layers.{mtp_layer_idx}.eh_proj.weight": "mtp.fc.weight",
+            f"mtp.layers.{mtp_layer_idx}.enorm.weight": "mtp.pre_fc_norm_embedding.weight",
+            f"mtp.layers.{mtp_layer_idx}.hnorm.weight": "mtp.pre_fc_norm_hidden.weight",
+            f"mtp.layers.{mtp_layer_idx}.final_layernorm.weight": "mtp.norm.weight",
+        }
+
+        if name in direct_name_mapping:
+            return [direct_name_mapping[name]]
+
+        if "transformer_layer" in name:
+            proxy_name = name.replace(
+                f"mtp.layers.{mtp_layer_idx}.transformer_layer",
+                f"decoder.layers.{mtp_layer_idx}",
+            )
+
+            if "self_attention" in proxy_name or "input_layernorm.weight" in proxy_name:
+                convert_names = super()._weight_name_mapping_attention(proxy_name)
+            elif "mlp" in proxy_name or "pre_mlp_layernorm" in proxy_name:
+                convert_names = super()._weight_name_mapping_mlp(proxy_name)
+            else:
+                raise NotImplementedError(f"Unsupported transformer component in MTP: {name}")
+
+            convert_names = [
+                cn.replace(f"model.layers.{mtp_layer_idx}", f"mtp.layers.{mtp_layer_idx}")
+                for cn in convert_names
+            ]
+            return convert_names
+
+        raise NotImplementedError(f"Unsupported MTP parameter name: {name}")
+
     def _weight_to_mcore_format(
         self, mcore_weights_name: str, hf_weights: list[torch.Tensor]
     ) -> tuple[list[str], list[torch.Tensor]]:
@@ -73,9 +131,25 @@ class Qwen3NextBridge(Qwen2MoEBridge):
             qgkv = torch.cat([q, k, v], dim=1).view(*out_shape).contiguous()
             return qgkv
 
-        return super()._weight_to_mcore_format(mcore_weights_name, hf_weights)
+        weight = super()._weight_to_mcore_format(mcore_weights_name, hf_weights)
+        if mcore_weights_name.endswith("eh_proj.weight"):
+            first_half, second_half = weight.chunk(2, dim=1)
+            weight = torch.cat([second_half, first_half], dim=1)
+        return weight
+
+    def _weight_to_hf_format(
+        self, mcore_weights_name: str, mcore_weights: torch.Tensor
+    ) -> tuple[list[str], list[torch.Tensor]]:
+        if mcore_weights_name.endswith("eh_proj.weight"):
+            first_half, second_half = mcore_weights.chunk(2, dim=1)
+            mcore_weights = torch.cat([second_half, first_half], dim=1)
+        return super()._weight_to_hf_format(mcore_weights_name, mcore_weights)
 
     def _build_config(self):
+        mtp_args = {}
+        if hasattr(self.hf_config, "num_nextn_predict_layers"):
+            mtp_args["mtp_num_layers"] = self.hf_config.num_nextn_predict_layers
+
         return self._build_base_config(
             use_cpu_initialization=False,
             # MoE specific
@@ -98,4 +172,5 @@ class Qwen3NextBridge(Qwen2MoEBridge):
             # Qwen3 Next specific
             attention_output_gate=True,
             moe_shared_expert_gate=True,
+            **mtp_args,
         )


### PR DESCRIPTION
This pull request adds support for MTP (Multi-Task Prediction) layers to the Qwen3 Next model integration. It introduces logic for handling MTP-specific parameters and weight conversions during model bridging and conversion, ensuring compatibility between the Megatron and Hugging Face formats. The main changes are grouped into support for MTP layers, parameter/weight conversion logic, and configuration handling.

**Support for MTP layers:**

* Added `--mtp-num-layers` argument to the Qwen3 Next model shell script to allow specifying the number of MTP layers.
* Integrated MTP block specification into the Qwen3 Next bridge by overriding `_get_gptmodel_args` to include `mtp_block_spec` when MTP layers are configured.

**Parameter and weight conversion logic:**

* Implemented MTP-specific logic in `convert_qwen3_next_to_hf` to map MTP layer parameters from Megatron to Hugging Face format, including custom handling for special weights and recursive mapping for transformer sublayers.
* Overrode `_weight_name_mapping_mcore_to_hf` and `_convert_mtp_param` in the Qwen3 Next bridge to handle MTP parameter name conversions, including direct mappings and recursive handling for transformer subcomponents.
* Added logic in `_weight_to_mcore_format` and `_weight_to_hf_format` to handle special tensor permutations for `eh_proj.weight` parameters in both conversion directions.

**Configuration handling:**

* Extended `_build_config` to propagate the number of MTP layers from the Hugging Face config to the Megatron config, ensuring consistent setup. [[1]](diffhunk://#diff-83714a4a283afd385946897fbafe809f106b3a97724b4c6cd1a637f1eea48f7cL76-R152) [[2]](diffhunk://#diff-83714a4a283afd385946897fbafe809f106b3a97724b4c6cd1a637f1eea48f7cR175)
* Imported the required MTP block spec utility function in the Qwen3 Next bridge.


### Test
1. test qwen3-next hf to torch_dict
[hf_to_torch_dist_success.log](https://github.com/user-attachments/files/24883581/hf_to_torch_dist_success.log)
2. test qwen3-next torch_dict to hf
[torch_dist_to_hf_success.log](https://github.com/user-attachments/files/24883584/torch_dist_to_hf_success.log)
3. original hf model and converted hf model accept length basically maintain consistency
```
python3 -m sglang.launch_server --model /root/Qwen3-Next-80B-A3B-Thinking/ --tp 4 --speculative-num-steps 3  --speculative-eagle-topk 1  --speculative-num-draft-tokens 4 --speculative-algo NEXTN

python -m sglang.bench_one_batch_server --base-url http://127.0.0.1:30000 --model-path /root/Qwen3-Next-80B-A3B-Thinking/  --batch-size 1024  --input-len 8192 --output-len 512

python3 -m sglang.launch_server --model /root/Qwen3-Next-80B-A3B-Thinking-test/ --tp 4 --speculative-num-steps 3  --speculative-eagle-topk 1  --speculative-num-draft-tokens 4 --speculative-algo NEXTN

python -m sglang.bench_one_batch_server --base-url http://127.0.0.1:30000 --model-path /root/Qwen3-Next-80B-A3B-Thinking-test/  --batch-size 1024  --input-len 8192 --output-len 512

```
4. During the sft and rl training process, the mtp loss converges normally.
