### PR TITLE
fix: pp broadcast_object_list patch bug of megatron bridge

### DIFF
--- a/slime/utils/reloadable_process_group.py
+++ b/slime/utils/reloadable_process_group.py
@@ -79,6 +79,7 @@ def monkey_patch_torch_dist():
     dist.send = get_new_function(dist.send)
     dist.recv = get_new_function(dist.recv)
     dist._coalescing_manager = get_new_function(dist._coalescing_manager)
+    dist.broadcast_object_list = get_new_function(dist.broadcast_object_list)
 
     # p2p
     old_isend = dist.isend


### PR DESCRIPTION
修复 [megatron-bridge 这里](https://github.com/fzyzcjy/Megatron-Bridge/blob/6b1b80cdd3f5387e378545399287bf4a21a56fe0/src/megatron/bridge/models/conversion/param_mapping.py#L423) pp broadcast_object_list 没有 patch 导致 pp 启动时报错的问题