### PR TITLE
fix: remove double-counting of LR scheduler steps on checkpoint resume

### DIFF
--- a/slime/backends/megatron_utils/model.py
+++ b/slime/backends/megatron_utils/model.py
@@ -783,6 +783,4 @@ def initialize_model_and_optimizer(
     )
     clear_memory()
 
-    opt_param_scheduler.step(increment=iteration * args.global_batch_size)
-
     return model, optimizer, opt_param_scheduler, iteration


### PR DESCRIPTION
Megatron's load_checkpoint() already calls opt_param_scheduler.load_state_dict() which internally increments num_steps. The extra step() call here was doubling the scheduler position on every resume.

More info: Issue #1546 