### PR TITLE
Add quantization support for bridge mode weight update

### DIFF
--- a/slime/backends/megatron_utils/megatron_to_hf/__init__.py
+++ b/slime/backends/megatron_utils/megatron_to_hf/__init__.py
@@ -11,10 +11,9 @@ from .qwen3moe import convert_qwen3moe_to_hf
 
 
 # TODO unify w/ `convert_to_hf`
-def postprocess_hf_param(args, megatron_param_name, hf_param_name, param):
+def postprocess_hf_param(args, megatron_param_name, hf_param_name, param, quantization_config=None):
     param = remove_padding(megatron_param_name, param, args.vocab_size)
-    # TODO support quant
-    return param
+    return quantize_params(args, megatron_param_name, [(hf_param_name, param)], quantization_config)
 
 
 # TODO optimize code details


### PR DESCRIPTION
I noticed that bridge mode does not yet support quantization during weight updates. So I made some changes:
- Add quantization_config parameter to postprocess_hf_param() to support fp8 and compressed-tensors quantization
- Update HfWeightIteratorBridge to pass quantization config during weight conversion