### PR TITLE
Sglang rollout timeout, refer to issue #1562  

### DIFF
--- a/train.py
+++ b/train.py
@@ -4,7 +4,7 @@ from slime.ray.placement_group import create_placement_groups, create_rollout_ma
 from slime.utils.arguments import parse_args
 from slime.utils.logging_utils import configure_logger, init_tracking
 from slime.utils.misc import should_run_periodic_action
-
+from tqdm import tqdm
 
 def train(args):
     configure_logger()
@@ -62,7 +62,7 @@ def train(args):
 
     # train loop.
     # note that for async training, one can change the position of the sync operation(ray.get).
-    for rollout_id in range(args.start_rollout_id, args.num_rollout):
+    for rollout_id in tqdm(range(args.start_rollout_id, args.num_rollout),desc=f"Training Progress, start {args.start_rollout_id}, total {args.num_rollout}"):
         if args.eval_interval is not None and rollout_id == 0 and not args.skip_eval_before_train:
             ray.get(rollout_manager.eval.remote(rollout_id))
 


### PR DESCRIPTION
fix rollout timeout by catching exception then retries or appending to abort groups

refer to issue #1562  

I assume the issue was raised by excessive token generation -> time out, and limit --rollout-max-response-len (4096).

Please check if this fixing is redundant cause I am not sure somewhere the code already fixed.