### PR TITLE
fix: Handle IPv6 addresses in weight sync init_method

### DIFF
--- a/slime/backends/megatron_utils/update_weight/update_weight_from_distributed.py
+++ b/slime/backends/megatron_utils/update_weight/update_weight_from_distributed.py
@@ -266,7 +266,8 @@ def connect_rollout_engines_from_distributed(
     ]
     model_update_groups = init_process_group(
         backend="nccl",
-        init_method=f"tcp://{master_address}:{master_port}",
+        # IPv6 addresses must be bracketed in URLs since they contain colons (e.g. tcp://[::1]:8080)
+        init_method=f"tcp://[{master_address}]:{master_port}" if ":" in master_address else f"tcp://{master_address}:{master_port}",
         world_size=world_size,
         rank=0,
         group_name=group_name,


### PR DESCRIPTION
IPv6 addresses contain colons that break tcp://addr:port URLs. Wrap IPv6 addresses in brackets: tcp://[::1]:port
This makes slime work on ipv6 only envorinment.