### PR TITLE
fix: restrict SymPy parser scope to prevent arbitrary code execution

### DIFF
--- a/slime/rollout/rm_hub/math_utils.py
+++ b/slime/rollout/rm_hub/math_utils.py
@@ -168,8 +168,13 @@ TUPLE_CHARS = "()[]"
 def _sympy_parse(expr: str):
     """Parses an expression with sympy."""
     py_expr = expr.replace("^", "**")
+    # We allow basic SymPy names but no builtins to prevent arbitrary code execution
+    # This whitelist approach ensures SymPy's internal transformations (like Integer) still work
+    safe_dict = {k: v for k, v in sympy.__dict__.items() if not k.startswith("_")}
     return sympy_parser.parse_expr(
         py_expr,
+        local_dict={},
+        global_dict={"__builtins__": {}, **safe_dict},
         transformations=(sympy_parser.standard_transformations + (sympy_parser.implicit_multiplication_application,)),
     )
 


### PR DESCRIPTION
## Description
Fixes a security vulnerability identified in #1586 where arbitrary code execution was possible through the SymPy parser in the math grading utility.

## Changes
- Modified `_sympy_parse()` in `slime/rollout/rm_hub/math_utils.py`
- Disabled `__builtins__` to prevent access to dangerous functions like `__import__`, `eval`, `exec`
- Added a whitelist of safe SymPy symbols to maintain mathematical functionality

## Security Impact
- **Before:** Model-generated answers could execute arbitrary Python code via `__import__('os').system()` and similar patterns
- **After:** Code execution is blocked while all legitimate math operations continue to work

## Testing
Verified that:
- ✅ Normal math operations work correctly (`1 + 1`, `sqrt(4)`, `pi`)
- ✅ Malicious code execution is blocked (tested with `__import__` patterns)
- ✅ No breaking changes to existing functionality

Fixes #1586
