### PR TITLE
[Feature] Add configurable arguments for rollout manager actor

### DIFF
--- a/slime/ray/placement_group.py
+++ b/slime/ray/placement_group.py
@@ -173,8 +173,10 @@ def create_training_models(args, pgs, rollout_manager):
 
 def create_rollout_manager(args, pg):
     rollout_manager = RolloutManager.options(
-        num_cpus=1,
-        num_gpus=0,
+        num_cpus=args.rollout_manager_num_cpus,
+        num_gpus=args.rollout_manager_num_gpus,
+        memory=args.rollout_manager_memory,
+        object_store_memory=args.rollout_manager_object_store_memory,
     ).remote(args, pg)
 
     # calculate num_rollout from num_epoch

--- a/slime/utils/arguments.py
+++ b/slime/utils/arguments.py
@@ -340,6 +340,32 @@ def get_slime_extra_args_provider(add_custom_arguments=None):
                 ),
             )
 
+            # rollout manager actor arguments
+            parser.add_argument(
+                "--rollout-manager-num-cpus",
+                type=float,
+                default=1.0,
+                help="Number of CPUs for the rollout manager actor. Note that the rollout manager will do some data processing and should have enough CPU to avoid being the bottleneck.",
+            )
+            parser.add_argument(
+                "--rollout-manager-num-gpus",
+                type=float,
+                default=0.0,
+                help="Number of GPUs for the rollout manager actor. Note that the rollout manager will do some data processing and should have enough GPU to avoid being the bottleneck.",
+            )
+            parser.add_argument(
+                "--rollout-manager-memory",
+                type=int,
+                default=None,
+                help="Heap memory (in bytes) to reserve for the rollout manager actor. None uses Ray's default.",
+            )
+            parser.add_argument(
+                "--rollout-manager-object-store-memory",
+                type=int,
+                default=None,
+                help="Object store memory (in bytes) to reserve for the rollout manager actor. None uses Ray's default.",
+            )
+
             # sampling
             parser.add_argument(
                 "--over-sampling-batch-size",


### PR DESCRIPTION
Add ability to configure the resources for RolloutManager if necessary. 

The default `num_cpus=1` is too restrictive in some use cases and it'd be beneficial to be able to override these parameters if necessary. According to ray [docs](https://docs.ray.io/en/latest/ray-core/api/doc/ray.actor.ActorClass.options.html#ray.actor.ActorClass.options), sending `None` values to the other parameters will be equivalent to the defaults ray chooses.
