### PR TITLE
fix: use getattr for sglang params when rollout_only is disabled

### DIFF
--- a/slime/utils/wandb_utils.py
+++ b/slime/utils/wandb_utils.py
@@ -116,7 +116,7 @@ def init_wandb_secondary(args, router_addr=None):
             x_update_finish_state=False,
         )
 
-    if args.sglang_enable_metrics and router_addr is not None:
+    if getattr(args, "sglang_enable_metrics", False) and router_addr is not None:
         logger.info(f"Forward SGLang metrics at {router_addr} to WandB.")
         settings_kwargs |= dict(
             x_stats_open_metrics_endpoints={

--- a/tools/convert_torch_dist_to_hf.py
+++ b/tools/convert_torch_dist_to_hf.py
@@ -104,9 +104,6 @@ def get_named_params(args, state_dict):
 
 
 def save_tensors(args, model_name, state_dict, output_dir, chunk_size, vocab_size=None):
-    # for slime update_weight compatible
-    args.sglang_enable_ep_moe = False
-
     print(f"start saving to {output_dir}")
     os.makedirs(output_dir, exist_ok=True)
     # 2GB


### PR DESCRIPTION
When rollout_only is off, the args object does not contain sglang-related attributes (e.g. sglang_enable_metrics), causing AttributeError during wandb secondary init. Use getattr with a default value to handle this gracefully.

Also remove the unnecessary sglang_enable_ep_moe workaround in convert_torch_dist_to_hf.py.