### PR TITLE
feat: add --lazy-multimodal-load to defer image process to rollout time

### DIFF
--- a/examples/geo3k_vlm_multi_turn/rollout.py
+++ b/examples/geo3k_vlm_multi_turn/rollout.py
@@ -152,6 +152,12 @@ def _initialize_resources(args: Any, sample: Sample):
 
 
 def _prepare_initial_inputs(sample: Sample, processor, tokenizer):
+    # Lazy-load multimodal inputs to avoid OOM during Dataset init
+    if processor and sample.multimodal_inputs is None and sample.raw_prompt is not None:
+        from slime.utils.processing_utils import process_vision_info
+
+        sample.multimodal_inputs = process_vision_info(sample.raw_prompt, processor)
+
     if processor:
         processor_output = processor(text=sample.prompt, **(sample.multimodal_inputs or {}))
         prompt_ids = processor_output["input_ids"][0]

--- a/slime/rollout/data_source.py
+++ b/slime/rollout/data_source.py
@@ -81,6 +81,7 @@ class RolloutDataSource(DataSource):
                 apply_chat_template=args.apply_chat_template,
                 apply_chat_template_kwargs=args.apply_chat_template_kwargs,
                 seed=args.rollout_seed,
+                lazy_multimodal_load=args.lazy_multimodal_load,
             )
             if self.args.rollout_shuffle:
                 self.dataset.shuffle(self.epoch_id)

--- a/slime/utils/arguments.py
+++ b/slime/utils/arguments.py
@@ -562,6 +562,12 @@ def get_slime_extra_args_provider(add_custom_arguments=None):
                     'JSON string for multimodal data mapping media types to data keys. Example: \'{"image": "image_file"}\''
                 ),
             )
+            parser.add_argument(
+                "--lazy-multimodal-load",
+                action="store_true",
+                default=False,
+                help="Defer image decoding to rollout time instead of loading all images at Dataset init. Reduces memory usage for large VLM datasets.",
+            )
             parser.add_argument("--metadata-key", type=str, default="metadata", help="JSON dataset key")
             parser.add_argument(
                 "--tool-key",

--- a/slime/utils/types.py
+++ b/slime/utils/types.py
@@ -13,6 +13,7 @@ class Sample:
     index: int | None = None
     # prompt
     prompt: str | list[dict[str, str]] = ""
+    raw_prompt: list[dict[str, str]] | None = None  # original conversation-format prompt for lazy multimodal loading
     tokens: list[int] = field(default_factory=list)
     multimodal_inputs: dict[str, Any] | None = None  # raw multimodal data, e.g. images, videos, etc.
     multimodal_train_inputs: dict[str, Any] | None = None  # processed multimodal data, e.g. pixel_values, etc.


### PR DESCRIPTION
Avoid OOM during Dataset init for large VLM datasets by deferring process_vision_info calls to rollout time. Controlled by the --lazy-multimodal-load flag (default off, preserving existing behavior).