### PR TITLE
fix: skip memory check for non-communication query functions in ReloadableProcessGroup

### DIFF
--- a/slime/utils/reloadable_process_group.py
+++ b/slime/utils/reloadable_process_group.py
@@ -47,7 +47,19 @@ def monkey_patch_torch_dist():
 
     dist.new_group = new_group
 
-    def get_new_function(func):
+    def get_new_query_function(func):
+        """Wrap query functions (get_rank, get_world_size, etc.) without memory check."""
+
+        def new_function(*args, **kwargs):
+            args = tuple([arg.group if isinstance(arg, ReloadableProcessGroup) else arg for arg in args])
+            kwargs = {k: (v.group if isinstance(v, ReloadableProcessGroup) else v) for k, v in kwargs.items()}
+            return func(*args, **kwargs)
+
+        return new_function
+
+    def get_new_comm_function(func):
+        """Wrap communication functions with memory check."""
+
         def new_function(*args, **kwargs):
             args = tuple([arg.group if isinstance(arg, ReloadableProcessGroup) else arg for arg in args])
             kwargs = {k: (v.group if isinstance(v, ReloadableProcessGroup) else v) for k, v in kwargs.items()}
@@ -56,36 +68,36 @@ def monkey_patch_torch_dist():
 
         return new_function
 
-    dist.get_rank = get_new_function(dist.get_rank)
-    dist.get_world_size = get_new_function(dist.get_world_size)
-    dist.get_backend = get_new_function(dist.get_backend)
-    dist.get_global_rank = get_new_function(dist.get_global_rank)
-    dist.get_group_rank = get_new_function(dist.get_group_rank)
-    dist.get_process_group_ranks = get_new_function(dist.get_process_group_ranks)
+    dist.get_rank = get_new_query_function(dist.get_rank)
+    dist.get_world_size = get_new_query_function(dist.get_world_size)
+    dist.get_backend = get_new_query_function(dist.get_backend)
+    dist.get_global_rank = get_new_query_function(dist.get_global_rank)
+    dist.get_group_rank = get_new_query_function(dist.get_group_rank)
+    dist.get_process_group_ranks = get_new_query_function(dist.get_process_group_ranks)
 
-    dist.all_reduce = get_new_function(dist.all_reduce)
-    dist.all_gather = get_new_function(dist.all_gather)
-    dist.all_gather_into_tensor = get_new_function(dist.all_gather_into_tensor)
-    dist.all_gather_object = get_new_function(dist.all_gather_object)
-    dist.all_to_all = get_new_function(dist.all_to_all)
-    dist.all_to_all_single = get_new_function(dist.all_to_all_single)
-    dist.broadcast = get_new_function(dist.broadcast)
-    dist.reduce = get_new_function(dist.reduce)
-    dist.reduce_scatter = get_new_function(dist.reduce_scatter)
-    dist.reduce_scatter_tensor = get_new_function(dist.reduce_scatter_tensor)
-    dist.scatter = get_new_function(dist.scatter)
-    dist.gather = get_new_function(dist.gather)
-    dist.barrier = get_new_function(dist.barrier)
-    dist.send = get_new_function(dist.send)
-    dist.recv = get_new_function(dist.recv)
-    dist._coalescing_manager = get_new_function(dist._coalescing_manager)
+    dist.all_reduce = get_new_comm_function(dist.all_reduce)
+    dist.all_gather = get_new_comm_function(dist.all_gather)
+    dist.all_gather_into_tensor = get_new_comm_function(dist.all_gather_into_tensor)
+    dist.all_gather_object = get_new_comm_function(dist.all_gather_object)
+    dist.all_to_all = get_new_comm_function(dist.all_to_all)
+    dist.all_to_all_single = get_new_comm_function(dist.all_to_all_single)
+    dist.broadcast = get_new_comm_function(dist.broadcast)
+    dist.reduce = get_new_comm_function(dist.reduce)
+    dist.reduce_scatter = get_new_comm_function(dist.reduce_scatter)
+    dist.reduce_scatter_tensor = get_new_comm_function(dist.reduce_scatter_tensor)
+    dist.scatter = get_new_comm_function(dist.scatter)
+    dist.gather = get_new_comm_function(dist.gather)
+    dist.barrier = get_new_comm_function(dist.barrier)
+    dist.send = get_new_comm_function(dist.send)
+    dist.recv = get_new_comm_function(dist.recv)
+    dist._coalescing_manager = get_new_comm_function(dist._coalescing_manager)
 
     # p2p
     old_isend = dist.isend
     old_irecv = dist.irecv
 
-    dist.isend = get_new_function(dist.isend)
-    dist.irecv = get_new_function(dist.irecv)
+    dist.isend = get_new_comm_function(dist.isend)
+    dist.irecv = get_new_comm_function(dist.irecv)
 
     def get_new_p2pop_function(func):
         def new_function(*args, **kwargs):
@@ -181,6 +193,13 @@ class ReloadableProcessGroup(torch.distributed.ProcessGroup):
         with _wrap_low_level_call():
             return getattr(inner, method)(*args, **kwargs)
 
+    def _fwd_query(self, method, *args, **kwargs):
+        """Forward non-communication calls without memory check."""
+        inner = self.group
+        if inner is None:
+            raise RuntimeError("ReloadableProcessGroup: inner PG is None, call reload() first.")
+        return getattr(inner, method)(*args, **kwargs)
+
     def barrier(self, *a, **kw):
         return self._fwd("barrier", *a, **kw)
 
@@ -239,19 +258,19 @@ class ReloadableProcessGroup(torch.distributed.ProcessGroup):
         return self._fwd("recv_anysource", *a, **kw)
 
     def _start_coalescing(self, *a, **kw):
-        return self._fwd("_start_coalescing", *a, **kw)
+        return self._fwd_query("_start_coalescing", *a, **kw)
 
     def _end_coalescing(self, *a, **kw):
         return self._fwd("_end_coalescing", *a, **kw)
 
     def _get_backend_name(self):
-        return self._fwd("_get_backend_name")
+        return self._fwd_query("_get_backend_name")
 
     def _get_backend(self, *a, **kw):
-        return self._fwd("_get_backend", *a, **kw)
+        return self._fwd_query("_get_backend", *a, **kw)
 
     def _set_default_backend(self, *a, **kw):
-        return self._fwd("_set_default_backend", *a, **kw)
+        return self._fwd_query("_set_default_backend", *a, **kw)
 
     @property
     def bound_device_id(self):


### PR DESCRIPTION
Previously all monkey-patched torch.distributed functions (including query functions like get_rank, get_world_size, get_backend, etc.) were wrapped with _wrap_low_level_call which checks available_memory on every invocation. This is unnecessary for non-communication queries and adds overhead.

Split the wrapping into two categories:
- get_new_query_function / _fwd_query: for metadata queries (no memory check)
- get_new_comm_function / _fwd: for actual communication ops (with memory check)

Affected query functions (no longer check memory):
- dist.get_rank, get_world_size, get_backend, get_global_rank, get_group_rank, get_process_group_ranks
- ReloadableProcessGroup._start_coalescing, _get_backend_name, _get_backend, _set_default_backend