### PR TITLE
fix: explicitly delete forward_data_store to prevent GPU memory leak

### DIFF
--- a/slime/backends/megatron_utils/model.py
+++ b/slime/backends/megatron_utils/model.py
@@ -293,6 +293,10 @@ def forward_only(
                     origin_values[origin_index] = value
                 values = origin_values
             rollout_data[f"{store_prefix}{key}"] = values
+
+    # 显式释放 forward_data_store 以避免显存泄漏
+    del forward_data_store
+
     return rollout_data
 
 


### PR DESCRIPTION
## Summary

Fixes a GPU memory leak in `forward_only()` in `slime/backends/megatron_utils/model.py`.

## Problem

`forward_data_store` is a list of dicts accumulated across all microbatches during the forward pass. On **non-last pipeline stages**, `mpu.is_pipeline_last_stage()` is `False`, so none of the data in `forward_data_store` is extracted into `rollout_data`. As a result, any GPU tensors held inside `forward_data_store` remain live until the Python garbage collector reclaims them, which may be delayed in long-running training loops, causing unnecessary GPU memory pressure.

## Fix

Add an explicit `del forward_data_store` after its contents have been fully consumed (after the `rollout_data` population block), so GPU tensor references are dropped as early as possible.

## Impact

- **Non-last pipeline stages**: GPU memory held by `forward_data_store` is freed immediately after use, reducing peak memory consumption during rollout.
- **Last pipeline stage**: Minor benefit — the dict/list wrapper overhead is freed, though the tensor data itself is still referenced by `rollout_data`.

## Notes

This is a targeted, minimal fix. A complementary improvement would be to call `torch.cuda.empty_cache()` after deletion if aggressive memory reclamation is needed, but that is left as a separate concern.