### PR TITLE
Add Qwen3.5 model support (27B dense and 35B-A3B MoE)

### DIFF
--- a/scripts/models/qwen3.5-27B.sh
+++ b/scripts/models/qwen3.5-27B.sh
@@ -1,0 +1,28 @@
+MODEL_ARGS=(
+   --spec "slime_plugins.models.qwen3_5" "get_qwen3_5_spec"
+
+   --disable-bias-linear
+   --qk-layernorm
+   --group-query-attention
+   --num-attention-heads 24
+   --num-query-groups 4
+   --kv-channels 256
+   --num-layers 64
+   --hidden-size 5120
+   --ffn-hidden-size 17408
+   --use-gated-attention
+
+   --normalization RMSNorm
+   --apply-layernorm-1p
+   --position-embedding-type rope
+   --norm-epsilon 1e-6
+   --rotary-percent 0.25
+   --swiglu
+   --untie-embeddings-and-output-weights
+   --vocab-size 248320
+
+   --rotary-base 10000000
+
+   # qwen3.5 specific
+   --attention-output-gate
+)

--- a/scripts/models/qwen3.5-35B-A3B.sh
+++ b/scripts/models/qwen3.5-35B-A3B.sh
@@ -1,0 +1,58 @@
+NLAYERS=40
+FIRST_K_DENSE_REPLACE=0
+
+arr=()
+for ((i=0; i<NLAYERS; i++)); do
+  if (( i < FIRST_K_DENSE_REPLACE )); then
+    arr+=(0)
+  else
+    arr+=(1)
+  fi
+done
+
+printf -v MOE_LAYER_FREQ "[%s]" "$(IFS=', '; echo "${arr[*]}")"
+
+
+MODEL_ARGS=(
+   --spec "slime_plugins.models.qwen3_5" "get_qwen3_5_spec"
+
+   --disable-bias-linear
+   --qk-layernorm
+   --group-query-attention
+   --num-attention-heads 16
+   --num-query-groups 2
+   --kv-channels 256
+   --num-layers 40
+   --hidden-size 2048
+   --ffn-hidden-size 512
+   --use-gated-attention
+
+   --normalization RMSNorm
+   --apply-layernorm-1p
+   --position-embedding-type rope
+   --norm-epsilon 1e-6
+   --rotary-percent 0.25
+   --swiglu
+   --untie-embeddings-and-output-weights
+   --vocab-size 248320
+
+   --rotary-base 10000000
+
+   # moe
+   --moe-ffn-hidden-size 512
+   --moe-shared-expert-intermediate-size 512
+   --moe-router-score-function softmax
+   --moe-token-dispatcher-type alltoall
+   --moe-router-topk 8
+   --moe-layer-freq $MOE_LAYER_FREQ
+   --num-experts 256
+   --moe-grouped-gemm
+   --moe-token-drop-policy probs
+   --moe-router-dtype fp32
+   --moe-permute-fusion
+   --moe-aux-loss-coeff 0
+
+   # qwen3.5 specific
+   --attention-output-gate
+   --moe-shared-expert-gate
+)

--- a/scripts/run-qwen3.5-27B.sh
+++ b/scripts/run-qwen3.5-27B.sh
@@ -1,0 +1,159 @@
+#!/bin/bash
+
+# for rerun the task
+pkill -9 sglang
+sleep 3
+ray stop --force
+pkill -9 ray
+pkill -9 python
+sleep 3
+pkill -9 ray
+pkill -9 python
+
+set -ex
+
+# will prevent ray from buffering stdout/stderr
+export PYTHONBUFFERED=16
+
+# unset proxy to avoid issues
+unset http_proxy https_proxy HTTP_PROXY HTTPS_PROXY
+
+NVLINK_COUNT=$(nvidia-smi topo -m 2>/dev/null | grep -o 'NV[0-9][0-9]*' | wc -l)
+if [ "$NVLINK_COUNT" -gt 0 ]; then
+    HAS_NVLINK=1
+else
+    HAS_NVLINK=0
+fi
+echo "HAS_NVLINK: $HAS_NVLINK (detected $NVLINK_COUNT NVLink references)"
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+source "${SCRIPT_DIR}/models/qwen3.5-27B.sh"
+
+CKPT_ARGS=(
+   --hf-checkpoint /root/Qwen3.5-27B
+   --ref-load /root/Qwen3.5-27B_torch_dist/
+   --load /root/Qwen3.5-27B_slime
+   --save /root/Qwen3.5-27B_slime
+   --save-interval 20
+)
+
+ROLLOUT_ARGS=(
+   --prompt-data /root/dapo-math-17k/dapo-math-17k.jsonl
+   --input-key prompt
+   --label-key label
+   --apply-chat-template
+   --rollout-shuffle
+   --rm-type deepscaler
+   --num-rollout 3000
+   --rollout-batch-size 32
+   --n-samples-per-prompt 8
+   --rollout-max-response-len 8192
+   --rollout-temperature 1
+
+   --global-batch-size 256
+   --balance-data
+)
+
+EVAL_ARGS=(
+   --eval-interval 20
+   --eval-prompt-data aime /root/aime-2024/aime-2024.jsonl
+   --n-samples-per-eval-prompt 16
+   --eval-max-response-len 16384
+   --eval-top-p 1
+)
+
+PERF_ARGS=(
+   --tensor-model-parallel-size 4
+   --sequence-parallel
+   --pipeline-model-parallel-size 1
+   --context-parallel-size 1
+   --expert-model-parallel-size 1
+   --expert-tensor-parallel-size 1
+
+   --recompute-granularity full
+   --recompute-method uniform
+   --recompute-num-layers 1
+
+   # --micro-batch-size 1
+   --use-dynamic-batch-size
+   --max-tokens-per-gpu 20480
+)
+
+GRPO_ARGS=(
+   --advantage-estimator grpo
+   --use-kl-loss
+   --kl-loss-coef 0.00
+   --kl-loss-type low_var_kl
+   --entropy-coef 0.00
+   --eps-clip 0.2
+   --eps-clip-high 0.28
+)
+
+OPTIMIZER_ARGS=(
+   --optimizer adam
+   --lr 1e-6
+   --lr-decay-style constant
+   --weight-decay 0.1
+   --adam-beta1 0.9
+   --adam-beta2 0.98
+
+   --optimizer-cpu-offload
+   --overlap-cpu-optimizer-d2h-h2d
+   --use-precision-aware-optimizer
+)
+
+WANDB_ARGS=(
+   #--use-wandb
+   # --wandb-project slime-dev
+   # --wandb-group qwen3.5-27B-test
+   # --wandb-key ${WANDB_KEY}
+)
+
+SGLANG_ARGS=(
+   --rollout-num-gpus-per-engine 8
+   --sglang-mem-fraction-static 0.7
+   --sglang-cuda-graph-bs 1 2 4 8 $(seq 16 8 256)
+)
+
+MISC_ARGS=(
+   # default dropout in megatron is 0.1
+   --attention-dropout 0.0
+   --hidden-dropout 0.0
+   # should be good for model performance
+   --accumulate-allreduce-grads-in-fp32
+   --attention-softmax-in-fp32
+   # need to comment this when using model with MLA
+   --attention-backend flash
+)
+
+# launch the master node of ray in container
+export MASTER_ADDR=${MASTER_ADDR:-"127.0.0.1"}
+export no_proxy="127.0.0.1,${MASTER_ADDR}"
+ray start --head --node-ip-address ${MASTER_ADDR} --num-gpus 8 --disable-usage-stats --dashboard-host=0.0.0.0 --dashboard-port=8265
+
+# Build the runtime environment JSON with proper variable substitution
+RUNTIME_ENV_JSON="{
+  \"env_vars\": {
+    \"PYTHONPATH\": \"/root/Megatron-LM/\",
+    \"CUDA_DEVICE_MAX_CONNECTIONS\": \"1\",
+    \"NCCL_NVLS_ENABLE\": \"${HAS_NVLINK}\",
+    \"no_proxy\": \"${no_proxy}\"
+  }
+}"
+
+ray job submit --address="http://127.0.0.1:8265" \
+   --runtime-env-json="${RUNTIME_ENV_JSON}" \
+   -- python3 train.py \
+   --actor-num-nodes 1 \
+   --actor-num-gpus-per-node 8 \
+   --colocate \
+   ${MODEL_ARGS[@]} \
+   ${CKPT_ARGS[@]} \
+   ${ROLLOUT_ARGS[@]} \
+   ${OPTIMIZER_ARGS[@]} \
+   ${GRPO_ARGS[@]} \
+   ${WANDB_ARGS[@]} \
+   ${PERF_ARGS[@]} \
+   ${EVAL_ARGS[@]} \
+   ${SGLANG_ARGS[@]} \
+   ${MISC_ARGS[@]}

--- a/scripts/run-qwen3.5-35B-A3B.sh
+++ b/scripts/run-qwen3.5-35B-A3B.sh
@@ -1,0 +1,171 @@
+#!/bin/bash
+
+# for rerun the task
+pkill -9 sglang
+sleep 3
+ray stop --force
+pkill -9 ray
+pkill -9 python
+sleep 3
+pkill -9 ray
+pkill -9 python
+
+set -ex
+
+# will prevent ray from buffering stdout/stderr
+export PYTHONBUFFERED=16
+
+# unset proxy to avoid issues
+unset http_proxy https_proxy HTTP_PROXY HTTPS_PROXY
+
+NVLINK_COUNT=$(nvidia-smi topo -m 2>/dev/null | grep -o 'NV[0-9][0-9]*' | wc -l)
+if [ "$NVLINK_COUNT" -gt 0 ]; then
+    HAS_NVLINK=1
+else
+    HAS_NVLINK=0
+fi
+echo "HAS_NVLINK: $HAS_NVLINK (detected $NVLINK_COUNT NVLink references)"
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+source "${SCRIPT_DIR}/models/qwen3.5-35B-A3B.sh"
+
+CKPT_ARGS=(
+   --hf-checkpoint /root/Qwen3.5-35B-A3B
+   --ref-load /root/Qwen3.5-35B-A3B_torch_dist
+   --load /root/Qwen3.5-35B-A3B_slime/
+   --save /root/Qwen3.5-35B-A3B_slime/
+   --save-interval 20
+)
+
+ROLLOUT_ARGS=(
+   --prompt-data /root/dapo-math-17k/dapo-math-17k.jsonl
+   --input-key prompt
+   --label-key label
+   --apply-chat-template
+   --rollout-shuffle
+   --rm-type deepscaler
+   --num-rollout 3000
+   --rollout-batch-size 32
+   --n-samples-per-prompt 8
+   --rollout-max-response-len 8192
+   --rollout-temperature 1
+
+   --global-batch-size 256
+   --balance-data
+)
+
+EVAL_ARGS=(
+   --eval-interval 20
+   --eval-prompt-data aime /root/aime-2024/aime-2024.jsonl
+   --n-samples-per-eval-prompt 16
+   --eval-max-response-len 16384
+   --eval-top-p 1
+)
+
+PERF_ARGS=(
+   --tensor-model-parallel-size 4
+   --sequence-parallel
+   --pipeline-model-parallel-size 1
+   --context-parallel-size 1
+   --expert-model-parallel-size 8
+   --expert-tensor-parallel-size 1
+
+   --recompute-granularity full
+   --recompute-method uniform
+   --recompute-num-layers 1
+
+   # --micro-batch-size 1
+   --use-dynamic-batch-size
+   --max-tokens-per-gpu 20480
+)
+
+GRPO_ARGS=(
+   --advantage-estimator grpo
+   --use-kl-loss
+   --kl-loss-coef 0.00
+   --kl-loss-type low_var_kl
+   --entropy-coef 0.00
+   --eps-clip 0.2
+   --eps-clip-high 0.28
+)
+
+OPTIMIZER_ARGS=(
+   --optimizer adam
+   --lr 1e-6
+   --lr-decay-style constant
+   --weight-decay 0.1
+   --adam-beta1 0.9
+   --adam-beta2 0.98
+
+   --optimizer-cpu-offload
+   --overlap-cpu-optimizer-d2h-h2d
+   --use-precision-aware-optimizer
+)
+
+WANDB_ARGS=(
+   #--use-wandb
+   # --wandb-project slime-dev
+   # --wandb-group qwen3.5-35B-A3B-test
+   # --wandb-key ${WANDB_KEY}
+)
+
+SGLANG_ARGS=(
+   --rollout-num-gpus-per-engine 8
+   --sglang-mem-fraction-static 0.7
+   --sglang-ep-size 8
+
+   --sglang-cuda-graph-bs 1 2 4 8 $(seq 16 8 256)
+
+   # mtp
+   --sglang-speculative-algorithm EAGLE
+   --sglang-speculative-num-steps 2
+   --sglang-speculative-eagle-topk 1
+   --sglang-speculative-num-draft-tokens 3
+
+   --sglang-max-running-requests 512
+)
+
+MISC_ARGS=(
+   # default dropout in megatron is 0.1
+   --attention-dropout 0.0
+   --hidden-dropout 0.0
+   # should be good for model performance
+   --accumulate-allreduce-grads-in-fp32
+   --attention-softmax-in-fp32
+   # need to comment this when using model with MLA
+   --attention-backend flash
+
+   --moe-token-dispatcher-type flex
+)
+
+# launch the master node of ray in container
+export MASTER_ADDR=${MASTER_ADDR:-"127.0.0.1"}
+export no_proxy="127.0.0.1,${MASTER_ADDR}"
+ray start --head --node-ip-address ${MASTER_ADDR} --num-gpus 8 --disable-usage-stats --dashboard-host=0.0.0.0 --dashboard-port=8265
+
+# Build the runtime environment JSON with proper variable substitution
+RUNTIME_ENV_JSON="{
+  \"env_vars\": {
+    \"PYTHONPATH\": \"/root/Megatron-LM/\",
+    \"CUDA_DEVICE_MAX_CONNECTIONS\": \"1\",
+    \"NCCL_NVLS_ENABLE\": \"${HAS_NVLINK}\",
+    \"no_proxy\": \"${no_proxy}\"
+  }
+}"
+
+ray job submit --address="http://127.0.0.1:8265" \
+   --runtime-env-json="${RUNTIME_ENV_JSON}" \
+   -- python3 train.py \
+   --actor-num-nodes 1 \
+   --actor-num-gpus-per-node 8 \
+   --colocate \
+   ${MODEL_ARGS[@]} \
+   ${CKPT_ARGS[@]} \
+   ${ROLLOUT_ARGS[@]} \
+   ${OPTIMIZER_ARGS[@]} \
+   ${GRPO_ARGS[@]} \
+   ${WANDB_ARGS[@]} \
+   ${PERF_ARGS[@]} \
+   ${EVAL_ARGS[@]} \
+   ${SGLANG_ARGS[@]} \
+   ${MISC_ARGS[@]}

--- a/slime/backends/megatron_utils/megatron_to_hf/__init__.py
+++ b/slime/backends/megatron_utils/megatron_to_hf/__init__.py
@@ -5,6 +5,7 @@ from .llama import convert_llama_to_hf
 from .mimo import convert_mimo_to_hf
 from .processors import quantize_params, remove_padding
 from .qwen2 import convert_qwen2_to_hf
+from .qwen3_5 import convert_qwen3_5_to_hf
 from .qwen3_next import convert_qwen3_next_to_hf
 from .qwen3_vl import convert_qwen3vl_to_hf
 from .qwen3moe import convert_qwen3moe_to_hf
@@ -42,6 +43,8 @@ def _convert_to_hf_core(args, model_name, name, param):
         converted_named_tensors = convert_qwen3moe_to_hf(args, name, param)
     elif "qwen3next" in model_name:
         converted_named_tensors = convert_qwen3_next_to_hf(args, name, param)
+    elif "qwen3_5" in model_name:
+        converted_named_tensors = convert_qwen3_5_to_hf(args, name, param)
     elif "qwen3vl" in model_name:
         converted_named_tensors = convert_qwen3vl_to_hf(args, name, param)
     elif "qwen2" in model_name or "qwen3" in model_name:

--- a/slime/backends/megatron_utils/megatron_to_hf/qwen3_5.py
+++ b/slime/backends/megatron_utils/megatron_to_hf/qwen3_5.py
@@ -1,0 +1,197 @@
+import re
+
+import torch
+
+
+def _convert_mtp_layer(args, name, param, layer_idx):
+    """Convert MTP layer parameters from Megatron to HuggingFace format."""
+    if "enorm.weight" in name:
+        return [("mtp.pre_fc_norm_embedding.weight", param)]
+    if "hnorm.weight" in name:
+        return [("mtp.pre_fc_norm_hidden.weight", param)]
+    if "final_layernorm.weight" in name:
+        return [("mtp.norm.weight", param)]
+    if "eh_proj.weight" in name:
+        if param.dim() < 2:
+            raise ValueError(f"eh_proj weight expects 2D tensor, got {param.shape}")
+        first_half, second_half = param.chunk(2, dim=1)
+        new_param = torch.cat([second_half, first_half], dim=1)
+        return [("mtp.fc.weight", new_param)]
+
+    if "transformer_layer" in name:
+        proxy_name = name.replace(f"mtp.layers.{layer_idx}.transformer_layer", f"decoder.layers.{layer_idx}")
+        mapped_params = convert_qwen3_5_to_hf(args, proxy_name, param)
+
+        final_params = []
+        for hf_name, tensor in mapped_params:
+            target_prefix = f"mtp.layers.{layer_idx}"
+            if f"model.language_model.layers.{layer_idx}" in hf_name:
+                new_hf_name = hf_name.replace(f"model.language_model.layers.{layer_idx}", target_prefix)
+                final_params.append((new_hf_name, tensor))
+            else:
+                final_params.append((hf_name, tensor))
+        return final_params
+
+    return None
+
+
+def convert_qwen3_5_to_hf(args, name, param):
+    """Convert Qwen3.5 model parameters from Megatron to HuggingFace format.
+
+    Qwen3.5 uses model.language_model.layers prefix and has separate
+    in_proj_qkv, in_proj_z, in_proj_b, in_proj_a for linear attention.
+    """
+    # Handle MTP layers
+    if "mtp.layers" in name:
+        parts = name.split(".")
+        try:
+            layer_idx_loc = parts.index("layers") + 1
+            layer_idx = parts[layer_idx_loc]
+        except (ValueError, IndexError) as e:
+            raise ValueError(f"Invalid MTP layer name format: {name}") from e
+
+        result = _convert_mtp_layer(args, name, param, layer_idx)
+        if result is not None:
+            return result
+
+    if name == "module.module.embedding.word_embeddings.weight":
+        return [("model.language_model.embed_tokens.weight", param)]
+    if name == "module.module.output_layer.weight":
+        return [("lm_head.weight", param)]
+    if name == "module.module.decoder.final_layernorm.weight":
+        return [("model.language_model.norm.weight", param)]
+
+    try:
+        head_dim = args.kv_channels if args.kv_channels is not None else args.hidden_size // args.num_attention_heads
+    except AttributeError:
+        head_dim = args.hidden_size // args.num_attention_heads
+    value_num_per_group = args.num_attention_heads // args.num_query_groups
+
+    decoder_layers_pattern = r"module\.module\.decoder\.layers\.(\d+)\.(.+)"
+    match = re.match(decoder_layers_pattern, name)
+    if match:
+        layer_idx, rest = match.groups()
+        prefix = f"model.language_model.layers.{layer_idx}"
+
+        # experts (grouped gemm - fused format)
+        if rest == "mlp.experts.linear_fc1":
+            return [(f"{prefix}.mlp.experts.gate_up_proj", param)]
+        elif rest == "mlp.experts.linear_fc2":
+            return [(f"{prefix}.mlp.experts.down_proj", param)]
+
+        # experts (ungrouped - individual expert format)
+        expert_pattern = r"mlp.experts\.(.+)\.weight(\d+)"
+        match = re.match(expert_pattern, rest)
+        if match:
+            rest, expert_idx = match.groups()
+            if rest == "linear_fc1":
+                gate_weight, up_weight = param.chunk(2, dim=0)
+                return [
+                    (f"{prefix}.mlp.experts.{expert_idx}.gate_proj.weight", gate_weight),
+                    (f"{prefix}.mlp.experts.{expert_idx}.up_proj.weight", up_weight),
+                ]
+            elif rest == "linear_fc2":
+                return [(f"{prefix}.mlp.experts.{expert_idx}.down_proj.weight", param)]
+            else:
+                raise ValueError(f"Unknown expert parameter name: {name}")
+
+        # shared expert
+        shared_expert_pattern = r"mlp.shared_experts\.(.+)"
+        match = re.match(shared_expert_pattern, rest)
+        if match:
+            rest = match.groups()[0]
+            if rest == "linear_fc1.weight":
+                gate_weight, up_weight = param.chunk(2, dim=0)
+                return [
+                    (f"{prefix}.mlp.shared_expert.gate_proj.weight", gate_weight),
+                    (f"{prefix}.mlp.shared_expert.up_proj.weight", up_weight),
+                ]
+            elif rest == "linear_fc2.weight":
+                return [(f"{prefix}.mlp.shared_expert.down_proj.weight", param)]
+            elif rest == "gate_weight":
+                return [(f"{prefix}.mlp.shared_expert_gate.weight", param)]
+            else:
+                raise ValueError(f"Unknown shared expert parameter name: {name}")
+
+        if rest == "self_attention.linear_proj.weight":
+            return [(f"{prefix}.self_attn.o_proj.weight", param)]
+        elif rest == "self_attention.linear_qkv.weight":
+            param = param.view(args.num_query_groups, -1, head_dim, args.hidden_size)
+            q_param, k_param, v_param = torch.split(
+                param, split_size_or_sections=[2 * value_num_per_group, 1, 1], dim=1
+            )
+            q_param = (
+                q_param.reshape(args.num_query_groups, 2, value_num_per_group, head_dim, args.hidden_size)
+                .transpose(1, 2)
+                .reshape(-1, args.hidden_size)
+            )
+            k_param = k_param.reshape(-1, args.hidden_size)
+            v_param = v_param.reshape(-1, args.hidden_size)
+            return [
+                (f"{prefix}.self_attn.q_proj.weight", q_param),
+                (f"{prefix}.self_attn.k_proj.weight", k_param),
+                (f"{prefix}.self_attn.v_proj.weight", v_param),
+            ]
+        elif rest == "self_attention.linear_qkv.bias":
+            param = param.view(args.num_query_groups, -1)
+            q_bias, k_bias, v_bias = torch.split(
+                param,
+                split_size_or_sections=[value_num_per_group * head_dim, head_dim, head_dim],
+                dim=1,
+            )
+            q_bias = q_bias.contiguous().flatten()
+            k_bias = k_bias.contiguous().flatten()
+            v_bias = v_bias.contiguous().flatten()
+            return [
+                (f"{prefix}.self_attn.q_proj.bias", q_bias),
+                (f"{prefix}.self_attn.k_proj.bias", k_bias),
+                (f"{prefix}.self_attn.v_proj.bias", v_bias),
+            ]
+        elif rest == "mlp.linear_fc1.weight":
+            gate_weight, up_weight = param.chunk(2, dim=0)
+            return [
+                (f"{prefix}.mlp.gate_proj.weight", gate_weight),
+                (f"{prefix}.mlp.up_proj.weight", up_weight),
+            ]
+        elif rest == "mlp.linear_fc2.weight":
+            return [(f"{prefix}.mlp.down_proj.weight", param)]
+        elif rest == "self_attention.linear_qkv.layer_norm_weight":
+            return [(f"{prefix}.input_layernorm.weight", param)]
+        elif rest == "mlp.linear_fc1.layer_norm_weight":
+            return [(f"{prefix}.post_attention_layernorm.weight", param)]
+        elif rest == "pre_mlp_layernorm.weight":
+            return [(f"{prefix}.post_attention_layernorm.weight", param)]
+        elif rest == "mlp.router.weight":
+            return [(f"{prefix}.mlp.gate.weight", param)]
+        elif rest == "mlp.router.expert_bias":
+            return [(f"{prefix}.mlp.gate.e_score_correction_bias", param)]
+
+        # qk norm
+        elif rest == "self_attention.q_layernorm.weight":
+            return [(f"{prefix}.self_attn.q_norm.weight", param)]
+        elif rest == "self_attention.k_layernorm.weight":
+            return [(f"{prefix}.self_attn.k_norm.weight", param)]
+        elif rest.startswith("self_attention.") and rest[len("self_attention.") :] in [
+            "input_layernorm.weight",
+            # linear attn (Qwen3.5 uses separate in_proj_b/in_proj_a)
+            "linear_attn.A_log",
+            "linear_attn.conv1d.weight",
+            "linear_attn.dt_bias",
+            "linear_attn.in_proj_a.weight",
+            "linear_attn.in_proj_b.weight",
+            "linear_attn.in_proj_qkv.weight",
+            "linear_attn.in_proj_z.weight",
+            "linear_attn.norm.weight",
+            "linear_attn.out_proj.weight",
+            # gated attn (full attention layers)
+            "self_attn.k_norm.weight",
+            "self_attn.k_proj.weight",
+            "self_attn.o_proj.weight",
+            "self_attn.q_norm.weight",
+            "self_attn.q_proj.weight",
+            "self_attn.v_proj.weight",
+        ]:
+            rest = rest[len("self_attention.") :]
+            return [(f"{prefix}.{rest}", param)]
+
+    raise ValueError(f"Unknown parameter name: {name}")

--- a/slime/rollout/sglang_rollout.py
+++ b/slime/rollout/sglang_rollout.py
@@ -117,7 +117,7 @@ async def generate(args: Namespace, sample: Sample, sampling_params: dict[str, A
         sample.status == Sample.Status.PENDING or sample.status == Sample.Status.ABORTED
     ), f"Sample status is {sample.status}"
 
-    if state.processor:
+    if state.processor and sample.multimodal_inputs and any(v is not None for v in sample.multimodal_inputs.values()):
         processor_kwargs = build_processor_kwargs(sample.multimodal_inputs)
         processor_output = state.processor(text=sample.prompt, **processor_kwargs)
         prompt_ids = processor_output["input_ids"][0]

--- a/slime_plugins/mbridge/__init__.py
+++ b/slime_plugins/mbridge/__init__.py
@@ -3,6 +3,15 @@ from .glm4 import GLM4Bridge
 from .glm4moe import GLM4MoEBridge
 from .glm4moe_lite import GLM4MoELiteBridge
 from .mimo import MimoBridge
+from .qwen3_5 import Qwen3_5Bridge
 from .qwen3_next import Qwen3NextBridge
 
-__all__ = ["GLM4Bridge", "GLM4MoEBridge", "GLM4MoELiteBridge", "Qwen3NextBridge", "MimoBridge", "DeepseekV32Bridge"]
+__all__ = [
+    "GLM4Bridge",
+    "GLM4MoEBridge",
+    "GLM4MoELiteBridge",
+    "Qwen3NextBridge",
+    "Qwen3_5Bridge",
+    "MimoBridge",
+    "DeepseekV32Bridge",
+]

--- a/slime_plugins/mbridge/qwen3_5.py
+++ b/slime_plugins/mbridge/qwen3_5.py
@@ -1,0 +1,294 @@
+import torch
+from megatron.core.models.gpt.gpt_layer_specs import get_gpt_mtp_block_spec
+
+from mbridge.core import register_model
+from mbridge.models import Qwen2MoEBridge
+
+
+@register_model(["qwen3_5", "qwen3_5_moe"])
+class Qwen3_5Bridge(Qwen2MoEBridge):
+    """
+    Bridge for Qwen3.5 models (both dense and MoE variants).
+    Qwen3.5 is a VLM model with weights under model.language_model.layers prefix,
+    separate in_proj_qkv + in_proj_z for linear attention, and nested text_config.
+    """
+
+    _DIRECT_MAPPING = {
+        "embedding.word_embeddings.weight": "model.language_model.embed_tokens.weight",
+        "decoder.final_layernorm.weight": "model.language_model.norm.weight",
+        "output_layer.weight": "lm_head.weight",
+    }
+
+    _ATTENTION_MAPPING = {
+        "self_attention.linear_proj.weight": ["model.language_model.layers.{layer_number}.self_attn.o_proj.weight"],
+        "self_attention.linear_qkv.layer_norm_weight": [
+            "model.language_model.layers.{layer_number}.input_layernorm.weight"
+        ],
+        "self_attention.q_layernorm.weight": ["model.language_model.layers.{layer_number}.self_attn.q_norm.weight"],
+        "self_attention.k_layernorm.weight": ["model.language_model.layers.{layer_number}.self_attn.k_norm.weight"],
+        "self_attention.linear_qkv.weight": [
+            "model.language_model.layers.{layer_number}.self_attn.q_proj.weight",
+            "model.language_model.layers.{layer_number}.self_attn.k_proj.weight",
+            "model.language_model.layers.{layer_number}.self_attn.v_proj.weight",
+        ],
+        "self_attention.linear_qkv.bias": [
+            "model.language_model.layers.{layer_number}.self_attn.q_proj.bias",
+            "model.language_model.layers.{layer_number}.self_attn.k_proj.bias",
+            "model.language_model.layers.{layer_number}.self_attn.v_proj.bias",
+        ],
+    } | {
+        f"self_attention.{weight_name}": ["model.language_model.layers.{layer_number}." + weight_name]
+        for weight_name in [
+            "input_layernorm.weight",
+            # linear attn
+            "linear_attn.A_log",
+            "linear_attn.conv1d.weight",
+            "linear_attn.dt_bias",
+            "linear_attn.in_proj_a.weight",
+            "linear_attn.in_proj_b.weight",
+            "linear_attn.in_proj_qkv.weight",
+            "linear_attn.in_proj_z.weight",
+            "linear_attn.norm.weight",
+            "linear_attn.out_proj.weight",
+            # gated attn (full attention layers)
+            "self_attn.k_norm.weight",
+            "self_attn.k_proj.weight",
+            "self_attn.o_proj.weight",
+            "self_attn.q_norm.weight",
+            "self_attn.q_proj.weight",
+            "self_attn.v_proj.weight",
+        ]
+    }
+
+    _MLP_MAPPING = {
+        "mlp.linear_fc1.weight": [
+            "model.language_model.layers.{layer_number}.mlp.gate_proj.weight",
+            "model.language_model.layers.{layer_number}.mlp.up_proj.weight",
+        ],
+        "mlp.linear_fc1.layer_norm_weight": [
+            "model.language_model.layers.{layer_number}.post_attention_layernorm.weight"
+        ],
+        "mlp.linear_fc2.weight": ["model.language_model.layers.{layer_number}.mlp.down_proj.weight"],
+        # MoE mappings
+        "shared_experts.linear_fc1.weight": [
+            "model.language_model.layers.{layer_number}.mlp.shared_expert.gate_proj.weight",
+            "model.language_model.layers.{layer_number}.mlp.shared_expert.up_proj.weight",
+        ],
+        "pre_mlp_layernorm": ["model.language_model.layers.{layer_number}.post_attention_layernorm.weight"],
+        "shared_experts.linear_fc2.weight": [
+            "model.language_model.layers.{layer_number}.mlp.shared_expert.down_proj.weight"
+        ],
+        "mlp.router.weight": ["model.language_model.layers.{layer_number}.mlp.gate.weight"],
+        "shared_experts.gate_weight": ["model.language_model.layers.{layer_number}.mlp.shared_expert_gate.weight"],
+        # Fused expert format: single 3D tensor for all experts
+        "mlp.experts.linear_fc1": [
+            "model.language_model.layers.{layer_number}.mlp.experts.gate_up_proj",
+        ],
+        "mlp.experts.linear_fc2": ["model.language_model.layers.{layer_number}.mlp.experts.down_proj"],
+    }
+
+    # MTP layer uses individual expert format (not fused)
+    _MTP_MLP_MAPPING = {
+        "mlp.experts.linear_fc1": [
+            "mtp.layers.{layer_number}.mlp.experts.{expert_id}.gate_proj.weight",
+            "mtp.layers.{layer_number}.mlp.experts.{expert_id}.up_proj.weight",
+        ],
+        "mlp.experts.linear_fc2": ["mtp.layers.{layer_number}.mlp.experts.{expert_id}.down_proj.weight"],
+    }
+
+    # Override to make ffn_hidden_size optional (Qwen3.5 MoE has no intermediate_size)
+    _CONFIG_MAPPING = {
+        "num_layers": "num_hidden_layers",
+        "hidden_size": "hidden_size",
+        "num_attention_heads": "num_attention_heads",
+        "num_query_groups": "num_key_value_heads",
+        "ffn_hidden_size": ("intermediate_size", None),
+        "attention_dropout": "attention_dropout",
+        "layernorm_epsilon": "rms_norm_eps",
+        "hidden_dropout": ("hidden_dropout", 0.0),
+        "kv_channels": ("head_dim", None),
+    }
+
+    def _get_text_config(self):
+        """Get the text config, handling VLM nesting."""
+        if hasattr(self.hf_config, "text_config"):
+            return self.hf_config.text_config
+        return self.hf_config
+
+    def _get_gptmodel_args(self) -> dict:
+        """Override to add MTP block spec if needed."""
+        ret = super()._get_gptmodel_args()
+        text_config = self._get_text_config()
+        if getattr(text_config, "mtp_num_hidden_layers", None) is not None:
+            transformer_layer_spec = self.config
+            mtp_block_spec = get_gpt_mtp_block_spec(self.config, transformer_layer_spec, use_transformer_engine=True)
+            ret["mtp_block_spec"] = mtp_block_spec
+        return ret
+
+    def _weight_name_mapping_mlp(self, name: str) -> list[str]:
+        """Override to handle fused expert weights.
+        For regular layers: experts use fused 3D format (all experts in one tensor).
+        For MTP layers: experts use individual format (per-expert tensors).
+        """
+        layer_number = name.split(".")[2]
+        convert_names = []
+        for keyword, mapping_names in self._MLP_MAPPING.items():
+            if keyword in name:
+                if "{expert_id}" in mapping_names[0]:
+                    expert_id = name.split("weight")[-1]
+                    convert_names.extend(
+                        [x.format(layer_number=layer_number, expert_id=expert_id) for x in mapping_names]
+                    )
+                else:
+                    convert_names.extend([x.format(layer_number=layer_number) for x in mapping_names])
+                break
+        if len(convert_names) == 0:
+            raise NotImplementedError(f"Unsupported parameter name: {name}")
+        return convert_names
+
+    def _weight_name_mapping_mcore_to_hf(self, mcore_weights_name: str) -> list[str]:
+        """Override to handle MTP layer mappings."""
+        if "mtp" in mcore_weights_name:
+            return self._convert_mtp_param(mcore_weights_name)
+        return super()._weight_name_mapping_mcore_to_hf(mcore_weights_name)
+
+    def _convert_mtp_param(self, name: str) -> list[str]:
+        """Convert MTP layer parameters from MCore to HF format."""
+        if "mtp.layers." not in name:
+            raise NotImplementedError(f"Invalid MTP parameter name: {name}")
+
+        parts = name.split(".")
+        mtp_layer_idx = parts[2]  # mtp.layers.{idx}
+
+        direct_name_mapping = {
+            f"mtp.layers.{mtp_layer_idx}.eh_proj.weight": "mtp.fc.weight",
+            f"mtp.layers.{mtp_layer_idx}.enorm.weight": "mtp.pre_fc_norm_embedding.weight",
+            f"mtp.layers.{mtp_layer_idx}.hnorm.weight": "mtp.pre_fc_norm_hidden.weight",
+            f"mtp.layers.{mtp_layer_idx}.final_layernorm.weight": "mtp.norm.weight",
+        }
+
+        if name in direct_name_mapping:
+            return [direct_name_mapping[name]]
+
+        if "transformer_layer" in name:
+            proxy_name = name.replace(
+                f"mtp.layers.{mtp_layer_idx}.transformer_layer",
+                f"decoder.layers.{mtp_layer_idx}",
+            )
+
+            if "self_attention" in proxy_name or "input_layernorm.weight" in proxy_name:
+                convert_names = super()._weight_name_mapping_attention(proxy_name)
+            elif "mlp" in proxy_name or "pre_mlp_layernorm" in proxy_name:
+                convert_names = super()._weight_name_mapping_mlp(proxy_name)
+            else:
+                raise NotImplementedError(f"Unsupported transformer component in MTP: {name}")
+
+            # MTP weights use model.language_model prefix in regular layers,
+            # but mtp.layers.{idx} directly for MTP layers
+            convert_names = [
+                cn.replace(f"model.language_model.layers.{mtp_layer_idx}", f"mtp.layers.{mtp_layer_idx}")
+                for cn in convert_names
+            ]
+            return convert_names
+
+        raise NotImplementedError(f"Unsupported MTP parameter name: {name}")
+
+    def _weight_to_mcore_format(
+        self, mcore_weights_name: str, hf_weights: list[torch.Tensor]
+    ) -> tuple[list[str], list[torch.Tensor]]:
+        if "self_attention.linear_qkv." in mcore_weights_name and "layer_norm" not in mcore_weights_name:
+            # merge qkv
+            assert len(hf_weights) == 3
+            text_config = self._get_text_config()
+            num_key_value_heads = text_config.num_key_value_heads
+            hidden_dim = text_config.hidden_size
+            num_attention_heads = text_config.num_attention_heads
+            num_querys_per_group = num_attention_heads // text_config.num_key_value_heads
+            head_dim = getattr(text_config, "head_dim", hidden_dim // num_attention_heads)
+            group_dim = head_dim * num_attention_heads // num_key_value_heads
+            q, k, v = hf_weights
+            # q k v might be tp split
+            real_num_key_value_heads = q.shape[0] // (2 * group_dim)
+            q = (
+                q.view(
+                    [
+                        real_num_key_value_heads,
+                        num_querys_per_group,
+                        2,
+                        head_dim,
+                        -1,
+                    ]
+                )
+                .transpose(1, 2)
+                .flatten(1, 3)
+            )
+            k = k.view([real_num_key_value_heads, head_dim, -1])
+            v = v.view([real_num_key_value_heads, head_dim, -1])
+            out_shape = [-1, hidden_dim] if ".bias" not in mcore_weights_name else [-1]
+
+            qgkv = torch.cat([q, k, v], dim=1).view(*out_shape).contiguous()
+            return qgkv
+
+        # Handle fused expert weights: extract single expert from 3D fused tensor
+        if "mlp.experts.linear_fc" in mcore_weights_name and len(hf_weights) == 1:
+            w = hf_weights[0]
+            if w.dim() == 3:
+                # Extract expert_id from name like "...linear_fc1.weight42"
+                expert_id = int(mcore_weights_name.split("weight")[-1])
+                expert_w = w[expert_id]  # (out_features, in_features)
+                return expert_w.contiguous()
+
+        weight = super()._weight_to_mcore_format(mcore_weights_name, hf_weights)
+        if mcore_weights_name.endswith("eh_proj.weight"):
+            first_half, second_half = weight.chunk(2, dim=1)
+            weight = torch.cat([second_half, first_half], dim=1)
+        return weight
+
+    def _weight_to_hf_format(
+        self, mcore_weights_name: str, mcore_weights: torch.Tensor
+    ) -> tuple[list[str], list[torch.Tensor]]:
+        if mcore_weights_name.endswith("eh_proj.weight"):
+            first_half, second_half = mcore_weights.chunk(2, dim=1)
+            mcore_weights = torch.cat([second_half, first_half], dim=1)
+        return super()._weight_to_hf_format(mcore_weights_name, mcore_weights)
+
+    def _build_config(self):
+        text_config = self._get_text_config()
+
+        mtp_args = {}
+        if hasattr(text_config, "mtp_num_hidden_layers"):
+            mtp_args["mtp_num_layers"] = text_config.mtp_num_hidden_layers
+
+        base_kwargs = dict(
+            text_config_key="text_config" if hasattr(self.hf_config, "text_config") else None,
+            use_cpu_initialization=False,
+            # Other optimizations
+            persist_layer_norm=True,
+            bias_activation_fusion=True,
+            bias_dropout_fusion=True,
+            # Qwen3.5 specific
+            moe_router_pre_softmax=False,
+            qk_layernorm=True,
+            attention_output_gate=True,
+            **mtp_args,
+        )
+
+        # Handle MoE-specific config
+        if hasattr(text_config, "num_experts"):
+            base_kwargs.update(
+                moe_ffn_hidden_size=text_config.moe_intermediate_size,
+                moe_shared_expert_intermediate_size=getattr(text_config, "shared_expert_intermediate_size", None),
+                moe_router_bias_update_rate=0.001,
+                moe_router_topk=text_config.num_experts_per_tok,
+                num_moe_experts=text_config.num_experts,
+                moe_aux_loss_coeff=text_config.router_aux_loss_coef,
+                moe_router_load_balancing_type="none",
+                moe_grouped_gemm=True,
+                moe_router_score_function="softmax",
+                moe_shared_expert_gate=True,
+            )
+            # For MoE models without intermediate_size, use shared_expert_intermediate_size
+            if not hasattr(text_config, "intermediate_size"):
+                base_kwargs["ffn_hidden_size"] = text_config.shared_expert_intermediate_size
+
+        return self._build_base_config(**base_kwargs)

--- a/slime_plugins/models/qwen3_5.py
+++ b/slime_plugins/models/qwen3_5.py
@@ -1,0 +1,236 @@
+import copy
+import json
+import os
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from megatron.core.models.gpt.gpt_layer_specs import get_gpt_decoder_block_spec
+from megatron.core.transformer.spec_utils import ModuleSpec
+from megatron.core.transformer.transformer_block import get_num_layers_to_build
+from megatron.core.transformer.transformer_layer import get_transformer_layer_offset
+from transformers.activations import ACT2FN
+
+
+def _load_hf_config(checkpoint_path):
+    """Load HF config, handling cases where transformers doesn't know the model type."""
+    try:
+        from transformers import AutoConfig
+
+        return AutoConfig.from_pretrained(checkpoint_path, trust_remote_code=True)
+    except (ValueError, KeyError):
+        # Fallback: load config.json directly as a SimpleNamespace
+        config_path = os.path.join(checkpoint_path, "config.json")
+        with open(config_path) as f:
+            config_dict = json.load(f)
+        # If there's a text_config, also make it a namespace
+        ns = type("HFConfig", (), config_dict)()
+        if "text_config" in config_dict:
+            ns.text_config = type("TextConfig", (), config_dict["text_config"])()
+        return ns
+
+
+try:
+    from fla.modules import FusedRMSNormGated, ShortConvolution
+    from fla.ops.gated_delta_rule import chunk_gated_delta_rule
+except ImportError:
+    pass
+
+from .hf_attention import HuggingfaceAttention
+
+
+def _get_text_config(hf_config):
+    """Extract text config from a VLM config if needed."""
+    if hasattr(hf_config, "text_config"):
+        return hf_config.text_config
+    return hf_config
+
+
+# Adapted from Qwen3NextGatedDeltaNet but with separate in_proj_qkv and in_proj_z
+class Qwen3_5GatedDeltaNet(nn.Module):
+    """
+    Qwen3.5 GatedDeltaNet with varlen support.
+    Unlike Qwen3Next which uses a combined in_proj_qkvz, Qwen3.5 uses
+    separate in_proj_qkv (for Q,K,V) and in_proj_z (for Z).
+    """
+
+    def __init__(self, config, layer_idx: int):
+        super().__init__()
+        self.hidden_size = config.hidden_size
+        self.num_v_heads = config.linear_num_value_heads
+        self.num_k_heads = config.linear_num_key_heads
+        self.head_k_dim = config.linear_key_head_dim
+        self.head_v_dim = config.linear_value_head_dim
+        self.key_dim = self.head_k_dim * self.num_k_heads
+        self.value_dim = self.head_v_dim * self.num_v_heads
+
+        self.conv_kernel_size = config.linear_conv_kernel_dim
+        self.layer_idx = layer_idx
+        self.activation = config.hidden_act
+        self.act = ACT2FN[config.hidden_act]
+        self.layer_norm_epsilon = config.rms_norm_eps
+
+        # QKV
+        self.conv_dim = self.key_dim * 2 + self.value_dim
+        self.conv1d = ShortConvolution(
+            hidden_size=self.conv_dim,
+            bias=False,
+            kernel_size=self.conv_kernel_size,
+        )
+
+        # Separate projections for QKV and Z (unlike Qwen3Next which combines QKVZ)
+        projection_size_qkv = self.key_dim * 2 + self.value_dim
+        projection_size_z = self.value_dim
+        self.in_proj_qkv = nn.Linear(self.hidden_size, projection_size_qkv, bias=False)
+        self.in_proj_z = nn.Linear(self.hidden_size, projection_size_z, bias=False)
+        self.in_proj_b = nn.Linear(self.hidden_size, self.num_v_heads, bias=False)
+        self.in_proj_a = nn.Linear(self.hidden_size, self.num_v_heads, bias=False)
+
+        # time step projection
+        self.dt_bias = nn.Parameter(torch.ones(self.num_v_heads))
+
+        A = torch.empty(self.num_v_heads).uniform_(0, 16)
+        self.A_log = nn.Parameter(torch.log(A))
+
+        self.norm = FusedRMSNormGated(
+            self.head_v_dim,
+            eps=self.layer_norm_epsilon,
+            activation=self.activation,
+            device=torch.cuda.current_device(),
+            dtype=config.dtype if config.dtype is not None else torch.get_current_dtype(),
+        )
+
+        self.out_proj = nn.Linear(self.value_dim, self.hidden_size, bias=False)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        cu_seqlens: torch.Tensor = None,
+    ):
+        batch_size, seq_len, _ = hidden_states.shape
+
+        # Projections (flat layout: [Q_all, K_all, V_all])
+        mixed_qkv = self.in_proj_qkv(hidden_states)
+        z = self.in_proj_z(hidden_states)
+        z = z.reshape(batch_size, seq_len, -1, self.head_v_dim)
+        b = self.in_proj_b(hidden_states)
+        a = self.in_proj_a(hidden_states)
+
+        # Convolution on the flat QKV
+        mixed_qkv, _ = self.conv1d(
+            x=mixed_qkv,
+            cu_seqlens=cu_seqlens,
+        )
+
+        # Split into Q, K, V (flat split, matching HF layout)
+        query, key, value = torch.split(
+            mixed_qkv,
+            [self.key_dim, self.key_dim, self.value_dim],
+            dim=-1,
+        )
+        query = query.reshape(batch_size, seq_len, -1, self.head_k_dim)
+        key = key.reshape(batch_size, seq_len, -1, self.head_k_dim)
+        value = value.reshape(batch_size, seq_len, -1, self.head_v_dim)
+
+        beta = b.sigmoid()
+        # If the model is loaded in fp16, without the .float() here, A might be -inf
+        g = -self.A_log.float().exp() * F.softplus(a.float() + self.dt_bias)
+        if self.num_v_heads // self.num_k_heads > 1:
+            query = query.repeat_interleave(self.num_v_heads // self.num_k_heads, dim=2)
+            key = key.repeat_interleave(self.num_v_heads // self.num_k_heads, dim=2)
+
+        core_attn_out, last_recurrent_state = chunk_gated_delta_rule(
+            query,
+            key,
+            value,
+            g=g,
+            beta=beta,
+            initial_state=None,
+            output_final_state=False,
+            use_qk_l2norm_in_kernel=True,
+        )
+
+        z_shape_og = z.shape
+        # reshape input data into 2D tensor
+        core_attn_out = core_attn_out.reshape(-1, core_attn_out.shape[-1])
+        z = z.reshape(-1, z.shape[-1])
+        core_attn_out = self.norm(core_attn_out, z)
+        core_attn_out = core_attn_out.reshape(z_shape_og)
+        core_attn_out = core_attn_out.reshape(batch_size, seq_len, -1)
+
+        output = self.out_proj(core_attn_out)
+        return output
+
+
+class Attention(HuggingfaceAttention):
+    def __init__(
+        self,
+        args,
+        config,
+        layer_number: int,
+        cp_comm_type: str = "p2p",
+        pg_collection=None,
+    ):
+        super().__init__(
+            args,
+            config,
+            layer_number,
+            cp_comm_type,
+            pg_collection,
+        )
+        # Qwen3.5 is a VLM model with nested text_config
+        self.hf_config = _get_text_config(self.hf_config)
+        self.hf_config._attn_implementation = "flash_attention_2"
+
+        self.linear_attn = Qwen3_5GatedDeltaNet(self.hf_config, self.hf_layer_idx)
+
+        # Use a simple RMSNorm
+        try:
+            from transformers.models.qwen3_next.modeling_qwen3_next import Qwen3NextRMSNorm
+
+            self.input_layernorm = Qwen3NextRMSNorm(self.hf_config.hidden_size, eps=self.hf_config.rms_norm_eps)
+        except ImportError:
+            from torch.nn import RMSNorm
+
+            self.input_layernorm = RMSNorm(self.hf_config.hidden_size, eps=self.hf_config.rms_norm_eps)
+
+    def hf_forward(self, hidden_states, packed_seq_params):
+        hidden_states = self.input_layernorm(hidden_states)
+        hidden_states = self.linear_attn(
+            hidden_states=hidden_states,
+            cu_seqlens=packed_seq_params.cu_seqlens_q,
+        )
+        return hidden_states
+
+
+def get_qwen3_5_spec(args, config, vp_stage):
+    # always use the moe path for MoE models
+    if not args.num_experts:
+        config.moe_layer_freq = [0] * config.num_layers
+
+    # Define the decoder block spec
+    kwargs = {
+        "use_transformer_engine": True,
+    }
+    if vp_stage is not None:
+        kwargs["vp_stage"] = vp_stage
+    transformer_layer_spec = get_gpt_decoder_block_spec(config, **kwargs)
+
+    assert config.pipeline_model_parallel_layout is None, "not support this at the moment"
+
+    # Slice the layer specs to only include the layers that are built in this pipeline stage.
+    num_layers_to_build = get_num_layers_to_build(config, vp_stage=vp_stage)
+    offset = get_transformer_layer_offset(config, vp_stage=vp_stage)
+
+    hf_config = _load_hf_config(args.hf_checkpoint)
+    text_config = _get_text_config(hf_config)
+
+    for layer_id in range(num_layers_to_build):
+        if text_config.layer_types[layer_id + offset] == "linear_attention":
+            layer_specs = copy.deepcopy(transformer_layer_spec.layer_specs[layer_id])
+            layer_specs.submodules.self_attention = ModuleSpec(
+                module=Attention,
+                params={"args": args},
+            )
+            transformer_layer_spec.layer_specs[layer_id] = layer_specs
+    return transformer_layer_spec


### PR DESCRIPTION
> Need to upgrade to transformers 0.5.2 manually for qwen3.5 support.

- New model plugin: slime_plugins/models/qwen3_5.py
  - Qwen3_5GatedDeltaNet with separate QKV/Z projections, conv1d, and flat QKV split
  - get_qwen3_5_spec replacing standard attention with linear attention per layer_types

- New weight bridge: slime_plugins/mbridge/qwen3_5.py
  - Handles VLM weight prefix (model.language_model.layers)
  - Fused expert weight format for MoE (3D tensors -> per-expert slices)
  - MTP layer support with individual expert format

- New HF converter: slime/backends/megatron_utils/megatron_to_hf/qwen3_5.py
  - TEGroupedMLP per-expert weight{i} -> HF fused expert format
  - Proper gate/up split for swiglu experts

- Fix sglang_rollout.py: skip processor for text-only VLM models

- Model configs and run scripts for both 27B and 35B-A3B

Tested: Both models verified end-to-end with training.
- 27B: TP=1 SGLang (8 engines), TP=2/PP=2/CP=2 Megatron, logprob_diff=0.017
- 35B-A3B: TP=2 SGLang (4 engines), EP=8 Megatron, logprob_diff=0.012