### PR TITLE
Fix: pass return_tensors in text_kwargs for transformers>=5.0.0 compatibility

### DIFF
--- a/slime/utils/processing_utils.py
+++ b/slime/utils/processing_utils.py
@@ -22,7 +22,7 @@ def build_processor_kwargs(multimodal_inputs: dict | None = None) -> dict:
 
     result = dict(multimodal_inputs) if multimodal_inputs else {}
 
-    # return_tensors=None for text (input_ids as lists), "pt" for vision/audio tensors
+    # return_tensors=None for text (input_ids as lists), "pt" for modality-specific outputs
     result["text_kwargs"] = {**result.get("text_kwargs", {}), "return_tensors": None}
     for key in ("audio_kwargs", "images_kwargs", "videos_kwargs"):
         if key in result:


### PR DESCRIPTION
In transformers v5.0.0, `return_tensors` was moved from
`CommonKwargs` into each modality's TypedDict (`TextKwargs`, `ImagesKwargs`, etc.).
This causes `_merge_kwargs` to raise a ValueError when `return_tensors` appears both
as a flat kwarg and inside a modality dict like `images_kwargs`.

Fix by moving `return_tensors=None` from a flat kwarg into `text_kwargs`, so all
`return_tensors` values are passed through per-modality dicts consistently.
