### PR TITLE
[fix]: Qwen3.5-35B-A3B 8-GPU: set TP size to 2 for num_query_groups=2

### DIFF
--- a/scripts/run-qwen3.5-35B-A3B.sh
+++ b/scripts/run-qwen3.5-35B-A3B.sh
@@ -63,7 +63,7 @@ EVAL_ARGS=(
 )
 
 PERF_ARGS=(
-   --tensor-model-parallel-size 4
+   --tensor-model-parallel-size 2
    --sequence-parallel
    --pipeline-model-parallel-size 1
    --context-parallel-size 1

--- a/slime/utils/data.py
+++ b/slime/utils/data.py
@@ -89,15 +89,30 @@ def filter_long_prompt(origin_samples: list[Sample], tokenizer, processor, max_l
         return origin_samples
 
     if processor:
-        filtered_samples = []
+        # Use processor only for samples with actual multimodal content; use batched tokenizer for text-only.
+        text_only = []
+        multimodal = []
         for sample in origin_samples:
+            if sample.multimodal_inputs and any(v is not None for v in sample.multimodal_inputs.values()):
+                multimodal.append(sample)
+            else:
+                text_only.append(sample)
+        filtered_samples = []
+        if text_only:
+            prompts = [s.prompt for s in text_only]
+            input_ids_list = tokenizer(prompts, add_special_tokens=False)["input_ids"]
+            for sample, input_ids in zip(text_only, input_ids_list, strict=True):
+                if len(input_ids) <= max_length:
+                    filtered_samples.append(sample)
+        if multimodal:
             from slime.utils.processing_utils import process_vision_info
 
-            multimodal_inputs = process_vision_info(sample.prompt, processor)
-            processor_output = processor(text=sample.prompt, **multimodal_inputs)
-            input_ids = processor_output["input_ids"][0]
-            if len(input_ids) <= max_length:
-                filtered_samples.append(sample)
+            for sample in multimodal:
+                multimodal_inputs = process_vision_info(sample.prompt, processor)
+                processor_output = processor(text=sample.prompt, **multimodal_inputs)
+                input_ids = processor_output["input_ids"][0]
+                if len(input_ids) <= max_length:
+                    filtered_samples.append(sample)
     else:
         prompts = [sample.prompt for sample in origin_samples]
         input_ids_list = tokenizer(prompts, add_special_tokens=False)["input_ids"]


### PR DESCRIPTION
- TP: Megatron needs num_query_groups % tensor_model_parallel_size == 0. Model has 2 query groups, so set --tensor-model-parallel-size 2 (with --expert-model-parallel-size 8) for single-node 8-GPU.
<img width="1045" height="529" alt="Clipboard_Screenshot_1772591767" src="https://github.com/user-attachments/assets/1b86ceea-c4d3-417d-87fd-53763b8fb3ff" />

https://github.com/THUDM/slime/blob/d78bb43eed5d714d681271fcf8c04f0f28f6b67c/scripts/models/qwen3.5-35B-A3B.sh#L23

- data.py / rollout: For multimodal models, use the processor only when a sample has real multimodal content (multimodal_inputs with non-None values). For text-only samples, use batched tokenizer(prompts, add_special_tokens=False) in filter_long_prompt and tokenizer in rollout so pure-text data is not run through the processor.

Just as in `slime/rollout/sglang_rollout.py`
https://github.com/THUDM/slime/blob/d78bb43eed5d714d681271fcf8c04f0f28f6b67c/slime/rollout/sglang_rollout.py#L120