### PR TITLE
fix: use semantic version comparison for PyTorch >= 2.6 detection

### DIFF
--- a/slime/utils/distributed_utils.py
+++ b/slime/utils/distributed_utils.py
@@ -2,6 +2,7 @@ from datetime import timedelta
 from typing import Any
 
 import torch
+from packaging.version import parse as V
 import torch.distributed as dist
 from torch.distributed.distributed_c10d import (
     Backend,
@@ -74,7 +75,7 @@ def init_process_group(
     # NOTE: The pg_options parameter was renamed into backend_options in PyTorch 2.6.0
     # https://github.com/pytorch/pytorch/commit/a0c7029a75628cd5fa8df83c0de0ea98ee7fd844
     # We need to determine the appropriate parameter name based on PyTorch version
-    pg_options_param_name = "backend_options" if str(torch.__version__) >= "2.6" else "pg_options"
+    pg_options_param_name = "backend_options" if V(torch.__version__) >= V("2.6") else "pg_options"
     pg, _ = _new_process_group_helper(
         world_size,
         rank,


### PR DESCRIPTION
Fixes #1666

Uses `packaging.version.parse` instead of string comparison, consistent with `sglang_rollout.py` and `sglang_engine.py`.