### PR TITLE
[fix] Fix numerical accuracy issue in dynamic sampling filter

### DIFF
--- a/slime/rollout/filter_hub/dynamic_sampling_filters.py
+++ b/slime/rollout/filter_hub/dynamic_sampling_filters.py
@@ -8,7 +8,7 @@ __all__ = ["check_reward_nonzero_std"]
 
 def check_reward_nonzero_std(args, samples: list[Sample], **kwargs):
     rewards = [sample.get_reward_value(args) for sample in samples]
-    keep = torch.tensor(rewards, dtype=torch.float).std() > 0.0
+    keep = torch.tensor(rewards, dtype=torch.float64).std() > 1e-6
     return DynamicFilterOutput(
         keep=keep,
         reason=None if keep else f"zero_std_{round(rewards[0], 1)}",


### PR DESCRIPTION
Use float64 instead of float32 and compare std against 1e-6 epsilon instead of exact 0.0 to avoid false negatives from floating-point precision errors.

Fix https://github.com/radixark/miles/issues/570