### PR TITLE
fix: quote `$MOE_LAYER_FREQ`

### DIFF
--- a/scripts/models/deepseek-v3.sh
+++ b/scripts/models/deepseek-v3.sh
@@ -43,7 +43,7 @@ MODEL_ARGS=(
 
     # moe
     --num-experts 256
-    --moe-layer-freq $MOE_LAYER_FREQ
+    --moe-layer-freq "$MOE_LAYER_FREQ"
     --moe-ffn-hidden-size 2048
     --moe-router-topk 8
     --moe-shared-expert-intermediate-size 2048

--- a/scripts/models/kimi-k2-thinking.sh
+++ b/scripts/models/kimi-k2-thinking.sh
@@ -43,7 +43,7 @@ MODEL_ARGS=(
 
     # moe
     --num-experts 384
-    --moe-layer-freq $MOE_LAYER_FREQ
+    --moe-layer-freq "$MOE_LAYER_FREQ"
     --moe-ffn-hidden-size 2048
     --moe-router-topk 8
     --moe-shared-expert-intermediate-size 2048

--- a/scripts/models/kimi-k2.sh
+++ b/scripts/models/kimi-k2.sh
@@ -43,7 +43,7 @@ MODEL_ARGS=(
 
     # moe
     --num-experts 384
-    --moe-layer-freq $MOE_LAYER_FREQ
+    --moe-layer-freq "$MOE_LAYER_FREQ"
     --moe-ffn-hidden-size 2048
     --moe-router-topk 8
     --moe-shared-expert-intermediate-size 2048

--- a/scripts/models/moonlight.sh
+++ b/scripts/models/moonlight.sh
@@ -48,7 +48,7 @@ MODEL_ARGS=(
 
     # moe
     --num-experts 64
-    --moe-layer-freq $MOE_LAYER_FREQ
+    --moe-layer-freq "$MOE_LAYER_FREQ"
     --moe-ffn-hidden-size $MOE_FFN_HIDDEN
     --moe-router-topk 6
     --moe-shared-expert-intermediate-size $MOE_SHARED_EXPERT_INTERMEDIATE_SIZE

--- a/scripts/models/qwen3-235B-A22B.sh
+++ b/scripts/models/qwen3-235B-A22B.sh
@@ -39,7 +39,7 @@ MODEL_ARGS=(
    --moe-router-score-function softmax
    --moe-token-dispatcher-type alltoall
    --moe-router-topk 8
-   --moe-layer-freq $MOE_LAYER_FREQ
+   --moe-layer-freq "$MOE_LAYER_FREQ"
    --num-experts 128
    --moe-grouped-gemm
    --moe-token-drop-policy probs

--- a/scripts/models/qwen3-30B-A3B.sh
+++ b/scripts/models/qwen3-30B-A3B.sh
@@ -39,7 +39,7 @@ MODEL_ARGS=(
    --moe-router-score-function softmax
    --moe-token-dispatcher-type alltoall
    --moe-router-topk 8
-   --moe-layer-freq $MOE_LAYER_FREQ
+   --moe-layer-freq "$MOE_LAYER_FREQ"
    --num-experts 128
    --moe-grouped-gemm
    --moe-token-drop-policy probs

--- a/scripts/models/qwen3-next-80B-A3B.sh
+++ b/scripts/models/qwen3-next-80B-A3B.sh
@@ -44,7 +44,7 @@ MODEL_ARGS=(
    --moe-router-score-function softmax
    --moe-token-dispatcher-type alltoall
    --moe-router-topk 10
-   --moe-layer-freq $MOE_LAYER_FREQ
+   --moe-layer-freq "$MOE_LAYER_FREQ"
    --num-experts 512
    --moe-grouped-gemm
    --moe-token-drop-policy probs

--- a/scripts/models/qwen3.5-35B-A3B.sh
+++ b/scripts/models/qwen3.5-35B-A3B.sh
@@ -44,7 +44,7 @@ MODEL_ARGS=(
    --moe-router-score-function softmax
    --moe-token-dispatcher-type alltoall
    --moe-router-topk 8
-   --moe-layer-freq $MOE_LAYER_FREQ
+   --moe-layer-freq "$MOE_LAYER_FREQ"
    --num-experts 256
    --moe-grouped-gemm
    --moe-token-drop-policy probs


### PR DESCRIPTION
If there is a file named "1", then `--moe-layer-freq` will be wrong.

Explanation:
```
$ echo [1,1,1]
[1,1,1]
$ touch 1
$ echo [1,1,1]
1
$ echo "[1,1,1]"
[1,1,1]
```

In SLIME context:
```
$ source scripts/models/qwen3.5-35B-A3B.sh
$ echo ${MODEL_ARGS[@]}
--spec slime_plugins.models.qwen3_5 get_qwen3_5_spec --disable-bias-linear --qk-layernorm --group-query-attention --num-attention-heads 16 --num-query-groups 2 --kv-channels 256 --num-layers 40 --hidden-size 2048 --ffn-hidden-size 512 --use-gated-attention --normalization RMSNorm --apply-layernorm-1p --position-embedding-type rope --norm-epsilon 1e-6 --rotary-percent 0.25 --swiglu --untie-embeddings-and-output-weights --vocab-size 248320 --rotary-base 10000000 --moe-ffn-hidden-size 512 --moe-shared-expert-intermediate-size 512 --moe-router-score-function softmax --moe-token-dispatcher-type alltoall --moe-router-topk 8 --moe-layer-freq [1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1] --num-experts 256 --moe-grouped-gemm --moe-token-drop-policy probs --moe-router-dtype fp32 --moe-permute-fusion --moe-aux-loss-coeff 0 --attention-output-gate --moe-shared-expert-gate
$ touch 1
$ source scripts/models/qwen3.5-35B-A3B.sh
$ echo ${MODEL_ARGS[@]}
--spec slime_plugins.models.qwen3_5 get_qwen3_5_spec --disable-bias-linear --qk-layernorm --group-query-attention --num-attention-heads 16 --num-query-groups 2 --kv-channels 256 --num-layers 40 --hidden-size 2048 --ffn-hidden-size 512 --use-gated-attention --normalization RMSNorm --apply-layernorm-1p --position-embedding-type rope --norm-epsilon 1e-6 --rotary-percent 0.25 --swiglu --untie-embeddings-and-output-weights --vocab-size 248320 --rotary-base 10000000 --moe-ffn-hidden-size 512 --moe-shared-expert-intermediate-size 512 --moe-router-score-function softmax --moe-token-dispatcher-type alltoall --moe-router-topk 8 --moe-layer-freq 1 --num-experts 256 --moe-grouped-gemm --moe-token-drop-policy probs --moe-router-dtype fp32 --moe-permute-fusion --moe-aux-loss-coeff 0 --attention-output-gate --moe-shared-expert-gate
```