### PR TITLE
[WIP] fix(cp): wrap linear attention CP in custom autograd.Function

### DIFF
--- a/slime_plugins/models/qwen3_5.py
+++ b/slime_plugins/models/qwen3_5.py
@@ -3,9 +3,13 @@ import json
 import os
 
 import torch
+import torch.distributed as dist
 import torch.nn as nn
 import torch.nn.functional as F
+from megatron.core import mpu, tensor_parallel
+from megatron.core.inference.contexts import BaseInferenceContext
 from megatron.core.models.gpt.gpt_layer_specs import get_gpt_decoder_block_spec
+from megatron.core.packed_seq_params import PackedSeqParams
 from megatron.core.transformer.spec_utils import ModuleSpec
 from megatron.core.transformer.transformer_block import get_num_layers_to_build
 from megatron.core.transformer.transformer_layer import get_transformer_layer_offset
@@ -44,6 +48,126 @@ def _get_text_config(hf_config):
     if hasattr(hf_config, "text_config"):
         return hf_config.text_config
     return hf_config
+
+
+# ---------------------------------------------------------------------------
+# Context-parallel helpers for linear attention
+# ---------------------------------------------------------------------------
+
+
+def _cp_all_gather_zigzag(local_tensor, cu_seqlens, cp_group, cp_size):
+    """All-gather from all CP ranks and reconstruct the full sequence in zigzag order.
+
+    Each CP rank holds two chunks per sequence arranged as [chunk_r, chunk_{2*cp-1-r}].
+    This function gathers all ranks' data and reassembles the original sequence order.
+
+    Args:
+        local_tensor: [local_total_seq, ...] - this rank's portion
+        cu_seqlens: [num_seqs + 1] - global cumulative sequence lengths
+        cp_group: the CP process group
+        cp_size: number of CP ranks
+
+    Returns:
+        full_tensor: [full_total_seq, ...] - reconstructed full sequence
+    """
+    gathered = [torch.empty_like(local_tensor) for _ in range(cp_size)]
+    dist.all_gather(gathered, local_tensor.contiguous(), group=cp_group)
+
+    local_cu_seqlens = cu_seqlens // cp_size
+    result = []
+    for i in range(len(cu_seqlens) - 1):
+        chunk_size = (cu_seqlens[i + 1] - cu_seqlens[i]) // 2 // cp_size
+        # First half: forward chunks from rank 0, 1, ..., cp_size-1
+        # Second half: backward chunks from rank cp_size-1, ..., 1, 0
+        result.extend(
+            [gathered[r][local_cu_seqlens[i] : local_cu_seqlens[i] + chunk_size] for r in range(cp_size)]
+            + [gathered[r][local_cu_seqlens[i] + chunk_size : local_cu_seqlens[i + 1]] for r in range(cp_size)][::-1]
+        )
+    return torch.cat(result, dim=0)
+
+
+def _cp_slice_zigzag(full_tensor, cu_seqlens, cp_rank, cp_size):
+    """Extract this CP rank's chunks from the full sequence in zigzag order.
+
+    Args:
+        full_tensor: [full_total_seq, ...] - full sequence
+        cu_seqlens: [num_seqs + 1] - global cumulative sequence lengths
+        cp_rank: this rank's position in the CP group
+        cp_size: number of CP ranks
+
+    Returns:
+        local_tensor: [local_total_seq, ...] - this rank's portion
+    """
+    chunks = []
+    for i in range(len(cu_seqlens) - 1):
+        seq = full_tensor[cu_seqlens[i] : cu_seqlens[i + 1]]
+        seq_chunks = torch.chunk(seq, 2 * cp_size, dim=0)
+        chunks.append(seq_chunks[cp_rank])
+        chunks.append(seq_chunks[2 * cp_size - 1 - cp_rank])
+    return torch.cat(chunks, dim=0)
+
+
+class CPLinearAttnFunction(torch.autograd.Function):
+    """Custom autograd function for context-parallel linear attention.
+
+    Forward: all-gather hidden_states -> compute on full sequence -> slice output.
+             Only local hidden_states are saved (full gathered tensor is freed).
+    Backward: re-all-gather hidden_states + grad_output -> recompute forward ->
+              backward -> slice gradient for this rank.
+
+    This fixes two issues with the previous dist.nn.all_gather approach:
+    1. The full all-gathered tensor is no longer kept in the autograd graph (memory savings).
+    2. Gradients (including dk, dv) are correctly handled via recomputation + slicing.
+    """
+
+    @staticmethod
+    def forward(ctx, hidden_states, cu_seqlens, module, packed_seq_params, cp_group, cp_size, cp_rank):
+        # All-gather and reconstruct full sequence
+        full_hidden = _cp_all_gather_zigzag(hidden_states, cu_seqlens, cp_group, cp_size)
+
+        # Forward without grad (will recompute in backward for activation savings)
+        with torch.no_grad():
+            full_bhd = full_hidden.permute(1, 0, 2)  # [seq, batch, hidden] -> [batch, seq, hidden]
+            output = module.hf_forward(full_bhd, packed_seq_params)
+            output_thd = output.permute(1, 0, 2)  # [batch, seq, hidden] -> [seq, batch, hidden]
+
+        # Slice output for this CP rank
+        local_output = _cp_slice_zigzag(output_thd, cu_seqlens, cp_rank, cp_size)
+
+        # Save only local data (full_hidden is freed after this scope)
+        ctx.save_for_backward(hidden_states, cu_seqlens)
+        ctx.module = module
+        ctx.packed_seq_params = packed_seq_params
+        ctx.cp_group = cp_group
+        ctx.cp_size = cp_size
+        ctx.cp_rank = cp_rank
+
+        return local_output
+
+    @staticmethod
+    def backward(ctx, d_local_output):
+        hidden_states, cu_seqlens = ctx.saved_tensors
+
+        # Re-gather hidden states for recomputation
+        full_hidden = _cp_all_gather_zigzag(hidden_states.detach(), cu_seqlens, ctx.cp_group, ctx.cp_size)
+        full_hidden = full_hidden.detach().requires_grad_(True)
+
+        # All-gather grad output from all CP ranks to reconstruct full gradient
+        d_full_output = _cp_all_gather_zigzag(d_local_output.contiguous(), cu_seqlens, ctx.cp_group, ctx.cp_size)
+
+        # Recompute forward with grad enabled (for parameter gradient computation)
+        with torch.enable_grad():
+            full_bhd = full_hidden.permute(1, 0, 2)
+            output = ctx.module.hf_forward(full_bhd, ctx.packed_seq_params)
+            output_thd = output.permute(1, 0, 2)
+
+        # Backward through recomputed graph (accumulates parameter gradients)
+        torch.autograd.backward(output_thd, d_full_output)
+
+        # Slice gradient for this CP rank (inverse of all-gather zigzag)
+        d_local_hidden = _cp_slice_zigzag(full_hidden.grad, cu_seqlens, ctx.cp_rank, ctx.cp_size)
+
+        return d_local_hidden, None, None, None, None, None, None
 
 
 # Adapted from Qwen3NextGatedDeltaNet but with separate in_proj_qkv and in_proj_z
@@ -202,6 +326,53 @@ class Attention(HuggingfaceAttention):
             cu_seqlens=packed_seq_params.cu_seqlens_q,
         )
         return hidden_states
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: torch.Tensor,
+        key_value_states: torch.Tensor | None = None,
+        inference_context: BaseInferenceContext | None = None,
+        rotary_pos_emb: torch.Tensor | tuple[torch.Tensor, torch.Tensor] | None = None,
+        rotary_pos_cos: torch.Tensor | None = None,
+        rotary_pos_sin: torch.Tensor | None = None,
+        rotary_pos_cos_sin: torch.Tensor | None = None,
+        attention_bias: torch.Tensor | None = None,
+        packed_seq_params: PackedSeqParams | None = None,
+        sequence_len_offset: int | None = None,
+        *,
+        inference_params: BaseInferenceContext | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        assert packed_seq_params is not None
+
+        if self.args.sequence_parallel:
+            hidden_states = tensor_parallel.gather_from_sequence_parallel_region(
+                hidden_states, group=mpu.get_tensor_model_parallel_group()
+            )
+
+        cp_size = mpu.get_context_parallel_world_size()
+
+        if cp_size > 1:
+            output = CPLinearAttnFunction.apply(
+                hidden_states,
+                packed_seq_params.cu_seqlens_q,
+                self,
+                packed_seq_params,
+                mpu.get_context_parallel_group(),
+                cp_size,
+                mpu.get_context_parallel_rank(),
+            )
+        else:
+            hidden_states = hidden_states.permute(1, 0, 2)  # [seq, batch, hidden] -> [batch, seq, hidden]
+            output = self.hf_forward(hidden_states, packed_seq_params)
+            output = output.permute(1, 0, 2)  # [batch, seq, hidden] -> [seq, batch, hidden]
+
+        if self.args.sequence_parallel:
+            output = tensor_parallel.scatter_to_sequence_parallel_region(
+                output, group=mpu.get_tensor_model_parallel_group()
+            )
+
+        return output, None
 
 
 def get_qwen3_5_spec(args, config, vp_stage):

--- a/tests/test_cp_linear_attn_precision.py
+++ b/tests/test_cp_linear_attn_precision.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""
+Test CP linear attention implementation for correctness.
+
+Verifies that CPLinearAttnFunction produces identical forward outputs and
+backward gradients compared to a non-CP reference, for different CP sizes.
+
+Run with:
+    torchrun --nproc_per_node=2 tests/test_cp_linear_attn_precision.py
+    torchrun --nproc_per_node=4 tests/test_cp_linear_attn_precision.py
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), ".."))
+
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+
+from slime_plugins.models.qwen3_5 import CPLinearAttnFunction, _cp_all_gather_zigzag, _cp_slice_zigzag
+
+
+def log(rank, msg):
+    if rank == 0:
+        print(msg, flush=True)
+
+
+def test_gather_slice_roundtrip():
+    """Test that slice -> all_gather reconstructs the original tensor exactly."""
+    rank = dist.get_rank()
+    cp_size = dist.get_world_size()
+    cp_group = dist.group.WORLD
+
+    torch.manual_seed(42)
+    seq_len = 128
+    hidden_dim = 32
+    full_tensor = torch.randn(seq_len, 1, hidden_dim, device="cuda")
+    dist.broadcast(full_tensor, src=0)
+
+    cu_seqlens = torch.tensor([0, seq_len], dtype=torch.int64, device="cuda")
+
+    local_tensor = _cp_slice_zigzag(full_tensor, cu_seqlens, rank, cp_size)
+    assert local_tensor.shape[0] == seq_len // cp_size
+
+    reconstructed = _cp_all_gather_zigzag(local_tensor, cu_seqlens, cp_group, cp_size)
+    max_diff = (reconstructed - full_tensor).abs().max().item()
+    log(rank, f"[roundtrip single-seq] max diff = {max_diff}")
+    assert max_diff == 0.0, f"Roundtrip failed: {max_diff}"
+
+
+def test_gather_slice_multi_seq():
+    """Test roundtrip with multiple packed sequences."""
+    rank = dist.get_rank()
+    cp_size = dist.get_world_size()
+    cp_group = dist.group.WORLD
+
+    torch.manual_seed(42)
+    # Two sequences: 64 and 128 tokens
+    seq_lens = [64, 128]
+    total_len = sum(seq_lens)
+    hidden_dim = 32
+    full_tensor = torch.randn(total_len, 1, hidden_dim, device="cuda")
+    dist.broadcast(full_tensor, src=0)
+
+    cu_seqlens = torch.tensor([0, 64, 192], dtype=torch.int64, device="cuda")
+
+    local_tensor = _cp_slice_zigzag(full_tensor, cu_seqlens, rank, cp_size)
+    reconstructed = _cp_all_gather_zigzag(local_tensor, cu_seqlens, cp_group, cp_size)
+    max_diff = (reconstructed - full_tensor).abs().max().item()
+    log(rank, f"[roundtrip multi-seq] max diff = {max_diff}")
+    assert max_diff == 0.0, f"Multi-seq roundtrip failed: {max_diff}"
+
+
+def test_cp_forward_backward():
+    """Test that CP forward/backward match non-CP reference exactly."""
+    rank = dist.get_rank()
+    cp_size = dist.get_world_size()
+    cp_group = dist.group.WORLD
+
+    torch.manual_seed(42)
+    hidden_dim = 64
+    model = nn.Sequential(
+        nn.Linear(hidden_dim, hidden_dim, bias=False),
+        nn.SiLU(),
+        nn.Linear(hidden_dim, hidden_dim, bias=False),
+    ).cuda()
+
+    # Ensure all ranks have identical model
+    for p in model.parameters():
+        dist.broadcast(p.data, src=0)
+
+    seq_len = 32 * cp_size  # divisible by 2 * cp_size
+    full_hidden = torch.randn(seq_len, 1, hidden_dim, device="cuda")
+    dist.broadcast(full_hidden, src=0)
+    cu_seqlens = torch.tensor([0, seq_len], dtype=torch.int64, device="cuda")
+
+    class FakeParams:
+        cu_seqlens_q = cu_seqlens
+
+    packed_params = FakeParams()
+
+    class FakeModule(nn.Module):
+        def __init__(self, net):
+            super().__init__()
+            self.net = net
+
+        def hf_forward(self, hidden_states, packed_seq_params):
+            return self.net(hidden_states)
+
+    module = FakeModule(model)
+
+    # --- Reference: full forward/backward (no CP) ---
+    model.zero_grad()
+    full_ref = full_hidden.clone().detach().requires_grad_(True)
+    ref_out = model(full_ref.permute(1, 0, 2)).permute(1, 0, 2)
+    ref_out.sum().backward()
+    ref_output = ref_out.detach().clone()
+    ref_grad = full_ref.grad.clone()
+    ref_pgrads = [p.grad.clone() for p in model.parameters()]
+
+    # --- CP: forward/backward ---
+    model.zero_grad()
+    local_hidden = _cp_slice_zigzag(full_hidden, cu_seqlens, rank, cp_size).clone().detach().requires_grad_(True)
+
+    local_output = CPLinearAttnFunction.apply(local_hidden, cu_seqlens, module, packed_params, cp_group, cp_size, rank)
+    local_output.sum().backward()
+
+    # Gather output and compare
+    gathered_out = _cp_all_gather_zigzag(local_output.detach(), cu_seqlens, cp_group, cp_size)
+    out_diff = (gathered_out - ref_output).abs().max().item()
+    log(rank, f"[CP fwd] output diff = {out_diff}")
+    assert out_diff < 5e-5, f"Output mismatch: {out_diff}"
+
+    # Gather hidden grad and compare
+    gathered_grad = _cp_all_gather_zigzag(local_hidden.grad.detach(), cu_seqlens, cp_group, cp_size)
+    grad_diff = (gathered_grad - ref_grad).abs().max().item()
+    log(rank, f"[CP bwd] hidden grad diff = {grad_diff}")
+    assert grad_diff < 5e-5, f"Hidden grad mismatch: {grad_diff}"
+
+    # Compare param grads
+    for i, p in enumerate(model.parameters()):
+        pdiff = (p.grad - ref_pgrads[i]).abs().max().item()
+        log(rank, f"[CP bwd] param {i} grad diff = {pdiff}")
+        assert pdiff < 5e-5, f"Param grad {i} mismatch: {pdiff}"
+
+
+def test_cp_multi_seq_forward_backward():
+    """Test CP with multiple packed sequences."""
+    rank = dist.get_rank()
+    cp_size = dist.get_world_size()
+    cp_group = dist.group.WORLD
+
+    torch.manual_seed(42)
+    hidden_dim = 64
+    model = nn.Sequential(
+        nn.Linear(hidden_dim, hidden_dim, bias=False),
+        nn.GELU(),
+        nn.Linear(hidden_dim, hidden_dim, bias=False),
+    ).cuda()
+
+    for p in model.parameters():
+        dist.broadcast(p.data, src=0)
+
+    # Two sequences, both divisible by 2 * cp_size
+    chunk = 2 * cp_size
+    s1, s2 = 4 * chunk, 6 * chunk
+    total_len = s1 + s2
+    full_hidden = torch.randn(total_len, 1, hidden_dim, device="cuda")
+    dist.broadcast(full_hidden, src=0)
+    cu_seqlens = torch.tensor([0, s1, s1 + s2], dtype=torch.int64, device="cuda")
+
+    class FakeParams:
+        cu_seqlens_q = cu_seqlens
+
+    class FakeModule(nn.Module):
+        def __init__(self, net):
+            super().__init__()
+            self.net = net
+
+        def hf_forward(self, hidden_states, packed_seq_params):
+            return self.net(hidden_states)
+
+    module = FakeModule(model)
+
+    # Reference
+    model.zero_grad()
+    full_ref = full_hidden.clone().detach().requires_grad_(True)
+    ref_out = model(full_ref.permute(1, 0, 2)).permute(1, 0, 2)
+    ref_out.sum().backward()
+    ref_output = ref_out.detach().clone()
+    ref_grad = full_ref.grad.clone()
+
+    # CP
+    model.zero_grad()
+    local_hidden = _cp_slice_zigzag(full_hidden, cu_seqlens, rank, cp_size).clone().detach().requires_grad_(True)
+    local_output = CPLinearAttnFunction.apply(local_hidden, cu_seqlens, module, FakeParams(), cp_group, cp_size, rank)
+    local_output.sum().backward()
+
+    gathered_out = _cp_all_gather_zigzag(local_output.detach(), cu_seqlens, cp_group, cp_size)
+    out_diff = (gathered_out - ref_output).abs().max().item()
+    log(rank, f"[CP multi-seq fwd] diff = {out_diff}")
+    assert out_diff < 5e-5, f"Multi-seq output mismatch: {out_diff}"
+
+    gathered_grad = _cp_all_gather_zigzag(local_hidden.grad.detach(), cu_seqlens, cp_group, cp_size)
+    grad_diff = (gathered_grad - ref_grad).abs().max().item()
+    log(rank, f"[CP multi-seq bwd] diff = {grad_diff}")
+    assert grad_diff < 5e-5, f"Multi-seq grad mismatch: {grad_diff}"
+
+
+if __name__ == "__main__":
+    dist.init_process_group(backend="nccl")
+    torch.cuda.set_device(dist.get_rank())
+    rank = dist.get_rank()
+
+    log(rank, f"=== Testing CP with {dist.get_world_size()} ranks ===")
+
+    test_gather_slice_roundtrip()
+    test_gather_slice_multi_seq()
+    test_cp_forward_backward()
+    test_cp_multi_seq_forward_backward()
+
+    log(rank, "=== ALL TESTS PASSED ===")
+    dist.destroy_process_group()


### PR DESCRIPTION
Replace dist.nn.all_gather-based CP handling for Qwen3.5 linear attention with a custom CPLinearAttnFunction that:

1. Frees all-gathered tensors after forward (saves memory proportional to cp_size * local_seq_len * hidden_dim)
2. Re-gathers and recomputes forward in backward, ensuring correct reduce-scatter of all gradients (including dk, dv)
3. All-gathers grad_output from all CP ranks so parameter gradients are computed from the full loss

The implementation follows the same pattern as TE's AttnFuncWithCPAndKVAllGather (gather in forward, re-gather + reduce in backward) adapted for linear attention where the entire sequence must be processed as a unit.

Also overrides Attention.forward in qwen3_5.py so the base class's generic CP logic (hf_attention.py) is no longer used for this model.

Tested with torchrun --nproc_per_node={2,4,8}: forward output and backward gradients (hidden + params) match non-CP reference within 5e-5 tolerance.