### PR TITLE
PipelineRL -- keep cache on weight update

### DIFF
--- a/slime/backends/megatron_utils/update_weight/update_weight_from_distributed.py
+++ b/slime/backends/megatron_utils/update_weight/update_weight_from_distributed.py
@@ -87,7 +87,8 @@ class UpdateWeightFromDistributed:
 
         if dist.get_rank() == 0:
             ray.get([engine.pause_generation.remote() for engine in self.rollout_engines])
-            ray.get([engine.flush_cache.remote() for engine in self.rollout_engines])
+            if not getattr(self.args, "keep_cache_on_weight_update", False):
+                ray.get([engine.flush_cache.remote() for engine in self.rollout_engines])
 
             # int4/fp4 pre_process
             if self.quantization_config and self.quantization_config["quant_method"] in ["compressed-tensors"]:

--- a/slime/utils/arguments.py
+++ b/slime/utils/arguments.py
@@ -435,6 +435,12 @@ def get_slime_extra_args_provider(add_custom_arguments=None):
                 help="Interval for updating the weights",
             )
             parser.add_argument(
+                "--keep-cache-on-weight-update",
+                action="store_true",
+                default=False,
+                help="If set, skip flushing the rollout engine cache during weight updates.",
+            )
+            parser.add_argument(
                 "--keep-old-actor",
                 action="store_true",
                 help="Whether to keep the rollout model on training process",


### PR DESCRIPTION
PipelineRL (https://arxiv.org/pdf/2509.19128, Figure 7) showed that retaining the old KV cache on weight update introduced a negligible amount of off-policyness, and recommend retaining the KV cache on weight update for maximum throughput. This can save a considerable amount of prefill time when training large models (we have observed up to 10-20 minute lag in generation post weight sync). 