### PR TITLE
fix: http_utils. disable system proxy for internal SGLang httpx clients

### DIFF
--- a/slime/utils/http_utils.py
+++ b/slime/utils/http_utils.py
@@ -209,6 +209,7 @@ def init_http_client(args):
         _http_client = httpx.AsyncClient(
             limits=httpx.Limits(max_connections=_client_concurrency),
             timeout=httpx.Timeout(None),
+            trust_env=False,  # internal SGLang comm only — never route through system proxy
         )
 
     # Optionally initialize distributed POST via Ray without changing interfaces
@@ -243,6 +244,7 @@ def _init_ray_distributed_post(args):
             self._client = httpx.AsyncClient(
                 limits=httpx.Limits(max_connections=max(1, concurrency)),
                 timeout=httpx.Timeout(None),
+                trust_env=False,  # internal SGLang comm only — never route through system proxy
             )
 
         async def do_post(self, url, payload, max_retries=60, headers=None):


### PR DESCRIPTION
httpx.AsyncClient defaults to trust_env=True, which reads http_proxy/ https_proxy from the environment and routes requests through the proxy. On clusters where proxy env vars are set for external internet access (e.g. W&B logging), all intra-cluster SGLang HTTP calls (/generate, /update_weights_from_distributed, /health, etc.) are routed through the proxy, resulting in 503 Service Unavailable errors.

The standard workaround of adding 10.0.0.0/8 to no_proxy does not work for httpx — unlike requests, httpx does not support CIDR notation in no_proxy (only exact hostnames/IPs and the * wildcard are supported).

Set trust_env=False on both AsyncClient instances in http_utils.py:
- local client in init_http_client()
- Ray actor client in _init_ray_distributed_post()

These clients are exclusively used for intra-cluster SGLang communication and should never be routed through a system proxy.