### PR TITLE
feat: add Qwen3.5-4B model support

### DIFF
--- a/slime/scripts/models/qwen3.5-4B.sh
+++ b/slime/scripts/models/qwen3.5-4B.sh
@@ -1,0 +1,27 @@
+MODEL_ARGS=(
+   --spec "slime_plugins.models.qwen3_5" "get_qwen3_5_spec"
+
+   --disable-bias-linear
+   --qk-layernorm
+   --group-query-attention
+   --num-attention-heads 16
+   --num-query-groups 4
+   --kv-channels 256
+   --num-layers 32
+   --hidden-size 2560
+   --ffn-hidden-size 9216
+   --use-gated-attention
+
+   --normalization RMSNorm
+   --apply-layernorm-1p
+   --position-embedding-type rope
+   --norm-epsilon 1e-6
+   --rotary-percent 0.25
+   --swiglu
+   --vocab-size 248320
+
+   --rotary-base 10000000
+
+   # qwen3.5 specific
+   --attention-output-gate
+)


### PR DESCRIPTION
This PR adds a `Qwen3.5-4B` model config script under `scripts/models/`.

The main `slime` repo already includes Qwen3.5 core support (`slime_plugins/models/qwen3_5.py`, `slime_plugins/mbridge/qwen3_5.py`, and `slime/backends/megatron_utils/megatron_to_hf/qwen3_5.py`). This PR only adds the missing 4B preset script so that downstream launch scripts can source a dedicated config for the dense hybrid Qwen3.5-4B model.

## Changes

- Add `scripts/models/qwen3.5-4B.sh`

## Model config

The script uses the Qwen3.5-specific spec entrypoint:

- `--spec "slime_plugins.models.qwen3_5" "get_qwen3_5_spec"`

and sets the architecture parameters for Qwen3.5-4B:

- `num_layers=32`
- `hidden_size=2560`
- `num_attention_heads=16`
- `num_query_groups=4`
- `kv_channels=256`
- `ffn_hidden_size=9216`
- `vocab_size=248320`
- `rotary_base=10000000`
- `rotary_percent=0.25`
- `--use-gated-attention`
- `--attention-output-gate`

I checked the config against the HuggingFace Qwen3.5-4B model config and verified that the parameters match.
