### PR TITLE
chore: translate remaining Chinese comments to English

### DIFF
--- a/examples/multi_agent/agent_system.py
+++ b/examples/multi_agent/agent_system.py
@@ -115,10 +115,10 @@ class RewriterAgent(Agent):
     async def rewrite(self, args, problem_statement, previous_solutions: list[str]) -> str:
         """Generates the rewrited solution."""
 
-        # 动态生成模板
+        # Build the prompt template dynamically.
         template = generate_rewriter_template(len(previous_solutions))
 
-        # 构建参数字典
+        # Populate the template arguments.
         format_params = {"problem_statement": problem_statement}
         for i, solution in enumerate(previous_solutions):
             format_params[f"solution{i+1}"] = solution
@@ -136,10 +136,10 @@ class SelectorAgent(Agent):
     async def select(self, args, problem_statement, candidate_solutions: list[str]) -> str:
         """Generates the rewrited solution."""
 
-        # 动态生成模板
+        # Build the prompt template dynamically.
         template = generate_select_template(len(candidate_solutions))
 
-        # 构建参数字典
+        # Populate the template arguments.
         format_params = {"problem_statement": problem_statement}
         for i, solution in enumerate(candidate_solutions):
             format_params[f"solution{i+1}"] = solution
@@ -170,7 +170,7 @@ async def rewrite_worker(args, previous_solutions, problem_statement, worker_id)
 
 async def solver_worker(args, problem_statement, worker_id):
     """
-    单组 solver 流程。
+    Run a single solver pipeline.
     """
 
     try:
@@ -186,10 +186,10 @@ async def solver_worker(args, problem_statement, worker_id):
 
 async def run_agent_system(args, sample):
     """
-    并发运行 num_parallel 组 pipeline。
+    Run `num_parallel` pipelines concurrently.
     """
 
-    args = deepcopy(args)  # 深拷贝 args，因为 args 在 rollout_with_multi_agents 中会被修改
+    args = deepcopy(args)  # Deep copy args because rollout_with_multi_agents mutates them.
     args.sample = sample
     args.results_dict = {"solver": [], "rewriter": [], "selector": []}
 
@@ -219,7 +219,7 @@ async def run_agent_system(args, sample):
     ]
     rewrited_solutions_raw = await asyncio.gather(*tasks, return_exceptions=True)
 
-    # 处理异常结果
+    # Filter out failed tasks and keep only valid rewritten solutions.
     rewrited_solutions = []
     for _i, result in enumerate(rewrited_solutions_raw):
         if isinstance(result, str):
@@ -258,7 +258,8 @@ async def run_agent_system(args, sample):
                     args.results_dict["selector"][0].reward = sample.reward
                     break
 
-    ## 如果最终答案正确，对所有reward添加正向的奖励；如果最终答案不正确，对所有reward添加负向的惩罚。
+    ## If the final answer is correct, add a positive bonus to all rewards.
+    ## Otherwise, add a negative penalty to all rewards.
     if args.results_dict["selector"][0].reward == 1:
         reward_adjustment(args.results_dict["solver"], args.correct_reward_weight)
         reward_adjustment(args.results_dict["rewriter"], args.correct_reward_weight)

--- a/examples/multi_agent/prompts.py
+++ b/examples/multi_agent/prompts.py
@@ -1,4 +1,4 @@
-## 定义了一些 prompts 的模板，用于生成不同的 prompts
+## Prompt templates used to generate different prompt variants.
 
 
 SOLVER_PROMPT_TEMPLATE = """{problem_statement}"""

--- a/tests/test_qwen2.5_0.5B_sglang_config_distributed.py
+++ b/tests/test_qwen2.5_0.5B_sglang_config_distributed.py
@@ -10,7 +10,7 @@ MODEL_TYPE = "qwen2.5-0.5B"
 NUM_GPUS = 8
 
 # Inline sglang config: same model, 3 engine groups with different parallelism.
-# Non-colocated (训推分离): actor uses 4 GPUs, rollout uses 4 GPUs.
+# Non-colocated (decoupled training and rollout): actor uses 4 GPUs, rollout uses 4 GPUs.
 # Group 1: 2 GPUs, 2 GPUs/engine (tp=2) → 1 engine
 # Group 2: 1 GPU,  1 GPU/engine  (tp=1) → 1 engine
 # Group 3: 1 GPU,  placeholder   → reserves 1 GPU slot, no engine created


### PR DESCRIPTION
## Summary
- translate remaining Chinese code comments and docstrings into English
- keep Chinese docs and zh documentation untouched
- clarify the training/rollout separation wording in the distributed test comment

## Testing
- not run (comments and docstrings only)