### PR TITLE
[docker] fix qwen3_vl visual module loading

### DIFF
--- a/docker/patch/latest/sglang.patch
+++ b/docker/patch/latest/sglang.patch
@@ -3098,6 +3098,14 @@ index d641826e3..3abc39ef3 100644
              hidden_states, residual = layer(
                  positions,
                  hidden_states,
+@@ -1112,6 +1117,7 @@ class Qwen3VLForConditionalGeneration(nn.Module):
+                 if "visual" in name:
+                     # adapt to VisionAttention
+                     name = name.replace(r"attn.qkv.", r"attn.qkv_proj.")
++                    name = name.replace(r"model.visual.", r"visual.")
+
+                 try:
+                     # Skip loading extra bias for GPTQ models.
 diff --git a/python/sglang/srt/multimodal/processors/glm4v.py b/python/sglang/srt/multimodal/processors/glm4v.py
 index 33cce6fe2..0970c4550 100644
 --- a/python/sglang/srt/multimodal/processors/glm4v.py


### PR DESCRIPTION
Backport sgl-project/sglang#19333 to fix Qwen3-VL visual weight loading in sglang v0.5.9. The missing name mapping (model.visual. -> visual.) caused visual component weights to fail to load.