### PR TITLE
fix: resolve rope_theta from rope_parameters in DeepseekV32Bridge

### DIFF
--- a/slime_plugins/mbridge/deepseek_v32.py
+++ b/slime_plugins/mbridge/deepseek_v32.py
@@ -6,6 +6,15 @@ from mbridge.models import DeepseekV3Bridge
 
 @register_model("deepseek_v32")
 class DeepseekV32Bridge(DeepseekV3Bridge):
+
+    def __init__(self, hf_config, **kwargs):
+        # transformers 5.x stores rope_theta inside rope_parameters dict,
+        # but DeepseekV3Bridge._build_config() expects hf_config.rope_theta directly.
+        if not hasattr(hf_config, "rope_theta"):
+            rope_params = getattr(hf_config, "rope_parameters", None) or {}
+            hf_config.rope_theta = rope_params.get("rope_theta", 1000000)
+        super().__init__(hf_config, **kwargs)
+
     _DSA_ATTENTION_MAPPING = {
         "self_attention.wq_b.weight": ["model.layers.{layer_number}.self_attn.indexer.wq_b.weight"],
         "self_attention.wk.weight": ["model.layers.{layer_number}.self_attn.indexer.wk.weight"],


### PR DESCRIPTION
## Summary
- `DeepseekV3Bridge._build_config()` expects `hf_config.rope_theta` as a top-level attribute, but transformers 5.x `RotaryEmbeddingConfigMixin` moves it into the `rope_parameters` dict
- Adds `__init__` to `DeepseekV32Bridge` to resolve `rope_theta` from `rope_parameters` when not available as a top-level attribute (no-op on transformers 4.x)
- Same fix pattern as `GLM4MoELiteBridge` in `glm4moe_lite.py`

## Test plan
- [x] Verified transformers 4.x sets `config.rope_theta` directly (fix is no-op)
- [x] Verified transformers 5.x stores it in `config.rope_parameters` dict (fix resolves it)
- [x] Successfully converted GLM-5 744B checkpoint with this fix applied as a runtime patch

🤖 Generated with [Claude Code](https://claude.com/claude-code)