### PR TITLE
fix: propagate moe_token_dispatcher_type in bridge model provider

### DIFF
--- a/slime/backends/megatron_utils/model_provider.py
+++ b/slime/backends/megatron_utils/model_provider.py
@@ -95,6 +95,8 @@ def get_model_provider_func(
         provider.sequence_parallel = args.sequence_parallel
         provider.context_parallel_size = args.context_parallel_size
         provider.variable_seq_lengths = args.variable_seq_lengths
+        if hasattr(args, "moe_token_dispatcher_type"):
+            provider.moe_token_dispatcher_type = args.moe_token_dispatcher_type
         if getattr(args, "decoder_first_pipeline_num_layers", None) is not None:
             provider.num_layers_in_first_pipeline_stage = args.decoder_first_pipeline_num_layers
         if getattr(args, "decoder_last_pipeline_num_layers", None) is not None:


### PR DESCRIPTION
fix #1725 

- Propagate `moe_token_dispatcher_type` from `args` to the bridge provider in `model_provider.py`, guarded by `hasattr` for compatibility with newer Megatron versions where the attribute may no longer exist on `args`.
- Fixes the `ValueError: Token dispatcher type: allgather does not support variable sequence length` raised by `finalize()` when using bridge mode, since slime always sets `variable_seq_lengths=True`.

