### PR TITLE
(fix):not have encoder_only attr cause run failed

### DIFF
--- a/slime/backends/sglang_utils/sglang_engine.py
+++ b/slime/backends/sglang_utils/sglang_engine.py
@@ -51,7 +51,7 @@ def _to_local_gpu_id(physical_gpu_id: int) -> int:
 
 
 def launch_server_process(server_args: ServerArgs) -> multiprocessing.Process:
-    if server_args.encoder_only:
+    if hasattr(server_args, "encoder_only") and server_args.encoder_only:
         from sglang.srt.disaggregation.encode_server import launch_server
     else:
         from sglang.srt.entrypoints.http_server import launch_server


### PR DESCRIPTION
(fix):not have encoder_only attr cause run failed
sglang_engine has server_args, if worker_type is regular,  server_args will not have encoder_only attr, then will happen a bug.
File "/code/slime/backends/sglang_utils/sglang_engine.py", line 164, in init
 self._init_normal(server_args_dict)
 File "/code/slime/backends/sglang_utils/sglang_engine.py", line 192, in _init_normal
self.process = launch_server_process(ServerArgs(**server_args_dict))
File "/code/slime/backends/sglang_utils/sglang_engine.py", line 54, in launch_server_process
if server_args.encoder_only:
AttributeError: 'ServerArgs' object has no attribute 'encoder_only
