### PR TITLE
feat: add npu patch for qwen3-vl-8b grpo & ppo

### DIFF
--- a/docker/npu_patch/README.md
+++ b/docker/npu_patch/README.md
@@ -1,0 +1,192 @@
+# Slime NPU Patch Installation Guide
+
+This guide provides instructions for installing Slime with NPU support, including all required dependencies and patches.
+
+## Component Version Mapping
+
+| Component       | Version/Commit                           | Source                                                                                                              |
+| --------------- | ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| Slime           | v0.2.2                                   | [GitHub](https://github.com/THUDM/slime/tree/v0.2.2)                                                                |
+| SGLang          | dce8b0606c06d3a191a24c7b8cbe8e238ab316c9 | [GitHub](https://github.com/sgl-project/sglang/tree/sglang-slime)                                             |
+| SGL Kernel NPU  | 2026.02.01                               | [GitHub](https://github.com/sgl-project/sgl-kernel-npu/releases/tag/2026.02.01)                                     |
+| Megatron-Bridge | 35b4ebfc486fb15dcc0273ceea804c3606be948a | [GitHub](https://github.com/fzyzcjy/Megatron-Bridge)                                                                |
+| Megatron-LM     | 3714d81d418c9f1bca4594fc35f9e8289f652862 | [GitHub](https://github.com/NVIDIA/Megatron-LM)                                                                     |
+| MindSpeed       | fc63de5c48426dd019c3b3f39e65f5bdf56e4086 | [GitCode](https://gitcode.com/Ascend/MindSpeed)                                                                     |
+| HDK             | 25.3.RC1                                 | [Ascend](https://www.hiascend.com/hardware/firmware-drivers/commercial?product=7\&model=33)                         |
+| CANN            | 8.5.0                                    | [Ascend](https://www.hiascend.com/developer/download/community/result?module=cann\&cann=8.5.0\&product=7\&model=33) |
+
+## Preparing the Running Environment
+
+### Python Version
+
+Only `python==3.11` is supported currently.
+
+```shell
+conda create -n slime_release python=3.11
+conda activate slime_release
+```
+
+### Working Directory Setup
+
+```shell
+mkdir <WORKSPACE> && cd <WORKSPACE>
+```
+
+### CANN Environment
+
+Prior to start work with Slime on Ascend you need to install CANN Toolkit, Kernels operator package and NNAL version 8.5.0, check the [installation guide](https://www.hiascend.com/document/detail/zh/CANNCommunityEdition/83RC1/softwareinst/instg/instg_0008.html?Mode=PmIns\&InstallType=local\&OS=openEuler\&Software=cannToolKit)
+
+```shell
+source <CANN_PATH>/ascend-toolkit/set_env.sh
+source <CANN_PATH>/nnal/atb/set_env.sh
+```
+
+### PyTorch and PyTorch NPU
+
+```shell
+pip install torch-npu==2.8.0
+```
+
+## Installing Dependencies
+
+### SGLang
+
+```shell
+cd <WORKSPACE>
+git clone https://github.com/sgl-project/sglang.git && cd sglang
+git checkout dce8b0606c06d3a191a24c7b8cbe8e238ab316c9
+mv python/pyproject.toml python/pyproject.toml.backup
+mv python/pyproject_other.toml python/pyproject.toml
+pip install -e "python[srt_npu]"
+pip install torch-npu==2.8.0
+```
+
+### SGL Kernel NPU and Torch Memory Saver
+
+Download `sgl-kernel-npu-2026.02.01-torch2.8.0-py311-cann8.5.0-a3-aarch64.zip` from the release link, then install:
+
+```shell
+pip install sgl_kernel_npu-2026.2.1-cp311-cp311-linux_aarch64.whl
+pip install torch_memory_saver-0.0.8-cp311-cp311-linux_aarch64.whl
+```
+
+### Megatron-Bridge
+
+```shell
+pip install git+https://github.com/ISEEKYAN/mbridge.git@89eb10887887bc74853f89a4de258c0702932a1c --no-deps
+
+cd <WORKSPACE>
+git clone https://github.com/fzyzcjy/Megatron-Bridge.git -b dev_rl
+pip install nvidia-modelopt[torch]>=0.37.0 --no-build-isolation
+```
+
+### Megatron-LM
+
+```shell
+cd <WORKSPACE>
+git clone https://github.com/NVIDIA/Megatron-LM.git --recursive && \
+  cd Megatron-LM/ && git checkout 3714d81d418c9f1bca4594fc35f9e8289f652862 && \
+  pip install -e .
+```
+
+### MindSpeed
+
+```shell
+cd <WORKSPACE>
+git clone https://gitcode.com/Ascend/MindSpeed.git && \
+  cd MindSpeed/ && git checkout fc63de5c48426dd019c3b3f39e65f5bdf56e4086 && \
+  pip install -e .
+```
+
+### Slime
+
+```shell
+cd <WORKSPACE>
+git clone https://github.com/ascend-slime/slime.git && cd slime
+cp -r docker/npu_patch ../npu_patch
+git checkout v0.2.2
+pip install -e .
+```
+
+## Applying Patches
+
+```shell
+cd <WORKSPACE>/slime
+git apply ../npu_patch/slime.patch
+
+cd <WORKSPACE>/sglang
+git apply ../slime/docker/patch/v0.5.7/sglang.patch
+git apply ../npu_patch/sglang.patch
+
+cd <WORKSPACE>/Megatron-LM
+git apply ../slime/docker/patch/v0.5.7/megatron.patch
+git apply ../npu_patch/megatron.patch
+
+cd <WORKSPACE>/Megatron-Bridge
+git apply ../npu_patch/megatron-bridge.patch
+
+cd <WORKSPACE>/MindSpeed
+git apply ../npu_patch/mindspeed.patch
+```
+
+## Additional Dependencies
+
+```shell
+cd <WORKSPACE>/slime
+pip install triton-ascend
+pip install torch-npu==2.8.0
+pip install torchvision==0.23.0
+pip install numpy==1.26.0
+```
+
+## Running the Training
+
+### Configuration
+
+Modify the paths in the following files according to your environment (note to use your CANN version):
+
+**Common (both GRPO and PPO):**
+
+- `slime/utils/external_utils/command_utils.py`
+
+**GRPO:**
+
+- `examples/geo3k_vlm_multi_turn/run_grpo_npu.sh`
+- `examples/geo3k_vlm_multi_turn/run_geo3k_vlm_multi_turn_grpo_npu.py`
+
+**PPO:**
+
+- `examples/geo3k_vlm_multi_turn/run_ppo_npu.sh`
+- `examples/geo3k_vlm_multi_turn/run_geo3k_vlm_multi_turn_ppo_npu.py`
+
+### Dataset
+
+Download the dataset from [HuggingFace](https://huggingface.co/datasets/VeraIsHere/geo3k_imgurl_processed) following the instructions in the script directory.
+
+### Execute Training
+
+```shell
+cd <WORKSPACE>/slime
+# GRPO
+bash examples/geo3k_vlm_multi_turn/run_grpo_npu.sh
+# PPO
+bash examples/geo3k_vlm_multi_turn/run_ppo_npu.sh
+```
+
+To save logs and display them simultaneously:
+
+```shell
+# GRPO
+bash examples/geo3k_vlm_multi_turn/run_grpo_npu.sh 2>&1 | tee -a <LOG_FILE>
+# PPO
+bash examples/geo3k_vlm_multi_turn/run_ppo_npu.sh 2>&1 | tee -a <LOG_FILE>
+```
+
+## Placeholders Reference
+
+| Placeholder   | Description                          | Example               |
+| ------------- | ------------------------------------ | --------------------- |
+| `<WORKSPACE>` | Root directory for all installations | `/root/slime-release` |
+| `<CANN_PATH>` | Path to CANN installation directory  | `/usr/local/ascend`   |
+| `<LOG_FILE>`  | Path to log file for training output | `training.log`        |
+

--- a/docker/npu_patch/megatron-bridge.patch
+++ b/docker/npu_patch/megatron-bridge.patch
@@ -1,0 +1,93 @@
+diff --git a/src/megatron/bridge/models/conversion/param_mapping.py b/src/megatron/bridge/models/conversion/param_mapping.py
+index dc7d0be..8156826 100644
+--- a/src/megatron/bridge/models/conversion/param_mapping.py
++++ b/src/megatron/bridge/models/conversion/param_mapping.py
+@@ -1088,15 +1088,19 @@ class AutoMapping(MegatronParamMapping[torch.Tensor]):
+             "ColumnParallelLinear",
+             "TEColumnParallelLinear",
+             "TELayerNormColumnParallelLinear",
++            "MindSpeedTELayerNormColumnParallelLinear",
+             "TEColumnParallelGroupedLinear",
++            "MindSpeedTEColumnParallelGroupedLinear",
+             "VocabParallelEmbedding",
+             "DotProductAttention",  # for attention sink only
+             "TEDotProductAttention",  # for attention sink only
++            "MindSpeedTEDotProductAttention",
+         },
+         "row": {
+             "RowParallelLinear",
+             "TERowParallelLinear",
+             "TERowParallelGroupedLinear",
++            "MindSpeedTERowParallelGroupedLinear",
+         },
+         "replicated": {
+             # Normalization layers
+@@ -1164,7 +1168,7 @@ class AutoMapping(MegatronParamMapping[torch.Tensor]):
+         # Handle fused modules like TELayerNormColumnParallelLinear
+         # These modules have both column-parallel weights (weight, bias)
+         # and replicated layer norm weights (layer_norm_weight, layer_norm_bias)
+-        if module_type == "TELayerNormColumnParallelLinear":
++        if module_type == "TELayerNormColumnParallelLinear" or module_type == "MindSpeedTELayerNormColumnParallelLinear":
+             # Check the actual parameter name to determine the correct parallelism type
+             if self.megatron_param and (
+                 self.megatron_param.endswith("layer_norm_weight") or self.megatron_param.endswith("layer_norm_bias")
+@@ -1195,7 +1199,7 @@ class AutoMapping(MegatronParamMapping[torch.Tensor]):
+             return "replicated"
+ 
+         # Check parallel_mode for TELinear
+-        if module_type == "TELinear":
++        if module_type == "TELinear" or module_type == "MindSpeedTELinear":
+             if module.parallel_mode == "column":
+                 return "column"
+             elif module.parallel_mode == "row":
+diff --git a/src/megatron/bridge/models/qwen_vl/modelling_qwen3_vl/transformer_block.py b/src/megatron/bridge/models/qwen_vl/modelling_qwen3_vl/transformer_block.py
+index 3f64d8d..9dadc4b 100644
+--- a/src/megatron/bridge/models/qwen_vl/modelling_qwen3_vl/transformer_block.py
++++ b/src/megatron/bridge/models/qwen_vl/modelling_qwen3_vl/transformer_block.py
+@@ -71,8 +71,9 @@ class Qwen3VLTransformerBlock(TransformerBlock):
+                 context_mask,
+                 rotary_pos_emb,
+                 visual_pos_masks,
+-                deepstack_visual_embeds,
++                *deepstack_visual_embeds_args,
+             ):
++                deepstack_visual_embeds = list(deepstack_visual_embeds_args) if deepstack_visual_embeds_args else None
+                 for index in range(start, end):
+                     layer = self._get_layer(index)
+                     inner_fp8_context = (
+@@ -103,6 +104,8 @@ class Qwen3VLTransformerBlock(TransformerBlock):
+                 return hidden_states, context
+ 
+             return custom_forward
++        
++        deepstack_visual_embeds_tuple = tuple(deepstack_visual_embeds) if deepstack_visual_embeds else ()
+ 
+         def checkpoint_handler(forward_func):
+             """Determines whether to use the `te_checkpoint` or `tensor_parallel.checkpoint`"""
+@@ -118,7 +121,7 @@ class Qwen3VLTransformerBlock(TransformerBlock):
+                     context_mask,
+                     rotary_pos_emb,
+                     visual_pos_masks,
+-                    deepstack_visual_embeds,
++                    *deepstack_visual_embeds_tuple,
+                 )
+             else:
+                 return tensor_parallel.checkpoint(
+@@ -130,7 +133,7 @@ class Qwen3VLTransformerBlock(TransformerBlock):
+                     context_mask,
+                     rotary_pos_emb,
+                     visual_pos_masks,
+-                    deepstack_visual_embeds,
++                    *deepstack_visual_embeds_tuple,
+                 )
+ 
+         if self.config.recompute_method == "uniform":
+@@ -169,7 +172,7 @@ class Qwen3VLTransformerBlock(TransformerBlock):
+                         context_mask,
+                         rotary_pos_emb,
+                         visual_pos_masks,
+-                        deepstack_visual_embeds,
++                        *deepstack_visual_embeds_tuple,
+                     )
+         else:
+             raise ValueError("Invalid activation recompute method.")

--- a/docker/npu_patch/megatron.patch
+++ b/docker/npu_patch/megatron.patch
@@ -1,0 +1,518 @@
+diff --git a/megatron/core/activations.py b/megatron/core/activations.py
+index 8b422d73a..58fba4667 100644
+--- a/megatron/core/activations.py
++++ b/megatron/core/activations.py
+@@ -5,19 +5,19 @@ import torch.nn.functional as F
+ from megatron.core.jit import jit_fuser
+ 
+ 
+-@jit_fuser
++
+ def squared_relu(x: torch.Tensor) -> torch.Tensor:
+     """Squared ReLU activation"""
+     return torch.pow(F.relu(x), 2)
+ 
+ 
+-@jit_fuser
++
+ def quick_gelu(x: torch.Tensor) -> torch.Tensor:
+     """Quick GELU activation"""
+     return x * torch.sigmoid(1.702 * x)
+ 
+ 
+-@jit_fuser
++
+ def fast_gelu(x: torch.Tensor) -> torch.Tensor:
+     """Fast GELU activation"""
+     return 0.5 * x * (1.0 + torch.tanh(x * 0.7978845608 * (1.0 + 0.044715 * x * x)))
+diff --git a/megatron/core/fusions/fused_bias_dropout.py b/megatron/core/fusions/fused_bias_dropout.py
+index 336452562..614ee1a48 100644
+--- a/megatron/core/fusions/fused_bias_dropout.py
++++ b/megatron/core/fusions/fused_bias_dropout.py
+@@ -64,14 +64,14 @@ def bias_dropout_add_unfused(training):
+     return _bias_dropout_add
+ 
+ 
+-@jit_fuser
++
+ def bias_dropout_add_fused_train(
+     x_with_bias: Tuple[torch.Tensor, Optional[torch.Tensor]], residual: torch.Tensor, prob: float
+ ) -> torch.Tensor:
+     return _bias_dropout_add_func(x_with_bias, residual, prob, True)
+ 
+ 
+-@jit_fuser
++
+ def bias_dropout_add_fused_inference(
+     x_with_bias: Tuple[torch.Tensor, Optional[torch.Tensor]], residual: torch.Tensor, prob: float
+ ) -> torch.Tensor:
+diff --git a/megatron/core/fusions/fused_bias_geglu.py b/megatron/core/fusions/fused_bias_geglu.py
+index 7a7fbe7f9..f9a438953 100644
+--- a/megatron/core/fusions/fused_bias_geglu.py
++++ b/megatron/core/fusions/fused_bias_geglu.py
+@@ -13,7 +13,7 @@ from megatron.core.jit import jit_fuser
+ # x * 0.5 * (1.0 + torch.erf(x * 0.70710678))
+ 
+ 
+-@jit_fuser
++
+ def geglu(y):
+     """Performs GEGLU (GELU-Gated Linear Unit) activation.
+ 
+@@ -27,7 +27,7 @@ def geglu(y):
+     return (y_1 * 0.5 * (1.0 + torch.tanh(0.79788456 * y_1 * (1 + 0.044715 * y_1 * y_1)))) * y_2
+ 
+ 
+-@jit_fuser
++
+ def bias_geglu(bias, y):
+     """Performs GEGLU activation with bias addition.
+ 
+@@ -45,7 +45,7 @@ def bias_geglu(bias, y):
+ # gradient of tanh approximation of gelu
+ # gradient of actual gelu is:
+ # 0.5 * (1. + torch.erf(x * 0.70710678)) + 0.3989423 * x * torch.exp(-0.5 * x * x)
+-@jit_fuser
++
+ def geglu_back(g, y):
+     """Computes the gradient for the GEGLU activation.
+ 
+@@ -65,7 +65,7 @@ def geglu_back(g, y):
+     return torch.cat(((g * y_2) * ff, g * (y_1 * 0.5 * (1.0 + tanh_out))), -1)
+ 
+ 
+-@jit_fuser
++
+ def bias_geglu_back(g, y, bias):
+     """Computes the gradient for the biased GEGLU activation.
+ 
+@@ -181,13 +181,13 @@ def bias_geglu_impl(input, bias):
+ # ------------------------- QUICK GEGLU FUSION --------------------------
+ 
+ 
+-@jit_fuser
++
+ def quick_gelu(y: torch.Tensor) -> torch.Tensor:
+     """Sigmoid approximation of gelu"""
+     return y * torch.sigmoid(1.702 * y)
+ 
+ 
+-@jit_fuser
++
+ def quick_geglu(y: torch.Tensor, linear_offset: float = 0.0) -> torch.Tensor:
+     """Performs Quick-GELU-based GEGLU activation : quick_gelu(y1) * (y2 + offset).
+ 
+@@ -202,7 +202,7 @@ def quick_geglu(y: torch.Tensor, linear_offset: float = 0.0) -> torch.Tensor:
+     return quick_gelu(y_1) * (y_2 + linear_offset)
+ 
+ 
+-@jit_fuser
++
+ def weighted_quick_geglu(
+     y: torch.Tensor, weights: torch.Tensor, linear_offset: float = 0.0
+ ) -> torch.Tensor:
+@@ -217,7 +217,7 @@ def weighted_quick_geglu(
+ 
+ 
+ # gradient of sigmoid approximation of gelu
+-@jit_fuser
++
+ def quick_geglu_back(g, y, linear_offset: float = 0.0) -> torch.Tensor:
+     """Backward helper for Quick-GEGLU.
+ 
+@@ -236,7 +236,7 @@ def quick_geglu_back(g, y, linear_offset: float = 0.0) -> torch.Tensor:
+     return torch.cat((dy_1, dy_2), -1)
+ 
+ 
+-@jit_fuser
++
+ def weighted_quick_geglu_back(g, y, weights, linear_offset: float = 0.0):
+     """Backward helper for weighted Quick-GEGLU.
+     Returns gradient w.r.t input `y` and `weights`.
+@@ -255,7 +255,7 @@ def weighted_quick_geglu_back(g, y, weights, linear_offset: float = 0.0):
+ # ---------------- Weighted Bias Quick-GEGLU helpers -----------------
+ 
+ 
+-@jit_fuser
++
+ def weighted_bias_quick_geglu(
+     y: torch.Tensor, bias: torch.Tensor, weights: torch.Tensor, linear_offset: float = 0.0
+ ) -> torch.Tensor:
+@@ -275,7 +275,7 @@ def weighted_bias_quick_geglu(
+     return res.to(dtype)
+ 
+ 
+-@jit_fuser
++
+ def weighted_bias_quick_geglu_back(g, y, bias, weights, linear_offset: float = 0.0):
+     """Backward helper for weighted Quick-GEGLU with bias.
+ 
+diff --git a/megatron/core/fusions/fused_bias_gelu.py b/megatron/core/fusions/fused_bias_gelu.py
+index 8cc90f617..fda8f2f5f 100644
+--- a/megatron/core/fusions/fused_bias_gelu.py
++++ b/megatron/core/fusions/fused_bias_gelu.py
+@@ -13,7 +13,7 @@ from megatron.core.jit import jit_fuser
+ # x * 0.5 * (1.0 + torch.erf(x * 0.70710678))
+ 
+ 
+-@jit_fuser
++
+ def bias_gelu(bias, y):
+     x = bias + y
+     return x * 0.5 * (1.0 + torch.tanh(0.79788456 * x * (1 + 0.044715 * x * x)))
+@@ -22,7 +22,7 @@ def bias_gelu(bias, y):
+ # gradient of tanh approximation of gelu
+ # gradient of actual gelu is:
+ # 0.5 * (1. + torch.erf(x * 0.70710678)) + 0.3989423 * x * torch.exp(-0.5 * x * x)
+-@jit_fuser
++
+ def bias_gelu_back(g, bias, y):
+     x = bias + y
+     tanh_out = torch.tanh(0.79788456 * x * (1 + 0.044715 * x * x))
+diff --git a/megatron/core/fusions/fused_bias_swiglu.py b/megatron/core/fusions/fused_bias_swiglu.py
+index 632470876..105936786 100644
+--- a/megatron/core/fusions/fused_bias_swiglu.py
++++ b/megatron/core/fusions/fused_bias_swiglu.py
+@@ -12,7 +12,7 @@ from megatron.core.utils import nvtx_decorator
+ ###### BIAS SWIGLU FUSION/ NO AUTOGRAD ################
+ 
+ 
+-@jit_fuser
++
+ def swiglu(y):
+     """Performs SwiGLU (Swish-Gated Linear Unit) activation function.
+ 
+@@ -26,7 +26,7 @@ def swiglu(y):
+     return F.silu(y_1) * y_2
+ 
+ 
+-@jit_fuser
++
+ def bias_swiglu(y, bias):
+     """Performs SwiGLU activation with bias addition.
+ 
+@@ -41,7 +41,7 @@ def bias_swiglu(y, bias):
+     return swiglu(y)
+ 
+ 
+-@jit_fuser
++
+ def weighted_swiglu(y, weights):
+     dtype = y.dtype
+     res = swiglu(y) * weights
+@@ -51,7 +51,7 @@ def weighted_swiglu(y, weights):
+ # gradient of tanh approximation of gelu
+ # gradient of actual gelu is:
+ # 0.5 * (1. + torch.erf(x * 0.70710678)) + 0.3989423 * x * torch.exp(-0.5 * x * x)
+-@jit_fuser
++
+ def swiglu_back(g, y):
+     """Computes the gradient for the SwiGLU activation function.
+ 
+@@ -69,7 +69,7 @@ def swiglu_back(g, y):
+     )
+ 
+ 
+-@jit_fuser
++
+ def bias_swiglu_back(g, y, bias):
+     """Computes the gradient for the biased SwiGLU activation function.
+ 
+@@ -86,7 +86,7 @@ def bias_swiglu_back(g, y, bias):
+     return swiglu_back(g, y)
+ 
+ 
+-@jit_fuser
++
+ def weighted_swiglu_back(g, y, weights):
+     input_dtype = y.dtype
+     w_dtype = weights.dtype
+diff --git a/megatron/core/fusions/fused_cross_entropy.py b/megatron/core/fusions/fused_cross_entropy.py
+index 23e4b6031..4d447e0e0 100644
+--- a/megatron/core/fusions/fused_cross_entropy.py
++++ b/megatron/core/fusions/fused_cross_entropy.py
+@@ -9,7 +9,7 @@ from megatron.core.tensor_parallel.cross_entropy import VocabParallelCrossEntrop
+ from megatron.core.tensor_parallel.utils import VocabUtility
+ 
+ 
+-@jit_fuser
++
+ def calculate_logits_max(vocab_parallel_logits: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+     """
+     Calculates the maximum logits of the predicted tokens.
+@@ -22,7 +22,7 @@ def calculate_logits_max(vocab_parallel_logits: torch.Tensor) -> Tuple[torch.Ten
+     return vocab_parallel_logits, logits_max
+ 
+ 
+-@jit_fuser
++
+ def calculate_predicted_logits(
+     vocab_parallel_logits: torch.Tensor,
+     target: torch.Tensor,
+@@ -44,7 +44,7 @@ def calculate_predicted_logits(
+     return target_mask, masked_target_1d, predicted_logits_sum_exp_logits, exp_logits
+ 
+ 
+-@jit_fuser
++
+ def calculate_cross_entropy_loss(
+     exp_logits: torch.Tensor, predicted_logits_sum_exp_logits: torch.Tensor
+ ) -> Tuple[torch.Tensor, torch.Tensor]:
+@@ -61,7 +61,7 @@ def calculate_cross_entropy_loss(
+     return exp_logits, loss
+ 
+ 
+-@jit_fuser
++
+ def calculate_gradients(
+     softmax: torch.Tensor,
+     grad_output: torch.Tensor,
+diff --git a/megatron/core/fusions/fused_pad_routing_map.py b/megatron/core/fusions/fused_pad_routing_map.py
+index c382178b6..563279edd 100644
+--- a/megatron/core/fusions/fused_pad_routing_map.py
++++ b/megatron/core/fusions/fused_pad_routing_map.py
+@@ -70,7 +70,7 @@ def _pad_routing_map_kernel(
+     tl.store(output_row_ptr + token_indices, output_row, mask=token_mask)
+ 
+ 
+-@jit_fuser
++
+ def fused_pad_routing_map(routing_map: torch.Tensor, pad_multiple: int) -> torch.Tensor:
+     """Fused version of pad_routing_map.
+     Args:
+diff --git a/megatron/core/fusions/fused_weighted_squared_relu.py b/megatron/core/fusions/fused_weighted_squared_relu.py
+index 02dabc14c..137022386 100644
+--- a/megatron/core/fusions/fused_weighted_squared_relu.py
++++ b/megatron/core/fusions/fused_weighted_squared_relu.py
+@@ -10,7 +10,7 @@ from megatron.core.utils import nvtx_decorator
+ ######################  WEIGHTED SQUARED ReLU FUSION  ######################
+ 
+ 
+-@jit_fuser
++
+ def weighted_squared_relu(x: torch.Tensor, weights: torch.Tensor) -> torch.Tensor:
+     """Element-wise weight applied after Squared-ReLU.
+ 
+@@ -28,7 +28,7 @@ def weighted_squared_relu(x: torch.Tensor, weights: torch.Tensor) -> torch.Tenso
+     return res.to(out_dtype)
+ 
+ 
+-@jit_fuser
++
+ def _squared_relu_back(g: torch.Tensor, x: torch.Tensor) -> torch.Tensor:
+     """Gradient of Squared-ReLU.
+ 
+@@ -37,7 +37,7 @@ def _squared_relu_back(g: torch.Tensor, x: torch.Tensor) -> torch.Tensor:
+     return g * 2 * F.relu(x)
+ 
+ 
+-@jit_fuser
++
+ def weighted_squared_relu_back(g: torch.Tensor, x: torch.Tensor, weights: torch.Tensor):
+     """Backward for weighted Squared-ReLU.
+ 
+diff --git a/megatron/core/models/gpt/gpt_layer_specs.py b/megatron/core/models/gpt/gpt_layer_specs.py
+index 712793853..76ea4333b 100755
+--- a/megatron/core/models/gpt/gpt_layer_specs.py
++++ b/megatron/core/models/gpt/gpt_layer_specs.py
+@@ -219,7 +219,7 @@ def get_gpt_layer_with_transformer_engine_spec(
+             'The fp8 argument in "get_gpt_layer_with_transformer_engine_spec" has been deprecated'
+             " and will be removed soon. Please update your code accordingly."
+         )
+-
++    from megatron.core.extensions.transformer_engine_spec_provider import TESpecProvider
+     if use_kitchen:
+         assert HAVE_KITCHEN
+         backend: BackendSpecProvider = KitchenSpecProvider(
+diff --git a/megatron/core/ssm/gated_delta_net.py b/megatron/core/ssm/gated_delta_net.py
+index dfa6e4c35..8b3621819 100644
+--- a/megatron/core/ssm/gated_delta_net.py
++++ b/megatron/core/ssm/gated_delta_net.py
+@@ -413,7 +413,7 @@ class GatedDeltaNet(MegatronModule):
+ 
+         return out, out_bias
+ 
+-    @jit_fuser
++    
+     def _apply_gated_norm(self, x, gate):
+         # Output Norm
+         x_dtype = x.dtype
+diff --git a/megatron/core/transformer/attention.py b/megatron/core/transformer/attention.py
+index 80e9ec6fc..b6bcef6a9 100644
+--- a/megatron/core/transformer/attention.py
++++ b/megatron/core/transformer/attention.py
+@@ -1026,7 +1026,7 @@ class Attention(MegatronModule, ABC):
+ 
+         return output, bias
+ 
+-    @jit_fuser
++    
+     def _apply_output_gate(self, x, gate):
+         x_dtype = x.dtype
+         gate = gate.contiguous()
+diff --git a/megatron/core/transformer/module.py b/megatron/core/transformer/module.py
+index 2330df91b..0446c9097 100644
+--- a/megatron/core/transformer/module.py
++++ b/megatron/core/transformer/module.py
+@@ -16,9 +16,9 @@ from megatron.core.transformer.utils import (
+     sharded_state_dict_default,
+ )
+ 
+-_FLOAT_TYPES = (torch.FloatTensor, torch.cuda.FloatTensor)
+-_HALF_TYPES = (torch.HalfTensor, torch.cuda.HalfTensor)
+-_BF16_TYPES = (torch.BFloat16Tensor, torch.cuda.BFloat16Tensor)
++_FLOAT_TYPES = (torch.FloatTensor, torch.cuda.FloatTensor, torch.npu.FloatTensor)
++_HALF_TYPES = (torch.HalfTensor, torch.cuda.HalfTensor, torch.npu.HalfTensor)
++_BF16_TYPES = (torch.BFloat16Tensor, torch.cuda.BFloat16Tensor, torch.npu.BFloat16Tensor)
+ 
+ 
+ def param_is_not_shared(param):  # pylint: disable=missing-function-docstring
+diff --git a/megatron/core/transformer/moe/experts.py b/megatron/core/transformer/moe/experts.py
+index 5eeafdd8d..a4dce6970 100644
+--- a/megatron/core/transformer/moe/experts.py
++++ b/megatron/core/transformer/moe/experts.py
+@@ -91,7 +91,7 @@ class GroupedMLP(MegatronModule):
+             if self.config.activation_func not in (F.silu, F.gelu):
+                 raise ValueError("Activation function must be silu or gelu when using GroupedMLP.")
+ 
+-            @jit_fuser
++            
+             def glu(x):
+                 x = torch.chunk(x, 2, dim=-1)
+                 return self.config.activation_func(x[0]) * x[1]
+@@ -108,7 +108,7 @@ class GroupedMLP(MegatronModule):
+                 "moe_act recompute for fp8 or fp4 cannot work with the legacy GroupedMLP."
+             )
+ 
+-        @jit_fuser
++        
+         def activation_func_with_probs(x, probs):
+             dtype = x.dtype
+             res = self.activation_func(x) * probs
+diff --git a/megatron/core/transformer/moe/router.py b/megatron/core/transformer/moe/router.py
+index 517944f25..2c5bc0728 100644
+--- a/megatron/core/transformer/moe/router.py
++++ b/megatron/core/transformer/moe/router.py
+@@ -472,7 +472,7 @@ class TopKRouter(Router):
+         else:
+             return input
+ 
+-    @jit_fuser
++    
+     def _apply_expert_bias(self, routing_map: torch.Tensor):
+         """
+         Update expert bias and tokens_per_expert
+diff --git a/megatron/core/transformer/moe/token_dispatcher.py b/megatron/core/transformer/moe/token_dispatcher.py
+index d0da38d63..6d092c88f 100644
+--- a/megatron/core/transformer/moe/token_dispatcher.py
++++ b/megatron/core/transformer/moe/token_dispatcher.py
+@@ -1403,7 +1403,7 @@ class MoEFlexTokenDispatcher(MoETokenDispatcher):
+         ).contiguous()
+         return routing_map, probs
+ 
+-    @jit_fuser
++    
+     def dispatch_preprocess(
+         self, hidden_states: torch.Tensor, routing_map: torch.Tensor, probs: torch.Tensor
+     ):
+diff --git a/megatron/core/transformer/torch_norm.py b/megatron/core/transformer/torch_norm.py
+index d0ceca7af..f16796680 100644
+--- a/megatron/core/transformer/torch_norm.py
++++ b/megatron/core/transformer/torch_norm.py
+@@ -69,7 +69,7 @@ class L2Norm(torch.nn.Module):
+         self.hidden_size = hidden_size
+         self.eps = eps
+ 
+-    @jit_fuser
++    
+     def _norm(self, x):
+         """
+         Performs the actual L2 normalization.
+diff --git a/megatron/core/transformer/utils.py b/megatron/core/transformer/utils.py
+index 880c53099..dbc95736e 100644
+--- a/megatron/core/transformer/utils.py
++++ b/megatron/core/transformer/utils.py
+@@ -51,7 +51,7 @@ def attention_mask_func(attention_scores, attention_mask):
+     return attention_scores
+ 
+ 
+-@jit_fuser
++
+ def gelu_impl(x):
+     """OpenAI's gelu implementation."""
+     return 0.5 * x * (1.0 + torch.tanh(0.7978845608028654 * x * (1.0 + 0.044715 * x * x)))
+@@ -65,7 +65,7 @@ def openai_gelu(x):
+ # This is actually Python equivalent of torch.nn.functional.gelu(), also with
+ # type hints for ONNX exporter
+ # pylint: disable=missing-function-docstring
+-@jit_fuser
++
+ def erf_gelu(x):
+     return (
+         x * 0.5 * (torch.erf(x / 1.41421).to(dtype=x.dtype) + torch.ones_like(x).to(dtype=x.dtype))
+diff --git a/megatron/legacy/model/fused_bias_gelu.py b/megatron/legacy/model/fused_bias_gelu.py
+index e00e63148..ffe4b7ec6 100644
+--- a/megatron/legacy/model/fused_bias_gelu.py
++++ b/megatron/legacy/model/fused_bias_gelu.py
+@@ -12,7 +12,7 @@ from megatron.core.jit import jit_fuser
+ # actual gelu is:
+ # x * 0.5 * (1.0 + torch.erf(x * 0.70710678))
+ 
+-@jit_fuser
++
+ def bias_gelu(bias, y):
+     x = bias + y
+     return  x * 0.5 * (1.0 + torch.tanh(0.79788456 * x * (1 + 0.044715 * x * x)))
+@@ -20,7 +20,7 @@ def bias_gelu(bias, y):
+ # gradient of tanh approximation of gelu
+ # gradient of actual gelu is:
+ # 0.5 * (1. + torch.erf(x * 0.70710678)) + 0.3989423 * x * torch.exp(-0.5 * x * x)
+-@jit_fuser
++
+ def bias_gelu_back(g, bias, y):
+     x = bias + y
+     tanh_out = torch.tanh(0.79788456 * x * (1 + 0.044715 * x * x))
+diff --git a/megatron/legacy/model/transformer.py b/megatron/legacy/model/transformer.py
+index 2a662a55b..2fc3e1bfb 100644
+--- a/megatron/legacy/model/transformer.py
++++ b/megatron/legacy/model/transformer.py
+@@ -856,7 +856,7 @@ def get_bias_dropout_add(training):
+     return _bias_dropout_add
+ 
+ 
+-@jit_fuser
++
+ def bias_dropout_add_fused_train(x: torch.Tensor,
+                                  bias: Optional[torch.Tensor],
+                                  residual: torch.Tensor,
+@@ -864,7 +864,7 @@ def bias_dropout_add_fused_train(x: torch.Tensor,
+     return bias_dropout_add(x, bias, residual, prob, True)
+ 
+ 
+-@jit_fuser
++
+ def bias_dropout_add_fused_inference(x: torch.Tensor,
+                                      bias: Optional[torch.Tensor],
+                                      residual: torch.Tensor,
+diff --git a/megatron/legacy/model/utils.py b/megatron/legacy/model/utils.py
+index 5762000d5..534858df7 100644
+--- a/megatron/legacy/model/utils.py
++++ b/megatron/legacy/model/utils.py
+@@ -43,7 +43,7 @@ def get_linear_layer(rows, columns, init_method):
+     return layer
+ 
+ 
+-@jit_fuser
++
+ def gelu_impl(x):
+     """OpenAI's gelu implementation."""
+     return 0.5 * x * (1.0 + torch.tanh(0.7978845608028654 * x *
+@@ -54,7 +54,7 @@ def openai_gelu(x):
+ 
+ 
+ #This is actually Python equivalent of torch.nn.functional.gelu(), also with type hints for ONNX exporter
+-@jit_fuser
++
+ def erf_gelu(x):
+     return x * 0.5 * (torch.erf(x / 1.41421).to(dtype=x.dtype)+torch.ones_like(x).to(dtype=x.dtype))
+ 

--- a/docker/npu_patch/mindspeed.patch
+++ b/docker/npu_patch/mindspeed.patch
@@ -1,0 +1,48 @@
+diff --git a/mindspeed/core/fusions/fused_rope.py b/mindspeed/core/fusions/fused_rope.py
+index a6f02e07..70f7cb08 100644
+--- a/mindspeed/core/fusions/fused_rope.py
++++ b/mindspeed/core/fusions/fused_rope.py
+@@ -126,5 +126,6 @@ def apply_rotary_pos_emb(
+         freqs,
+         rotary_interleaved=config.rotary_interleaved,
+         multi_latent_attention=config.multi_latent_attention,
+-        mscale=mscale
++        mscale=mscale,
++        cp_group=cp_group
+     )
+diff --git a/mindspeed/megatron_adaptor.py b/mindspeed/megatron_adaptor.py
+index f14b231d..4615590e 100644
+--- a/mindspeed/megatron_adaptor.py
++++ b/mindspeed/megatron_adaptor.py
+@@ -57,6 +57,7 @@ def delete_lock_file():
+ def repatch(args):
+     MindSpeedFeaturesManager.remove_patches()
+     full_args = get_full_args()
++    args = vars(args)
+     for k, v in args.items():
+         setattr(full_args, k, v)
+     MindSpeedFeaturesManager.apply_features_pre_patches(full_args)
+diff --git a/mindspeed/te/pytorch/attention/dot_product_attention/dot_product_attention.py b/mindspeed/te/pytorch/attention/dot_product_attention/dot_product_attention.py
+index ac4eabe5..78c5866d 100644
+--- a/mindspeed/te/pytorch/attention/dot_product_attention/dot_product_attention.py
++++ b/mindspeed/te/pytorch/attention/dot_product_attention/dot_product_attention.py
+@@ -330,6 +330,8 @@ class DotProductAttention(torch.nn.Module):
+         inference_params: Any = None,
+         pad_between_seqs: Optional[bool] = None,
+         fp8_output: Optional[bool] = False,
++        local_cp_size=None,
++        cp_group=None,
+     ) -> torch.Tensor:
+         """
+         Dot Product Attention Layer.
+@@ -659,7 +661,9 @@ class MindSpeedTEDotProductAttention(DotProductAttention):
+         ) and not getattr(self.config, 'is_llava', False):
+             self.config.sparse_mode = 2
+             attention_mask = get_attention_mask(self.config)
+-
++        attention_mask = torch.triu(
++            torch.ones((2048, 2048),
++                       device=query.device, dtype=torch.bool), diagonal=1)
+         packed_seq_kwargs = (
+             {key: getattr(packed_seq_params, key) for key in self.kept_packed_seq_params}
+             if packed_seq_params is not None

--- a/docker/npu_patch/sglang.patch
+++ b/docker/npu_patch/sglang.patch
@@ -1,0 +1,610 @@
+diff --git a/python/sglang/srt/hardware_backend/npu/attention/ascend_backend.py b/python/sglang/srt/hardware_backend/npu/attention/ascend_backend.py
+index 8a343d43b..3e49dddb0 100644
+--- a/python/sglang/srt/hardware_backend/npu/attention/ascend_backend.py
++++ b/python/sglang/srt/hardware_backend/npu/attention/ascend_backend.py
+@@ -1050,93 +1050,36 @@ class AscendAttnBackend(AttentionBackend):
+                 )
+ 
+         if not self.use_mla:
+-            num_tokens = q.shape[0]
+-            """PA will support bs<tp in the later version of CANN"""
+-            if num_tokens < get_attention_tp_size():
+-                k_cache = forward_batch.token_to_kv_pool.get_key_buffer(
+-                    layer.layer_id
+-                ).view(-1, self.page_size, layer.tp_k_head_num * layer.qk_head_dim)
+-                v_cache = forward_batch.token_to_kv_pool.get_value_buffer(
+-                    layer.layer_id
+-                ).view(-1, self.page_size, layer.tp_v_head_num * layer.v_head_dim)
+-                query = q.reshape(-1, 1, layer.tp_q_head_num * layer.qk_head_dim)
+-                if self.forward_metadata.seq_lens_cpu_int is None:
+-                    actual_seq_len_kv = self.forward_metadata.seq_lens_cpu_list
+-                else:
+-                    actual_seq_len_kv = (
+-                        self.forward_metadata.seq_lens_cpu_int.cpu().int().tolist()
+-                    )
+-                num_tokens = query.shape[0]
+-                workspace = (
+-                    torch_npu._npu_fused_infer_attention_score_get_max_workspace(
+-                        query,
+-                        k_cache,
+-                        v_cache,
+-                        block_table=self.forward_metadata.block_tables,
+-                        block_size=self.page_size,
+-                        num_heads=layer.tp_q_head_num,
+-                        num_key_value_heads=layer.tp_k_head_num,
+-                        input_layout="BSH",
+-                        scale=layer.scaling,
+-                        actual_seq_lengths_kv=actual_seq_len_kv,
+-                    )
+-                )
+-                output = torch.empty(
+-                    (num_tokens, 1, layer.tp_q_head_num * layer.v_head_dim),
+-                    dtype=q.dtype,
+-                    device=q.device,
+-                )
+-                softmax_lse = torch.empty(1, dtype=q.dtype, device=q.device)
+-                torch_npu.npu_fused_infer_attention_score.out(
+-                    query,
+-                    k_cache,
+-                    v_cache,
+-                    block_table=self.forward_metadata.block_tables,
+-                    block_size=self.page_size,
+-                    num_heads=layer.tp_q_head_num,
+-                    num_key_value_heads=layer.tp_k_head_num,
+-                    input_layout="BSH",
+-                    scale=layer.scaling,
+-                    actual_seq_lengths_kv=actual_seq_len_kv,
+-                    workspace=workspace,
+-                    out=[output, softmax_lse],
+-                )
+-                return output.view(num_tokens, layer.tp_q_head_num * layer.v_head_dim)
++            k_cache = forward_batch.token_to_kv_pool.get_key_buffer(
++                layer.layer_id
++            ).view(-1, self.page_size, layer.tp_k_head_num * layer.qk_head_dim)
++            v_cache = forward_batch.token_to_kv_pool.get_value_buffer(
++                layer.layer_id
++            ).view(-1, self.page_size, layer.tp_v_head_num * layer.v_head_dim)
++            query = q.reshape(-1, layer.tp_q_head_num, layer.qk_head_dim)
++            num_tokens = query.shape[0]
++            if self.forward_metadata.seq_lens_cpu_int is None:
++                actual_seq_len_kv = self.forward_metadata.seq_lens_cpu_list
+             else:
+-                k_cache = forward_batch.token_to_kv_pool.get_key_buffer(layer.layer_id)
+-                v_cache = forward_batch.token_to_kv_pool.get_value_buffer(
+-                    layer.layer_id
+-                )
+-                query = q.reshape(-1, layer.tp_q_head_num, layer.qk_head_dim)
+-                num_tokens = query.shape[0]
+-                attn_output = torch.empty(
+-                    (num_tokens, layer.tp_q_head_num, layer.v_head_dim),
+-                    dtype=query.dtype,
+-                    device=query.device,
+-                )
+-                if self.forward_metadata.seq_lens_cpu_int is None:
+-                    actual_seq_len_kv = torch.from_numpy(
+-                        np.array(self.forward_metadata.seq_lens_cpu_list).astype(
+-                            np.int32
+-                        )
+-                    )
+-                else:
+-                    actual_seq_len_kv = self.forward_metadata.seq_lens_cpu_int
+-
+-                torch_npu._npu_paged_attention(
+-                    query=query,
+-                    key_cache=k_cache,
+-                    value_cache=v_cache,
+-                    num_heads=layer.tp_q_head_num,
+-                    num_kv_heads=layer.tp_k_head_num,
+-                    scale_value=layer.scaling,
+-                    block_table=self.forward_metadata.block_tables,
+-                    context_lens=actual_seq_len_kv,
+-                    out=attn_output,
+-                )
+-                return attn_output.view(
+-                    num_tokens, layer.tp_q_head_num * layer.v_head_dim
++                actual_seq_len_kv = (
++                    self.forward_metadata.seq_lens_cpu_int.cpu().int().tolist()
+                 )
++            actual_seq_lengths = np.arange(1, num_tokens + 1)
++            attn_output, _ = torch.ops.npu.npu_fused_infer_attention_score(
++                query,
++                k_cache,
++                v_cache,
++                block_table=self.forward_metadata.block_tables,
++                block_size=self.page_size,
++                num_heads=layer.tp_q_head_num,
++                num_key_value_heads=layer.tp_k_head_num,
++                input_layout="TND",
++                scale=layer.scaling,
++                actual_seq_lengths=actual_seq_lengths,
++                actual_seq_lengths_kv=actual_seq_len_kv,
++                sparse_mode=0,
++            )
++            return attn_output.view(num_tokens, layer.tp_q_head_num * layer.v_head_dim)
+         else:
+             c_kv, k_rope = forward_batch.token_to_kv_pool.get_kv_buffer(layer.layer_id)
+             if is_fia_nz():
+diff --git a/python/sglang/srt/hardware_backend/npu/graph_runner/npu_graph_runner.py b/python/sglang/srt/hardware_backend/npu/graph_runner/npu_graph_runner.py
+index d089fcc63..ce19d2cd0 100644
+--- a/python/sglang/srt/hardware_backend/npu/graph_runner/npu_graph_runner.py
++++ b/python/sglang/srt/hardware_backend/npu/graph_runner/npu_graph_runner.py
+@@ -29,6 +29,7 @@ import sglang
+ from sglang.srt.configs.model_config import AttentionArch, is_deepseek_nsa
+ from sglang.srt.distributed.parallel_state import GroupCoordinator
+ from sglang.srt.layers.dp_attention import get_attention_tp_size
++from sglang.srt.environ import envs
+ from sglang.srt.model_executor.cuda_graph_runner import CudaGraphRunner
+ from sglang.srt.utils import (
+     empty_context,
+@@ -111,23 +112,15 @@ class NPUGraphRunner(CudaGraphRunner):
+             out = run_once_fn()
+         return out
+ 
+-    def _get_update_attr_name(self, model_runner, forward_batch):
+-        if (
+-            self.bs < get_attention_tp_size()
+-            or forward_batch.forward_mode.is_target_verify()
+-            or self.use_fia
+-        ):
+-            return self.attr_name[AttentionArch.MLA]
+-        return self.attr_name[model_runner.model_config.attention_arch]
+-
+-    def _get_update_attr_type(self, model_runner, forward_batch):
+-        if (
+-            self.bs < get_attention_tp_size()
+-            or forward_batch.forward_mode.is_target_verify()
+-            or self.use_fia
+-        ):
+-            return self.attr_type[AttentionArch.MLA]
+-        return self.attr_type[model_runner.model_config.attention_arch]
++    def _get_update_attr_name(self):
++        # if envs.SGLANG_USE_PAGED_ATTENTION.get():
++        #     return self.attr_name[AttentionArch.MHA]
++        return self.attr_name[AttentionArch.MLA]
++
++    def _get_update_attr_type(self):
++        # if envs.SGLANG_USE_PAGED_ATTENTION.get():
++        #     return self.attr_type[AttentionArch.MHA]
++        return self.attr_type[AttentionArch.MLA]
+ 
+     def _update_inputs(self, seq_lens):
+         if isinstance(self.update_attr_type, torch.Tensor):
+@@ -144,6 +137,10 @@ class NPUGraphRunner(CudaGraphRunner):
+         output_dir = os.path.join(
+             os.getenv("SGLANG_TORCH_PROFILER_DIR", "/tmp"), "graph_capture_profile"
+         )
++        if ".." in output_dir:
++            raise ValueError(
++                "Output directory path contains '..', which is not allowed."
++            )
+         if not Path(output_dir).exists():
+             Path(output_dir).mkdir(parents=True, exist_ok=True)
+         logger.info(
+@@ -181,12 +178,8 @@ class NPUGraphRunner(CudaGraphRunner):
+             self.buffers.input_ids[: self.raw_num_token].copy_(forward_batch.input_ids)
+             self.buffers.positions[: self.raw_num_token].copy_(forward_batch.positions)
+ 
+-        self.update_attr_name = self._get_update_attr_name(
+-            self.model_runner, forward_batch
+-        )
+-        self.update_attr_type = self._get_update_attr_type(
+-            self.model_runner, forward_batch
+-        )
++        self.update_attr_name = self._get_update_attr_name()
++        self.update_attr_type = self._get_update_attr_type()
+         # Replay
+         if not is_deepseek_nsa(self.model_runner.model_config.hf_config):
+             if forward_batch.forward_mode.is_target_verify():
+diff --git a/python/sglang/srt/layers/rotary_embedding.py b/python/sglang/srt/layers/rotary_embedding.py
+index dd8ca7d4f..92be78315 100644
+--- a/python/sglang/srt/layers/rotary_embedding.py
++++ b/python/sglang/srt/layers/rotary_embedding.py
+@@ -115,9 +115,10 @@ class RotaryEmbedding(MultiPlatformOp):
+             cache = cache.to(dtype)
+ 
+         if (
+-            (not (_is_cuda or _is_npu) or self.head_size not in [64, 128, 256, 512])
++            (not (_is_cuda) or self.head_size not in [64, 128, 256, 512])
+             and not (_is_cpu and _is_cpu_amx_available)
+             and not (_is_xpu)
++            and not (_is_npu)
+         ):
+             if _is_cuda or _is_hip:
+                 from sgl_kernel import rotary_embedding
+@@ -292,8 +293,8 @@ class RotaryEmbedding(MultiPlatformOp):
+         assert (
+             fused_set_kv_buffer_arg is None
+         ), "fused_set_kv_buffer_arg is not supported for npu implementation"
+-
+-        rotary_mode = "half"
++        if query.dtype == torch.bfloat16 and self.cos_sin_cache.dtype == torch.float:
++            return self.forward_native(positions, query, key, offsets)
+         if self.is_neox_style:
+             rotary_mode = "half"
+         else:
+diff --git a/python/sglang/srt/layers/vocab_parallel_embedding.py b/python/sglang/srt/layers/vocab_parallel_embedding.py
+index f171a15f2..192970904 100644
+--- a/python/sglang/srt/layers/vocab_parallel_embedding.py
++++ b/python/sglang/srt/layers/vocab_parallel_embedding.py
+@@ -31,6 +31,7 @@ from sglang.srt.utils import (
+     cpu_has_amx_support,
+     get_compiler_backend,
+     is_cpu,
++    is_npu,
+     set_weight_attrs,
+ )
+ 
+@@ -38,6 +39,7 @@ DEFAULT_VOCAB_PADDING_SIZE = 64
+ 
+ _is_cpu_amx_available = cpu_has_amx_support()
+ _is_cpu = is_cpu()
++_is_npu = is_npu()
+ 
+ logger = logging.getLogger(__name__)
+ 
+@@ -123,7 +125,7 @@ class VocabParallelEmbeddingShardIndices:
+         assert self.num_added_elements <= self.num_added_elements_padded
+ 
+ 
+-@torch.compile(dynamic=True, backend=get_compiler_backend())
++@torch.compile(dynamic=True, backend=get_compiler_backend(), disable=_is_npu)
+ def get_masked_input_and_mask(
+     input_: torch.Tensor,
+     org_vocab_start_index: int,
+diff --git a/python/sglang/srt/models/llama.py b/python/sglang/srt/models/llama.py
+index 4176af28d..ffcf73d46 100644
+--- a/python/sglang/srt/models/llama.py
++++ b/python/sglang/srt/models/llama.py
+@@ -52,10 +52,14 @@ from sglang.srt.model_loader.weight_utils import (
+     maybe_remap_kv_scale_name,
+ )
+ from sglang.srt.server_args import get_global_server_args
+-from sglang.srt.utils import add_prefix, make_layers
++from sglang.srt.utils import add_prefix, is_npu, make_layers
+ from sglang.utils import get_exception_traceback
+ 
+ logger = logging.getLogger(__name__)
++_is_npu = is_npu()
++
++if _is_npu:
++    from sgl_kernel_npu.norm.split_qkv_rmsnorm_rope import split_qkv_rmsnorm_rope
+ 
+ 
+ class LlamaMLP(nn.Module):
+@@ -185,15 +189,44 @@ class LlamaAttention(nn.Module):
+             prefix=add_prefix("attn", prefix),
+         )
+ 
++    def forward_prepare_native(self, positions, hidden_states):
++        qkv, _ = self.qkv_proj(hidden_states)
++        q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
++        q, k = self.rotary_emb(positions, q, k)
++        return q, k, v
++
++    def forward_prepare_npu(self, positions, hidden_states, forward_batch):
++        qkv, _ = self.qkv_proj(hidden_states)
++        if self.attn.layer_id == forward_batch.token_to_kv_pool.start_layer:
++            self.rotary_emb.get_cos_sin_with_position(positions)
++        q, k, v = split_qkv_rmsnorm_rope(
++            qkv,
++            self.rotary_emb.position_sin,
++            self.rotary_emb.position_cos,
++            self.q_size,
++            self.kv_size,
++            self.head_dim,
++        )
++        return q, k, v
++
+     def forward(
+         self,
+         positions: torch.Tensor,
+         hidden_states: torch.Tensor,
+         forward_batch: ForwardBatch,
+     ) -> torch.Tensor:
+-        qkv, _ = self.qkv_proj(hidden_states)
+-        q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
+-        q, k = self.rotary_emb(positions, q, k)
++        if not _is_npu or not hasattr(self.rotary_emb, "get_cos_sin_with_position"):
++            q, k, v = self.forward_prepare_native(
++                positions=positions,
++                hidden_states=hidden_states,
++            )
++        else:
++            q, k, v = self.forward_prepare_npu(
++                positions=positions,
++                hidden_states=hidden_states,
++                forward_batch=forward_batch,
++            )
++
+         attn_output = self.attn(q, k, v, forward_batch)
+         output, _ = self.o_proj(attn_output)
+         return output
+diff --git a/python/sglang/srt/models/qwen3.py b/python/sglang/srt/models/qwen3.py
+index 47a1a4e4c..2cdbf8906 100644
+--- a/python/sglang/srt/models/qwen3.py
++++ b/python/sglang/srt/models/qwen3.py
+@@ -161,12 +161,12 @@ class Qwen3Attention(nn.Module):
+             qkv,
+             self.rotary_emb.position_sin,
+             self.rotary_emb.position_cos,
+-            self.q_norm.weight,
+-            self.k_norm.weight,
+             self.q_size,
+             self.kv_size,
+             self.head_dim,
+-            self.q_norm.variance_epsilon,
++            eps=self.q_norm.variance_epsilon,
++            q_weight=self.q_norm.weight,
++            k_weight=self.k_norm.weight,
+             q_bias=getattr(self.q_norm, "bias", None),
+             k_bias=getattr(self.k_norm, "bias", None),
+         )
+@@ -370,6 +370,7 @@ class Qwen3ForCausalLM(nn.Module):
+                     config.vocab_size,
+                     config.hidden_size,
+                     quant_config=quant_config,
++                    use_attn_tp_group=get_global_server_args().enable_dp_lm_head,
+                     prefix=add_prefix("lm_head", prefix),
+                 )
+         else:
+diff --git a/python/sglang/srt/models/qwen3_moe.py b/python/sglang/srt/models/qwen3_moe.py
+index e277d46f2..9e49156da 100644
+--- a/python/sglang/srt/models/qwen3_moe.py
++++ b/python/sglang/srt/models/qwen3_moe.py
+@@ -549,12 +549,12 @@ class Qwen3MoeAttention(nn.Module):
+             qkv,
+             self.rotary_emb.position_sin,
+             self.rotary_emb.position_cos,
+-            self.q_norm.weight,
+-            self.k_norm.weight,
+             self.q_size,
+             self.kv_size,
+             self.head_dim,
+-            self.q_norm.variance_epsilon,
++            eps=self.q_norm.variance_epsilon,
++            q_weight=self.q_norm.weight,
++            k_weight=self.k_norm.weight,
+             q_bias=getattr(self.q_norm, "bias", None),
+             k_bias=getattr(self.k_norm, "bias", None),
+         )
+diff --git a/python/sglang/srt/models/qwen3_vl.py b/python/sglang/srt/models/qwen3_vl.py
+index 218e32362..9f3141ce2 100644
+--- a/python/sglang/srt/models/qwen3_vl.py
++++ b/python/sglang/srt/models/qwen3_vl.py
+@@ -19,6 +19,7 @@ import re
+ from functools import lru_cache, partial
+ from typing import Callable, Iterable, List, Optional, Tuple, Union
+ 
++import numpy as np
+ import torch
+ import torch.nn as nn
+ from einops import rearrange
+@@ -397,70 +398,89 @@ class Qwen3VLMoeVisionModel(nn.Module, RotaryPosMixin):
+         return cos_combined, sin_combined
+ 
+     def fast_pos_embed_interpolate(self, grid_thw):
+-        grid_ts, grid_hs, grid_ws = grid_thw[:, 0], grid_thw[:, 1], grid_thw[:, 2]
+         num_grid_per_side = int(self.num_position_embeddings**0.5)
+-        device = self.pos_embed.weight.device
+ 
+         idx_list = [[] for _ in range(4)]
+         weight_list = [[] for _ in range(4)]
+ 
+-        for t, h, w in zip(grid_ts, grid_hs, grid_ws):
+-            h_idxs = torch.linspace(0, num_grid_per_side - 1, h)
+-            w_idxs = torch.linspace(0, num_grid_per_side - 1, w)
++        # TODO: use torch instand of np
++        for t, h, w in grid_thw:
++            h_idxs = np.linspace(0, num_grid_per_side - 1, h)
++            w_idxs = np.linspace(0, num_grid_per_side - 1, w)
+ 
+-            h_idxs_floor = h_idxs.int()
+-            w_idxs_floor = w_idxs.int()
+-            h_idxs_ceil = (h_idxs.int() + 1).clip(max=num_grid_per_side - 1)
+-            w_idxs_ceil = (w_idxs.int() + 1).clip(max=num_grid_per_side - 1)
++            h_idxs_floor = h_idxs.astype(int)
++            w_idxs_floor = w_idxs.astype(int)
++            h_idxs_ceil = (h_idxs.astype(int) + 1).clip(max=num_grid_per_side - 1)
++            w_idxs_ceil = (w_idxs.astype(int) + 1).clip(max=num_grid_per_side - 1)
+ 
+             dh = h_idxs - h_idxs_floor
+             dw = w_idxs - w_idxs_floor
+ 
+-            base_h = h_idxs_floor * num_grid_per_side
+-            base_h_ceil = h_idxs_ceil * num_grid_per_side
+-
+-            indices = [
+-                (base_h[None].T + w_idxs_floor[None]).flatten(),
+-                (base_h[None].T + w_idxs_ceil[None]).flatten(),
+-                (base_h_ceil[None].T + w_idxs_floor[None]).flatten(),
+-                (base_h_ceil[None].T + w_idxs_ceil[None]).flatten(),
+-            ]
++            idx_list[0].extend(
++                ((h_idxs_floor * num_grid_per_side)[None].T + w_idxs_floor[None])
++                .flatten()
++                .tolist()
++                * t
++            )
++            idx_list[1].extend(
++                ((h_idxs_floor * num_grid_per_side)[None].T + w_idxs_ceil[None])
++                .flatten()
++                .tolist()
++                * t
++            )
++            idx_list[2].extend(
++                ((h_idxs_ceil * num_grid_per_side)[None].T + w_idxs_floor[None])
++                .flatten()
++                .tolist()
++                * t
++            )
++            idx_list[3].extend(
++                ((h_idxs_ceil * num_grid_per_side)[None].T + w_idxs_ceil[None])
++                .flatten()
++                .tolist()
++                * t
++            )
+ 
+-            weights = [
+-                ((1 - dh)[None].T * (1 - dw)[None]).flatten(),
+-                ((1 - dh)[None].T * dw[None]).flatten(),
+-                (dh[None].T * (1 - dw)[None]).flatten(),
+-                (dh[None].T * dw[None]).flatten(),
+-            ]
++            weight_list[0].extend(
++                ((1 - dh)[None].T * (1 - dw)[None]).flatten().tolist() * t
++            )
++            weight_list[1].extend(((1 - dh)[None].T * dw[None]).flatten().tolist() * t)
++            weight_list[2].extend((dh[None].T * (1 - dw)[None]).flatten().tolist() * t)
++            weight_list[3].extend((dh[None].T * dw[None]).flatten().tolist() * t)
+ 
+-            for i in range(4):
+-                idx_list[i].extend(indices[i].tolist())
+-                weight_list[i].extend(weights[i].tolist())
++        device = self.pos_embed.weight.device
++        dtype = self.pos_embed.weight.dtype
+ 
+-        idx_tensor = torch.tensor(idx_list, dtype=torch.long, device=device)
+-        weight_tensor = torch.tensor(
+-            weight_list, dtype=self.pos_embed.weight.dtype, device=device
++        p0 = (
++            self.pos_embed(torch.tensor(idx_list[0], dtype=torch.long, device=device))
++            * torch.tensor(weight_list[0], dtype=dtype, device=device)[:, None]
+         )
+-        pos_embeds = self.pos_embed(idx_tensor).to(device) * weight_tensor[:, :, None]
+-        patch_pos_embeds = pos_embeds[0] + pos_embeds[1] + pos_embeds[2] + pos_embeds[3]
+-
+-        patch_pos_embeds = patch_pos_embeds.split(
+-            [h * w for h, w in zip(grid_hs, grid_ws)]
++        p1 = (
++            self.pos_embed(torch.tensor(idx_list[1], dtype=torch.long, device=device))
++            * torch.tensor(weight_list[1], dtype=dtype, device=device)[:, None]
++        )
++        p2 = (
++            self.pos_embed(torch.tensor(idx_list[2], dtype=torch.long, device=device))
++            * torch.tensor(weight_list[2], dtype=dtype, device=device)[:, None]
++        )
++        p3 = (
++            self.pos_embed(torch.tensor(idx_list[3], dtype=torch.long, device=device))
++            * torch.tensor(weight_list[3], dtype=dtype, device=device)[:, None]
+         )
+ 
++        patch_pos_embeds = p0 + p1 + p2 + p3
++        patch_pos_embeds = patch_pos_embeds.split([t * h * w for t, h, w in grid_thw])
+         patch_pos_embeds_permute = []
+-        merge_size = self.spatial_merge_size
+-        for pos_embed, t, h, w in zip(patch_pos_embeds, grid_ts, grid_hs, grid_ws):
+-            pos_embed = pos_embed.repeat(t, 1)
++        m_size = self.spatial_merge_size
++        for pos_embed, (t, h, w) in zip(patch_pos_embeds, grid_thw):
+             pos_embed = (
+-                pos_embed.view(
+-                    t, h // merge_size, merge_size, w // merge_size, merge_size, -1
+-                )
++                pos_embed.view(t, h // m_size, m_size, w // m_size, m_size, -1)
+                 .permute(0, 1, 3, 2, 4, 5)
+                 .flatten(0, 4)
+             )
+             patch_pos_embeds_permute.append(pos_embed)
+-        return torch.cat(patch_pos_embeds_permute)
++        patch_pos_embeds = torch.cat(patch_pos_embeds_permute)
++        return patch_pos_embeds
+ 
+     def forward(
+         self,
+@@ -650,31 +670,20 @@ class Qwen3LLMModel(Qwen3Model):
+                     hidden_states + residual if residual is not None else hidden_states
+                 )
+ 
+-            deepstack_embeds = None
+-            if input_deepstack_embeds is not None:
+-                prev_layer_idx = layer_idx - 1
+-                if prev_layer_idx in self.deepstack_embed_to_decoder_layer:
+-                    sep = self.hidden_size * prev_layer_idx
+-                    deepstack_embeds = input_deepstack_embeds[
+-                        :, sep : sep + self.hidden_size
+-                    ]
+-
+-            # SGLang applies residual at the START of the next layer, not at the END like HuggingFace.
+-            # See: https://github.com/huggingface/transformers/blob/v5.0.0rc0/src/transformers/models/qwen3_vl/modeling_qwen3_vl.py#L549
+-            # To match HF behavior, deepstack must be added AFTER residual: (hidden_states + residual) + deepstack
+-            # The order matters because addition with different tensors is not associative in practice.
+             hidden_states, residual = layer(
+                 positions,
+                 hidden_states,
+                 forward_batch,
+                 residual,
+-                post_residual_addition=deepstack_embeds,
+             )
++            # process deepstack
++            if (
++                input_deepstack_embeds is not None
++                and layer_idx in self.deepstack_embed_to_decoder_layer
++            ):
+ 
+-        # Handle deepstack for the last processed layer if it exists.
+-        last_deepstack = self.get_deepstack_embeds(
+-            self.end_layer - 1, input_deepstack_embeds
+-        )
++                sep = self.hidden_size * layer_idx
++                hidden_states += input_deepstack_embeds[:, sep : sep + self.hidden_size]
+ 
+         if not self.pp_group.is_last_rank:
+             return PPProxyTensors(
+@@ -688,9 +697,7 @@ class Qwen3LLMModel(Qwen3Model):
+                 if residual is None:
+                     hidden_states = self.norm(hidden_states)
+                 else:
+-                    hidden_states, _ = self.norm(
+-                        hidden_states, residual, post_residual_addition=last_deepstack
+-                    )
++                    hidden_states, _ = self.norm(hidden_states, residual)
+ 
+         if len(aux_hidden_states) == 0:
+             return hidden_states
+@@ -805,15 +812,15 @@ class Qwen3VLForConditionalGeneration(nn.Module):
+         max_images_per_call = get_int_env_var("SGLANG_VLM_MAX_IMAGES_PER_VIT", 0)
+ 
+         if max_patches_per_call == 0 and max_images_per_call == 0:
+-            if self.use_data_parallel:
+-                return run_dp_sharded_mrope_vision_model(
+-                    self.visual,
+-                    pixel_values,
+-                    image_grid_thw.tolist(),
+-                    rope_type="rope_3d",
+-                )
+-            else:
+-                return self.visual(pixel_values, grid_thw=image_grid_thw)
++            # if self.use_data_parallel:
++            #     return run_dp_sharded_mrope_vision_model(
++            #         self.visual,
++            #         pixel_values,
++            #         image_grid_thw.tolist(),
++            #         rope_type="rope_3d",
++            #     )
++            # else:
++            return self.visual(pixel_values, grid_thw=image_grid_thw)
+ 
+         # compute the number of patches per image and the slice positions in pixel_values
+         grid_thw_list = (
+@@ -995,7 +1002,7 @@ class Qwen3VLForConditionalGeneration(nn.Module):
+                 name = name.replace(r"model.language_model.", r"model.")
+             layer_id = get_layer_id(name)
+ 
+-            if self.pp_group.is_last_rank and "model.embed_tokens.weight" in name:
++            if self.pp_group.is_last_rank and "model.embed_tokens.weight" in name and self.config.tie_word_embeddings:
+                 if "lm_head.weight" in params_dict:
+                     lm_head_param = params_dict["lm_head.weight"]
+                     weight_loader = getattr(
+diff --git a/scripts/ci/npu_ci_install_dependency.sh b/scripts/ci/npu_ci_install_dependency.sh
+index 6172db3b4..8cc8fbf39 100755
+--- a/scripts/ci/npu_ci_install_dependency.sh
++++ b/scripts/ci/npu_ci_install_dependency.sh
+@@ -49,7 +49,7 @@ wget -O "${BISHENG_NAME}" "${BISHENG_URL}" && chmod a+x "${BISHENG_NAME}" && "./
+ 
+ 
+ ### Install sgl-kernel-npu
+-SGL_KERNEL_NPU_TAG="20251206"
++SGL_KERNEL_NPU_TAG="2025.12.31"
+ git clone --depth 1 https://github.com/sgl-project/sgl-kernel-npu.git --branch ${SGL_KERNEL_NPU_TAG}
+ (cd sgl-kernel-npu && bash ./build.sh && ${PIP_INSTALL} output/deep_ep*.whl output/sgl_kernel_npu*.whl && cd "$(python3 -m pip show deep-ep | grep -E '^Location:' | awk '{print $2}')" && ln -s deep_ep/deep_ep_cpp*.so)
+ 

--- a/docker/npu_patch/slime.patch
+++ b/docker/npu_patch/slime.patch
@@ -1,0 +1,941 @@
+diff --git a/slime/backends/megatron_utils/__init__.py b/slime/backends/megatron_utils/__init__.py
+index a4666fbe..2a07086a 100644
+--- a/slime/backends/megatron_utils/__init__.py
++++ b/slime/backends/megatron_utils/__init__.py
+@@ -21,21 +21,35 @@ except ImportError:
+     logging.warning("deep_ep is not installed, some functionalities may be limited.")
+ 
+ try:
+-    from megatron.bridge.models.qwen_vl.modelling_qwen3_vl.text_model import (
+-        Qwen3VLMoETextRotaryEmbedding,
+-        Qwen3VLTextRotaryEmbedding,
+-    )
+-
+-    def patch_rotary_embedding(cls):
+-        _original_forward = cls.forward
+-
+-        def _patched_forward(self, *args, packed_seq_params=None, **kwargs):
+-            return _original_forward(self, *args, **kwargs)
++    from megatron.bridge.models.qwen_vl.modelling_qwen3_vl.text_model import Qwen3VLTextRotaryEmbedding, Qwen3VLMoETextRotaryEmbedding
++        
++    _original_forward = Qwen3VLTextRotaryEmbedding.forward
++    _original_forward_1 = Qwen3VLMoETextRotaryEmbedding.forward
++    
++    def _patched_forward(self, *args, packed_seq_params=None, **kwargs):
++        return _original_forward(self, *args, **kwargs)
++    def _patched_forward_1(self, *args, packed_seq_params=None, **kwargs):
++        return _original_forward_1(self, *args, **kwargs)
++    Qwen3VLTextRotaryEmbedding.forward = _patched_forward
++    Qwen3VLMoETextRotaryEmbedding.forward = _patched_forward_1
++except ImportError:
++    pass
+ 
+-        cls.forward = _patched_forward
++try:
++    from mbridge.models.qwen3_vl.model import Qwen3VLModel
++    _original_forward2 = Qwen3VLModel.forward
++    def _patched_forward2(self, *args, loss_mask=None, **kwargs):
++        return _original_forward2(self, *args, **kwargs)
++    Qwen3VLModel.forward = _patched_forward2
++except ImportError:
++    pass
+ 
+-    patch_rotary_embedding(Qwen3VLTextRotaryEmbedding)
+-    patch_rotary_embedding(Qwen3VLMoETextRotaryEmbedding)
++try:
++    from megatron.bridge.models.qwen_vl.modelling_qwen3_vl.model import Qwen3VLModel
++    _original_forward3 = Qwen3VLModel.forward
++    def _patched_forward3(self, *args, loss_mask=None, **kwargs):
++        return _original_forward3(self, *args, **kwargs)
++    Qwen3VLModel.forward = _patched_forward3
+ except ImportError:
+     pass
+ 
+diff --git a/slime/backends/megatron_utils/actor.py b/slime/backends/megatron_utils/actor.py
+index 7bc4f910..a0b1f63a 100644
+--- a/slime/backends/megatron_utils/actor.py
++++ b/slime/backends/megatron_utils/actor.py
+@@ -8,6 +8,10 @@ from contextlib import nullcontext
+ import ray
+ import torch
+ import torch.distributed as dist
++from slime.utils.common import is_npu
++if is_npu():
++    import mindspeed.megatron_adaptor
++    from mindspeed.megatron_adaptor import repatch
+ from megatron.core import mpu
+ from ray.actor import ActorHandle
+ from torch_memory_saver import torch_memory_saver
+@@ -55,6 +59,8 @@ class MegatronTrainRayActor(TrainRayActor):
+         super().init(args, role, with_ref)
+ 
+         init(args)
++        if is_npu():
++            repatch(args)
+ 
+         if is_megatron_main_rank():
+             init_tracking(args, primary=False)
+@@ -596,8 +602,12 @@ class MegatronTrainRayActor(TrainRayActor):
+ 
+         group_name = "actor_critic"
+         world_size = 2
++        if is_npu():
++            backend = "hccl"
++        else:
++            backend = "nccl"
+         self._actor_critic_groups = init_process_group(
+-            backend="nccl",
++            backend=backend,
+             init_method=f"tcp://{master_address}:{master_port}",
+             world_size=world_size,
+             rank=0 if self.role == "actor" else 1,
+diff --git a/slime/backends/megatron_utils/megatron_to_hf/__init__.py b/slime/backends/megatron_utils/megatron_to_hf/__init__.py
+index 84ff899a..a0e2e43c 100644
+--- a/slime/backends/megatron_utils/megatron_to_hf/__init__.py
++++ b/slime/backends/megatron_utils/megatron_to_hf/__init__.py
+@@ -7,7 +7,7 @@ from .processors import quantize_params, remove_padding
+ from .qwen2 import convert_qwen2_to_hf
+ from .qwen3_next import convert_qwen3_next_to_hf
+ from .qwen3moe import convert_qwen3moe_to_hf
+-
++from .qwen3_vl import convert_qwen3vl_to_hf
+ 
+ # TODO unify w/ `convert_to_hf`
+ def postprocess_hf_param(args, megatron_param_name, hf_param_name, param):
+@@ -40,7 +40,10 @@ def _convert_to_hf_core(args, model_name, name, param):
+     elif "qwen3next" in model_name:
+         converted_named_tensors = convert_qwen3_next_to_hf(args, name, param)
+     elif "qwen2" in model_name or "qwen3" in model_name:
+-        converted_named_tensors = convert_qwen2_to_hf(args, name, param)
++        if "qwen3vl" in model_name:
++            converted_named_tensors = convert_qwen3vl_to_hf(args, name, param)
++        else:
++            converted_named_tensors = convert_qwen2_to_hf(args, name, param)
+     elif "deepseekv3" in model_name:
+         converted_named_tensors = convert_deepseekv3_to_hf(args, name, param)
+ 
+diff --git a/slime/backends/megatron_utils/megatron_to_hf/qwen3_vl.py b/slime/backends/megatron_utils/megatron_to_hf/qwen3_vl.py
+new file mode 100644
+index 00000000..5a3aa56d
+--- /dev/null
++++ b/slime/backends/megatron_utils/megatron_to_hf/qwen3_vl.py
+@@ -0,0 +1,133 @@
++import re
++import torch
++from megatron.core import parallel_state as mpu
++
++
++def convert_qwen3vl_to_hf(args, name, param):
++    """
++    Convert Megatron-style Qwen3-VL parameter names to HF-style names.
++    Supports both language model and vision model parameters.
++
++    Args:
++        args: megatron model args (num_attention_heads, kv_channels, etc.)
++        name: str, Megatron parameter name
++        param: torch.Tensor, parameter value
++
++    Returns:
++        List of tuples [(hf_name, hf_param), ...]
++    """
++
++    hf_name_param = None
++
++    # ----------------------------
++    # 1. language model & vision model parameters
++    # ----------------------------
++
++    try:
++        head_dim = args.kv_channels if args.kv_channels is not None else args.hidden_size // args.num_attention_heads
++    except:
++        head_dim = args.hidden_size // args.num_attention_heads
++    value_num_per_group = args.num_attention_heads // args.num_query_groups
++    language_num_layers = args.num_layers
++    
++    pp_size = args.pipeline_model_parallel_size
++    pp_rank = mpu.get_pipeline_model_parallel_rank()
++    assert language_num_layers % pp_size == 0
++
++    num_layers_per_rank = language_num_layers // pp_size
++    offsets = pp_rank * num_layers_per_rank
++
++
++
++    # ----------------------------
++    # 2. LM Embeddings & output
++    # ----------------------------
++    if name == "module.module.language_model.embedding.word_embeddings.weight":
++        hf_name_param = [("model.language_model.embed_tokens.weight", param)]
++    elif name == "module.module.language_model.decoder.final_layernorm.weight":
++        hf_name_param = [("model.language_model.norm.weight", param)]
++    elif name == "module.module.language_model.output_layer.weight":
++        if not args.untie_embeddings_and_output_weights:
++            return [("model.language_model.embed_tokens.weight", param)]
++        else:
++            return [("lm_head.weight", param)]
++
++    else:
++
++        decoder_layers_pattern = r"module\.module\.language_model.decoder\.layers\.(\d+)\.(.+)"
++        vision_pattern = r"module\.module\.vision_model\.(.+)"
++
++        if match := re.match(decoder_layers_pattern, name):
++            # ----------------------------
++            # 3. Attention and MLP layers in language model
++            # ----------------------------
++
++            layer_idx, rest = match.groups()
++            layer_idx = str(int(layer_idx) + offsets)
++            # Self-attention projection
++            if rest == "self_attention.linear_proj.weight":
++                hf_name_param = [(f"model.language_model.layers.{layer_idx}.self_attn.o_proj.weight", param)]
++            
++            elif rest == "self_attention.linear_qkv.weight":
++                param = param.view(args.num_query_groups, -1, head_dim, args.hidden_size)
++                q_param, k_param, v_param = torch.split(
++                    param, split_size_or_sections=[value_num_per_group, 1, 1], dim=1
++                )
++                q_param = q_param.reshape(-1, args.hidden_size)
++                k_param = k_param.reshape(-1, args.hidden_size)
++                v_param = v_param.reshape(-1, args.hidden_size)
++                hf_name_param = [
++                    (f"model.language_model.layers.{layer_idx}.self_attn.q_proj.weight", q_param),
++                    (f"model.language_model.layers.{layer_idx}.self_attn.k_proj.weight", k_param),
++                    (f"model.language_model.layers.{layer_idx}.self_attn.v_proj.weight", v_param),
++                ]
++
++            # MLP layers
++            elif rest == "mlp.linear_fc1.weight":
++                gate_weight, up_weight = param.chunk(2, dim=0)
++
++                hf_name_param = [
++                    (f"model.language_model.layers.{layer_idx}.mlp.gate_proj.weight", gate_weight),
++                    (f"model.language_model.layers.{layer_idx}.mlp.up_proj.weight", up_weight),
++                ]
++
++            elif rest == "mlp.linear_fc2.weight":
++                hf_name_param = [(f"model.language_model.layers.{layer_idx}.mlp.down_proj.weight", param)]
++
++            # LayerNorms
++            elif rest == "self_attention.linear_qkv.layer_norm_weight":
++                hf_name_param = [(f"model.language_model.layers.{layer_idx}.input_layernorm.weight", param)]
++            elif rest == "mlp.linear_fc1.layer_norm_weight":
++                hf_name_param = [(f"model.language_model.layers.{layer_idx}.post_attention_layernorm.weight", param)]
++            elif rest == "self_attention.q_layernorm.weight":
++                hf_name_param = [(f"model.language_model.layers.{layer_idx}.self_attn.q_norm.weight", param)]
++            elif rest == "self_attention.k_layernorm.weight":
++                hf_name_param = [(f"model.language_model.layers.{layer_idx}.self_attn.k_norm.weight", param)]
++
++        elif match_v := re.match(vision_pattern, name):
++            # ----------------------------
++            # 4. Vision model parameters
++            # ----------------------------
++            deepstack_merger_pattern = r"deepstack_merger_list\.(\d+)\.(.+)"
++            decoder_layer_pattern = r"blocks\.(\d+)\.(.+)"
++
++            rest = match_v.groups()[0]
++
++            if match_layer := re.match(deepstack_merger_pattern, rest):
++                layer_idx, layer_rest = match_layer.groups()
++                layer_idx = str(int(layer_idx) + offsets)
++                hf_name_param = [(f"model.visual.deepstack_merger_list.{layer_idx}.{layer_rest}", param)]
++
++            # Decoder layers
++            elif match_layer := re.match(decoder_layer_pattern, rest):
++
++                layer_idx, layer_rest = match_layer.groups()
++                layer_idx = str(int(layer_idx) + offsets)
++                hf_name_param = [(f"model.visual.blocks.{layer_idx}.{layer_rest}", param)]
++            else:
++                hf_name_param = [(f"model.visual.{rest}", param)]
++
++    if hf_name_param == None:
++        raise ValueError(f"Unknown parameter name: {name}")
++    else:
++        return hf_name_param
+diff --git a/slime/backends/megatron_utils/model_provider.py b/slime/backends/megatron_utils/model_provider.py
+index 8174c7ac..1f1c0e09 100644
+--- a/slime/backends/megatron_utils/model_provider.py
++++ b/slime/backends/megatron_utils/model_provider.py
+@@ -17,7 +17,7 @@ from megatron.core.transformer.transformer_config import TransformerConfig
+ from megatron.training.arguments import core_transformer_config_from_args
+ 
+ from slime.utils.misc import load_function
+-
++import slime_plugins.patch.mbridge_patch
+ 
+ # Adapt from https://github.com/volcengine/verl/blob/c3b20575d2bc815fcccd84bddb4c0401fc4b632b/verl/models/llama/megatron/layers/parallel_linear.py#L82
+ class LinearForLastLayer(torch.nn.Linear):
+@@ -33,7 +33,7 @@ class LinearForLastLayer(torch.nn.Linear):
+         self.sequence_parallel = config.sequence_parallel
+         if self.sequence_parallel:
+             self.weight.sequence_parallel = True
+-
++            self.bias.sequence_parallel = True
+         self.weight.data.normal_(mean=0.0, std=0.02)
+         if bias:
+             self.bias.data.zero_()
+@@ -51,10 +51,59 @@ class LinearForLastLayer(torch.nn.Linear):
+         return logits, None
+ 
+ 
++def get_qwen3vl_provide_wrapper(provider, role):
++
++    def provide_wrapper(pre_process=None, post_process=None, vp_stage=None):
++        """
++        Provide a Qwen3VL MoE model instance with vision and language components.
++        """
++        from megatron.bridge.models.qwen_vl.modelling_qwen3_vl.model import Qwen3VLModel
++        language_transformer_config = provider
++
++        # Create vision transformer config - placeholder for future use
++        hf_config = provider.vision_config
++
++        language_transformer_layer_spec = get_gpt_layer_with_transformer_engine_spec(
++            num_experts=provider.num_moe_experts,
++            moe_grouped_gemm=True,
++            qk_layernorm=provider.qk_layernorm,
++            fp8=False,
++            normalization="RMSNorm",
++        )
++
++        # reuse Qwen3VLModel for MoE model but replace the language model with MoE language model
++        model = Qwen3VLModel(
++            language_transformer_config=language_transformer_config,
++            language_transformer_layer_spec=language_transformer_layer_spec,
++            vision_transformer_config=hf_config,
++            pre_process=pre_process,
++            post_process=post_process,
++        )
++
++        if role == "critic" and post_process:
++            model.language_model.output_layer = LinearForLastLayer(input_size=provider.hidden_size, output_size=1, config=provider).to(
++                device=model.language_model.output_layer.weight.device,
++                dtype=model.language_model.output_layer.weight.dtype,
++            )
++
++        # Apply freeze options if any are enabled for fine-tuning
++        if provider.freeze_language_model or provider.freeze_vision_model or provider.freeze_vision_projection:
++            model.freeze(
++                freeze_language_model=provider.freeze_language_model,
++                freeze_vision_model=provider.freeze_vision_model,
++                freeze_vision_projection=provider.freeze_vision_projection,
++            )
++
++        return model
++    return provide_wrapper
++
++
+ def get_model_provider_func(
+     args: argparse.Namespace,
+     role: Literal["actor", "critic"] = "actor",
+ ):
++    from megatron.bridge.models.conversion.param_mapping import AutoMapping
++    AutoMapping.register_module_type('LinearForLastLayer', 'replicated')  # 或 'column' / 'replicated'
+     # Support custom model provider path (similar to --custom-rm-path for reward models)
+     if getattr(args, "custom_model_provider_path", None):
+ 
+@@ -88,6 +137,27 @@ def get_model_provider_func(
+         provider.expert_model_parallel_size = args.expert_model_parallel_size
+         provider.expert_tensor_parallel_size = args.expert_tensor_parallel_size
+         provider.sequence_parallel = args.sequence_parallel
++        provider.gradient_accumulation_fusion = args.gradient_accumulation_fusion
++        provider.recompute_granularity = args.recompute_granularity
++        provider.recompute_method = args.recompute_method
++        provider.recompute_num_layers = args.recompute_num_layers
++        for key, value in vars(args).items():
++            if hasattr(provider, key):
++                continue
++            setattr(provider, key, value)
++
++        is_qwen3vl = (
++            hasattr(bridge.hf_pretrained, 'config') 
++            and hasattr(bridge.hf_pretrained.config, 'model_type') 
++            and 'qwen3_vl' in bridge.hf_pretrained.config.model_type.lower()
++        )
++
++        if role == 'critic' and is_qwen3vl:
++            from megatron.bridge.models.conversion.model_bridge import MegatronModelBridge
++            from slime_plugins.patch.critic_patch import load_weights_hf_to_megatron_wrapper
++            MegatronModelBridge.load_weights_hf_to_megatron = load_weights_hf_to_megatron_wrapper
++            provider.provide = get_qwen3vl_provide_wrapper(provider, role)
++            
+         provider.finalize()
+         return provider.provide
+ 
+diff --git a/slime/backends/megatron_utils/update_weight/common.py b/slime/backends/megatron_utils/update_weight/common.py
+index a2e4e129..ce40b446 100644
+--- a/slime/backends/megatron_utils/update_weight/common.py
++++ b/slime/backends/megatron_utils/update_weight/common.py
+@@ -10,7 +10,7 @@ from megatron.core.transformer.transformer_layer import get_transformer_layer_of
+ 
+ from slime.backends.megatron_utils.misc_utils import strip_param_name_prefix
+ from slime.utils.types import ParamInfo
+-
++from slime.utils.common import is_npu
+ 
+ def all_gather_param(name: str, param: torch.nn.Parameter) -> torch.Tensor:
+     """
+@@ -40,6 +40,8 @@ def all_gather_param(name: str, param: torch.nn.Parameter) -> torch.Tensor:
+     if "linear_fc1.weight" in name:
+         param_partitions = [p.chunk(2, dim=0) for p in param_partitions]
+         param_partitions = [p[0] for p in param_partitions] + [p[1] for p in param_partitions]
++        if is_npu():
++            partition_dim = 0
+     # this is bug in megatron's grouped moe.
+     if "linear_fc2.weight" in name:
+         if partition_dim == 0:
+@@ -102,6 +104,8 @@ def all_gather_params_async(
+             if "linear_fc1.weight" in info.name:
+                 param_partitions = [p.chunk(2, dim=0) for p in param_partitions]
+                 param_partitions = [p[0] for p in param_partitions] + [p[1] for p in param_partitions]
++                if is_npu():
++                    partition_dim = 0
+             # this is bug in megatron's grouped moe.
+             if "linear_fc2.weight" in info.name:
+                 if partition_dim == 0:
+diff --git a/slime/backends/megatron_utils/update_weight/update_weight_from_distributed.py b/slime/backends/megatron_utils/update_weight/update_weight_from_distributed.py
+index a8e50e0e..b3c6ac24 100644
+--- a/slime/backends/megatron_utils/update_weight/update_weight_from_distributed.py
++++ b/slime/backends/megatron_utils/update_weight/update_weight_from_distributed.py
+@@ -12,6 +12,7 @@ from ray.actor import ActorHandle
+ from tqdm import tqdm
+ 
+ from slime.utils.distributed_utils import get_gloo_group, init_process_group
++from slime.utils.common import is_npu
+ 
+ from ..megatron_to_hf import convert_to_hf
+ from .common import all_gather_param, named_params_and_buffers
+@@ -253,6 +254,7 @@ def connect_rollout_engines_from_distributed(
+         master_port = sock.getsockname()[1]
+     world_size = len(rollout_engines) * args.rollout_num_gpus_per_engine + 1
+ 
++    backend = "hccl" if is_npu() else "nccl"
+     refs = [
+         engine.init_weights_update_group.remote(
+             master_address,
+@@ -260,12 +262,12 @@ def connect_rollout_engines_from_distributed(
+             i * args.rollout_num_gpus_per_engine + 1,
+             world_size,
+             group_name,
+-            backend="nccl",
++            backend=backend,
+         )
+         for i, engine in enumerate(rollout_engines)
+     ]
+     model_update_groups = init_process_group(
+-        backend="nccl",
++        backend=backend,
+         init_method=f"tcp://{master_address}:{master_port}",
+         world_size=world_size,
+         rank=0,
+diff --git a/slime/backends/sglang_utils/sglang_engine.py b/slime/backends/sglang_utils/sglang_engine.py
+index af0f5620..03ded2c8 100644
+--- a/slime/backends/sglang_utils/sglang_engine.py
++++ b/slime/backends/sglang_utils/sglang_engine.py
+@@ -15,6 +15,7 @@ from urllib3.exceptions import NewConnectionError
+ 
+ from slime.ray.ray_actor import RayActor
+ from slime.utils.http_utils import get_host_info
++from slime.utils.common import is_npu
+ 
+ logger = logging.getLogger(__name__)
+ 
+@@ -33,7 +34,10 @@ def get_base_gpu_id(args, rank):
+ 
+ 
+ def _to_local_gpu_id(physical_gpu_id: int) -> int:
+-    cvd = os.environ.get("CUDA_VISIBLE_DEVICES")
++    if is_npu():
++        cvd = os.environ.get("ASCEND_RT_VISIBLE_DEVICES")
++    else:
++        cvd = os.environ.get("CUDA_VISIBLE_DEVICES")
+     if not cvd:
+         return physical_gpu_id  # no remapping
+     # CUDA_VISIBLE_DEVICES can be like "4,5,6,7"
+diff --git a/slime/ray/actor_group.py b/slime/ray/actor_group.py
+index 4cac07a2..098bdf92 100644
+--- a/slime/ray/actor_group.py
++++ b/slime/ray/actor_group.py
+@@ -5,6 +5,7 @@ from ray.util.placement_group import PlacementGroup
+ from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
+ 
+ from slime.ray.utils import NOSET_VISIBLE_DEVICES_ENV_VARS_LIST
++from slime.utils.common import is_npu
+ 
+ 
+ class RayTrainGroup:
+@@ -87,19 +88,19 @@ class RayTrainGroup:
+ 
+             actor_impl = FSDPTrainRayActor
+ 
+-        TrainRayActor = ray.remote(num_gpus=1, runtime_env={"env_vars": env_vars})(actor_impl)
+-
++        TrainRayActor = ray.remote(runtime_env={"env_vars": env_vars})(actor_impl)
++        device_name = "NPU" if is_npu() else "GPU"
+         # Create worker actors
+         self._actor_handlers = []
+         master_addr, master_port = None, None
+         for rank in range(world_size):
+             actor = TrainRayActor.options(
+                 num_cpus=num_gpus_per_actor,
+-                num_gpus=num_gpus_per_actor,
+                 scheduling_strategy=PlacementGroupSchedulingStrategy(
+                     placement_group=pg,
+                     placement_group_bundle_index=reordered_bundle_indices[rank],
+                 ),
++                resources={device_name:num_gpus_per_actor}
+             ).remote(world_size, rank, master_addr, master_port)
+             if rank == 0:
+                 master_addr, master_port = ray.get(actor.get_master_addr_and_port.remote())
+diff --git a/slime/ray/placement_group.py b/slime/ray/placement_group.py
+index eb232b16..963b4071 100644
+--- a/slime/ray/placement_group.py
++++ b/slime/ray/placement_group.py
+@@ -4,6 +4,7 @@ import socket
+ import ray
+ from ray.util.placement_group import placement_group
+ from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
++from slime.utils.common import is_npu
+ 
+ from .actor_group import RayTrainGroup
+ from .rollout import RolloutManager
+@@ -11,10 +12,13 @@ from .rollout import RolloutManager
+ logger = logging.getLogger(__name__)
+ 
+ 
+-@ray.remote(num_gpus=1)
++@ray.remote
+ class InfoActor:
+     def get_ip_and_gpu_id(self):
+-        return ray.util.get_node_ip_address(), ray.get_gpu_ids()[0]
++        if is_npu():
++            return ray.util.get_node_ip_address(), ray.get_runtime_context().get_accelerator_ids()["NPU"][0]
++        else:
++            return ray.util.get_node_ip_address(), ray.get_gpu_ids()[0]
+ 
+ 
+ def sort_key(x):
+@@ -35,12 +39,13 @@ def sort_key(x):
+             # representation that allows for sorting.
+             node_ip_parts = [ord(c) for c in node_identifier]
+ 
+-    return (node_ip_parts, gpu_id)
++    return (node_ip_parts, int(gpu_id))
+ 
+ 
+ def _create_placement_group(num_gpus):
+     """Create a placement group with the specified number of GPUs."""
+-    bundles = [{"GPU": 1, "CPU": 1} for _ in range(num_gpus)]
++    device_name = "NPU" if is_npu() else "GPU"
++    bundles = [{device_name: 1, "CPU": 1} for _ in range(num_gpus)]
+     pg = placement_group(bundles, strategy="PACK")
+     num_bundles = len(bundles)
+ 
+@@ -53,7 +58,8 @@ def _create_placement_group(num_gpus):
+                 scheduling_strategy=PlacementGroupSchedulingStrategy(
+                     placement_group=pg,
+                     placement_group_bundle_index=i,
+-                )
++                ),
++                resources={device_name:1}
+             ).remote()
+         )
+     gpu_ids = ray.get([actor.get_ip_and_gpu_id.remote() for actor in info_actors])
+@@ -167,9 +173,11 @@ def create_training_models(args, pgs, rollout_manager):
+ 
+ 
+ def create_rollout_manager(args, pg):
++    device_name = "NPU" if is_npu() else "GPU"
+     rollout_manager = RolloutManager.options(
+         num_cpus=1,
+         num_gpus=0,
++        resources={device_name:0}
+     ).remote(args, pg)
+ 
+     # calculate num_rollout from num_epoch
+diff --git a/slime/ray/rollout.py b/slime/ray/rollout.py
+index 75cb053c..c54a3854 100644
+--- a/slime/ray/rollout.py
++++ b/slime/ray/rollout.py
+@@ -28,6 +28,7 @@ from slime.utils.metric_utils import (
+ from slime.utils.misc import Box, group_by, load_function
+ from slime.utils.seqlen_balancing import get_seqlen_balanced_partitions
+ from slime.utils.types import Sample
++from slime.utils.common import is_npu
+ 
+ from ..utils.metric_utils import has_repetition
+ from .utils import NOSET_VISIBLE_DEVICES_ENV_VARS_LIST, Lock
+@@ -76,7 +77,8 @@ class RolloutManager:
+             self.all_rollout_engines = [None] * num_engines
+         self.num_new_engines = init_rollout_engines(args, pg, self.all_rollout_engines)
+         self.nodes_per_engine = max(1, args.rollout_num_gpus_per_engine // args.num_gpus_per_node)
+-        self.rollout_engine_lock = Lock.options(num_cpus=1, num_gpus=0).remote()
++        device_name = "NPU" if is_npu() else "GPU"
++        self.rollout_engine_lock = Lock.options(num_cpus=1, num_gpus=0, resources={device_name:0}).remote()
+         self.rollout_id = -1
+ 
+         self._metric_checker = MetricChecker.maybe_create(args)
+@@ -467,6 +469,7 @@ def init_rollout_engines(args, pg, all_rollout_engines):
+     RolloutRayActor = ray.remote(SGLangEngine)
+ 
+     rollout_engines = []
++    device_name = "NPU" if is_npu() else "GPU"
+     for i in range(num_engines):
+         if all_rollout_engines[i] is not None:
+             continue
+@@ -503,11 +506,11 @@ def init_rollout_engines(args, pg, all_rollout_engines):
+ 
+         rollout_engine = RolloutRayActor.options(
+             num_cpus=num_cpus,
+-            num_gpus=num_gpus,
+             scheduling_strategy=scheduling_strategy,
+             runtime_env={
+                 "env_vars": env_vars,
+             },
++            resources={device_name:num_gpus}
+         ).remote(args, rank=i, worker_type=worker_type, base_gpu_id=base_gpu_id)
+ 
+         rollout_engines.append((i, rollout_engine))
+diff --git a/slime/ray/train_actor.py b/slime/ray/train_actor.py
+index 2e900ca5..d0a25583 100644
+--- a/slime/ray/train_actor.py
++++ b/slime/ray/train_actor.py
+@@ -13,16 +13,23 @@ from slime.ray.ray_actor import RayActor
+ from slime.utils.distributed_utils import init_gloo_group
+ from slime.utils.logging_utils import configure_logger
+ from slime.utils.memory_utils import clear_memory, print_memory
++from slime.utils.common import is_npu
+ 
+ logger = logging.getLogger(__name__)
+ 
+ 
+ def get_local_gpu_id():
+-    cvd = os.environ.get("CUDA_VISIBLE_DEVICES", None)
++    if is_npu():
++        env_var = "ASCEND_RT_VISIBLE_DEVICES"
++        device_ids = ray.get_runtime_context().get_accelerator_ids()["NPU"]
++    else:
++        env_var = "CUDA_VISIBLE_DEVICES"
++        device_ids = ray.get_gpu_ids()
++    cvd = os.environ.get(env_var, None)
+     if cvd is None:
+-        return ray.get_gpu_ids()[0]
++        return device_ids[0]
+     else:
+-        return cvd.split(",").index(str(ray.get_gpu_ids()[0]))
++        return cvd.split(",").index(str(device_ids[0]))
+ 
+ 
+ class TrainRayActor(RayActor):
+diff --git a/slime/utils/common.py b/slime/utils/common.py
+new file mode 100644
+index 00000000..60ee5b5c
+--- /dev/null
++++ b/slime/utils/common.py
+@@ -0,0 +1,12 @@
++import torch
++
++def is_npu() -> bool:
++    if not hasattr(torch, "npu"):
++        return False
++
++    if not torch.npu.is_available():
++        raise RuntimeError(
++            "torch_npu detected, but NPU device is not available or visible."
++        )
++
++    return True
+diff --git a/slime/utils/external_utils/command_utils.py b/slime/utils/external_utils/command_utils.py
+index 9f51ecdf..d4b47eca 100644
+--- a/slime/utils/external_utils/command_utils.py
++++ b/slime/utils/external_utils/command_utils.py
+@@ -184,6 +184,108 @@ def execute_train(
+             f"{train_args}"
+         )
+ 
++def execute_train_npu(
++    train_args: str,
++    megatron_model_type: str | None,
++    train_script: str = "train.py",
++    before_ray_job_submit=None,
++    extra_env_vars=None,
++    config: ExecuteTrainConfig | None = None,
++):
++    if extra_env_vars is None:
++        extra_env_vars = {}
++    if config is None:
++        config = ExecuteTrainConfig()
++    external_ray = get_bool_env_var("SLIME_SCRIPT_EXTERNAL_RAY")
++    master_addr = os.environ.get("MASTER_ADDR", "127.0.0.1")
++
++    train_backend_fsdp = "--train-backend fsdp" in train_args
++    assert train_backend_fsdp == (megatron_model_type is None)
++
++    exec_command(
++        "pkill -9 sglang; "
++        "sleep 3; "
++        f"{'' if external_ray else 'ray stop --force; '}"
++        f"{'' if external_ray else 'pkill -9 ray; '}"
++        # cannot be run in CI, o/w kill the parent script
++        # TODO: do we really need this kill? (or can we instead kill slime)
++        # "pkill -9 python; "
++        "pkill -9 slime; "
++        "sleep 3; "
++        f"{'' if external_ray else 'pkill -9 ray; '}"
++        # "pkill -9 python; "
++        "pkill -9 slime; "
++        "pkill -9 redis; "
++        "true; "
++    )
++
++    if not external_ray:
++        exec_command(
++            # will prevent ray from buffering stdout/stderr
++            f"export PYTHONBUFFERED=16 && "
++            f"ray start --head --node-ip-address {master_addr} --disable-usage-stats"
++        )
++
++    if (f := before_ray_job_submit) is not None:
++        f()
++
++    runtime_env_json = json.dumps(
++        {
++            "env_vars": {
++                # "PYTHONPATH": "/root/Megatron-LM/",
++                "CUDA_DEVICE_MAX_CONNECTIONS": "1",
++                "RAY_EXPERIMENTAL_NOSET_ASCEND_RT_VISIBLE_DEVICES": "1",
++                "ASCEND_TOOLKIT_HOME": "/path/to/ascend/Ascend/ascend-toolkit/latest/",
++                "ASCEND_OPP_PATH": "/path/to/ascend/Ascend/ascend-toolkit/latest/opp/",
++                "ASCEND_AICPU_PATH": "/path/to/ascend/Ascend/ascend-toolkit/latest/",
++                "ASCEND_HOME_PATH": "/path/to/ascend/Ascend/ascend-toolkit/latest/",
++                "set_env_path": "/path/to/ascend/Ascend/nnal/atb/set_env.sh",
++                "HYDRA_FULL_ERROR": "1",
++                "HCCL_HOST_SOCKET_PORT_RANGE": "60000-60050",
++                "HCCL_NPU_SOCKET_PORT_RANGE": "61000-61050",
++                # If setting this in FSDP, the computation communication overlapping may have issues
++                **(
++                    {}
++                    if train_backend_fsdp
++                    else {
++                        "CUDA_DEVICE_MAX_CONNECTIONS": "1",
++                    }
++                ),
++                "NCCL_NVLS_ENABLE": str(int(check_has_nvlink())),
++                "no_proxy": f"127.0.0.1,{master_addr}",
++                # This is needed by megatron / torch distributed in multi-node setup
++                "MASTER_ADDR": master_addr,
++                **(
++                    {
++                        "CUDA_ENABLE_COREDUMP_ON_EXCEPTION": "1",
++                        "CUDA_COREDUMP_SHOW_PROGRESS": "1",
++                        "CUDA_COREDUMP_GENERATION_FLAGS": "skip_nonrelocated_elf_images,skip_global_memory,skip_shared_memory,skip_local_memory,skip_constbank_memory",
++                        "CUDA_COREDUMP_FILE": "/root/shared_data/cuda_coredump_%h.%p.%t",
++                    }
++                    if config.cuda_core_dump
++                    else {}
++                ),
++                **extra_env_vars,
++                **_parse_extra_env_vars(config.extra_env_vars),
++            }
++        }
++    )
++
++    if get_bool_env_var("SLIME_SCRIPT_ENABLE_RAY_SUBMIT", "1"):
++        cmd_megatron_model_source = (
++            f'source "{repo_base_dir}/scripts/models/{megatron_model_type}.sh" && '
++            if megatron_model_type is not None
++            else ""
++        )
++        exec_command(
++            f"export no_proxy=127.0.0.1 && export PYTHONBUFFERED=16 && "
++            f"{cmd_megatron_model_source}"
++            f'ray job submit --address="http://127.0.0.1:8265" '
++            f"--runtime-env-json='{runtime_env_json}' "
++            f"-- python3 {train_script} "
++            f"{'${MODEL_ARGS[@]}' if megatron_model_type is not None else ''} "
++            f"{train_args}"
++        )
+ 
+ def _parse_extra_env_vars(text: str):
+     try:
+diff --git a/slime/utils/memory_utils.py b/slime/utils/memory_utils.py
+index c12f3cd0..89078266 100644
+--- a/slime/utils/memory_utils.py
++++ b/slime/utils/memory_utils.py
+@@ -3,6 +3,7 @@ import logging
+ 
+ import torch
+ import torch.distributed as dist
++from slime.utils.common import is_npu
+ 
+ logger = logging.getLogger(__name__)
+ 
+@@ -12,12 +13,19 @@ def clear_memory(clear_host_memory: bool = False):
+     gc.collect()
+     torch.cuda.empty_cache()
+     if clear_host_memory:
+-        torch._C._host_emptyCache()
++        if is_npu():
++            torch.npu.empty_cache()
++        else:
++            torch._C._host_emptyCache()
+ 
+ 
+ def available_memory():
+-    device = torch.cuda.current_device()
+-    free, total = torch.cuda.mem_get_info(device)
++    if is_npu():
++        device = torch.npu.current_device()
++        free, total = torch.npu.mem_get_info(device)
++    else:
++        device = torch.cuda.current_device()
++        free, total = torch.cuda.mem_get_info(device)
+     return {
+         "gpu": str(device),
+         "total_GB": _byte_to_gb(total),
+diff --git a/slime_plugins/patch/critic_patch.py b/slime_plugins/patch/critic_patch.py
+new file mode 100644
+index 00000000..1f4e1bc6
+--- /dev/null
++++ b/slime_plugins/patch/critic_patch.py
+@@ -0,0 +1,94 @@
++import torch
++from typing import (
++    List,
++    Mapping,
++    TypeVar,
++    Union,
++)
++from megatron.core.transformer.module import MegatronModule
++HFPreTrained = TypeVar("HFPreTrained")
++MegatronModel = TypeVar("MegatronModel", bound=MegatronModule)
++
++
++def load_weights_hf_to_megatron_wrapper(
++        self, hf_pretrained: HFPreTrained, megatron_model: Union[MegatronModel, List[MegatronModel]]
++    ) -> List[MegatronModel]:
++        """Load HuggingFace weights into Megatron models.
++
++        This method orchestrates the complete weight loading process from HuggingFace
++        format to Megatron's distributed format. It builds a conversion task and
++        executes it with proper progress tracking and error handling.
++
++        The actual weight transformations and distribution are delegated to the
++        appropriate MegatronParamMapping instances based on the state mappings.
++
++        Args:
++            hf_pretrained (HFPreTrained): HuggingFace model or state source containing the
++                weights to load.
++            megatron_model (Union[MegatronModel, List[MegatronModel]]): Megatron model instance
++                or list of model instances (one per virtual pipeline stage).
++
++        Returns:
++            List[MegatronModel]: The input megatron_model as a list with loaded weights.
++
++        Process:
++        1. Build a task mapping each Megatron parameter to its source
++        2. For each parameter in the task:
++            - Fetch source weights from HuggingFace state
++            - Apply format transformation via the param mapping
++            - Distribute to appropriate TP/PP ranks
++            - Copy into the Megatron parameter
++
++        Example:
++            .. code-block:: python
++
++                hf_model = PreTrainedCausalLM.from_pretrained("gpt2")
++                megatron_model = create_megatron_model()  # Single model or list
++                bridge.load_weights_hf_to_megatron(hf_model, megatron_model)
++
++        Note:
++            Progress is shown only on rank 0 to avoid cluttered output in
++            distributed environments.
++
++        Raises:
++            ValueError: If hf_pretrained doesn't have state attribute or if weight shapes don't match.
++            AttributeError: If required HF weights are missing.
++        """
++        if not isinstance(megatron_model, list):
++            megatron_model = [megatron_model]
++
++        hf_to_megatron_tasks = self.build_conversion_tasks(hf_pretrained, megatron_model)
++        hf_state_dict: Mapping[str, torch.Tensor] = hf_pretrained.state if hasattr(hf_pretrained, "state") else {}
++
++        description = f"Loading from {hf_pretrained.model_name_or_path}"
++        for task in self._with_progress_tracking(hf_to_megatron_tasks, description):
++            # None means megatron module not on current rank, skip if this task is not going to happen
++            if task.megatron_module is None:
++                continue
++            # 1) Fetch source tensor(s) from HF state dict
++            hf_weights = self.maybe_modify_loaded_hf_weight(task.mapping.hf_param, hf_state_dict)
++
++            # 2) Delegate conversion & distribution to the bridge
++            converted_weights = task.mapping.hf_to_megatron(hf_weights, task.megatron_module)
++
++            # 3) Copy into Megatron param if this rank received a shard
++            if converted_weights is not None:
++                # Assert that param_weight is not None for HF->Megatron tasks
++                assert task.param_weight is not None, "param_weight is required for HF->Megatron conversion"
++
++                if converted_weights.shape != task.param_weight.shape and task.param_name == 'language_model.output_layer.weight':
++                    continue
++
++                # Check shape compatibility before copying
++                if converted_weights.shape != task.param_weight.shape:
++                    raise ValueError(
++                        f"Shape mismatch for megatron param {task.mapping.megatron_param}:\n"
++                        f"  Expected shape: {task.param_weight.shape}\n"
++                        f"  Got shape: {converted_weights.shape}\n"
++                        f"  Bridge type: {type(task.mapping).__name__}\n"
++                        f"  HF mapping: {task.mapping.hf_param}"
++                    )
++                task.param_weight.data.copy_(converted_weights)
++
++        self._broadcast_shared_embeddings(megatron_model)
++        return megatron_model
+\ No newline at end of file
+diff --git a/slime_plugins/patch/mbridge_patch.py b/slime_plugins/patch/mbridge_patch.py
+new file mode 100644
+index 00000000..606fff9b
+--- /dev/null
++++ b/slime_plugins/patch/mbridge_patch.py
+@@ -0,0 +1,25 @@
++try:
++    from megatron.bridge.models.conversion.model_bridge import MegatronModelBridge
++    _original_build_conversion_tasks = MegatronModelBridge.build_conversion_tasks
++
++    def _patched_build_conversion_tasks(self, hf_pretrained, megatron_model):
++        """
++        Invoke the original build_conversion_tasks and filter out any actual None tasks.
++
++        The original implementation might return List[None | WeightConversionTask]. 
++        We consolidate it here into List[WeightConversionTask] to avoid errors 
++        when accessing None.task.xxx later.
++        """
++        tasks = _original_build_conversion_tasks(self, hf_pretrained, megatron_model)
++
++        if tasks is None:
++            return []
++
++        filtered = [t for t in tasks if t is not None]
++
++        return filtered
++
++    MegatronModelBridge.build_conversion_tasks = _patched_build_conversion_tasks
++
++except ImportError:
++    pass
+diff --git a/train.py b/train.py
+index 01883c47..18faa6d2 100644
+--- a/train.py
++++ b/train.py
+@@ -1,5 +1,7 @@
+ import ray
+-
++from slime.utils.common import is_npu
++if is_npu():
++    import mindspeed.megatron_adaptor
+ from slime.ray.placement_group import create_placement_groups, create_rollout_manager, create_training_models
+ from slime.utils.arguments import parse_args
+ from slime.utils.logging_utils import configure_logger, init_tracking

--- a/examples/geo3k_vlm_multi_turn/run_geo3k_vlm_multi_turn_grpo_npu.py
+++ b/examples/geo3k_vlm_multi_turn/run_geo3k_vlm_multi_turn_grpo_npu.py
@@ -1,0 +1,154 @@
+import os
+
+import slime.utils.misc as U
+from slime.utils.external_utils.command_utils import execute_train_npu
+
+MODEL_NAME = os.environ.get("SLIME_SCRIPT_MODEL_NAME", "Qwen3-VL-2B-Instruct")
+assert MODEL_NAME in {
+    "Qwen3-VL-2B-Instruct",
+    "Qwen3-VL-4B-Instruct",
+    "Qwen3-VL-8B-Instruct",
+    "Qwen3-VL-2B-Thinking",
+    "Qwen3-VL-4B-Thinking",
+    "Qwen3-VL-8B-Thinking",
+}
+
+EXTERNAL_RAY = int(os.environ.get("SLIME_SCRIPT_EXTERNAL_RAY", "0"))
+TRAIN_BACKEND = os.environ.get("SLIME_SCRIPT_TRAIN_BACKEND", "fsdp").lower()
+assert TRAIN_BACKEND in {"fsdp", "megatron"}
+
+DATASET_NAME = "VeraIsHere/geo3k_imgurl_processed"
+DATA_ROOT = "/path/to/datasets/geo3k_imgurl_processed"
+TRAIN_DATA_PATH = os.path.join(DATA_ROOT, "train.parquet")
+
+
+def get_megatron_model_type(model_name: str) -> str:
+    model_type = model_name.replace("-Instruct", "").replace("-Thinking", "")
+    model_type = model_type.replace("Qwen3-VL-", "qwen3-")
+    return model_type.replace("-2B", "-1.7B")
+
+
+def execute():
+    ckpt_args = f"--hf-checkpoint /path/to/model/checkpoints/{MODEL_NAME} "
+
+    wandb_args = (
+        (
+            "--use-wandb "
+            "--wandb-project slime-dev "
+            "--wandb-group geo3k_vlm_multi_turn "
+            f"--wandb-key '{wandb_api_key}' "
+        )
+        if (wandb_api_key := os.environ.get("WANDB_API_KEY"))
+        else ""
+    )
+
+    rollout_args = (
+        f"--prompt-data {TRAIN_DATA_PATH} "
+        "--input-key problem "
+        "--label-key answer "
+        '--multimodal-keys \'{"image": "images"}\' '
+        "--rm-type math "
+        "--apply-chat-template "
+        "--custom-generate-function-path examples.geo3k_vlm_multi_turn.rollout.generate "
+        "--custom-config-path examples/geo3k_vlm_multi_turn/geo3k_vlm_multi_turn_config.yaml "
+        "--rollout-shuffle "
+        "--num-rollout 3000 "
+        "--rollout-batch-size 32 "
+        "--n-samples-per-prompt 8 "
+        "--rollout-max-response-len 4096 "
+        "--rollout-temperature 1 "
+        "--global-batch-size 256 "
+    )
+
+    grpo_args = (
+        "--advantage-estimator grpo "
+        "--kl-loss-coef 0.00 "
+        "--kl-loss-type low_var_kl "
+        "--kl-coef 0.00 "
+        "--entropy-coef 0.00 "
+        "--eps-clip 0.2 "
+        "--eps-clip-high 0.28 "
+        "--use-kl-loss "
+    )
+
+    optimizer_args = (
+        "--optimizer adam "
+        "--lr 1e-6 "
+        "--lr-decay-style constant "
+        "--weight-decay 0.1 "
+        "--adam-beta1 0.9 "
+        "--adam-beta2 0.98 "
+
+        "--optimizer-cpu-offload "
+        "--overlap-cpu-optimizer-d2h-h2d "
+        "--use-precision-aware-optimizer "
+    )
+
+    sglang_args = (
+        "--rollout-num-gpus-per-engine 1 "
+        "--sglang-mem-fraction-static 0.6 "
+        f"--sglang-cuda-graph-bs {' '.join(map(str, [4, 8] + list(range(16, 257, 8))))} "
+        "--sglang-device npu "
+        "--sglang-disable-radix-cache "
+        "--sglang-chunked-prefill-size 32768 "
+        "--sglang-max-prefill-tokens 4000 "
+        "--sglang-max-total-tokens 327680 "
+    )
+
+    megatron_args = (
+        "--train-backend megatron "
+        f"--load /path/to/model/checkpoints/{MODEL_NAME} "
+        f"--ref-load /path/to/model/checkpoints/{MODEL_NAME} "
+        "--tensor-model-parallel-size 4 "
+        "--sequence-parallel "
+        "--pipeline-model-parallel-size 1 "
+        "--context-parallel-size 1 "
+        "--expert-model-parallel-size 1 "
+        "--expert-tensor-parallel-size 1 "
+        "--recompute-granularity full "
+        "--recompute-method uniform "
+        "--recompute-num-layers 1 "
+        "--use-dynamic-batch-size "
+        "--max-tokens-per-gpu 16384 "
+        "--balance-data "
+        "--attention-dropout 0.0 "
+        "--hidden-dropout 0.0 "
+        "--accumulate-allreduce-grads-in-fp32 "
+        "--attention-softmax-in-fp32 "
+        "--attention-backend flash "
+        "--megatron-to-hf-mode bridge "
+    )
+
+    misc_args = (
+        "--actor-num-nodes 1 " f"--actor-num-gpus-per-node 8 " f"--rollout-num-gpus 8 "
+        "--no-gradient-accumulation-fusion "
+        "--use-flash-attn "
+    )
+
+    if TRAIN_BACKEND == "megatron":
+        backend_args = megatron_args
+        megatron_model_type = get_megatron_model_type(MODEL_NAME)
+        os.environ["MODEL_ARGS_ROTARY_BASE"] = "5000000"
+    else:
+        exit()
+
+    train_args = (
+        f"{ckpt_args} "
+        f"{rollout_args} "
+        f"{optimizer_args} "
+        f"{grpo_args} "
+        f"{sglang_args} "
+        f"{backend_args} "
+        f"{misc_args} "
+        f"{wandb_args} "
+    )
+
+    execute_train_npu(
+        train_args=train_args,
+        megatron_model_type=megatron_model_type,
+        extra_env_vars=({"WANDB_API_KEY": os.environ["WANDB_API_KEY"]} if os.environ.get("WANDB_API_KEY") else {}),
+    )
+
+
+if __name__ == "__main__":
+    execute()

--- a/examples/geo3k_vlm_multi_turn/run_geo3k_vlm_multi_turn_ppo_npu.py
+++ b/examples/geo3k_vlm_multi_turn/run_geo3k_vlm_multi_turn_ppo_npu.py
@@ -1,0 +1,159 @@
+import os
+
+import slime.utils.misc as U
+from slime.utils.external_utils.command_utils import execute_train_npu
+
+MODEL_NAME = os.environ.get("SLIME_SCRIPT_MODEL_NAME", "Qwen3-VL-2B-Instruct")
+assert MODEL_NAME in {
+    "Qwen3-VL-2B-Instruct",
+    "Qwen3-VL-4B-Instruct",
+    "Qwen3-VL-8B-Instruct",
+    "Qwen3-VL-2B-Thinking",
+    "Qwen3-VL-4B-Thinking",
+    "Qwen3-VL-8B-Thinking",
+}
+
+EXTERNAL_RAY = int(os.environ.get("SLIME_SCRIPT_EXTERNAL_RAY", "0"))
+TRAIN_BACKEND = os.environ.get("SLIME_SCRIPT_TRAIN_BACKEND", "fsdp").lower()
+assert TRAIN_BACKEND in {"fsdp", "megatron"}
+
+DATASET_NAME = "VeraIsHere/geo3k_imgurl_processed"
+DATA_ROOT = "/path/to/datasets/geo3k_imgurl_processed"
+TRAIN_DATA_PATH = os.path.join(DATA_ROOT, "train.parquet")
+
+
+def get_megatron_model_type(model_name: str) -> str:
+    model_type = model_name.replace("-Instruct", "").replace("-Thinking", "")
+    model_type = model_type.replace("Qwen3-VL-", "qwen3-")
+    return model_type.replace("-2B", "-1.7B")
+
+
+def execute():
+    ckpt_args = f"--hf-checkpoint /path/to/model/checkpoints/{MODEL_NAME} "
+
+    wandb_args = (
+        (
+            "--use-wandb "
+            "--wandb-project slime-dev "
+            "--wandb-group geo3k_vlm_multi_turn "
+            f"--wandb-key '{wandb_api_key}' "
+        )
+        if (wandb_api_key := os.environ.get("WANDB_API_KEY"))
+        else ""
+    )
+
+    rollout_args = (
+        f"--prompt-data {TRAIN_DATA_PATH} "
+        "--input-key problem "
+        "--label-key answer "
+        '--multimodal-keys \'{"image": "images"}\' '
+        "--rm-type math "
+        "--apply-chat-template "
+        "--custom-generate-function-path examples.geo3k_vlm_multi_turn.rollout.generate "
+        "--custom-config-path examples/geo3k_vlm_multi_turn/geo3k_vlm_multi_turn_config.yaml "
+        "--rollout-shuffle "
+        "--num-rollout 3000 "
+        "--rollout-batch-size 32 "
+        "--n-samples-per-prompt 8 "
+        "--rollout-max-response-len 4096 "
+        "--rollout-temperature 1 "
+        "--global-batch-size 256 "
+    )
+
+    ppo_args = (
+        "--advantage-estimator ppo "
+        "--kl-loss-coef 0.00 "
+        "--kl-loss-type k1 "
+        "--kl-coef 0.00 "
+        "--entropy-coef 0.00 "
+        "--eps-clip 4e-4 "
+        "--num-critic-only-steps 1 "
+        "--normalize-advantages "
+        "--critic-lr 1e-5 "
+    )
+
+    optimizer_args = (
+        "--optimizer adam "
+        "--lr 1e-6 "
+        "--lr-decay-style constant "
+        "--weight-decay 0.1 "
+        "--adam-beta1 0.9 "
+        "--adam-beta2 0.98 "
+
+        "--optimizer-cpu-offload "
+        "--overlap-cpu-optimizer-d2h-h2d "
+        "--use-precision-aware-optimizer "
+    )
+
+    sglang_args = (
+        "--rollout-num-gpus-per-engine 1 "
+        "--sglang-mem-fraction-static 0.6 "
+        f"--sglang-cuda-graph-bs {' '.join(map(str, [4, 8] + list(range(16, 257, 8))))} "
+        "--sglang-device npu "
+        "--sglang-disable-radix-cache "
+        "--sglang-chunked-prefill-size 32768 "
+        "--sglang-max-prefill-tokens 4000 "
+        "--sglang-max-total-tokens 327680 "
+    )
+
+    megatron_args = (
+        "--train-backend megatron "
+        f"--load /path/to/model/checkpoints/{MODEL_NAME} "
+        f"--ref-load /path/to/model/checkpoints/{MODEL_NAME} "
+        "--tensor-model-parallel-size 4 "
+        "--sequence-parallel "
+        "--pipeline-model-parallel-size 1 "
+        "--context-parallel-size 1 "
+        "--expert-model-parallel-size 1 "
+        "--expert-tensor-parallel-size 1 "
+        "--recompute-granularity full "
+        "--recompute-method uniform "
+        "--recompute-num-layers 1 "
+        "--use-dynamic-batch-size "
+        "--max-tokens-per-gpu 16384 "
+        "--balance-data "
+        "--attention-dropout 0.0 "
+        "--hidden-dropout 0.0 "
+        "--accumulate-allreduce-grads-in-fp32 "
+        "--attention-softmax-in-fp32 "
+        "--attention-backend flash "
+        "--megatron-to-hf-mode bridge "
+    )
+
+    misc_args = (
+        "--actor-num-nodes 1 "
+        "--actor-num-gpus-per-node 4 "
+        "--critic-num-nodes 1 "
+        "--critic-num-gpus-per-node 4 "
+        "--rollout-num-gpus 8 "
+        "--no-gradient-accumulation-fusion "
+        "--use-flash-attn "
+    )
+
+    if TRAIN_BACKEND == "megatron":
+        backend_args = megatron_args
+        megatron_model_type = get_megatron_model_type(MODEL_NAME)
+        os.environ["MODEL_ARGS_ROTARY_BASE"] = "5000000"
+    else:
+        exit()
+
+    train_args = (
+        f"{ckpt_args} "
+        f"{rollout_args} "
+        f"{optimizer_args} "
+        f"{ppo_args} "
+        f"{sglang_args} "
+        f"{backend_args} "
+        f"{misc_args} "
+        f"{wandb_args} "
+    )
+
+    execute_train_npu(
+        train_args=train_args,
+        megatron_model_type=megatron_model_type,
+        extra_env_vars=({"WANDB_API_KEY": os.environ["WANDB_API_KEY"]} if os.environ.get("WANDB_API_KEY") else {}),
+    )
+
+
+if __name__ == "__main__":
+    execute()

--- a/examples/geo3k_vlm_multi_turn/run_grpo_npu.sh
+++ b/examples/geo3k_vlm_multi_turn/run_grpo_npu.sh
@@ -1,0 +1,15 @@
+export SLIME_SCRIPT_MODEL_NAME=Qwen3-VL-8B-Instruct
+export SLIME_SCRIPT_TRAIN_BACKEND=megatron
+export PYTORCH_ALLOC_CONF=expandable_segments:True
+export PYTHONPATH="/root/Megatron-Bridge/src:/root/Megatron-LM/:/root/sglang/python:$PYTHONPATH"
+export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15
+export CUDA_DEVICE_MAX_CONNECTIONS=1
+export RAY_EXPERIMENTAL_NOSET_ASCEND_RT_VISIBLE_DEVICES=1
+export HCCL_HOST_SOCKET_PORT_RANGE=60000-60050
+export HCCL_NPU_SOCKET_PORT_RANGE=61000-61050
+export HYDRA_FULL_ERROR=1
+export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+export MASTER_PORT=$(shuf -i 20000-65000 -n 1)  # or any free port
+
+
+python examples/geo3k_vlm_multi_turn/run_geo3k_vlm_multi_turn_grpo_npu.py

--- a/examples/geo3k_vlm_multi_turn/run_ppo_npu.sh
+++ b/examples/geo3k_vlm_multi_turn/run_ppo_npu.sh
@@ -1,0 +1,15 @@
+export SLIME_SCRIPT_MODEL_NAME=Qwen3-VL-8B-Instruct
+export SLIME_SCRIPT_TRAIN_BACKEND=megatron
+export PYTORCH_ALLOC_CONF=expandable_segments:True
+export PYTHONPATH="/root/Megatron-Bridge/src:/root/Megatron-LM/:/root/sglang/python:$PYTHONPATH"
+export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15
+export CUDA_DEVICE_MAX_CONNECTIONS=1
+export RAY_EXPERIMENTAL_NOSET_ASCEND_RT_VISIBLE_DEVICES=1
+export HCCL_HOST_SOCKET_PORT_RANGE=60000-60050
+export HCCL_NPU_SOCKET_PORT_RANGE=61000-61050
+export HYDRA_FULL_ERROR=1
+export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+export MASTER_PORT=$(shuf -i 20000-65000 -n 1)  # or any free port
+
+
+python examples/geo3k_vlm_multi_turn/run_geo3k_vlm_multi_turn_ppo_npu.py


### PR DESCRIPTION
## PR Description

### Overview
This PR includes a set of patches to adapt the training stack (megatron-bridge, megatron, mindspeed, sglang, slime) for NPU (Ascend) compatibility, along with several bug fixes.

---

### megatron-bridge.patch

- **param_mapping.py**: Added compatibility handling for the extra prefix introduced by mindspeed's patch on the TE module.
- **transformer_block.py**: Fixed a recomputation (activation checkpointing) bug in the Qwen3-VL transformer block.

---

### megatron.patch

- **`@jit_fuser` removal**: Removed all `@jit_fuser` decorators, as `torch_npu` does not support the corresponding fused operators and causes errors on certain versions.
- **CUDA → NPU translation**: Applied manual `cuda`→`npu` replacements where `torch_npu`'s automatic translation failed to take effect.

---

### mindspeed.patch

- **fused_rope.py**: Added argument alignment shim to handle the version gap between mindspeed and upstream megatron.
- **megatron_adaptor.py**: Added an args format conversion layer, as slime passes args in a format incompatible with mindspeed's expected structure.

---

### sglang.patch

- **qwen3_vl.py - `fast_pos_embed_interpolate`**: Fixed the `fast_pos_embed_interpolate` function in the vision model to correct positional embedding interpolation behavior. ([[Reference](https://github.com/sgl-project/sglang/pull/19693/changes#diff-ae8ed8a721eecaefcf77446a0f593b7c92d2270cbb1589ceaeea2e2b68981c6cR401-R483)](https://github.com/sgl-project/sglang/pull/19693/changes#diff-ae8ed8a721eecaefcf77446a0f593b7c92d2270cbb1589ceaeea2e2b68981c6cR401-R483))
- **`input_deepstack_embeds` revert**: Reverted a previous modification to `input_deepstack_embeds`, replacing it with the equivalent three-line implementation from upstream. ([[Reference](https://github.com/sgl-project/sglang/pull/19693/changes#diff-190683f5c7ffde48eb0ce015d76532f833fe1e122779eae6da8181dbfab3895bR142-R144)](https://github.com/sgl-project/sglang/pull/19693/changes#diff-190683f5c7ffde48eb0ce015d76532f833fe1e122779eae6da8181dbfab3895bR142-R144))
- **attention_backend**: Routed attention computation through the FIA operator in the attention backend for NPU compatibility.

---

### slime.patch

- **NPU detection**: Added an `is_npu()` utility in `common.py` to gate NPU-specific logic throughout the codebase.
- **Ray resource allocation**: Replaced `num_gpus=N` in `ray.remote` / `.options()` calls with `resources={"NPU": N}` (or `"GPU"` on non-NPU), as `ray.remote(num_gpus=...)` is not supported on NPU. Affects `actor_group.py`, `placement_group.py`, and `rollout.py`.
- **Ray GPU ID API**: Replaced unsupported `ray.get_gpu_ids()` with `ray.get_runtime_context().get_accelerator_ids()["NPU"]`, with additional `int()` casting since the returned values are strings. Affects `placement_group.py`.
- **Manual device/backend replacements**: Applied manual corrections for cases `torch_npu` cannot auto-translate: `nccl`→`hccl` (`actor.py`, `update_weight_from_distributed.py`), `cuda`→`npu` (`memory_utils.py`), and `CUDA_VISIBLE_DEVICES`→`ASCEND_RT_VISIBLE_DEVICES` (`sglang_engine.py`).
- **MindSpeed plugin integration**: Added the necessary initialization code to load the mindspeed plugin when using megatron as the training backend. Affects `train.py` and `actor.py`.
- **model_provider argument injection**: Injected mindspeed-specific arguments into the megatron_bridge model provider, as they are otherwise not recognized during model loading. Also injects recomputation-related config here, since setting it at the script level has no effect. This will be simplified once mindspeed handles injection natively. Affects `model_provider.py`.
---
grpo raw_reward curve:
<img width="1312" height="776" alt="image" src="https://github.com/user-attachments/assets/5734e21b-4de3-42e2-9e4f-fbe1956a8027" />
