### PR TITLE
[Fix] Fix duplicate Megatron LR scheduler resume when optimizer state is not loaded

### DIFF
--- a/slime/backends/megatron_utils/model.py
+++ b/slime/backends/megatron_utils/model.py
@@ -782,7 +782,4 @@ def initialize_model_and_optimizer(
     )
     clear_memory()
 
-    # `load_checkpoint()` already restores scheduler state when optimizer state is resumed.
-    # Keep a fresh schedule when `--no-load-optim` is set instead of fast-forwarding here.
-
     return model, optimizer, opt_param_scheduler, iteration


### PR DESCRIPTION
 
  ## Summary

  This PR removes the extra LR scheduler fast-forward in `initialize_model_and_optimizer()`.

  ## Why

  Megatron already restores scheduler state inside `load_checkpoint()` when optimizer state is resumed via:

  - `opt_param_scheduler.load_state_dict(...)`

  The additional manual call to:

  - `opt_param_scheduler.step(increment=iteration * args.global_batch_size)`

  was therefore redundant.

  It also caused incorrect behavior when `--no-load-optim` was used:
  - model weights were loaded from the checkpoint
  - optimizer/scheduler state was intentionally not restored
  - but the fresh scheduler was still fast-forwarded to the checkpoint iteration

  In that case, the LR could be pushed directly to `min_lr` at startup, which matched the observed `lr = 0` behavior.

  ## Change

  - Remove the redundant scheduler fast-forward in `slime/backends/megatron_utils/model.py`