### PR TITLE
fix(geo3k-vlm-sft): remove --apply-chat-template from SFT launch script

### DIFF
--- a/examples/geo3k_vlm/run_geo3k_vlm_sft.sh
+++ b/examples/geo3k_vlm/run_geo3k_vlm_sft.sh
@@ -82,7 +82,6 @@ SFT_ARGS=(
    --rollout-function-path slime.rollout.sft_rollout.generate_rollout
    --prompt-data /root/datasets/${DATASET_LOCAL_NAME}/train_formatted.parquet
    --input-key messages
-   --apply-chat-template
    --rollout-shuffle
    --num-epoch 3000
    --rollout-batch-size 128


### PR DESCRIPTION
## Problem

`--apply-chat-template` in `run_geo3k_vlm_sft.sh` converts the `messages` list into a plain string before it reaches the SFT rollout. `sft_rollout.generate_rollout()` expects `sample.prompt` to be a list of message dicts, so passing a string causes a **TypeError** at runtime — training fails immediately.

## Fix

Remove the flag. The `messages` column produced by `prepare_sft_data.py` is already a structured list; the SFT rollout consumes it directly to build the per-token loss mask.