### PR TITLE
fix missing position_ids in log-prob forward step

### DIFF
--- a/slime/backends/megatron_utils/model.py
+++ b/slime/backends/megatron_utils/model.py
@@ -226,6 +226,7 @@ def forward_only(
         response_lengths = batch["response_lengths"]
         forward_kwargs = {
             "input_ids": tokens,
+            "position_ids": None,
             "attention_mask": None,
             "labels": None,
             "packed_seq_params": packed_seq_params,


### PR DESCRIPTION
Fix `TypeError: GPTModel.forward() missing 1 required positional argument: 'position_ids'` introduced in https://github.com/THUDM/slime/pull/1807