### PR TITLE
[codex] Support Qwen3.5 MoE hybrid CP v1

### DIFF
--- a/build_conda.sh
+++ b/build_conda.sh
@@ -42,7 +42,7 @@ MAX_JOBS=64 pip -v install flash-attn==2.7.4.post1 --no-build-isolation
 
 pip install git+https://github.com/ISEEKYAN/mbridge.git@89eb10887887bc74853f89a4de258c0702932a1c --no-deps
 pip install --no-build-isolation "transformer_engine[pytorch]==2.10.0"
-pip install flash-linear-attention==0.4.1
+pip install git+https://github.com/fla-org/flash-linear-attention.git@606851e90a5b3f26fcc818391f1303faa703de30
 NVCC_APPEND_FLAGS="--threads 4" \
   pip -v install --disable-pip-version-check --no-cache-dir \
   --no-build-isolation \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -34,7 +34,7 @@ RUN git clone https://github.com/Dao-AILab/flash-attention.git && \
 
 RUN pip install git+https://github.com/ISEEKYAN/mbridge.git@89eb10887887bc74853f89a4de258c0702932a1c --no-deps
 
-RUN pip install flash-linear-attention==0.4.1
+RUN pip install git+https://github.com/fla-org/flash-linear-attention.git@606851e90a5b3f26fcc818391f1303faa703de30
 RUN pip install tilelang -f https://tile-ai.github.io/whl/nightly/cu128/
 
 # TE does not have wheel on cuda 13 yet, thus need to install from source

--- a/examples/geo3k_vlm/README.md
+++ b/examples/geo3k_vlm/README.md
@@ -95,7 +95,7 @@ SLIME_SCRIPT_MODEL_NAME=Qwen3-VL-4B-Instruct ./examples/geo3k_vlm/run_geo3k_vlm.
 #### Qwen3.5 Series
 We provide an [example](./run_geo3k_qwen35.sh) for Qwen3.5-35B-A3B. To support other Qwen3.5 models, add a model config file in `scripts/models/` and update the model name and config path in the script accordingly.
 
-Since Megatron does not currently support packing for GDN, you must set `--qkv-format bshd`, `--micro-batch-size 1`, and remove `--use-dynamic-batch-size`.
+Qwen3.5 GDN currently supports context parallelism in Slime only on the `bshd` path. You must set `--qkv-format bshd`, `--micro-batch-size 1`, and remove `--use-dynamic-batch-size`. In the example script, set `SLIME_SCRIPT_CP_SIZE` to enable CP.
 
 ## Notes
 

--- a/examples/geo3k_vlm/run_geo3k_qwen35.sh
+++ b/examples/geo3k_vlm/run_geo3k_qwen35.sh
@@ -155,7 +155,7 @@ BACKEND_ARGS=(
    --tensor-model-parallel-size 2
    --sequence-parallel
    --pipeline-model-parallel-size 1
-   --context-parallel-size 1
+   --context-parallel-size ${SLIME_SCRIPT_CP_SIZE:-1}
    --expert-model-parallel-size 8
    --expert-tensor-parallel-size 1
    --recompute-granularity full

--- a/slime_plugins/models/qwen3_5.py
+++ b/slime_plugins/models/qwen3_5.py
@@ -3,6 +3,8 @@ import copy
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+import torch.distributed as dist
+from megatron.core import mpu, tensor_parallel
 from megatron.core.models.gpt.gpt_layer_specs import get_gpt_decoder_block_spec
 from megatron.core.transformer.spec_utils import ModuleSpec
 from megatron.core.transformer.transformer_block import get_num_layers_to_build
@@ -11,9 +13,15 @@ from transformers.activations import ACT2FN
 
 try:
     from fla.modules import FusedRMSNormGated, ShortConvolution
+    from fla.modules.convolution import causal_conv1d
+    from fla.ops.cp import build_cp_context
     from fla.ops.gated_delta_rule import chunk_gated_delta_rule
 except ImportError:
-    pass
+    FusedRMSNormGated = None
+    ShortConvolution = None
+    causal_conv1d = None
+    build_cp_context = None
+    chunk_gated_delta_rule = None
 
 from .hf_attention import HuggingfaceAttention, _load_hf_config
 
@@ -23,6 +31,133 @@ def _get_text_config(hf_config):
     if hasattr(hf_config, "text_config"):
         return hf_config.text_config
     return hf_config
+
+
+def _chunk_owner_for_layout(chunk_idx: int, cp_size: int, layout: str) -> int:
+    if layout == "contiguous":
+        return chunk_idx // 2
+    if layout == "zigzag":
+        return chunk_idx if chunk_idx < cp_size else 2 * cp_size - 1 - chunk_idx
+    raise ValueError(f"Unsupported CP layout: {layout}")
+
+
+def _local_chunk_ids_for_layout(cp_rank: int, cp_size: int, layout: str) -> list[int]:
+    if layout == "contiguous":
+        return [2 * cp_rank, 2 * cp_rank + 1]
+    if layout == "zigzag":
+        return [cp_rank, 2 * cp_size - 1 - cp_rank]
+    raise ValueError(f"Unsupported CP layout: {layout}")
+
+
+def _redistribute_sequence_chunks(
+    tensor: torch.Tensor,
+    *,
+    cp_group,
+    cp_rank: int,
+    cp_size: int,
+    source_layout: str,
+    target_layout: str,
+) -> torch.Tensor:
+    if cp_size == 1 or source_layout == target_layout:
+        return tensor
+
+    if tensor.size(0) % 2 != 0:
+        raise ValueError(f"Hybrid CP expects an even local sequence length, got {tensor.size(0)}")
+
+    local_chunks = [chunk.contiguous() for chunk in tensor.chunk(2, dim=0)]
+    chunk_len = local_chunks[0].size(0)
+    if local_chunks[1].size(0) != chunk_len:
+        raise ValueError("Hybrid CP expects the two local CP chunks to have equal length.")
+
+    local_chunk_ids = _local_chunk_ids_for_layout(cp_rank, cp_size, source_layout)
+    send_plan = [
+        (_chunk_owner_for_layout(chunk_id, cp_size, target_layout), chunk_id, chunk)
+        for chunk_id, chunk in zip(local_chunk_ids, local_chunks, strict=False)
+    ]
+    send_plan.sort(key=lambda item: item[0])
+
+    input_split_sizes = [0] * cp_size
+    send_parts: list[torch.Tensor] = []
+    for dest_rank, _, chunk in send_plan:
+        input_split_sizes[dest_rank] += chunk.size(0)
+        send_parts.append(chunk)
+    send_buffer = torch.cat(send_parts, dim=0) if send_parts else tensor.new_empty((0,) + tensor.shape[1:])
+
+    target_chunk_ids = _local_chunk_ids_for_layout(cp_rank, cp_size, target_layout)
+    recv_plan = [
+        (_chunk_owner_for_layout(chunk_id, cp_size, source_layout), chunk_id)
+        for chunk_id in target_chunk_ids
+    ]
+    output_split_sizes = [0] * cp_size
+    for src_rank, _ in recv_plan:
+        output_split_sizes[src_rank] += chunk_len
+
+    recv_buffer = tensor.new_empty((sum(output_split_sizes),) + tensor.shape[1:])
+    dist.all_to_all_single(
+        recv_buffer,
+        send_buffer,
+        output_split_sizes=output_split_sizes,
+        input_split_sizes=input_split_sizes,
+        group=cp_group,
+    )
+
+    recv_segments: dict[int, torch.Tensor] = {}
+    offset = 0
+    for src_rank, split_size in enumerate(output_split_sizes):
+        if split_size == 0:
+            continue
+        recv_segments[src_rank] = recv_buffer[offset : offset + split_size]
+        offset += split_size
+
+    reordered = []
+    for src_rank, _ in recv_plan:
+        recv_chunk = recv_segments[src_rank]
+        if recv_chunk.size(0) != chunk_len:
+            raise ValueError(
+                f"Expected one chunk of length {chunk_len} from rank {src_rank}, got {recv_chunk.size(0)}"
+            )
+        reordered.append(recv_chunk)
+    return torch.cat(reordered, dim=0)
+
+
+class _CPLayoutRedistribute(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, tensor: torch.Tensor, cp_group, source_layout: str, target_layout: str):
+        cp_rank = dist.get_rank(group=cp_group)
+        cp_size = dist.get_world_size(group=cp_group)
+        ctx.cp_group = cp_group
+        ctx.cp_rank = cp_rank
+        ctx.cp_size = cp_size
+        ctx.source_layout = source_layout
+        ctx.target_layout = target_layout
+        return _redistribute_sequence_chunks(
+            tensor,
+            cp_group=cp_group,
+            cp_rank=cp_rank,
+            cp_size=cp_size,
+            source_layout=source_layout,
+            target_layout=target_layout,
+        )
+
+    @staticmethod
+    def backward(ctx, grad_output: torch.Tensor):
+        grad_input = _redistribute_sequence_chunks(
+            grad_output,
+            cp_group=ctx.cp_group,
+            cp_rank=ctx.cp_rank,
+            cp_size=ctx.cp_size,
+            source_layout=ctx.target_layout,
+            target_layout=ctx.source_layout,
+        )
+        return grad_input, None, None, None
+
+
+def _zigzag_to_contiguous_cp(tensor: torch.Tensor, cp_group) -> torch.Tensor:
+    return _CPLayoutRedistribute.apply(tensor, cp_group, "zigzag", "contiguous")
+
+
+def _contiguous_to_zigzag_cp(tensor: torch.Tensor, cp_group) -> torch.Tensor:
+    return _CPLayoutRedistribute.apply(tensor, cp_group, "contiguous", "zigzag")
 
 
 # Adapted from Qwen3NextGatedDeltaNet but with separate in_proj_qkv and in_proj_z
@@ -35,6 +170,8 @@ class Qwen3_5GatedDeltaNet(nn.Module):
 
     def __init__(self, config, layer_idx: int):
         super().__init__()
+        if FusedRMSNormGated is None or ShortConvolution is None or chunk_gated_delta_rule is None:
+            raise ImportError("Qwen3.5 GDN requires flash-linear-attention to be installed.")
         self.hidden_size = config.hidden_size
         self.num_v_heads = config.linear_num_value_heads
         self.num_k_heads = config.linear_num_key_heads
@@ -80,6 +217,23 @@ class Qwen3_5GatedDeltaNet(nn.Module):
         )
 
         self.out_proj = nn.Linear(self.value_dim, self.hidden_size, bias=False)
+        self.cp_group = None
+        self.cp_rank = 0
+        self.cp_world_size = 1
+
+    def _build_cp_context(self, seq_len: int, device: torch.device):
+        if self.cp_group is None or self.cp_world_size == 1:
+            return None
+        if build_cp_context is None:
+            raise ImportError(
+                "Qwen3.5 hybrid CP requires a flash-linear-attention build with CP support (build_cp_context)."
+            )
+        global_seq_len = seq_len * self.cp_world_size
+        return build_cp_context(
+            cu_seqlens=torch.tensor([0, global_seq_len], dtype=torch.int32, device=device),
+            group=self.cp_group,
+            conv1d_kernel_size=self.conv_kernel_size,
+        )
 
     def forward(
         self,
@@ -87,6 +241,7 @@ class Qwen3_5GatedDeltaNet(nn.Module):
         cu_seqlens: torch.Tensor = None,
     ):
         batch_size, seq_len, _ = hidden_states.shape
+        cp_context = self._build_cp_context(seq_len, hidden_states.device)
 
         # Projections (flat layout: [Q_all, K_all, V_all])
         mixed_qkv = self.in_proj_qkv(hidden_states)
@@ -96,10 +251,25 @@ class Qwen3_5GatedDeltaNet(nn.Module):
         a = self.in_proj_a(hidden_states)
 
         # Convolution on the flat QKV
-        mixed_qkv, _ = self.conv1d(
-            x=mixed_qkv,
-            cu_seqlens=cu_seqlens,
-        )
+        if cp_context is not None:
+            if causal_conv1d is None:
+                raise ImportError(
+                    "Qwen3.5 hybrid CP requires a flash-linear-attention build with causal_conv1d CP support."
+                )
+            mixed_qkv, _ = causal_conv1d(
+                x=mixed_qkv.contiguous(),
+                weight=self.conv1d.weight.squeeze(1),
+                bias=getattr(self.conv1d, "bias", None),
+                activation=self.activation,
+                initial_state=None,
+                output_final_state=False,
+                cp_context=cp_context,
+            )
+        else:
+            mixed_qkv, _ = self.conv1d(
+                x=mixed_qkv,
+                cu_seqlens=cu_seqlens,
+            )
 
         # Split into Q, K, V (flat split, matching HF layout)
         query, key, value = torch.split(
@@ -118,16 +288,24 @@ class Qwen3_5GatedDeltaNet(nn.Module):
             query = query.repeat_interleave(self.num_v_heads // self.num_k_heads, dim=2)
             key = key.repeat_interleave(self.num_v_heads // self.num_k_heads, dim=2)
 
-        core_attn_out, last_recurrent_state = chunk_gated_delta_rule(
+        gated_delta_kwargs = {
+            "g": g,
+            "beta": beta,
+            "initial_state": None,
+            "output_final_state": False,
+            "use_qk_l2norm_in_kernel": True,
+        }
+        if cp_context is not None:
+            gated_delta_kwargs["cu_seqlens"] = cp_context.cu_seqlens
+            gated_delta_kwargs["cp_context"] = cp_context
+        elif cu_seqlens is not None:
+            gated_delta_kwargs["cu_seqlens"] = cu_seqlens
+
+        core_attn_out, _ = chunk_gated_delta_rule(
             query,
             key,
             value,
-            g=g,
-            beta=beta,
-            initial_state=None,
-            output_final_state=False,
-            use_qk_l2norm_in_kernel=True,
-            cu_seqlens=cu_seqlens,
+            **gated_delta_kwargs,
         )
 
         z_shape_og = z.shape
@@ -181,6 +359,77 @@ class Attention(HuggingfaceAttention):
             cu_seqlens=packed_seq_params.cu_seqlens_q,
         )
         return hidden_states
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: torch.Tensor,
+        key_value_states: torch.Tensor | None = None,
+        inference_context=None,
+        rotary_pos_emb: torch.Tensor | tuple[torch.Tensor, torch.Tensor] | None = None,
+        rotary_pos_cos: torch.Tensor | None = None,
+        rotary_pos_sin: torch.Tensor | None = None,
+        rotary_pos_cos_sin: torch.Tensor | None = None,
+        attention_bias: torch.Tensor | None = None,
+        packed_seq_params=None,
+        sequence_len_offset: int | None = None,
+        *,
+        inference_params=None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        # Keep the original THD / packed-sequence path intact. Hybrid CP is only
+        # enabled for the documented Qwen3.5 MoE bshd path.
+        if packed_seq_params is not None or getattr(self.args, "qkv_format", None) != "bshd":
+            return super().forward(
+                hidden_states,
+                attention_mask,
+                key_value_states=key_value_states,
+                inference_context=inference_context,
+                rotary_pos_emb=rotary_pos_emb,
+                rotary_pos_cos=rotary_pos_cos,
+                rotary_pos_sin=rotary_pos_sin,
+                rotary_pos_cos_sin=rotary_pos_cos_sin,
+                attention_bias=attention_bias,
+                packed_seq_params=packed_seq_params,
+                sequence_len_offset=sequence_len_offset,
+                inference_params=inference_params,
+            )
+
+        if self.args.sequence_parallel:
+            hidden_states = tensor_parallel.gather_from_sequence_parallel_region(
+                hidden_states,
+                tensor_parallel_output_grad=False,
+                group=mpu.get_tensor_model_parallel_group(),
+            )
+
+        cp_size = mpu.get_context_parallel_world_size()
+        cp_group = mpu.get_context_parallel_group() if cp_size > 1 else None
+        cp_rank = mpu.get_context_parallel_rank() if cp_size > 1 else 0
+
+        if cp_size > 1:
+            if hidden_states.size(1) != 1:
+                raise NotImplementedError(
+                    "Qwen3.5 MoE hybrid CP currently requires micro-batch-size 1 on the bshd path."
+                )
+            hidden_states = _zigzag_to_contiguous_cp(hidden_states, cp_group)
+
+        hidden_states = hidden_states.permute(1, 0, 2)  # [batch, seq_len, hidden_dim]
+        self.linear_attn.cp_group = cp_group
+        self.linear_attn.cp_rank = cp_rank
+        self.linear_attn.cp_world_size = cp_size
+
+        hidden_states = self.input_layernorm(hidden_states)
+        output = self.linear_attn(hidden_states=hidden_states, cu_seqlens=None)
+        output = output.permute(1, 0, 2)  # [seq_len, batch, hidden_dim]
+
+        if cp_size > 1:
+            output = _contiguous_to_zigzag_cp(output, cp_group)
+
+        if self.args.sequence_parallel:
+            output = tensor_parallel.scatter_to_sequence_parallel_region(
+                output, group=mpu.get_tensor_model_parallel_group()
+            )
+
+        return output, None
 
 
 def get_qwen3_5_spec(args, config, vp_stage):

--- a/tests/test_qwen3_linear_attention_cu_seqlens.py
+++ b/tests/test_qwen3_linear_attention_cu_seqlens.py
@@ -88,6 +88,15 @@ class FakeShortConvolution(nn.Module):
         return x, None
 
 
+class FakeShortConvolutionWithWeights(FakeShortConvolution):
+    def __init__(self, *args, **kwargs):
+        super().__init__()
+        hidden_size = kwargs["hidden_size"]
+        kernel_size = kwargs["kernel_size"]
+        self.weight = nn.Parameter(torch.ones(hidden_size, 1, kernel_size))
+        self.bias = None
+
+
 class FakeFusedRMSNormGated(nn.Module):
     def __init__(self, *args, **kwargs):
         super().__init__()
@@ -163,3 +172,94 @@ def test_linear_attention_forwards_cu_seqlens_to_chunk_kernel(monkeypatch, modul
     assert output.shape == hidden_states.shape
     assert len(chunk_calls) == 1
     assert torch.equal(chunk_calls[0], cu_seqlens)
+
+
+@pytest.mark.unit
+def test_qwen35_linear_attention_builds_cp_context(monkeypatch):
+    module = load_module("slime_plugins.models.qwen3_5")
+
+    monkeypatch.setattr(module.torch.cuda, "current_device", lambda: "cpu")
+    monkeypatch.setattr(module, "ShortConvolution", FakeShortConvolutionWithWeights)
+    monkeypatch.setattr(module, "FusedRMSNormGated", FakeFusedRMSNormGated)
+
+    cp_context_calls = {}
+
+    def fake_build_cp_context(*, cu_seqlens, group, conv1d_kernel_size):
+        cp_context_calls["cu_seqlens"] = cu_seqlens.clone()
+        cp_context_calls["group"] = group
+        cp_context_calls["conv1d_kernel_size"] = conv1d_kernel_size
+        return SimpleNamespace(cu_seqlens=cu_seqlens)
+
+    def fake_causal_conv1d(x, **kwargs):
+        cp_context_calls["conv_weight_shape"] = tuple(kwargs["weight"].shape)
+        cp_context_calls["conv_cp_context"] = kwargs["cp_context"]
+        return x, None
+
+    def fake_chunk_gated_delta_rule(
+        q,
+        k,
+        v,
+        *,
+        g,
+        beta,
+        initial_state,
+        output_final_state,
+        use_qk_l2norm_in_kernel,
+        cu_seqlens=None,
+        cp_context=None,
+        **kwargs,
+    ):
+        cp_context_calls["gdn_cu_seqlens"] = cu_seqlens.clone() if cu_seqlens is not None else None
+        cp_context_calls["gdn_cp_context"] = cp_context
+        return torch.zeros_like(v), None
+
+    monkeypatch.setattr(module, "build_cp_context", fake_build_cp_context)
+    monkeypatch.setattr(module, "causal_conv1d", fake_causal_conv1d)
+    monkeypatch.setattr(module, "chunk_gated_delta_rule", fake_chunk_gated_delta_rule)
+
+    layer = module.Qwen3_5GatedDeltaNet(make_config(), layer_idx=0)
+    layer.cp_group = "fake-cp-group"
+    layer.cp_world_size = 4
+    hidden_states = torch.randn(1, 8, 32)
+
+    output = layer(hidden_states)
+
+    assert output.shape == hidden_states.shape
+    assert torch.equal(cp_context_calls["cu_seqlens"], torch.tensor([0, 32], dtype=torch.int32))
+    assert cp_context_calls["group"] == "fake-cp-group"
+    assert cp_context_calls["conv1d_kernel_size"] == 4
+    assert cp_context_calls["conv_weight_shape"] == (32, 4)
+    assert cp_context_calls["conv_cp_context"] is cp_context_calls["gdn_cp_context"]
+    assert torch.equal(cp_context_calls["gdn_cu_seqlens"], torch.tensor([0, 32], dtype=torch.int32))
+
+
+@pytest.mark.unit
+def test_qwen35_attention_supports_bshd_without_packed_seq_params(monkeypatch):
+    module = load_module("slime_plugins.models.qwen3_5")
+    hf_attention = importlib.import_module("slime_plugins.models.hf_attention")
+
+    monkeypatch.setattr(hf_attention, "_load_hf_config", lambda checkpoint_path: make_config())
+
+    class FakeLinearAttention(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.calls = []
+            self.cp_group = None
+            self.cp_rank = 0
+            self.cp_world_size = 1
+
+        def forward(self, hidden_states, cu_seqlens=None):
+            self.calls.append(cu_seqlens)
+            return hidden_states
+
+    monkeypatch.setattr(module, "Qwen3_5GatedDeltaNet", lambda config, layer_idx: FakeLinearAttention())
+
+    args = SimpleNamespace(sequence_parallel=False, qkv_format="bshd", hf_checkpoint="/tmp/unused")
+    attention = module.Attention(args, config=SimpleNamespace(), layer_number=1)
+    hidden_states = torch.randn(6, 2, 32)
+
+    output, bias = attention(hidden_states, attention_mask=None, packed_seq_params=None)
+
+    assert output.shape == hidden_states.shape
+    assert bias is None
+    assert attention.linear_attn.calls == [None]


### PR DESCRIPTION
## Summary

This PR adds a Qwen3.5 MoE hybrid context-parallel v1 path in Slime.

The change keeps the existing THD/packed wrapper behavior intact, but adds a dedicated `bshd` path for Qwen3.5 GatedDeltaNet layers that:
- converts Slime's local zigzag CP shards into contiguous per-rank sequence shards before entering the GDN kernel
- builds fla native `cp_context` metadata for the local shard
- runs CP-aware `causal_conv1d` and `chunk_gated_delta_rule`
- converts outputs back to Slime's zigzag CP layout after the GDN layer

It also bumps `flash-linear-attention` to a CP-capable revision, exposes CP in the Qwen3.5 example script, and adds focused unit coverage for the new CP-context wiring.

## Why

Qwen3.5 linear-attention layers currently OOM during backward with CP because Slime's wrapper all-gathers CP shards back to the full sequence before calling the HF GDN implementation. That removes the memory benefit of CP for the GDN path.

This PR fixes that for the initial Qwen3.5 MoE scope by using fla native CP inside the GDN layer while leaving the full-attention path on the normal Megatron CP flow.

## Impact

For Qwen3.5 MoE models, Slime can now take the first step toward CP support without Megatron source changes.

The current v1 scope is intentionally narrow:
- Qwen3.5 MoE only
- `--qkv-format bshd`
- micro-batch size `1`
- no packed or dynamic batching for GDN

## Validation

Checks run locally:
- `python3 -m py_compile slime_plugins/models/qwen3_5.py tests/test_qwen3_linear_attention_cu_seqlens.py`
- CP layout redistribution sanity check for CP sizes 2 through 8

Not run here:
- torch-based unit tests
- distributed runtime or long-context backward tests

The local workspace used for this change does not have `torch` installed, so runtime validation still needs to happen in the normal Slime training environment.
