### PR TITLE
[Fix]  Fix cuda-python pin in build_conda.sh

### DIFF
--- a/build_conda.sh
+++ b/build_conda.sh
@@ -22,8 +22,7 @@ cd $BASE_DIR
 micromamba install -n slime cuda cuda-nvtx cuda-nvtx-dev nccl -c nvidia/label/cuda-12.9.1 -y
 micromamba install -n slime -c conda-forge cudnn -y
 
-# prevent installing cuda 13.0 for sglang
-pip install cuda-python==13.1.0
+pip install cuda-python==12.9
 pip install torch==2.9.1 torchvision==0.24.1 torchaudio==2.9.1 --index-url https://download.pytorch.org/whl/cu129
 
 # install sglang


### PR DESCRIPTION
  Closes #1826.

  ## Summary

  This PR fixes the `cuda-python` pin in `build_conda.sh`.

  The current script installs:
  - CUDA `12.9.1`
  - PyTorch `2.9.1` from `cu129`
  - `cuda-python==13.1.0`

  This is inconsistent with the pinned SGLang dependency line and with the environment setup described in the script.

  This change updates the pin to:

  ```bash
  pip install cuda-python==12.9
  ```

  ## Why

  As discussed in #1826, build_conda.sh mixed the CUDA 12.9 / cu129 stack with cuda-python==13.1.0.

<img width="1132" height="586" alt="image" src="https://github.com/user-attachments/assets/f7db0bd2-8622-40a9-99e7-90a1c84241d9" />

  The reason CI can still pass is that the later step

  pip install -e "python[all]"

  installs the pinned SGLang commit with dependencies enabled, and that SGLang version requires cuda-python==12.9. In practice, pip resolves that dependency and reinstalls cuda-python onto
  the 12.9 line, effectively correcting the earlier wrong pin.

  Even so, build_conda.sh should not rely on a later reinstall step to fix an explicitly inconsistent package version. The script should be correct on its own.

  ## Validation

  - bash -n build_conda.sh
  - Confirmed the change is limited to the cuda-python version pin in build_conda.sh