### PR TITLE
[fix] eval sample logging when sample is a list

### DIFF
--- a/slime/rollout/sglang_rollout.py
+++ b/slime/rollout/sglang_rollout.py
@@ -573,10 +573,11 @@ async def eval_rollout_single_dataset(
     for coro in asyncio.as_completed(tasks):
         sample = await coro
         if do_print:
+            logged_sample = sample[0] if isinstance(sample, list) else sample
             logger.info(
                 "eval_rollout_single_dataset example data: "
-                f"{[str(sample.prompt) + sample.response]} "
-                f"reward={sample.reward}"
+                f"{[str(logged_sample.prompt) + logged_sample.response]} "
+                f"reward={logged_sample.reward}"
             )
             do_print = False
         if isinstance(sample, list):


### PR DESCRIPTION
In multi-agent scenarios, the return type of `generate` might be `List[Sample]`. The eval logic assumes that the type is always a `Sample`, so when running `examples/multi_agent/run-qwen3-30B-A3B-multi-agent.sh`, this error surfaces.

This PR fixes it by checking the type and setting the logged sample appropriately.