### PR TITLE
fix: make Megatron one-shot train() assumptions idempotent across slime rollouts

### DIFF
--- a/slime/backends/megatron_utils/model.py
+++ b/slime/backends/megatron_utils/model.py
@@ -525,13 +525,17 @@ def train(
     config.grad_scale_func = optimizer.scale_loss
     config.timers = None
     if isinstance(model[0], DDP) and args.overlap_grad_reduce:
-        assert config.no_sync_func is None, (
-            "When overlap_grad_reduce is True, config.no_sync_func must be None; "
-            "a custom no_sync_func is not supported when overlapping grad-reduce"
-        )
-        config.no_sync_func = [model_chunk.no_sync for model_chunk in model]
-        if len(model) == 1:
-            config.no_sync_func = config.no_sync_func[0]
+        # Install model.no_sync as the DDP grad-sync gate. Required by
+        # --overlap-grad-reduce so the pipeline scheduler wraps intermediate
+        # micro-batches in no_sync_func(). Megatron's upstream asserts
+        # `config.no_sync_func is None` here (written for a one-shot
+        # pretraining loop), but slime calls train() once per rollout — on
+        # the 2nd entry the value we installed last time is still there.
+        # Skip the install if already set with our value.
+        if config.no_sync_func is None:
+            config.no_sync_func = [model_chunk.no_sync for model_chunk in model]
+            if len(model) == 1:
+                config.no_sync_func = config.no_sync_func[0]
         if args.align_grad_reduce:
             config.grad_sync_func = [model_chunk.start_grad_sync for model_chunk in model]
             if len(model) == 1:

--- a/slime/backends/megatron_utils/model.py
+++ b/slime/backends/megatron_utils/model.py
@@ -581,7 +581,10 @@ def train(
     # or random initialization don't propagate to all ranks in first all-gather (which is a
     # no-op if things work correctly).
     if should_disable_forward_pre_hook(args):
-        disable_forward_pre_hook(model, param_sync=False)
+        # On re-entry (2nd+ rollout), hooks were already disabled at the end of
+        # the previous call, so only disable if any chunk still has active hooks.
+        if any(len(m.remove_forward_pre_hook_handles) > 0 for m in model if isinstance(m, DDP)):
+            disable_forward_pre_hook(model, param_sync=False)
         # Also remove param_sync_func temporarily so that sync calls made in
         # `forward_backward_func` are no-ops.
         param_sync_func = config.param_sync_func


### PR DESCRIPTION
Megatron's upstream `train()` is written for one-shot invocation. Slime invokes `train()` once per rollout, which trips two separate per-rollout idempotency bugs in `slime/backends/megatron_utils/model.py`. This PR fixes both.

### Fix 1: `no_sync_func` install (commit 14abe6af)

Megatron asserts `config.no_sync_func is None` on entry. Slime installs `model.no_sync` at the end of rollout 1, so rollout 2 trips the assert.

Replace the assert with `if ... is None: install`. Same first-time behavior, idempotent on re-entry. Encountered when I enabled `--overlap-grad-reduce`.

### Fix 2: `disable_forward_pre_hook` re-entry (commit a9243e41)

At the end of rollout N, `disable_forward_pre_hook()` removes forward pre-hooks from each DDP chunk and clears that chunk's `remove_forward_pre_hook_handles` list. On rollout N+1, slime calls `disable_forward_pre_hook` again; with no hooks left to disable, Megatron's internal Float16Module lookup fails with `KeyError`.

Guard the call: only disable if any chunk still has an active hook. Encountered when I enabled `--overlap-param-gather` alongside `--overlap-grad-reduce`.

### Scope

Both fixes are only triggered when overlap flags are on (`--overlap-grad-reduce`, `--overlap-param-gather`). Without them, the relevant code paths don't execute and the existing assert is unreachable. So these changes are no-ops for users who don't enable overlap, and make overlap usable for slime's multi-rollout model.