### PR TITLE
chore: include length context in slice_log_prob_with_cp assert

### DIFF
--- a/slime/backends/megatron_utils/cp_utils.py
+++ b/slime/backends/megatron_utils/cp_utils.py
@@ -223,7 +223,10 @@ def slice_log_prob_with_cp(
     qkv_format: str = "thd",
     max_token_len: int | None = None,
 ) -> list[float] | torch.Tensor:
-    assert len(log_prob) == response_length
+    assert len(log_prob) == response_length, (
+        f"log_prob length mismatch: len(log_prob)={len(log_prob)}, "
+        f"response_length={response_length}, total_length={total_length}"
+    )
 
     cp_size = mpu.get_context_parallel_world_size()
 


### PR DESCRIPTION
## Summary

Pure debuggability improvement. When `len(log_prob) != response_length` the bare assert raised `AssertionError` with no message; you had to add prints and re-run to figure out whether `rollout_log_probs` was trimmed, `response_length` was stale, or `prompt_length` was miscomputed upstream.

Including the three numbers in the assertion message makes the root cause immediately obvious from the stack trace alone.

## Before

```
AssertionError
```

## After

```
AssertionError: log_prob length mismatch: len(log_prob)=812,
response_length=456, total_length=512
```