### PR TITLE
[Fix] Use Ray ObjectRef await instead of asyncio.to_thread in distributed POST

### DIFF
--- a/slime/utils/http_utils.py
+++ b/slime/utils/http_utils.py
@@ -280,9 +280,14 @@ async def post(url, payload, max_retries=60, headers=None):
 
             actor = _next_actor()
             if actor is not None:
-                # Use a thread to avoid blocking the event loop on ray.get
+                # Await the Ray ObjectRef directly. The previous
+                # `asyncio.to_thread(ray.get, obj_ref)` blocked an OS thread
+                # from the default ThreadPoolExecutor (capped at
+                # `min(32, cpu+4)`), which becomes a hard upper bound on the
+                # number of in-flight POSTs that can be waited on in parallel
+                # and produces large tail latencies under high concurrency.
                 obj_ref = actor.do_post.remote(url, payload, max_retries, headers=headers)
-                return await asyncio.to_thread(ray.get, obj_ref)
+                return await obj_ref
         except Exception as e:
             logger.info(f"[http_utils] Distributed POST failed, falling back to local: {e} (url={url})")
             # fall through to local


### PR DESCRIPTION
## Problem

In `http_utils.post()` the distributed dispatch path is:

```python
obj_ref = actor.do_post.remote(...)
return await asyncio.to_thread(ray.get, obj_ref)
```

`asyncio.to_thread()` schedules the blocking `ray.get()` on the event loop's default `ThreadPoolExecutor`, whose size is hard-coded by CPython to `min(32, os.cpu_count() + 4)` (see `Lib/concurrent/futures/thread.py`).

This means at most ~32 in-flight POSTs can be awaited at any moment. When more than 32 long-running requests are in flight at the same time, every additional request — including ones whose response the actor has already produced — must queue for an OS-thread slot before its `await` can resolve. The result is large, artificial tail latency on requests that should return quickly, and POST_RETURN events arriving in bursts rather than smoothly.

## Fix

`ObjectRef` is awaitable in async context, which is the [documented Ray API](https://docs.ray.io/en/latest/ray-core/actors/async_api.html#objectrefs-as-asyncio-futures):

```python
obj_ref = actor.do_post.remote(...)
return await obj_ref
```

`await obj_ref` parks the coroutine on an `asyncio.Future` callback and does not consume an OS thread slot. Ray uses a single shared background polling thread per asyncio loop to wake the future via `loop.call_soon_threadsafe(...)` when the result is ready, so the 32-slot ceiling is removed entirely.

This affects only the distributed POST path
(`--use-distributed-post`); the non-distributed path is unchanged.