### PR TITLE
Filter zero-advantage samples in convert_samples_to_train_data

### DIFF
--- a/slime/ray/rollout.py
+++ b/slime/ray/rollout.py
@@ -665,6 +665,24 @@ class RolloutManager:
         assert len(raw_rewards) == len(samples)
         assert len(rewards) == len(samples)
 
+        if self.args.advantage_estimator in ["grpo", "gspo"]:
+            keep = [r != 0.0 for r in rewards]
+            total_before = len(keep)
+            num_dropped = total_before - sum(keep)
+            if num_dropped:
+                samples = [s for s, k in zip(samples, keep, strict=True) if k]
+                raw_rewards = [r for r, k in zip(raw_rewards, keep, strict=True) if k]
+                rewards = [r for r, k in zip(rewards, keep, strict=True) if k]
+            logger.info(f"dropped {num_dropped}/{total_before} zero-advantage samples")
+            logging_utils.log(
+                self.args,
+                {
+                    "rollout/dropped_ratio": num_dropped / total_before if total_before else 0.0,
+                    "rollout/step": compute_rollout_step(self.args, self.rollout_id),
+                },
+                step_key="rollout/step",
+            )
+
         train_data = {
             "tokens": [sample.tokens for sample in samples],
             "response_lengths": [sample.response_length for sample in samples],


### PR DESCRIPTION
## Summary

In `_convert_samples_to_train_data`, after `_post_process_rewards`, drop samples whose post-processed reward is 0. Limited to `advantage_estimator in {grpo, gspo}` (these compute per-token advantage as a scalar broadcast of `rewards`, so r==0 ⇒ zero gradient; ppo/reinforce_plus_plus mix in values/kl/GAE so this isn't safe there).

Caveat: some rollout loggings(e.g. `raw_reward`) semantics got changed, the denominator is the filtered size not original size. this is wrong and need further refactor to make rollout loggings happened before entering training stage.