### PR TITLE
fix: use getattr for sglang_speculative_algorithm to avoid AttributeError

### DIFF
--- a/slime/ray/rollout.py
+++ b/slime/ray/rollout.py
@@ -1255,7 +1255,7 @@ def _compute_zero_std_metrics(args, all_samples: list[Sample]):
 
 
 def _compute_spec_metrics(args, all_samples: list[Sample]):
-    if args.sglang_speculative_algorithm is None:
+    if getattr(args, "sglang_speculative_algorithm", None) is None:
         return {}
     num_samples = len(all_samples)
     metrics = {}


### PR DESCRIPTION


When sglang args are not parsed (e.g. debug_train_only mode), the args namespace does not have the sglang_speculative_algorithm attribute, causing an AttributeError in _compute_spec_metrics. Using getattr with a default of None safely handles both cases.
<img width="1698" height="536" alt="Clipboard_Screenshot_1778838539" src="https://github.com/user-attachments/assets/90977e4d-2c94-4dae-82c7-4a921e3fb81f" />
