### PR TITLE
Move micro-batch scheduling from training side to rollout side

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -440,7 +440,7 @@ jobs:
             '
 
 
-  e2e-test-plugin-contracts:
+  cpu-unittest:
 
     if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
 

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -450,7 +450,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        info: [{"num_gpus": 0, "test_file": "test_megatron_argument_validation.py"}, {"num_gpus": 0, "test_file": "plugin_contracts/test_plugin_rollout_contracts.py"}, {"num_gpus": 0, "test_file": "plugin_contracts/test_plugin_runtime_hook_contracts.py"}, {"num_gpus": 0, "test_file": "plugin_contracts/test_plugin_path_loading_contracts.py"}, {"num_gpus": 0, "test_file": "plugin_contracts/test_plugin_generate_contracts.py"}]
+        info: [{"num_gpus": 0, "test_file": "test_megatron_argument_validation.py"}, {"num_gpus": 0, "test_file": "test_dp_schedule.py"}, {"num_gpus": 0, "test_file": "plugin_contracts/test_plugin_rollout_contracts.py"}, {"num_gpus": 0, "test_file": "plugin_contracts/test_plugin_runtime_hook_contracts.py"}, {"num_gpus": 0, "test_file": "plugin_contracts/test_plugin_path_loading_contracts.py"}, {"num_gpus": 0, "test_file": "plugin_contracts/test_plugin_generate_contracts.py"}]
     defaults:
       run:
         working-directory: ${{ github.workspace }}

--- a/.github/workflows/pr-test.yml.j2
+++ b/.github/workflows/pr-test.yml.j2
@@ -57,6 +57,7 @@
       'cpu': True,
       'tests': [
         {'test_file': 'test_megatron_argument_validation.py', 'num_gpus': 0},
+        {'test_file': 'test_dp_schedule.py', 'num_gpus': 0},
         {'test_file': 'plugin_contracts/test_plugin_rollout_contracts.py', 'num_gpus': 0},
         {'test_file': 'plugin_contracts/test_plugin_runtime_hook_contracts.py', 'num_gpus': 0},
         {'test_file': 'plugin_contracts/test_plugin_path_loading_contracts.py', 'num_gpus': 0},

--- a/.github/workflows/pr-test.yml.j2
+++ b/.github/workflows/pr-test.yml.j2
@@ -51,8 +51,8 @@
       ],
     },
 
-    'e2e-test-plugin-contracts': {
-      'label': 'run-ci-plugin-contracts',
+    'cpu-unittest': {
+      'label': 'run-ci-cpu-unittest',
       'always': True,
       'cpu': True,
       'tests': [

--- a/docs/en/get_started/customization.md
+++ b/docs/en/get_started/customization.md
@@ -435,7 +435,7 @@ python -m pytest \
 
 Each test file can also be executed directly with `python tests/plugin_contracts/<file>.py`, which keeps them compatible with `run-ci-changed`.
 
-A dedicated `run-ci-plugin-contracts` CI label is also available. Adding it to a PR triggers all four contract test files in parallel (no GPU required).
+A dedicated `run-ci-cpu-unittest` CI label is also available. Adding it to a PR triggers the CPU-only unit-test job, which runs the contract tests plus other lightweight unit tests in parallel (no GPU required).
 
 For user-defined implementations, you can either export environment variables such as `SLIME_CONTRACT_ROLLOUT_FUNCTION_PATH` and `SLIME_CONTRACT_CUSTOM_RM_PATH`, or pass overrides directly when running a test file, for example:
 

--- a/docs/zh/get_started/customization.md
+++ b/docs/zh/get_started/customization.md
@@ -437,7 +437,7 @@ python -m pytest \
 
 每个测试文件也支持直接通过 `python tests/plugin_contracts/<file>.py` 执行，这样可以和 `run-ci-changed` 保持兼容。
 
-CI 中也提供了独立的 `run-ci-plugin-contracts` label，给 PR 打上该标签后会并行运行上述全部四个契约测试（无需 GPU）。
+CI 中也提供了独立的 `run-ci-cpu-unittest` label，给 PR 打上该标签后会并行运行 CPU-only 的单元测试任务，包含上述契约测试以及其他轻量单测（无需 GPU）。
 
 如果你要验证自己的自定义实现，可以直接设置环境变量，例如 `SLIME_CONTRACT_ROLLOUT_FUNCTION_PATH`、`SLIME_CONTRACT_CUSTOM_RM_PATH`，也可以在直接运行测试文件时传参，例如：
 

--- a/slime/backends/megatron_utils/actor.py
+++ b/slime/backends/megatron_utils/actor.py
@@ -393,7 +393,8 @@ class MegatronTrainRayActor(TrainRayActor):
 
     def train_critic(self, rollout_id: int, rollout_data: RolloutBatch):
         """Train critic and return CPU values (used as old-values for the next actor train)."""
-        data_iterator, num_microbatches = get_data_iterator(self.args, self.model, rollout_data)
+        data_iterator = get_data_iterator(rollout_data)
+        num_microbatches = rollout_data["num_microbatches"]
 
         # Compute current critic values (used as old_values for value loss and for actor advantages).
         rollout_data.update(forward_only(get_values, self.args, self.model, data_iterator, num_microbatches))
@@ -418,7 +419,8 @@ class MegatronTrainRayActor(TrainRayActor):
 
     def train_actor(self, rollout_id: int, rollout_data: RolloutBatch, external_data=None) -> None:
         # Create data iterator for log_probs and train.
-        data_iterator, num_microbatches = get_data_iterator(self.args, self.model, rollout_data)
+        data_iterator = get_data_iterator(rollout_data)
+        num_microbatches = rollout_data["num_microbatches"]
 
         if self.args.use_rollout_routing_replay:
             self.fill_routing_replay(data_iterator, num_microbatches, rollout_data)

--- a/slime/backends/megatron_utils/actor.py
+++ b/slime/backends/megatron_utils/actor.py
@@ -71,9 +71,6 @@ class MegatronTrainRayActor(TrainRayActor):
                 self.tokenizer = AutoTokenizer.from_pretrained(self.args.hf_checkpoint, trust_remote_code=True)
             dist.barrier(group=get_gloo_group())
 
-        self.train_parallel_config = {
-            "dp_size": mpu.get_data_parallel_world_size(with_context_parallel=False),
-        }
         dist.barrier(group=get_gloo_group())
 
         if args.offload_train:
@@ -84,6 +81,20 @@ class MegatronTrainRayActor(TrainRayActor):
         self.model, self.optimizer, self.opt_param_scheduler, loaded_rollout_id = initialize_model_and_optimizer(
             args, role
         )
+
+        vpp_size = mpu.get_virtual_pipeline_model_parallel_world_size() or 1
+        if vpp_size > 1:
+            from megatron.core.utils import get_model_config
+
+            microbatch_group_size_per_vp_stage = get_model_config(self.model[0]).microbatch_group_size_per_vp_stage
+        else:
+            microbatch_group_size_per_vp_stage = 1
+        self.train_parallel_config = {
+            "dp_size": mpu.get_data_parallel_world_size(with_context_parallel=False),
+            "cp_size": mpu.get_context_parallel_world_size(),
+            "vpp_size": vpp_size,
+            "microbatch_group_size_per_vp_stage": microbatch_group_size_per_vp_stage,
+        }
 
         start_rollout_id = loaded_rollout_id + 1
 

--- a/slime/backends/megatron_utils/data.py
+++ b/slime/backends/megatron_utils/data.py
@@ -299,6 +299,8 @@ def log_rollout_data(
                 "rollout_routed_experts",
                 "max_seq_lens",
                 "dynamic_global_batch_size",
+                "num_microbatches",
+                "micro_batch_indices",
             ]:
                 continue
             # Upload per sample mean for each rollout value

--- a/slime/backends/megatron_utils/data.py
+++ b/slime/backends/megatron_utils/data.py
@@ -222,61 +222,37 @@ def gather_log_data(
 
 
 class DataIterator:
-    """Micro-batch iterator over rollout dicts.
-
-    Supports either fixed contiguous micro-batches or an explicit per-step
-    index schedule (for dynamic batch sizing / sequence-length balancing).
-    """
+    """Iterator over a rollout dict following an explicit micro-batch index schedule."""
 
     def __init__(
         self,
         rollout_data: RolloutBatch,
-        micro_batch_size: int | None = None,
-        micro_batch_indices: list[list[int]] | None = None,
+        micro_batch_indices: list[list[int]],
     ) -> None:
-        """Initialize an iterator over `rollout_data`.
+        """Initialize an iterator over ``rollout_data``.
 
         Args:
-            rollout_data: Dict of per-sample fields for the local step.
-            micro_batch_size: Fixed contiguous slice size when not using dynamic scheduling.
-            micro_batch_indices: Explicit indices per micro-batch when using dynamic balancing.
-                Must be mutually exclusive with `micro_batch_size`.
+            rollout_data: Dict of per-sample fields for this DP rank.
+            micro_batch_indices: List of mbs, each mbs being the local sample indices to select.
         """
         self.rollout_data = rollout_data
-        self.micro_batch_size = micro_batch_size
         self.micro_batch_indices = micro_batch_indices
-        assert micro_batch_size is None or micro_batch_indices is None
         self.offset = 0
 
     def get_next(self, keys: Sequence[str]) -> dict[str, list[object] | None]:
         """Return the next micro-batch for the requested keys.
 
-        - If `micro_batch_indices` is provided, selects rows according to the current
-          index list for each requested key.
-        - Otherwise, slices a contiguous window of size `micro_batch_size` starting
-          at the current offset.
-
         Returns a dict mapping each key to a list subset (or None if absent).
         """
         batch = {}
+        indices = self.micro_batch_indices[self.offset]
         for key in keys:
             vals = self.rollout_data.get(key, None)
             if vals is None:
                 batch[key] = None
             else:
-                if self.micro_batch_indices is not None:
-                    indices = self.micro_batch_indices[self.offset]
-                    batch[key] = [vals[i] for i in indices]
-                else:
-                    assert self.offset + self.micro_batch_size <= len(
-                        vals
-                    ), f"offset: {self.offset}, micro_batch_size: {self.micro_batch_size}, len(vals): {len(vals)}"
-                    batch[key] = vals[self.offset : self.offset + self.micro_batch_size]
-
-        if self.micro_batch_indices is not None:
-            self.offset += 1
-        else:
-            self.offset += self.micro_batch_size
+                batch[key] = [vals[i] for i in indices]
+        self.offset += 1
         return batch
 
     def reset(self) -> "DataIterator":
@@ -285,32 +261,11 @@ class DataIterator:
         return self
 
 
-def get_data_iterator(
-    args: Namespace,
-    model: torch.nn.Module | Sequence[torch.nn.Module],
-    rollout_data: RolloutBatch,
-) -> tuple[list[DataIterator], list[int]]:
-    """
-    Create iterators from the micro-batch schedule pre-computed on the rollout side.
-
-    ``rollout_data["num_microbatches"]`` (list[int], one per local step) is always
-    present. For ``use_dynamic_batch_size``, ``rollout_data["micro_batch_indices"]``
-    holds the per-mbs sample index lists (local to this DP rank). For the static
-    path, the iterator offset-steps by ``args.micro_batch_size``.
-
-    Returns ``(data_iterators, num_microbatches)`` where ``data_iterators`` has one
-    entry per VPP stage (size 1 if VPP disabled).
-    """
+def get_data_iterator(rollout_data: RolloutBatch) -> list[DataIterator]:
+    """Build one ``DataIterator`` per VPP stage from the pre-computed schedule in ``rollout_data``."""
     vpp_size = mpu.get_virtual_pipeline_model_parallel_world_size() or 1
-    num_microbatches = rollout_data["num_microbatches"]
-
-    if not args.use_dynamic_batch_size:
-        data_iterator = [DataIterator(rollout_data, args.micro_batch_size, None) for _ in range(vpp_size)]
-    else:
-        micro_batch_indices = rollout_data["micro_batch_indices"]
-        data_iterator = [DataIterator(rollout_data, None, micro_batch_indices) for _ in range(vpp_size)]
-
-    return data_iterator, num_microbatches
+    micro_batch_indices = rollout_data["micro_batch_indices"]
+    return [DataIterator(rollout_data, micro_batch_indices) for _ in range(vpp_size)]
 
 
 def log_rollout_data(

--- a/slime/backends/megatron_utils/data.py
+++ b/slime/backends/megatron_utils/data.py
@@ -10,10 +10,8 @@ from megatron.core import mpu
 from megatron.core.packed_seq_params import PackedSeqParams
 
 from slime.utils import train_metric_utils
-from slime.utils.data import get_minimum_num_micro_batch_size
 from slime.utils.flops_utils import calculate_fwd_flops
 from slime.utils.metric_utils import compute_pass_rate, compute_rollout_step
-from slime.utils.seqlen_balancing import get_seqlen_balanced_partitions
 from slime.utils.types import RolloutBatch
 
 from ...utils import logging_utils
@@ -293,96 +291,26 @@ def get_data_iterator(
     rollout_data: RolloutBatch,
 ) -> tuple[list[DataIterator], list[int]]:
     """
-    Create iterators and a micro-batch schedule for a rollout step.
+    Create iterators from the micro-batch schedule pre-computed on the rollout side.
 
-    - If `use_dynamic_batch_size` is False, splits into fixed-size contiguous
-      micro-batches of `micro_batch_size`.
-    - If True, computes the number of micro-batches per local step based on
-      `max_tokens_per_gpu` and per-sample lengths, all-reduces to a DP-wide
-      maximum, optionally enforces divisibility for Virtual Pipeline Parallelism (VPP), and builds a balanced
-      index schedule to equalize token counts across micro-batches.
+    ``rollout_data["num_microbatches"]`` (list[int], one per local step) is always
+    present. For ``use_dynamic_batch_size``, ``rollout_data["micro_batch_indices"]``
+    holds the per-mbs sample index lists (local to this DP rank). For the static
+    path, the iterator offset-steps by ``args.micro_batch_size``.
 
-    Returns `(data_iterators, num_microbatches)` where:
-    - `data_iterators`: list of `DataIterator`, one per VPP stage (size 1 if VPP disabled)
-    - `num_microbatches`: list[int], one per local step in the rollout (length = steps)
+    Returns ``(data_iterators, num_microbatches)`` where ``data_iterators`` has one
+    entry per VPP stage (size 1 if VPP disabled).
     """
-    dp_size = mpu.get_data_parallel_world_size(with_context_parallel=False)
-    dp_group = mpu.get_data_parallel_group()
-    vpp_size = mpu.get_virtual_pipeline_model_parallel_world_size()
-    if vpp_size is None:
-        vpp_size = 1
-    if vpp_size > 1:
-        from megatron.core.utils import get_model_config
-
-        config = get_model_config(model[0])
-        microbatch_group_size_per_vp_stage = config.microbatch_group_size_per_vp_stage
-    cp_size = mpu.get_context_parallel_world_size()
-
-    num_local_samples = len(rollout_data["total_lengths"])
-    global_batch_size = rollout_data.get("dynamic_global_batch_size", args.global_batch_size)
-    num_local_gbs = global_batch_size // dp_size
-    num_steps_per_rollout = num_local_samples // num_local_gbs
-
-    if global_batch_size != args.global_batch_size:
-        logger.info(
-            f"Using dynamic global_batch_size={global_batch_size} (original={args.global_batch_size}), "
-            f"num_local_samples={num_local_samples}, num_steps_per_rollout={num_steps_per_rollout}"
-        )
-
-    def _generate_data_iterator(rollout_data, micro_batch_size, micro_batch_indices=None):
-        data_iterator = []
-        for _ in range(vpp_size):
-            data_iterator.append(DataIterator(rollout_data, micro_batch_size, micro_batch_indices))
-        return data_iterator
+    vpp_size = mpu.get_virtual_pipeline_model_parallel_world_size() or 1
+    num_microbatches = rollout_data["num_microbatches"]
 
     if not args.use_dynamic_batch_size:
-        num_microbatches = [num_local_gbs // args.micro_batch_size for _ in range(num_steps_per_rollout)]
-        data_iterator = _generate_data_iterator(rollout_data, args.micro_batch_size)
+        data_iterator = [DataIterator(rollout_data, args.micro_batch_size, None) for _ in range(vpp_size)]
     else:
-        assert args.max_tokens_per_gpu is not None
-        # calculate the number of mirobatches for each step
-        samples = rollout_data["total_lengths"]
-        assert len(samples) == num_local_samples
-        num_microbatches = []
-        for i in range(num_steps_per_rollout):
-            start, end = i * num_local_gbs, (i + 1) * num_local_gbs
-            num_microbatches.append(
-                get_minimum_num_micro_batch_size(samples[start:end], args.max_tokens_per_gpu * cp_size)
-            )
+        micro_batch_indices = rollout_data["micro_batch_indices"]
+        data_iterator = [DataIterator(rollout_data, None, micro_batch_indices) for _ in range(vpp_size)]
 
-        num_microbatches = torch.tensor(num_microbatches, dtype=torch.int, device=torch.cuda.current_device())
-        dist.all_reduce(num_microbatches, op=dist.ReduceOp.MAX, group=dp_group)
-
-        if vpp_size > 1:
-            # vpp requies the number of microbatches to be divisible by vpp_size
-            num_microbatches = torch.clamp(
-                num_microbatches // microbatch_group_size_per_vp_stage * microbatch_group_size_per_vp_stage,
-                min=1,
-            )
-
-        num_microbatches = num_microbatches.tolist()
-
-        # balance the each micro batch
-        samples = rollout_data["total_lengths"]
-        # balance the number of mirobatches across steps
-        micro_batch_indices = []
-        for i, num_mbs in enumerate(num_microbatches):
-            start, end = i * num_local_gbs, (i + 1) * num_local_gbs
-            samples = rollout_data["total_lengths"][start:end]
-            partitions = get_seqlen_balanced_partitions(samples, num_mbs, equal_size=False)
-            for j in range(num_mbs):
-                for k in range(len(partitions[j])):
-                    partitions[j][k] += start
-            micro_batch_indices.extend(partitions)
-
-        assert len(set(sum(micro_batch_indices, []))) == num_local_samples
-
-        data_iterator = _generate_data_iterator(rollout_data, None, micro_batch_indices)
-
-    return (
-        data_iterator,
-        num_microbatches,
-    )
+    return data_iterator, num_microbatches
 
 
 def log_rollout_data(

--- a/slime/backends/megatron_utils/model.py
+++ b/slime/backends/megatron_utils/model.py
@@ -561,9 +561,11 @@ def train_one_step(
         # Update parameters.
         update_successful, grad_norm, num_zeros_in_grad = optimizer.step()
 
-        # Update learning rate.
+        # Update learning rate. Use the per-step global_batch_size when dynamic
+        # batching is on so the scheduler's samples-seen counter tracks reality.
         assert update_successful
-        opt_param_scheduler.step(increment=args.global_batch_size)
+        increment = data_iterator[0].rollout_data.get("dynamic_global_batch_size", args.global_batch_size)
+        opt_param_scheduler.step(increment=increment)
 
     # release grad
     for model_chunk in model:

--- a/slime/ray/rollout.py
+++ b/slime/ray/rollout.py
@@ -756,27 +756,25 @@ class RolloutManager:
         vpp_size = self.train_parallel_config["vpp_size"]
         mb_group = self.train_parallel_config["microbatch_group_size_per_vp_stage"]
 
-        # 1. Resolve gbs and 2. trim data
-        num_samples = len(data["tokens"])
-        if not self.args.disable_rollout_trim_samples:
-            if self.args.use_dynamic_global_batch_size:
-                logger.info(f"Collected {num_samples} samples from rollout to train with dynamic global batch size")
-                self._dynamic_global_batch_size = self._compute_dynamic_global_batch_size(num_samples)
-                global_batch_size = self._dynamic_global_batch_size
-            else:
-                global_batch_size = self.args.global_batch_size
+        # 1. Resolve effective global_batch_size
+        dynamic_global_batch_size: int | None = None
+        if self.args.use_dynamic_global_batch_size and not self.args.disable_rollout_trim_samples:
+            dynamic_global_batch_size = self._compute_dynamic_global_batch_size(len(data["tokens"]))
+            global_batch_size = dynamic_global_batch_size
+        else:
+            global_batch_size = self.args.global_batch_size
 
-            trim_len = (num_samples // global_batch_size) * global_batch_size
+        # 2. Trim data to a multiple of global_batch_size
+        if not self.args.disable_rollout_trim_samples:
+            num_samples = len(data["tokens"])
+            trim_len = num_samples // global_batch_size * global_batch_size
             if trim_len == 0:
                 raise ValueError(f"Not enough samples {num_samples} for global_batch_size {global_batch_size}")
             if trim_len < num_samples:
-                for key, val in list(data.items()):
+                logger.info(f"Trimmed samples from {num_samples} to {trim_len}")
+                for key, val in data.items():
                     if isinstance(val, list):
                         data[key] = val[:trim_len]
-                logger.info(f"trim number of samples from {num_samples} to {trim_len}")
-            logger.info(f"Final collected {trim_len} samples from rollout to train")
-        else:
-            global_batch_size = self.args.global_batch_size
 
         total_lengths = [len(t) for t in data["tokens"]]
         data["total_lengths"] = total_lengths
@@ -856,8 +854,8 @@ class RolloutManager:
                     continue
                 rollout_data[key] = data[key]
             # Pass dynamic global_batch_size to training side
-            if hasattr(self, "_dynamic_global_batch_size"):
-                rollout_data["dynamic_global_batch_size"] = self._dynamic_global_batch_size
+            if dynamic_global_batch_size is not None:
+                rollout_data["dynamic_global_batch_size"] = dynamic_global_batch_size
             rollout_data["num_microbatches"] = num_microbatches_per_step
             rollout_data["micro_batch_indices"] = per_rank_mbs_indices[r]
             rollout_data_refs.append(Box(ray.put(rollout_data)))

--- a/slime/ray/rollout.py
+++ b/slime/ray/rollout.py
@@ -781,6 +781,17 @@ class RolloutManager:
         balance_by_tokens = self.args.use_dynamic_batch_size or self.args.balance_data
         num_steps = len(total_lengths) // global_batch_size
 
+        # Accumulated outputs of the per-step loop below. Indexed by DP rank.
+        #   per_rank_sample_indices[r] — global sample indices assigned to rank r,
+        #     concatenated across all steps. Used as the "partition" that selects
+        #     which rows of each ``data[key]`` list go to rank r.
+        #   per_rank_mbs_indices[r] — rank r's mbs schedule: a flat list of mbs
+        #     (across all steps, in step order), each mbs being LOCAL indices into
+        #     rank r's own samples (i.e. offsets within per_rank_sample_indices[r]).
+        #     This is what DataIterator iterates over on the training side.
+        #   num_microbatches_per_step[s] — number of mbs each rank runs in step s.
+        #     Same value on every DP rank (PP sync requirement); training side reads
+        #     this to drive its per-step forward/backward loop.
         per_rank_sample_indices: list[list[int]] = [[] for _ in range(dp_size)]
         per_rank_mbs_indices: list[list[list[int]]] = [[] for _ in range(dp_size)]
         num_microbatches_per_step: list[int] = []

--- a/slime/ray/rollout.py
+++ b/slime/ray/rollout.py
@@ -489,9 +489,7 @@ class RolloutManager:
             # if debug rollout only, we don't convert samples to train data and directly return
             return
         data = self._convert_samples_to_train_data(data)
-        data["total_lengths"] = [len(t) for t in data["tokens"]]
-        per_step_mbs = self._build_micro_batch_schedule(data["total_lengths"])
-        return self._split_train_data_by_dp(data, per_step_mbs)
+        return self._split_train_data_by_dp(data)
 
     def eval(self, rollout_id):
         if self.args.debug_train_only:
@@ -589,23 +587,6 @@ class RolloutManager:
             # flatten the data if it is a list of lists
             while isinstance(data[0], list):
                 data = list(itertools.chain.from_iterable(data))
-
-            if not self.args.disable_rollout_trim_samples and not self.args.debug_rollout_only:
-                global_batch_size = self.args.global_batch_size
-                if self.args.use_dynamic_global_batch_size:
-                    logger.info(f"Collected {len(data)} samples from rollout to train with dynamic global batch size")
-                    # TODO: this is a temporary solution, we should directly save dynamic_global_batch_size to rollout data
-                    self._dynamic_global_batch_size = self._compute_dynamic_global_batch_size(len(data))
-                    global_batch_size = self._dynamic_global_batch_size
-
-                if len(data) % global_batch_size != 0:
-                    trim_len = (len(data) // global_batch_size) * global_batch_size
-                    if trim_len == 0:
-                        raise ValueError(f"Not enough samples {len(data)} for global_batch_size {global_batch_size}")
-                    origin_data_length = len(data)
-                    data = data[:trim_len]
-                    logger.info(f"trim number of samples from {origin_data_length} to {trim_len}")
-                logger.info(f"Final collected {len(data)} samples from rollout to train")
 
         return data, metrics
 
@@ -754,28 +735,59 @@ class RolloutManager:
     def set_train_parallel_config(self, config: dict):
         self.train_parallel_config = config
 
-    def _build_micro_batch_schedule(self, total_lengths):
-        """Partition each training step's samples into micro-batches.
+    def _split_train_data_by_dp(self, data):
+        """Convert collected samples into per-DP-rank training shards.
 
-        Returns ``list[list[list[int]]]``: per step, list of micro-batches, each mbs
-        being step-local sample indices. The mbs count per step is always a multiple
-        of ``dp_size`` so DP assignment can give every rank the same count.
-
-        Static path: each mbs is ``args.micro_batch_size`` consecutive samples.
-        Dynamic path: bin-pack the step globally so each bin holds
-        ``<= max_tokens_per_gpu * cp_size`` tokens, with per-rank mbs count rounded up
-        (and to ``microbatch_group_size_per_vp_stage`` when VPP is on).
+        Pipeline:
+          1. Resolve the effective ``global_batch_size`` (dynamic if enabled).
+          2. Trim ``data`` to a multiple of it (skipped if ``disable_rollout_trim_samples``).
+          3. For each training step (chunk of ``global_batch_size`` samples):
+             - Build mbs. Static: ``args.micro_batch_size``-sized contiguous mbs.
+               Dynamic: bin-pack the step globally so each mbs fits
+               ``max_tokens_per_gpu * cp_size`` (per-rank mbs count rounded up,
+               and to ``microbatch_group_size_per_vp_stage`` when VPP is on).
+             - Assign mbs to DP ranks: token-balanced for dynamic / ``balance_data``,
+               otherwise strided across mbs.
+          4. Package each rank's rollout_data into a Ray Box, with ``num_microbatches``
+             and ``micro_batch_indices`` so the training side just consumes the schedule.
         """
         dp_size = self.train_parallel_config["dp_size"]
         cp_size = self.train_parallel_config["cp_size"]
         vpp_size = self.train_parallel_config["vpp_size"]
         mb_group = self.train_parallel_config["microbatch_group_size_per_vp_stage"]
 
-        global_batch_size = getattr(self, "_dynamic_global_batch_size", self.args.global_batch_size)
-        num_samples = len(total_lengths)
-        num_steps = num_samples // global_batch_size
+        # 1. Resolve gbs and 2. trim data
+        num_samples = len(data["tokens"])
+        if not self.args.disable_rollout_trim_samples:
+            if self.args.use_dynamic_global_batch_size:
+                logger.info(f"Collected {num_samples} samples from rollout to train with dynamic global batch size")
+                self._dynamic_global_batch_size = self._compute_dynamic_global_batch_size(num_samples)
+                global_batch_size = self._dynamic_global_batch_size
+            else:
+                global_batch_size = self.args.global_batch_size
 
-        per_step_mbs: list[list[list[int]]] = []
+            trim_len = (num_samples // global_batch_size) * global_batch_size
+            if trim_len == 0:
+                raise ValueError(f"Not enough samples {num_samples} for global_batch_size {global_batch_size}")
+            if trim_len < num_samples:
+                for key, val in list(data.items()):
+                    if isinstance(val, list):
+                        data[key] = val[:trim_len]
+                logger.info(f"trim number of samples from {num_samples} to {trim_len}")
+            logger.info(f"Final collected {trim_len} samples from rollout to train")
+        else:
+            global_batch_size = self.args.global_batch_size
+
+        total_lengths = [len(t) for t in data["tokens"]]
+        data["total_lengths"] = total_lengths
+        balance_by_tokens = self.args.use_dynamic_batch_size or self.args.balance_data
+        num_steps = len(total_lengths) // global_batch_size
+
+        per_rank_sample_indices: list[list[int]] = [[] for _ in range(dp_size)]
+        per_rank_mbs_indices: list[list[list[int]]] = [[] for _ in range(dp_size)]
+        num_microbatches_per_step: list[int] = []
+
+        # 3. Build mbs schedule and assign to DP ranks, per step
         for step_i in range(num_steps):
             step_start = step_i * global_batch_size
             step_lengths = total_lengths[step_start : step_start + global_batch_size]
@@ -794,32 +806,13 @@ class RolloutManager:
                     num_mbs_per_rank = max(num_mbs_per_rank // mb_group * mb_group, 1)
                 total_mbs = num_mbs_per_rank * dp_size
                 mbs_list = get_seqlen_balanced_partitions(step_lengths, total_mbs, equal_size=False)
-            per_step_mbs.append(mbs_list)
-        return per_step_mbs
 
-    def _split_train_data_by_dp(self, data, per_step_mbs):
-        """Assign micro-batches to DP ranks and package each rank's rollout_data.
-
-        With ``balance_data`` or dynamic mbs, mbs are distributed across DP ranks by
-        balancing total token counts; otherwise mbs are striped across ranks.
-        """
-        dp_size = self.train_parallel_config["dp_size"]
-        total_lengths = data["total_lengths"]
-        global_batch_size = getattr(self, "_dynamic_global_batch_size", self.args.global_batch_size)
-        balance_by_tokens = self.args.use_dynamic_batch_size or self.args.balance_data
-
-        per_rank_sample_indices: list[list[int]] = [[] for _ in range(dp_size)]
-        per_rank_mbs_indices: list[list[list[int]]] = [[] for _ in range(dp_size)]
-        num_microbatches_per_step: list[int] = []
-
-        for step_i, mbs_list in enumerate(per_step_mbs):
-            step_start = step_i * global_batch_size
             total_mbs = len(mbs_list)
             assert total_mbs % dp_size == 0, f"total_mbs {total_mbs} not divisible by dp_size {dp_size}"
             num_microbatches_per_step.append(total_mbs // dp_size)
 
             if balance_by_tokens:
-                mbs_totals = [sum(total_lengths[step_start + i] for i in m) for m in mbs_list]
+                mbs_totals = [sum(step_lengths[i] for i in m) for m in mbs_list]
                 rank_assignment = get_seqlen_balanced_partitions(mbs_totals, dp_size, equal_size=True)
             else:
                 rank_assignment = [list(range(r, total_mbs, dp_size)) for r in range(dp_size)]
@@ -832,6 +825,7 @@ class RolloutManager:
                     per_rank_sample_indices[r].extend(step_start + i for i in mbs_local)
                     offset += len(mbs_local)
 
+        # 4. Package per-rank rollout_data
         rollout_data_refs = []
         for r in range(dp_size):
             partition = per_rank_sample_indices[r]

--- a/slime/ray/rollout.py
+++ b/slime/ray/rollout.py
@@ -18,6 +18,7 @@ from slime.backends.sglang_utils.sglang_config import ModelConfig, ServerGroupCo
 from slime.backends.sglang_utils.sglang_engine import SGLangEngine
 from slime.rollout.base_types import call_rollout_fn
 from slime.utils import logging_utils
+from slime.utils.data import get_minimum_num_micro_batch_size
 from slime.utils.health_monitor import RolloutHealthMonitor
 from slime.utils.http_utils import _wrap_ipv6, find_available_port, get_host_info, init_http_client
 from slime.utils.logging_utils import configure_logger, init_tracking
@@ -488,7 +489,7 @@ class RolloutManager:
             # if debug rollout only, we don't convert samples to train data and directly return
             return
         data = self._convert_samples_to_train_data(data)
-        return self._split_train_data_by_dp(data, self.train_parallel_config["dp_size"])
+        return self._split_train_data_by_dp(data)
 
     def eval(self, rollout_id):
         if self.args.debug_train_only:
@@ -751,27 +752,79 @@ class RolloutManager:
     def set_train_parallel_config(self, config: dict):
         self.train_parallel_config = config
 
-    def _split_train_data_by_dp(self, data, dp_size):
-        """Split the train data by data parallel size."""
-        rollout_data = {}
+    def _split_train_data_by_dp(self, data):
+        """Split the train data by DP and pre-compute the per-step micro-batch schedule.
 
-        if "prompt" in data:
-            rollout_data["prompt"] = data["prompt"]
+        For each training step (chunk of ``global_batch_size`` samples):
+          - Static mbs: split samples into DP ranks (balanced or strided) and emit a
+            fixed ``num_microbatches = (gbs/dp) // micro_batch_size``.
+          - Dynamic mbs: bin-pack the step globally so each bin holds
+            <= ``max_tokens_per_gpu * cp_size`` tokens, then balance bins across DP ranks
+            so every rank ends up with the same ``num_microbatches`` and similar tokens.
+
+        The training side just consumes ``num_microbatches`` and (in the dynamic case)
+        ``micro_batch_indices`` — no per-step all-reduce needed.
+        """
+        dp_size = self.train_parallel_config["dp_size"]
+        cp_size = self.train_parallel_config["cp_size"]
+        vpp_size = self.train_parallel_config["vpp_size"]
+        mb_group = self.train_parallel_config["microbatch_group_size_per_vp_stage"]
 
         total_lengths = [len(t) for t in data["tokens"]]
         data["total_lengths"] = total_lengths
 
-        if self.args.balance_data:
-            partitions = get_seqlen_balanced_partitions(total_lengths, dp_size, equal_size=True)
-        else:
-            partitions = [range(i, len(total_lengths), dp_size) for i in range(dp_size)]
+        global_batch_size = getattr(self, "_dynamic_global_batch_size", self.args.global_batch_size)
+        num_samples = len(total_lengths)
+        num_local_gbs = global_batch_size // dp_size
+        num_steps = num_samples // global_batch_size
+
+        per_rank_sample_indices: list[list[int]] = [[] for _ in range(dp_size)]
+        num_microbatches_per_step: list[int] = []
+        per_rank_mbs_indices: list[list[list[int]]] | None = (
+            [[] for _ in range(dp_size)] if self.args.use_dynamic_batch_size else None
+        )
+
+        for step_i in range(num_steps):
+            step_start = step_i * global_batch_size
+            step_lengths = total_lengths[step_start : step_start + global_batch_size]
+
+            if not self.args.use_dynamic_batch_size:
+                num_microbatches_per_step.append(num_local_gbs // self.args.micro_batch_size)
+                if self.args.balance_data:
+                    rank_parts = get_seqlen_balanced_partitions(step_lengths, dp_size, equal_size=True)
+                else:
+                    rank_parts = [list(range(r, global_batch_size, dp_size)) for r in range(dp_size)]
+                for r in range(dp_size):
+                    per_rank_sample_indices[r].extend(idx + step_start for idx in rank_parts[r])
+            else:
+                assert self.args.max_tokens_per_gpu is not None
+                # Compute the global minimum mbs across the whole step; ceil-divide by dp to
+                # get per-rank num_mbs. This is tighter than the original per-rank min + MAX.
+                global_min_mbs = get_minimum_num_micro_batch_size(step_lengths, self.args.max_tokens_per_gpu * cp_size)
+                num_mbs_per_rank = max((global_min_mbs + dp_size - 1) // dp_size, 1)
+                if vpp_size > 1:
+                    # Match the original floor-to-mb_group rounding (with min=1).
+                    num_mbs_per_rank = max(num_mbs_per_rank // mb_group * mb_group, 1)
+                num_microbatches_per_step.append(num_mbs_per_rank)
+
+                total_mbs = num_mbs_per_rank * dp_size
+                bin_parts = get_seqlen_balanced_partitions(step_lengths, total_mbs, equal_size=False)
+                # Balance bins across DP ranks by total tokens so per-rank load is even.
+                bin_totals = [sum(step_lengths[idx] for idx in b) for b in bin_parts]
+                rank_bin_assignment = get_seqlen_balanced_partitions(bin_totals, dp_size, equal_size=True)
+                assert per_rank_mbs_indices is not None
+                for r in range(dp_size):
+                    offset = len(per_rank_sample_indices[r])
+                    for bin_idx in rank_bin_assignment[r]:
+                        bin_local_indices = bin_parts[bin_idx]
+                        per_rank_mbs_indices[r].append(list(range(offset, offset + len(bin_local_indices))))
+                        per_rank_sample_indices[r].extend(idx + step_start for idx in bin_local_indices)
+                        offset += len(bin_local_indices)
 
         rollout_data_refs = []
-
-        for i in range(dp_size):
-            rollout_data = {}
-            partition = partitions[i]
-            rollout_data["partition"] = partition
+        for r in range(dp_size):
+            partition = per_rank_sample_indices[r]
+            rollout_data = {"partition": partition}
             for key in [
                 "tokens",
                 "multimodal_train_inputs",
@@ -788,8 +841,7 @@ class RolloutManager:
             ]:
                 if key not in data:
                     continue
-                val = [data[key][j] for j in partition]
-                rollout_data[key] = val
+                rollout_data[key] = [data[key][j] for j in partition]
             # keys that need to be splited at train side
             for key in [
                 "raw_reward",
@@ -801,6 +853,9 @@ class RolloutManager:
             # Pass dynamic global_batch_size to training side
             if hasattr(self, "_dynamic_global_batch_size"):
                 rollout_data["dynamic_global_batch_size"] = self._dynamic_global_batch_size
+            rollout_data["num_microbatches"] = num_microbatches_per_step
+            if per_rank_mbs_indices is not None:
+                rollout_data["micro_batch_indices"] = per_rank_mbs_indices[r]
             rollout_data_refs.append(Box(ray.put(rollout_data)))
         return rollout_data_refs
 

--- a/slime/ray/rollout.py
+++ b/slime/ray/rollout.py
@@ -489,7 +489,9 @@ class RolloutManager:
             # if debug rollout only, we don't convert samples to train data and directly return
             return
         data = self._convert_samples_to_train_data(data)
-        return self._split_train_data_by_dp(data)
+        data["total_lengths"] = [len(t) for t in data["tokens"]]
+        per_step_mbs = self._build_micro_batch_schedule(data["total_lengths"])
+        return self._split_train_data_by_dp(data, per_step_mbs)
 
     def eval(self, rollout_id):
         if self.args.debug_train_only:
@@ -752,76 +754,83 @@ class RolloutManager:
     def set_train_parallel_config(self, config: dict):
         self.train_parallel_config = config
 
-    def _split_train_data_by_dp(self, data):
-        """Split the train data by DP and pre-compute the per-step micro-batch schedule.
+    def _build_micro_batch_schedule(self, total_lengths):
+        """Partition each training step's samples into micro-batches.
 
-        For each training step (chunk of ``global_batch_size`` samples):
-          - Static mbs: split samples into DP ranks (balanced or strided) and emit
-            ``num_microbatches = (gbs/dp) // micro_batch_size`` contiguous mbs.
-          - Dynamic mbs: bin-pack the step globally so each bin holds
-            <= ``max_tokens_per_gpu * cp_size`` tokens, then balance bins across DP ranks
-            so every rank ends up with the same ``num_microbatches`` and similar tokens.
+        Returns ``list[list[list[int]]]``: per step, list of micro-batches, each mbs
+        being step-local sample indices. The mbs count per step is always a multiple
+        of ``dp_size`` so DP assignment can give every rank the same count.
 
-        Both paths emit ``num_microbatches`` and ``micro_batch_indices`` so the training
-        side just consumes them — no per-step all-reduce needed.
+        Static path: each mbs is ``args.micro_batch_size`` consecutive samples.
+        Dynamic path: bin-pack the step globally so each bin holds
+        ``<= max_tokens_per_gpu * cp_size`` tokens, with per-rank mbs count rounded up
+        (and to ``microbatch_group_size_per_vp_stage`` when VPP is on).
         """
         dp_size = self.train_parallel_config["dp_size"]
         cp_size = self.train_parallel_config["cp_size"]
         vpp_size = self.train_parallel_config["vpp_size"]
         mb_group = self.train_parallel_config["microbatch_group_size_per_vp_stage"]
 
-        total_lengths = [len(t) for t in data["tokens"]]
-        data["total_lengths"] = total_lengths
-
         global_batch_size = getattr(self, "_dynamic_global_batch_size", self.args.global_batch_size)
         num_samples = len(total_lengths)
-        num_local_gbs = global_batch_size // dp_size
         num_steps = num_samples // global_batch_size
 
-        per_rank_sample_indices: list[list[int]] = [[] for _ in range(dp_size)]
-        per_rank_mbs_indices: list[list[list[int]]] = [[] for _ in range(dp_size)]
-        num_microbatches_per_step: list[int] = []
-
+        per_step_mbs: list[list[list[int]]] = []
         for step_i in range(num_steps):
             step_start = step_i * global_batch_size
             step_lengths = total_lengths[step_start : step_start + global_batch_size]
 
             if not self.args.use_dynamic_batch_size:
                 mbs = self.args.micro_batch_size
-                num_microbatches_per_step.append(num_local_gbs // mbs)
-                if self.args.balance_data:
-                    rank_parts = get_seqlen_balanced_partitions(step_lengths, dp_size, equal_size=True)
-                else:
-                    rank_parts = [list(range(r, global_batch_size, dp_size)) for r in range(dp_size)]
-                for r in range(dp_size):
-                    offset = len(per_rank_sample_indices[r])
-                    rank_samples = rank_parts[r]
-                    for j in range(0, len(rank_samples), mbs):
-                        per_rank_mbs_indices[r].append(list(range(offset + j, offset + j + mbs)))
-                    per_rank_sample_indices[r].extend(idx + step_start for idx in rank_samples)
+                mbs_list = [list(range(j, j + mbs)) for j in range(0, global_batch_size, mbs)]
             else:
                 assert self.args.max_tokens_per_gpu is not None
-                # Compute the global minimum mbs across the whole step; ceil-divide by dp to
-                # get per-rank num_mbs. This is tighter than the original per-rank min + MAX.
+                # Compute the global minimum mbs across the whole step; ceil-divide by dp
+                # to get per-rank num_mbs. Tighter than the original per-rank min + MAX.
                 global_min_mbs = get_minimum_num_micro_batch_size(step_lengths, self.args.max_tokens_per_gpu * cp_size)
                 num_mbs_per_rank = max((global_min_mbs + dp_size - 1) // dp_size, 1)
                 if vpp_size > 1:
                     # Match the original floor-to-mb_group rounding (with min=1).
                     num_mbs_per_rank = max(num_mbs_per_rank // mb_group * mb_group, 1)
-                num_microbatches_per_step.append(num_mbs_per_rank)
-
                 total_mbs = num_mbs_per_rank * dp_size
-                bin_parts = get_seqlen_balanced_partitions(step_lengths, total_mbs, equal_size=False)
-                # Balance bins across DP ranks by total tokens so per-rank load is even.
-                bin_totals = [sum(step_lengths[idx] for idx in b) for b in bin_parts]
-                rank_bin_assignment = get_seqlen_balanced_partitions(bin_totals, dp_size, equal_size=True)
-                for r in range(dp_size):
-                    offset = len(per_rank_sample_indices[r])
-                    for bin_idx in rank_bin_assignment[r]:
-                        bin_local_indices = bin_parts[bin_idx]
-                        per_rank_mbs_indices[r].append(list(range(offset, offset + len(bin_local_indices))))
-                        per_rank_sample_indices[r].extend(idx + step_start for idx in bin_local_indices)
-                        offset += len(bin_local_indices)
+                mbs_list = get_seqlen_balanced_partitions(step_lengths, total_mbs, equal_size=False)
+            per_step_mbs.append(mbs_list)
+        return per_step_mbs
+
+    def _split_train_data_by_dp(self, data, per_step_mbs):
+        """Assign micro-batches to DP ranks and package each rank's rollout_data.
+
+        With ``balance_data`` or dynamic mbs, mbs are distributed across DP ranks by
+        balancing total token counts; otherwise mbs are striped across ranks.
+        """
+        dp_size = self.train_parallel_config["dp_size"]
+        total_lengths = data["total_lengths"]
+        global_batch_size = getattr(self, "_dynamic_global_batch_size", self.args.global_batch_size)
+        balance_by_tokens = self.args.use_dynamic_batch_size or self.args.balance_data
+
+        per_rank_sample_indices: list[list[int]] = [[] for _ in range(dp_size)]
+        per_rank_mbs_indices: list[list[list[int]]] = [[] for _ in range(dp_size)]
+        num_microbatches_per_step: list[int] = []
+
+        for step_i, mbs_list in enumerate(per_step_mbs):
+            step_start = step_i * global_batch_size
+            total_mbs = len(mbs_list)
+            assert total_mbs % dp_size == 0, f"total_mbs {total_mbs} not divisible by dp_size {dp_size}"
+            num_microbatches_per_step.append(total_mbs // dp_size)
+
+            if balance_by_tokens:
+                mbs_totals = [sum(total_lengths[step_start + i] for i in m) for m in mbs_list]
+                rank_assignment = get_seqlen_balanced_partitions(mbs_totals, dp_size, equal_size=True)
+            else:
+                rank_assignment = [list(range(r, total_mbs, dp_size)) for r in range(dp_size)]
+
+            for r in range(dp_size):
+                offset = len(per_rank_sample_indices[r])
+                for mbs_idx in rank_assignment[r]:
+                    mbs_local = mbs_list[mbs_idx]
+                    per_rank_mbs_indices[r].append(list(range(offset, offset + len(mbs_local))))
+                    per_rank_sample_indices[r].extend(step_start + i for i in mbs_local)
+                    offset += len(mbs_local)
 
         rollout_data_refs = []
         for r in range(dp_size):

--- a/slime/ray/rollout.py
+++ b/slime/ray/rollout.py
@@ -708,12 +708,12 @@ class RolloutManager:
         self.train_parallel_config = config
 
     def _split_train_data_by_dp(self, data):
-        """Build per-rank rollout_data shards and wrap each in a Ray Box.
-
-        The scheduling/packaging logic lives in :func:`slime.utils.dp_schedule.build_dp_rollout_data`
-        as a pure function so it can be unit-tested without Ray/sglang imports.
-        """
+        """Resolve gbs, trim ``data`` to a multiple of it, then build per-rank
+        rollout_data shards (delegated to :func:`build_dp_rollout_data` so the
+        scheduling/packaging logic stays unit-testable without Ray/sglang)."""
         dp_size = self.train_parallel_config["dp_size"]
+
+        # 1. Resolve effective global_batch_size
         dynamic_gbs: int | None = None
         if self.args.use_dynamic_global_batch_size and not self.args.disable_rollout_trim_samples:
             dynamic_gbs = compute_dynamic_global_batch_size(len(data["tokens"]), dp_size)
@@ -722,11 +722,27 @@ class RolloutManager:
                     f"Dynamic global_batch_size: {self.args.global_batch_size} -> {dynamic_gbs} "
                     f"(num_samples={len(data['tokens'])}, dp_size={dp_size}, num_steps=1)"
                 )
+            global_batch_size = dynamic_gbs
+        else:
+            global_batch_size = self.args.global_batch_size
+
+        # 2. Trim data to a multiple of global_batch_size
+        if not self.args.disable_rollout_trim_samples:
+            num_samples = len(data["tokens"])
+            trim_len = num_samples // global_batch_size * global_batch_size
+            if trim_len == 0:
+                raise ValueError(f"Not enough samples {num_samples} for global_batch_size {global_batch_size}")
+            if trim_len < num_samples:
+                logger.info(f"Trimmed samples from {num_samples} to {trim_len}")
+                for key, val in data.items():
+                    if isinstance(val, list):
+                        data[key] = val[:trim_len]
 
         rollout_data_list = build_dp_rollout_data(
             self.args,
             self.train_parallel_config,
             data,
+            global_batch_size=global_batch_size,
             dynamic_global_batch_size=dynamic_gbs,
         )
         return [Box(ray.put(d)) for d in rollout_data_list]

--- a/slime/ray/rollout.py
+++ b/slime/ray/rollout.py
@@ -18,7 +18,7 @@ from slime.backends.sglang_utils.sglang_config import ModelConfig, ServerGroupCo
 from slime.backends.sglang_utils.sglang_engine import SGLangEngine
 from slime.rollout.base_types import call_rollout_fn
 from slime.utils import logging_utils
-from slime.utils.dp_schedule import build_dp_rollout_data, compute_dynamic_global_batch_size
+from slime.utils.dp_schedule import build_dp_schedule, compute_dynamic_global_batch_size
 from slime.utils.health_monitor import RolloutHealthMonitor
 from slime.utils.http_utils import _wrap_ipv6, find_available_port, get_host_info, init_http_client
 from slime.utils.logging_utils import configure_logger, init_tracking
@@ -708,9 +708,9 @@ class RolloutManager:
         self.train_parallel_config = config
 
     def _split_train_data_by_dp(self, data):
-        """Resolve gbs, trim ``data`` to a multiple of it, then build per-rank
-        rollout_data shards (delegated to :func:`build_dp_rollout_data` so the
-        scheduling/packaging logic stays unit-testable without Ray/sglang)."""
+        """Resolve gbs, trim ``data``, compute the DP/mbs schedule, and package each
+        rank's rollout_data into a Ray Box. The schedule itself is computed by
+        :func:`build_dp_schedule` so it stays unit-testable without Ray/sglang."""
         dp_size = self.train_parallel_config["dp_size"]
 
         # 1. Resolve effective global_batch_size
@@ -738,14 +738,49 @@ class RolloutManager:
                     if isinstance(val, list):
                         data[key] = val[:trim_len]
 
-        rollout_data_list = build_dp_rollout_data(
+        # 3. Compute schedule
+        total_lengths = [len(t) for t in data["tokens"]]
+        data["total_lengths"] = total_lengths
+        partitions, micro_batch_indices, num_microbatches = build_dp_schedule(
             self.args,
             self.train_parallel_config,
-            data,
+            total_lengths,
             global_batch_size=global_batch_size,
-            dynamic_global_batch_size=dynamic_gbs,
         )
-        return [Box(ray.put(d)) for d in rollout_data_list]
+
+        # 4. Package per-rank rollout_data
+        rollout_data_refs = []
+        for r in range(dp_size):
+            partition = partitions[r]
+            rollout_data = {"partition": partition}
+            for key in [
+                "tokens",
+                "multimodal_train_inputs",
+                "response_lengths",
+                "rewards",
+                "truncated",
+                "loss_masks",
+                "round_number",
+                "sample_indices",
+                "rollout_log_probs",
+                "rollout_routed_experts",
+                "prompt",
+                "teacher_log_probs",
+            ]:
+                if key not in data:
+                    continue
+                rollout_data[key] = [data[key][j] for j in partition]
+            # keys that need to be splited at train side
+            for key in ["raw_reward", "total_lengths"]:
+                if key not in data:
+                    continue
+                rollout_data[key] = data[key]
+            if dynamic_gbs is not None:
+                rollout_data["dynamic_global_batch_size"] = dynamic_gbs
+            rollout_data["num_microbatches"] = num_microbatches
+            rollout_data["micro_batch_indices"] = micro_batch_indices[r]
+            rollout_data_refs.append(Box(ray.put(rollout_data)))
+        return rollout_data_refs
 
 
 def _allocate_rollout_engine_addr_and_ports_external(args, rollout_engines):

--- a/slime/ray/rollout.py
+++ b/slime/ray/rollout.py
@@ -18,13 +18,13 @@ from slime.backends.sglang_utils.sglang_config import ModelConfig, ServerGroupCo
 from slime.backends.sglang_utils.sglang_engine import SGLangEngine
 from slime.rollout.base_types import call_rollout_fn
 from slime.utils import logging_utils
-from slime.utils.data import get_minimum_num_micro_batch_size
+from slime.utils.data import first_fit_pack
 from slime.utils.health_monitor import RolloutHealthMonitor
 from slime.utils.http_utils import _wrap_ipv6, find_available_port, get_host_info, init_http_client
 from slime.utils.logging_utils import configure_logger, init_tracking
 from slime.utils.metric_utils import compute_pass_rate, compute_rollout_step, compute_statistics, dict_add_prefix
 from slime.utils.misc import Box, group_by, load_function
-from slime.utils.seqlen_balancing import get_seqlen_balanced_partitions
+from slime.utils.seqlen_balancing import expand_bins_by_splitting, get_seqlen_balanced_partitions
 from slime.utils.types import Sample
 
 from ..utils.metric_utils import has_repetition
@@ -778,8 +778,15 @@ class RolloutManager:
 
         total_lengths = [len(t) for t in data["tokens"]]
         data["total_lengths"] = total_lengths
-        balance_by_tokens = self.args.use_dynamic_batch_size or self.args.balance_data
         num_steps = len(total_lengths) // global_batch_size
+
+        if self.args.use_dynamic_batch_size:
+            assert self.args.max_tokens_per_gpu is not None
+            max_per_bin = self.args.max_tokens_per_gpu * cp_size
+            longest = max(total_lengths)
+            assert (
+                longest <= max_per_bin
+            ), f"sample with length {longest} exceeds max_tokens_per_gpu * cp_size = {max_per_bin}"
 
         # Accumulated outputs of the per-step loop below. Indexed by DP rank.
         #   per_rank_sample_indices[r] — global sample indices assigned to rank r,
@@ -796,43 +803,54 @@ class RolloutManager:
         per_rank_mbs_indices: list[list[list[int]]] = [[] for _ in range(dp_size)]
         num_microbatches_per_step: list[int] = []
 
-        # 3. Build mbs schedule and assign to DP ranks, per step
+        # 3. Per step: split samples into DP ranks with equal sample counts, then
+        #    build each rank's mbs schedule.
         for step_i in range(num_steps):
             step_start = step_i * global_batch_size
             step_lengths = total_lengths[step_start : step_start + global_batch_size]
 
-            if not self.args.use_dynamic_batch_size:
-                mbs = self.args.micro_batch_size
-                mbs_list = [list(range(j, j + mbs)) for j in range(0, global_batch_size, mbs)]
+            # Split samples to DP ranks (each rank gets gbs/dp samples).
+            if self.args.balance_data:
+                rank_parts = get_seqlen_balanced_partitions(step_lengths, dp_size, equal_size=True)
             else:
-                assert self.args.max_tokens_per_gpu is not None
-                # Compute the global minimum mbs across the whole step; ceil-divide by dp
-                # to get per-rank num_mbs. Tighter than the original per-rank min + MAX.
-                global_min_mbs = get_minimum_num_micro_batch_size(step_lengths, self.args.max_tokens_per_gpu * cp_size)
-                num_mbs_per_rank = max((global_min_mbs + dp_size - 1) // dp_size, 1)
+                rank_parts = [list(range(r, global_batch_size, dp_size)) for r in range(dp_size)]
+
+            if not self.args.use_dynamic_batch_size:
+                # Static: each rank's samples chunked into mbs of args.micro_batch_size.
+                mbs = self.args.micro_batch_size
+                rank_mbs = [
+                    [rank_parts[r][i : i + mbs] for i in range(0, len(rank_parts[r]), mbs)] for r in range(dp_size)
+                ]
+                num_mbs_per_rank = len(rank_mbs[0])
+            else:
+                # Dynamic: per-rank first-fit (strict bin sum <= max_per_bin), take MAX
+                # across ranks for VPP/PP alignment, then expand each rank to MAX bins
+                # by splitting its largest bins (split halves are <= original, so the
+                # <= max_per_bin guarantee is preserved).
+                rank_mbs = []
+                for r in range(dp_size):
+                    local_indices = rank_parts[r]
+                    local_bins = first_fit_pack([step_lengths[i] for i in local_indices], max_per_bin)
+                    # first_fit_pack returns indices into the local list; translate back to step-local.
+                    rank_mbs.append([[local_indices[i] for i in b] for b in local_bins])
+
+                num_mbs_per_rank = max(len(b) for b in rank_mbs)
                 if vpp_size > 1:
                     # Match the original floor-to-mb_group rounding (with min=1).
                     num_mbs_per_rank = max(num_mbs_per_rank // mb_group * mb_group, 1)
-                total_mbs = num_mbs_per_rank * dp_size
-                mbs_list = get_seqlen_balanced_partitions(step_lengths, total_mbs, equal_size=False)
 
-            total_mbs = len(mbs_list)
-            assert total_mbs % dp_size == 0, f"total_mbs {total_mbs} not divisible by dp_size {dp_size}"
-            num_microbatches_per_step.append(total_mbs // dp_size)
+                for r in range(dp_size):
+                    expand_bins_by_splitting(rank_mbs[r], num_mbs_per_rank, step_lengths)
 
-            if balance_by_tokens:
-                mbs_totals = [sum(step_lengths[i] for i in m) for m in mbs_list]
-                rank_assignment = get_seqlen_balanced_partitions(mbs_totals, dp_size, equal_size=True)
-            else:
-                rank_assignment = [list(range(r, total_mbs, dp_size)) for r in range(dp_size)]
+            num_microbatches_per_step.append(num_mbs_per_rank)
 
+            # Accumulate this step's per-rank samples (in mbs order) and local mbs indices.
             for r in range(dp_size):
                 offset = len(per_rank_sample_indices[r])
-                for mbs_idx in rank_assignment[r]:
-                    mbs_local = mbs_list[mbs_idx]
-                    per_rank_mbs_indices[r].append(list(range(offset, offset + len(mbs_local))))
-                    per_rank_sample_indices[r].extend(step_start + i for i in mbs_local)
-                    offset += len(mbs_local)
+                for mbs_indices in rank_mbs[r]:
+                    per_rank_mbs_indices[r].append(list(range(offset, offset + len(mbs_indices))))
+                    per_rank_sample_indices[r].extend(step_start + i for i in mbs_indices)
+                    offset += len(mbs_indices)
 
         # 4. Package per-rank rollout_data
         rollout_data_refs = []

--- a/slime/ray/rollout.py
+++ b/slime/ray/rollout.py
@@ -18,13 +18,12 @@ from slime.backends.sglang_utils.sglang_config import ModelConfig, ServerGroupCo
 from slime.backends.sglang_utils.sglang_engine import SGLangEngine
 from slime.rollout.base_types import call_rollout_fn
 from slime.utils import logging_utils
-from slime.utils.data import first_fit_pack
+from slime.utils.dp_schedule import build_dp_rollout_data, compute_dynamic_global_batch_size
 from slime.utils.health_monitor import RolloutHealthMonitor
 from slime.utils.http_utils import _wrap_ipv6, find_available_port, get_host_info, init_http_client
 from slime.utils.logging_utils import configure_logger, init_tracking
 from slime.utils.metric_utils import compute_pass_rate, compute_rollout_step, compute_statistics, dict_add_prefix
 from slime.utils.misc import Box, group_by, load_function
-from slime.utils.seqlen_balancing import expand_bins_by_splitting, get_seqlen_balanced_partitions
 from slime.utils.types import Sample
 
 from ..utils.metric_utils import has_repetition
@@ -590,33 +589,6 @@ class RolloutManager:
 
         return data, metrics
 
-    def _compute_dynamic_global_batch_size(self, num_samples: int) -> int:
-        """Calculate dynamic global_batch_size to ensure only one training step.
-
-        Strategy: global_batch_size = num_samples rounded down to a multiple of dp_size
-        This ensures num_steps_per_rollout = num_samples // global_batch_size = 1
-        """
-        dp_size = self.train_parallel_config["dp_size"]
-        original_gbs = self.args.global_batch_size
-
-        # Round down to a multiple of dp_size to ensure only one training step
-        dynamic_gbs = (num_samples // dp_size) * dp_size
-
-        if dynamic_gbs == 0:
-            # Too few samples, use at least dp_size
-            dynamic_gbs = dp_size
-            logger.warning(f"num_samples={num_samples} < dp_size={dp_size}, using dp_size as global_batch_size")
-
-        # Calculate how many samples will be discarded
-        wasted = num_samples - dynamic_gbs
-
-        if dynamic_gbs != original_gbs or wasted > 0:
-            logger.info(
-                f"Dynamic global_batch_size: {original_gbs} -> {dynamic_gbs} (num_samples={num_samples}, dp_size={dp_size}, num_steps=1, wasted={wasted})"
-            )
-
-        return dynamic_gbs
-
     def _save_debug_rollout_data(self, data, rollout_id, evaluation: bool):
         # TODO to be refactored (originally Buffer._set_data)
         if (path_template := self.args.save_debug_rollout_data) is not None:
@@ -736,155 +708,28 @@ class RolloutManager:
         self.train_parallel_config = config
 
     def _split_train_data_by_dp(self, data):
-        """Convert collected samples into per-DP-rank training shards.
+        """Build per-rank rollout_data shards and wrap each in a Ray Box.
 
-        Pipeline:
-          1. Resolve the effective ``global_batch_size`` (dynamic if enabled).
-          2. Trim ``data`` to a multiple of it (skipped if ``disable_rollout_trim_samples``).
-          3. For each training step (chunk of ``global_batch_size`` samples):
-             - Build mbs. Static: ``args.micro_batch_size``-sized contiguous mbs.
-               Dynamic: bin-pack the step globally so each mbs fits
-               ``max_tokens_per_gpu * cp_size`` (per-rank mbs count rounded up,
-               and to ``microbatch_group_size_per_vp_stage`` when VPP is on).
-             - Assign mbs to DP ranks: token-balanced for dynamic / ``balance_data``,
-               otherwise strided across mbs.
-          4. Package each rank's rollout_data into a Ray Box, with ``num_microbatches``
-             and ``micro_batch_indices`` so the training side just consumes the schedule.
+        The scheduling/packaging logic lives in :func:`slime.utils.dp_schedule.build_dp_rollout_data`
+        as a pure function so it can be unit-tested without Ray/sglang imports.
         """
         dp_size = self.train_parallel_config["dp_size"]
-        cp_size = self.train_parallel_config["cp_size"]
-        vpp_size = self.train_parallel_config["vpp_size"]
-        mb_group = self.train_parallel_config["microbatch_group_size_per_vp_stage"]
-
-        # 1. Resolve effective global_batch_size
-        dynamic_global_batch_size: int | None = None
+        dynamic_gbs: int | None = None
         if self.args.use_dynamic_global_batch_size and not self.args.disable_rollout_trim_samples:
-            dynamic_global_batch_size = self._compute_dynamic_global_batch_size(len(data["tokens"]))
-            global_batch_size = dynamic_global_batch_size
-        else:
-            global_batch_size = self.args.global_batch_size
+            dynamic_gbs = compute_dynamic_global_batch_size(len(data["tokens"]), dp_size)
+            if dynamic_gbs != self.args.global_batch_size:
+                logger.info(
+                    f"Dynamic global_batch_size: {self.args.global_batch_size} -> {dynamic_gbs} "
+                    f"(num_samples={len(data['tokens'])}, dp_size={dp_size}, num_steps=1)"
+                )
 
-        # 2. Trim data to a multiple of global_batch_size
-        if not self.args.disable_rollout_trim_samples:
-            num_samples = len(data["tokens"])
-            trim_len = num_samples // global_batch_size * global_batch_size
-            if trim_len == 0:
-                raise ValueError(f"Not enough samples {num_samples} for global_batch_size {global_batch_size}")
-            if trim_len < num_samples:
-                logger.info(f"Trimmed samples from {num_samples} to {trim_len}")
-                for key, val in data.items():
-                    if isinstance(val, list):
-                        data[key] = val[:trim_len]
-
-        total_lengths = [len(t) for t in data["tokens"]]
-        data["total_lengths"] = total_lengths
-        num_steps = len(total_lengths) // global_batch_size
-
-        if self.args.use_dynamic_batch_size:
-            assert self.args.max_tokens_per_gpu is not None
-            max_per_bin = self.args.max_tokens_per_gpu * cp_size
-
-        # Accumulated outputs of the per-step loop below. Indexed by DP rank.
-        #   per_rank_sample_indices[r] — global sample indices assigned to rank r,
-        #     concatenated across all steps. Used as the "partition" that selects
-        #     which rows of each ``data[key]`` list go to rank r.
-        #   per_rank_mbs_indices[r] — rank r's mbs schedule: a flat list of mbs
-        #     (across all steps, in step order), each mbs being LOCAL indices into
-        #     rank r's own samples (i.e. offsets within per_rank_sample_indices[r]).
-        #     This is what DataIterator iterates over on the training side.
-        #   num_microbatches_per_step[s] — number of mbs each rank runs in step s.
-        #     Same value on every DP rank (PP sync requirement); training side reads
-        #     this to drive its per-step forward/backward loop.
-        per_rank_sample_indices: list[list[int]] = [[] for _ in range(dp_size)]
-        per_rank_mbs_indices: list[list[list[int]]] = [[] for _ in range(dp_size)]
-        num_microbatches_per_step: list[int] = []
-
-        # 3. Per step: split samples into DP ranks with equal sample counts, then
-        #    build each rank's mbs schedule.
-        for step_i in range(num_steps):
-            step_start = step_i * global_batch_size
-            step_lengths = total_lengths[step_start : step_start + global_batch_size]
-
-            # Split samples to DP ranks (each rank gets gbs/dp samples).
-            if self.args.balance_data:
-                rank_parts = get_seqlen_balanced_partitions(step_lengths, dp_size, equal_size=True)
-            else:
-                rank_parts = [list(range(r, global_batch_size, dp_size)) for r in range(dp_size)]
-
-            if not self.args.use_dynamic_batch_size:
-                # Static: each rank's samples chunked into mbs of args.micro_batch_size.
-                mbs = self.args.micro_batch_size
-                rank_mbs = [
-                    [rank_parts[r][i : i + mbs] for i in range(0, len(rank_parts[r]), mbs)] for r in range(dp_size)
-                ]
-                num_mbs_per_rank = len(rank_mbs[0])
-            else:
-                # Dynamic: per-rank first-fit (strict bin sum <= max_per_bin), take MAX
-                # across ranks for VPP/PP alignment, then expand each rank to MAX bins
-                # by splitting its largest bins (split halves are <= original, so the
-                # <= max_per_bin guarantee is preserved).
-                rank_mbs = []
-                for r in range(dp_size):
-                    local_indices = rank_parts[r]
-                    local_bins = first_fit_pack([step_lengths[i] for i in local_indices], max_per_bin)
-                    # first_fit_pack returns indices into the local list; translate back to step-local.
-                    rank_mbs.append([[local_indices[i] for i in b] for b in local_bins])
-
-                num_mbs_per_rank = max(len(b) for b in rank_mbs)
-                if vpp_size > 1:
-                    # Match the original floor-to-mb_group rounding (with min=1).
-                    num_mbs_per_rank = max(num_mbs_per_rank // mb_group * mb_group, 1)
-
-                for r in range(dp_size):
-                    expand_bins_by_splitting(rank_mbs[r], num_mbs_per_rank, step_lengths)
-
-            num_microbatches_per_step.append(num_mbs_per_rank)
-
-            # Accumulate this step's per-rank samples (in mbs order) and local mbs indices.
-            for r in range(dp_size):
-                offset = len(per_rank_sample_indices[r])
-                for mbs_indices in rank_mbs[r]:
-                    per_rank_mbs_indices[r].append(list(range(offset, offset + len(mbs_indices))))
-                    per_rank_sample_indices[r].extend(step_start + i for i in mbs_indices)
-                    offset += len(mbs_indices)
-
-        # 4. Package per-rank rollout_data
-        rollout_data_refs = []
-        for r in range(dp_size):
-            partition = per_rank_sample_indices[r]
-            rollout_data = {"partition": partition}
-            for key in [
-                "tokens",
-                "multimodal_train_inputs",
-                "response_lengths",
-                "rewards",
-                "truncated",
-                "loss_masks",
-                "round_number",
-                "sample_indices",
-                "rollout_log_probs",
-                "rollout_routed_experts",
-                "prompt",
-                "teacher_log_probs",
-            ]:
-                if key not in data:
-                    continue
-                rollout_data[key] = [data[key][j] for j in partition]
-            # keys that need to be splited at train side
-            for key in [
-                "raw_reward",
-                "total_lengths",
-            ]:
-                if key not in data:
-                    continue
-                rollout_data[key] = data[key]
-            # Pass dynamic global_batch_size to training side
-            if dynamic_global_batch_size is not None:
-                rollout_data["dynamic_global_batch_size"] = dynamic_global_batch_size
-            rollout_data["num_microbatches"] = num_microbatches_per_step
-            rollout_data["micro_batch_indices"] = per_rank_mbs_indices[r]
-            rollout_data_refs.append(Box(ray.put(rollout_data)))
-        return rollout_data_refs
+        rollout_data_list = build_dp_rollout_data(
+            self.args,
+            self.train_parallel_config,
+            data,
+            dynamic_global_batch_size=dynamic_gbs,
+        )
+        return [Box(ray.put(d)) for d in rollout_data_list]
 
 
 def _allocate_rollout_engine_addr_and_ports_external(args, rollout_engines):

--- a/slime/ray/rollout.py
+++ b/slime/ray/rollout.py
@@ -756,14 +756,14 @@ class RolloutManager:
         """Split the train data by DP and pre-compute the per-step micro-batch schedule.
 
         For each training step (chunk of ``global_batch_size`` samples):
-          - Static mbs: split samples into DP ranks (balanced or strided) and emit a
-            fixed ``num_microbatches = (gbs/dp) // micro_batch_size``.
+          - Static mbs: split samples into DP ranks (balanced or strided) and emit
+            ``num_microbatches = (gbs/dp) // micro_batch_size`` contiguous mbs.
           - Dynamic mbs: bin-pack the step globally so each bin holds
             <= ``max_tokens_per_gpu * cp_size`` tokens, then balance bins across DP ranks
             so every rank ends up with the same ``num_microbatches`` and similar tokens.
 
-        The training side just consumes ``num_microbatches`` and (in the dynamic case)
-        ``micro_batch_indices`` — no per-step all-reduce needed.
+        Both paths emit ``num_microbatches`` and ``micro_batch_indices`` so the training
+        side just consumes them — no per-step all-reduce needed.
         """
         dp_size = self.train_parallel_config["dp_size"]
         cp_size = self.train_parallel_config["cp_size"]
@@ -779,23 +779,26 @@ class RolloutManager:
         num_steps = num_samples // global_batch_size
 
         per_rank_sample_indices: list[list[int]] = [[] for _ in range(dp_size)]
+        per_rank_mbs_indices: list[list[list[int]]] = [[] for _ in range(dp_size)]
         num_microbatches_per_step: list[int] = []
-        per_rank_mbs_indices: list[list[list[int]]] | None = (
-            [[] for _ in range(dp_size)] if self.args.use_dynamic_batch_size else None
-        )
 
         for step_i in range(num_steps):
             step_start = step_i * global_batch_size
             step_lengths = total_lengths[step_start : step_start + global_batch_size]
 
             if not self.args.use_dynamic_batch_size:
-                num_microbatches_per_step.append(num_local_gbs // self.args.micro_batch_size)
+                mbs = self.args.micro_batch_size
+                num_microbatches_per_step.append(num_local_gbs // mbs)
                 if self.args.balance_data:
                     rank_parts = get_seqlen_balanced_partitions(step_lengths, dp_size, equal_size=True)
                 else:
                     rank_parts = [list(range(r, global_batch_size, dp_size)) for r in range(dp_size)]
                 for r in range(dp_size):
-                    per_rank_sample_indices[r].extend(idx + step_start for idx in rank_parts[r])
+                    offset = len(per_rank_sample_indices[r])
+                    rank_samples = rank_parts[r]
+                    for j in range(0, len(rank_samples), mbs):
+                        per_rank_mbs_indices[r].append(list(range(offset + j, offset + j + mbs)))
+                    per_rank_sample_indices[r].extend(idx + step_start for idx in rank_samples)
             else:
                 assert self.args.max_tokens_per_gpu is not None
                 # Compute the global minimum mbs across the whole step; ceil-divide by dp to
@@ -812,7 +815,6 @@ class RolloutManager:
                 # Balance bins across DP ranks by total tokens so per-rank load is even.
                 bin_totals = [sum(step_lengths[idx] for idx in b) for b in bin_parts]
                 rank_bin_assignment = get_seqlen_balanced_partitions(bin_totals, dp_size, equal_size=True)
-                assert per_rank_mbs_indices is not None
                 for r in range(dp_size):
                     offset = len(per_rank_sample_indices[r])
                     for bin_idx in rank_bin_assignment[r]:
@@ -854,8 +856,7 @@ class RolloutManager:
             if hasattr(self, "_dynamic_global_batch_size"):
                 rollout_data["dynamic_global_batch_size"] = self._dynamic_global_batch_size
             rollout_data["num_microbatches"] = num_microbatches_per_step
-            if per_rank_mbs_indices is not None:
-                rollout_data["micro_batch_indices"] = per_rank_mbs_indices[r]
+            rollout_data["micro_batch_indices"] = per_rank_mbs_indices[r]
             rollout_data_refs.append(Box(ray.put(rollout_data)))
         return rollout_data_refs
 

--- a/slime/ray/rollout.py
+++ b/slime/ray/rollout.py
@@ -783,10 +783,6 @@ class RolloutManager:
         if self.args.use_dynamic_batch_size:
             assert self.args.max_tokens_per_gpu is not None
             max_per_bin = self.args.max_tokens_per_gpu * cp_size
-            longest = max(total_lengths)
-            assert (
-                longest <= max_per_bin
-            ), f"sample with length {longest} exceeds max_tokens_per_gpu * cp_size = {max_per_bin}"
 
         # Accumulated outputs of the per-step loop below. Indexed by DP rank.
         #   per_rank_sample_indices[r] — global sample indices assigned to rank r,

--- a/slime/utils/data.py
+++ b/slime/utils/data.py
@@ -282,18 +282,30 @@ class Dataset:
         return len(self.samples)
 
 
-def get_minimum_num_micro_batch_size(total_lengths, max_tokens_per_gpu):
-    # use first fit to get the number of micro batches
-    batches = []
-    for length in total_lengths:
-        for i in range(len(batches)):
-            if batches[i] + length <= max_tokens_per_gpu:
-                batches[i] += length
+def first_fit_pack(total_lengths, max_tokens_per_bin):
+    """First-fit bin packing.
+
+    Returns ``list[list[int]]`` — each bin is a list of indices into ``total_lengths``
+    whose sum is ``<= max_tokens_per_bin``. Assumes every individual ``length`` already
+    fits within ``max_tokens_per_bin`` (caller should assert this).
+    """
+    bins: list[list[int]] = []
+    bin_sums: list[int] = []
+    for idx, length in enumerate(total_lengths):
+        for j in range(len(bins)):
+            if bin_sums[j] + length <= max_tokens_per_bin:
+                bins[j].append(idx)
+                bin_sums[j] += length
                 break
         else:
-            batches.append(length)
+            bins.append([idx])
+            bin_sums.append(length)
+    return bins
 
-    return len(batches)
+
+def get_minimum_num_micro_batch_size(total_lengths, max_tokens_per_gpu):
+    # use first fit to get the number of micro batches
+    return len(first_fit_pack(total_lengths, max_tokens_per_gpu))
 
 
 def process_rollout_data(args, rollout_data_ref, dp_rank, dp_size):

--- a/slime/utils/data.py
+++ b/slime/utils/data.py
@@ -285,9 +285,9 @@ class Dataset:
 def first_fit_pack(total_lengths, max_tokens_per_bin):
     """First-fit bin packing.
 
-    Returns ``list[list[int]]`` — each bin is a list of indices into ``total_lengths``
-    whose sum is ``<= max_tokens_per_bin``. Assumes every individual ``length`` already
-    fits within ``max_tokens_per_bin`` (caller should assert this).
+    Returns ``list[list[int]]`` — each bin is a list of indices into ``total_lengths``.
+    Bin sums are ``<= max_tokens_per_bin`` whenever every individual ``length`` fits;
+    an oversized sample lands alone in its own bin with sum equal to its length.
     """
     bins: list[list[int]] = []
     bin_sums: list[int] = []

--- a/slime/utils/data.py
+++ b/slime/utils/data.py
@@ -282,32 +282,6 @@ class Dataset:
         return len(self.samples)
 
 
-def first_fit_pack(total_lengths, max_tokens_per_bin):
-    """First-fit bin packing.
-
-    Returns ``list[list[int]]`` — each bin is a list of indices into ``total_lengths``.
-    Bin sums are ``<= max_tokens_per_bin`` whenever every individual ``length`` fits;
-    an oversized sample lands alone in its own bin with sum equal to its length.
-    """
-    bins: list[list[int]] = []
-    bin_sums: list[int] = []
-    for idx, length in enumerate(total_lengths):
-        for j in range(len(bins)):
-            if bin_sums[j] + length <= max_tokens_per_bin:
-                bins[j].append(idx)
-                bin_sums[j] += length
-                break
-        else:
-            bins.append([idx])
-            bin_sums.append(length)
-    return bins
-
-
-def get_minimum_num_micro_batch_size(total_lengths, max_tokens_per_gpu):
-    # use first fit to get the number of micro batches
-    return len(first_fit_pack(total_lengths, max_tokens_per_gpu))
-
-
 def process_rollout_data(args, rollout_data_ref, dp_rank, dp_size):
     assert len(rollout_data_ref) == dp_size
     rollout_data = ray.get(rollout_data_ref[dp_rank].inner)

--- a/slime/utils/dp_schedule.py
+++ b/slime/utils/dp_schedule.py
@@ -1,8 +1,13 @@
 """Per-rollout DP/microbatch scheduling.
 
-Pure-Python logic that turns collected rollout samples into per-DP-rank training
-shards plus the micro-batch schedule each rank will follow. Lives outside the
-ray/sglang-importing modules so it can be unit-tested under CPU-only CI.
+Pure-Python logic that turns the (already-trimmed) collected rollout samples into
+per-DP-rank training shards plus the micro-batch schedule each rank will follow.
+Lives outside the ray/sglang-importing modules so it can be unit-tested under
+CPU-only CI.
+
+Trim and dynamic-global_batch_size resolution stay on the caller's side; this
+module just consumes the resolved ``global_batch_size`` and assumes ``data`` is
+already a multiple of it.
 
 Invariants guaranteed by :func:`build_dp_rollout_data` (asserted by the tests):
   - every DP rank holds the same number of samples (``num_samples // dp_size``);
@@ -18,14 +23,9 @@ Invariants guaranteed by :func:`build_dp_rollout_data` (asserted by the tests):
 
 from __future__ import annotations
 
-import logging
 from typing import Any
 
-from slime.utils.data import first_fit_pack
-from slime.utils.seqlen_balancing import expand_bins_by_splitting, get_seqlen_balanced_partitions
-
-logger = logging.getLogger(__name__)
-
+from slime.utils.seqlen_balancing import expand_bins_by_splitting, first_fit_pack, get_seqlen_balanced_partitions
 
 # Sample-aligned fields: split per-rank using ``partition`` (rank-r's sample indices).
 _SAMPLE_KEYS = (
@@ -63,15 +63,13 @@ def build_dp_rollout_data(
     train_parallel_config: dict,
     data: dict,
     *,
+    global_batch_size: int,
     dynamic_global_batch_size: int | None = None,
 ) -> list[dict]:
     """Return one ``rollout_data`` dict per DP rank.
 
     Pipeline (also see module docstring for invariants):
-      1. Resolve the effective ``global_batch_size`` (the ``dynamic_global_batch_size``
-         arg overrides ``args.global_batch_size`` when provided).
-      2. Trim ``data`` to a multiple of that, unless ``args.disable_rollout_trim_samples``.
-      3. For each training step (chunk of ``global_batch_size`` samples):
+      1. For each training step (chunk of ``global_batch_size`` samples):
          a. Split samples to DP ranks with equal counts (``balance_data`` => token-
             balanced via Karmarkar-Karp, otherwise strided).
          b. Static path: chunk each rank's samples into mbs of ``args.micro_batch_size``.
@@ -79,24 +77,24 @@ def build_dp_rollout_data(
             ``MAX`` across ranks for PP/VPP alignment, then expand each rank to that
             count by splitting its largest multi-sample bins. Split halves are ``<=``
             their parent, so the cap is preserved.
-      4. Materialize each rank's sample list in mbs order so each mbs occupies a
+      2. Materialize each rank's sample list in mbs order so each mbs occupies a
          contiguous range of local positions, then build ``micro_batch_indices``
          pointing at those ranges.
 
-    Mutates ``data`` in place: trims sample-aligned lists when needed and writes
-    ``data["total_lengths"]``.
+    Mutates ``data`` in place: writes ``data["total_lengths"]``. Assumes the caller
+    has already trimmed ``data`` to a multiple of ``global_batch_size``.
 
     Args:
-        args: Namespace with ``global_batch_size``, ``micro_batch_size``,
-            ``use_dynamic_batch_size``, ``max_tokens_per_gpu``, ``balance_data``,
-            ``disable_rollout_trim_samples``.
+        args: Namespace with ``micro_batch_size``, ``use_dynamic_batch_size``,
+            ``max_tokens_per_gpu``, ``balance_data``.
         train_parallel_config: ``{"dp_size", "cp_size", "vpp_size",
             "microbatch_group_size_per_vp_stage"}``.
         data: Rollout dict with at least ``"tokens"`` (list of token id sequences);
             other ``_SAMPLE_KEYS`` are sliced per rank when present.
-        dynamic_global_batch_size: precomputed dynamic gbs to use; if ``None``,
-            ``args.global_batch_size`` is used. Caller should compute this via
-            :func:`compute_dynamic_global_batch_size` to keep that decision local.
+        global_batch_size: samples per training step.
+        dynamic_global_batch_size: if set, stamped onto every per-rank dict so the
+            training side reads the dynamic value instead of the static
+            ``args.global_batch_size``.
 
     Returns:
         List of ``dp_size`` dicts, each ready to be ``ray.put`` and consumed by the
@@ -110,24 +108,6 @@ def build_dp_rollout_data(
     vpp_size = train_parallel_config["vpp_size"]
     mb_group = train_parallel_config["microbatch_group_size_per_vp_stage"]
 
-    # 1. Resolve effective global_batch_size
-    if dynamic_global_batch_size is not None:
-        global_batch_size = dynamic_global_batch_size
-    else:
-        global_batch_size = args.global_batch_size
-
-    # 2. Trim data to a multiple of global_batch_size
-    if not args.disable_rollout_trim_samples:
-        num_samples = len(data["tokens"])
-        trim_len = num_samples // global_batch_size * global_batch_size
-        if trim_len == 0:
-            raise ValueError(f"Not enough samples {num_samples} for global_batch_size {global_batch_size}")
-        if trim_len < num_samples:
-            logger.info(f"Trimmed samples from {num_samples} to {trim_len}")
-            for key, val in data.items():
-                if isinstance(val, list):
-                    data[key] = val[:trim_len]
-
     total_lengths = [len(t) for t in data["tokens"]]
     data["total_lengths"] = total_lengths
     num_steps = len(total_lengths) // global_batch_size
@@ -137,16 +117,16 @@ def build_dp_rollout_data(
         max_per_bin = args.max_tokens_per_gpu * cp_size
 
     # Accumulators indexed by DP rank.
-    #   per_rank_sample_indices[r] — global sample indices going to rank r,
-    #     concatenated across all steps in mbs-order.
+    #   partitions[r] — global sample indices going to rank r, concatenated across
+    #     all steps in mbs-order. Also becomes ``rollout_data["partition"]``.
     #   per_rank_mbs_indices[r] — flat list of mbs (across all steps in order),
-    #     each mbs being LOCAL indices into per_rank_sample_indices[r].
+    #     each mbs being LOCAL indices into partitions[r].
     #   num_microbatches_per_step[s] — same value on every DP rank (PP sync).
-    per_rank_sample_indices: list[list[int]] = [[] for _ in range(dp_size)]
+    partitions: list[list[int]] = [[] for _ in range(dp_size)]
     per_rank_mbs_indices: list[list[list[int]]] = [[] for _ in range(dp_size)]
     num_microbatches_per_step: list[int] = []
 
-    # 3. Per step: DP split, then per-rank mbs schedule.
+    # 1. Per step: DP split, then per-rank mbs schedule.
     for step_i in range(num_steps):
         step_start = step_i * global_batch_size
         step_lengths = total_lengths[step_start : step_start + global_batch_size]
@@ -175,18 +155,18 @@ def build_dp_rollout_data(
 
         num_microbatches_per_step.append(num_mbs_per_rank)
 
-        # 4. Materialize per-rank schedule. Samples are appended in mbs order so each
-        # mbs occupies a contiguous range of positions in per_rank_sample_indices[r].
+        # 2. Materialize per-rank schedule. Samples are appended in mbs order so each
+        # mbs occupies a contiguous range of positions in partitions[r].
         for r in range(dp_size):
             for mbs_local in rank_mbs[r]:
-                local_start = len(per_rank_sample_indices[r])
-                per_rank_sample_indices[r].extend(step_start + rank_parts[r][i] for i in mbs_local)
+                local_start = len(partitions[r])
+                partitions[r].extend(step_start + rank_parts[r][i] for i in mbs_local)
                 per_rank_mbs_indices[r].append(list(range(local_start, local_start + len(mbs_local))))
 
-    # 5. Build per-rank rollout_data dicts (caller wraps in Ray Box).
+    # 3. Build per-rank rollout_data dicts (caller wraps in Ray Box).
     rollout_data_list: list[dict] = []
     for r in range(dp_size):
-        partition = per_rank_sample_indices[r]
+        partition = partitions[r]
         rollout_data: dict = {"partition": partition}
         for key in _SAMPLE_KEYS:
             if key in data:

--- a/slime/utils/dp_schedule.py
+++ b/slime/utils/dp_schedule.py
@@ -1,0 +1,202 @@
+"""Per-rollout DP/microbatch scheduling.
+
+Pure-Python logic that turns collected rollout samples into per-DP-rank training
+shards plus the micro-batch schedule each rank will follow. Lives outside the
+ray/sglang-importing modules so it can be unit-tested under CPU-only CI.
+
+Invariants guaranteed by :func:`build_dp_rollout_data` (asserted by the tests):
+  - every DP rank holds the same number of samples (``num_samples // dp_size``);
+  - every DP rank runs the same ``num_microbatches`` per training step
+    (required for PP sync);
+  - every mbs holds ``<= max_tokens_per_gpu * cp_size`` tokens, with one exception
+    — an individual sample larger than that cap lands alone in its own mbs (and
+    that mbs is the only one allowed to exceed the cap);
+  - the union of per-rank sample indices equals ``range(num_samples)`` and the
+    per-rank index sets are disjoint;
+  - flattening ``micro_batch_indices`` for a rank yields ``range(num_samples_rank)``.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from slime.utils.data import first_fit_pack
+from slime.utils.seqlen_balancing import expand_bins_by_splitting, get_seqlen_balanced_partitions
+
+logger = logging.getLogger(__name__)
+
+
+# Sample-aligned fields: split per-rank using ``partition`` (rank-r's sample indices).
+_SAMPLE_KEYS = (
+    "tokens",
+    "multimodal_train_inputs",
+    "response_lengths",
+    "rewards",
+    "truncated",
+    "loss_masks",
+    "round_number",
+    "sample_indices",
+    "rollout_log_probs",
+    "rollout_routed_experts",
+    "prompt",
+    "teacher_log_probs",
+)
+# Whole-batch fields: passed through unsliced; the training side picks its own slice.
+_PASSTHROUGH_KEYS = ("raw_reward", "total_lengths")
+
+
+def compute_dynamic_global_batch_size(num_samples: int, dp_size: int) -> int:
+    """Round ``num_samples`` down to the nearest multiple of ``dp_size`` (min ``dp_size``).
+
+    Used when ``args.use_dynamic_global_batch_size`` is set, so each rollout produces
+    exactly one training step regardless of how many samples were collected.
+    """
+    dynamic_gbs = (num_samples // dp_size) * dp_size
+    if dynamic_gbs == 0:
+        return dp_size
+    return dynamic_gbs
+
+
+def build_dp_rollout_data(
+    args: Any,
+    train_parallel_config: dict,
+    data: dict,
+    *,
+    dynamic_global_batch_size: int | None = None,
+) -> list[dict]:
+    """Return one ``rollout_data`` dict per DP rank.
+
+    Pipeline (also see module docstring for invariants):
+      1. Resolve the effective ``global_batch_size`` (the ``dynamic_global_batch_size``
+         arg overrides ``args.global_batch_size`` when provided).
+      2. Trim ``data`` to a multiple of that, unless ``args.disable_rollout_trim_samples``.
+      3. For each training step (chunk of ``global_batch_size`` samples):
+         a. Split samples to DP ranks with equal counts (``balance_data`` => token-
+            balanced via Karmarkar-Karp, otherwise strided).
+         b. Static path: chunk each rank's samples into mbs of ``args.micro_batch_size``.
+            Dynamic path: per-rank first-fit (``<= max_tokens_per_gpu * cp_size``), take
+            ``MAX`` across ranks for PP/VPP alignment, then expand each rank to that
+            count by splitting its largest multi-sample bins. Split halves are ``<=``
+            their parent, so the cap is preserved.
+      4. Materialize each rank's sample list in mbs order so each mbs occupies a
+         contiguous range of local positions, then build ``micro_batch_indices``
+         pointing at those ranges.
+
+    Mutates ``data`` in place: trims sample-aligned lists when needed and writes
+    ``data["total_lengths"]``.
+
+    Args:
+        args: Namespace with ``global_batch_size``, ``micro_batch_size``,
+            ``use_dynamic_batch_size``, ``max_tokens_per_gpu``, ``balance_data``,
+            ``disable_rollout_trim_samples``.
+        train_parallel_config: ``{"dp_size", "cp_size", "vpp_size",
+            "microbatch_group_size_per_vp_stage"}``.
+        data: Rollout dict with at least ``"tokens"`` (list of token id sequences);
+            other ``_SAMPLE_KEYS`` are sliced per rank when present.
+        dynamic_global_batch_size: precomputed dynamic gbs to use; if ``None``,
+            ``args.global_batch_size`` is used. Caller should compute this via
+            :func:`compute_dynamic_global_batch_size` to keep that decision local.
+
+    Returns:
+        List of ``dp_size`` dicts, each ready to be ``ray.put`` and consumed by the
+        training side. Each dict carries: ``partition`` (global sample indices for
+        that rank), the sliced ``_SAMPLE_KEYS``, the passthrough ``_PASSTHROUGH_KEYS``,
+        ``num_microbatches`` (same list on every rank), ``micro_batch_indices``
+        (rank-local), and ``dynamic_global_batch_size`` when applicable.
+    """
+    dp_size = train_parallel_config["dp_size"]
+    cp_size = train_parallel_config["cp_size"]
+    vpp_size = train_parallel_config["vpp_size"]
+    mb_group = train_parallel_config["microbatch_group_size_per_vp_stage"]
+
+    # 1. Resolve effective global_batch_size
+    if dynamic_global_batch_size is not None:
+        global_batch_size = dynamic_global_batch_size
+    else:
+        global_batch_size = args.global_batch_size
+
+    # 2. Trim data to a multiple of global_batch_size
+    if not args.disable_rollout_trim_samples:
+        num_samples = len(data["tokens"])
+        trim_len = num_samples // global_batch_size * global_batch_size
+        if trim_len == 0:
+            raise ValueError(f"Not enough samples {num_samples} for global_batch_size {global_batch_size}")
+        if trim_len < num_samples:
+            logger.info(f"Trimmed samples from {num_samples} to {trim_len}")
+            for key, val in data.items():
+                if isinstance(val, list):
+                    data[key] = val[:trim_len]
+
+    total_lengths = [len(t) for t in data["tokens"]]
+    data["total_lengths"] = total_lengths
+    num_steps = len(total_lengths) // global_batch_size
+
+    if args.use_dynamic_batch_size:
+        assert args.max_tokens_per_gpu is not None
+        max_per_bin = args.max_tokens_per_gpu * cp_size
+
+    # Accumulators indexed by DP rank.
+    #   per_rank_sample_indices[r] — global sample indices going to rank r,
+    #     concatenated across all steps in mbs-order.
+    #   per_rank_mbs_indices[r] — flat list of mbs (across all steps in order),
+    #     each mbs being LOCAL indices into per_rank_sample_indices[r].
+    #   num_microbatches_per_step[s] — same value on every DP rank (PP sync).
+    per_rank_sample_indices: list[list[int]] = [[] for _ in range(dp_size)]
+    per_rank_mbs_indices: list[list[list[int]]] = [[] for _ in range(dp_size)]
+    num_microbatches_per_step: list[int] = []
+
+    # 3. Per step: DP split, then per-rank mbs schedule.
+    for step_i in range(num_steps):
+        step_start = step_i * global_batch_size
+        step_lengths = total_lengths[step_start : step_start + global_batch_size]
+
+        if args.balance_data:
+            rank_parts = get_seqlen_balanced_partitions(step_lengths, dp_size, equal_size=True)
+        else:
+            rank_parts = [list(range(r, global_batch_size, dp_size)) for r in range(dp_size)]
+
+        # rank_mbs[r][k] is one mbs of LOCAL indices into rank_parts[r] (positions
+        # within this rank's sample list, not step- or global-indices).
+        if not args.use_dynamic_batch_size:
+            mbs = args.micro_batch_size
+            n = len(rank_parts[0])  # gbs / dp, same for every rank
+            rank_mbs = [[list(range(i, i + mbs)) for i in range(0, n, mbs)] for _ in range(dp_size)]
+            num_mbs_per_rank = n // mbs
+        else:
+            rank_lens = [[step_lengths[i] for i in rank_parts[r]] for r in range(dp_size)]
+            rank_mbs = [first_fit_pack(rank_lens[r], max_per_bin) for r in range(dp_size)]
+            num_mbs_per_rank = max(len(b) for b in rank_mbs)
+            if vpp_size > 1:
+                # Match the original floor-to-mb_group rounding (with min=1).
+                num_mbs_per_rank = max(num_mbs_per_rank // mb_group * mb_group, 1)
+            for r in range(dp_size):
+                expand_bins_by_splitting(rank_mbs[r], num_mbs_per_rank, rank_lens[r])
+
+        num_microbatches_per_step.append(num_mbs_per_rank)
+
+        # 4. Materialize per-rank schedule. Samples are appended in mbs order so each
+        # mbs occupies a contiguous range of positions in per_rank_sample_indices[r].
+        for r in range(dp_size):
+            for mbs_local in rank_mbs[r]:
+                local_start = len(per_rank_sample_indices[r])
+                per_rank_sample_indices[r].extend(step_start + rank_parts[r][i] for i in mbs_local)
+                per_rank_mbs_indices[r].append(list(range(local_start, local_start + len(mbs_local))))
+
+    # 5. Build per-rank rollout_data dicts (caller wraps in Ray Box).
+    rollout_data_list: list[dict] = []
+    for r in range(dp_size):
+        partition = per_rank_sample_indices[r]
+        rollout_data: dict = {"partition": partition}
+        for key in _SAMPLE_KEYS:
+            if key in data:
+                rollout_data[key] = [data[key][j] for j in partition]
+        for key in _PASSTHROUGH_KEYS:
+            if key in data:
+                rollout_data[key] = data[key]
+        if dynamic_global_batch_size is not None:
+            rollout_data["dynamic_global_batch_size"] = dynamic_global_batch_size
+        rollout_data["num_microbatches"] = num_microbatches_per_step
+        rollout_data["micro_batch_indices"] = per_rank_mbs_indices[r]
+        rollout_data_list.append(rollout_data)
+    return rollout_data_list

--- a/slime/utils/dp_schedule.py
+++ b/slime/utils/dp_schedule.py
@@ -1,24 +1,25 @@
 """Per-rollout DP/microbatch scheduling.
 
-Pure-Python logic that turns the (already-trimmed) collected rollout samples into
-per-DP-rank training shards plus the micro-batch schedule each rank will follow.
-Lives outside the ray/sglang-importing modules so it can be unit-tested under
-CPU-only CI.
+Pure-Python logic that decides, for one (already-trimmed) rollout's worth of
+sample lengths, which global sample goes to which DP rank and how each rank
+groups its samples into micro-batches. Lives outside the ray/sglang-importing
+modules so it can be unit-tested under CPU-only CI.
 
-Trim and dynamic-global_batch_size resolution stay on the caller's side; this
-module just consumes the resolved ``global_batch_size`` and assumes ``data`` is
-already a multiple of it.
+Trim, dynamic-global_batch_size resolution, and per-rank rollout_data
+packaging all stay on the caller's side; this module only computes the
+schedule itself.
 
-Invariants guaranteed by :func:`build_dp_rollout_data` (asserted by the tests):
+Invariants guaranteed by :func:`build_dp_schedule` (asserted by the tests):
   - every DP rank holds the same number of samples (``num_samples // dp_size``);
   - every DP rank runs the same ``num_microbatches`` per training step
     (required for PP sync);
-  - every mbs holds ``<= max_tokens_per_gpu * cp_size`` tokens, with one exception
-    — an individual sample larger than that cap lands alone in its own mbs (and
-    that mbs is the only one allowed to exceed the cap);
-  - the union of per-rank sample indices equals ``range(num_samples)`` and the
-    per-rank index sets are disjoint;
-  - flattening ``micro_batch_indices`` for a rank yields ``range(num_samples_rank)``.
+  - every mbs holds ``<= max_tokens_per_gpu * cp_size`` tokens, with one
+    exception — an individual sample larger than that cap lands alone in its
+    own mbs (and that mbs is the only one allowed to exceed the cap);
+  - the union of per-rank sample indices equals ``range(num_samples)`` and
+    the per-rank index sets are disjoint;
+  - flattening ``micro_batch_indices`` for a rank yields
+    ``range(num_samples_rank)``.
 """
 
 from __future__ import annotations
@@ -26,24 +27,6 @@ from __future__ import annotations
 from typing import Any
 
 from slime.utils.seqlen_balancing import expand_bins_by_splitting, first_fit_pack, get_seqlen_balanced_partitions
-
-# Sample-aligned fields: split per-rank using ``partition`` (rank-r's sample indices).
-_SAMPLE_KEYS = (
-    "tokens",
-    "multimodal_train_inputs",
-    "response_lengths",
-    "rewards",
-    "truncated",
-    "loss_masks",
-    "round_number",
-    "sample_indices",
-    "rollout_log_probs",
-    "rollout_routed_experts",
-    "prompt",
-    "teacher_log_probs",
-)
-# Whole-batch fields: passed through unsliced; the training side picks its own slice.
-_PASSTHROUGH_KEYS = ("raw_reward", "total_lengths")
 
 
 def compute_dynamic_global_batch_size(num_samples: int, dp_size: int) -> int:
@@ -58,75 +41,59 @@ def compute_dynamic_global_batch_size(num_samples: int, dp_size: int) -> int:
     return dynamic_gbs
 
 
-def build_dp_rollout_data(
+def build_dp_schedule(
     args: Any,
     train_parallel_config: dict,
-    data: dict,
+    total_lengths: list[int],
     *,
     global_batch_size: int,
-    dynamic_global_batch_size: int | None = None,
-) -> list[dict]:
-    """Return one ``rollout_data`` dict per DP rank.
+) -> tuple[list[list[int]], list[list[list[int]]], list[int]]:
+    """Compute the per-rank DP partition and micro-batch schedule.
 
-    Pipeline (also see module docstring for invariants):
-      1. For each training step (chunk of ``global_batch_size`` samples):
-         a. Split samples to DP ranks with equal counts (``balance_data`` => token-
-            balanced via Karmarkar-Karp, otherwise strided).
-         b. Static path: chunk each rank's samples into mbs of ``args.micro_batch_size``.
-            Dynamic path: per-rank first-fit (``<= max_tokens_per_gpu * cp_size``), take
-            ``MAX`` across ranks for PP/VPP alignment, then expand each rank to that
-            count by splitting its largest multi-sample bins. Split halves are ``<=``
-            their parent, so the cap is preserved.
-      2. Materialize each rank's sample list in mbs order so each mbs occupies a
-         contiguous range of local positions, then build ``micro_batch_indices``
-         pointing at those ranges.
+    For each training step (chunk of ``global_batch_size`` samples):
+      a. Split samples to DP ranks with equal counts (``balance_data`` => token-
+         balanced via Karmarkar-Karp, otherwise strided).
+      b. Static path: chunk each rank's samples into mbs of ``args.micro_batch_size``.
+         Dynamic path: per-rank first-fit (``<= max_tokens_per_gpu * cp_size``), take
+         ``MAX`` across ranks for PP/VPP alignment, then expand each rank to that
+         count by splitting its largest multi-sample bins. Split halves are ``<=``
+         their parent, so the cap is preserved.
 
-    Mutates ``data`` in place: writes ``data["total_lengths"]``. Assumes the caller
-    has already trimmed ``data`` to a multiple of ``global_batch_size``.
+    Samples are appended to ``partitions[r]`` in mbs order so each mbs occupies a
+    contiguous range of positions there; ``micro_batch_indices[r][k]`` is that range.
 
     Args:
         args: Namespace with ``micro_batch_size``, ``use_dynamic_batch_size``,
             ``max_tokens_per_gpu``, ``balance_data``.
         train_parallel_config: ``{"dp_size", "cp_size", "vpp_size",
             "microbatch_group_size_per_vp_stage"}``.
-        data: Rollout dict with at least ``"tokens"`` (list of token id sequences);
-            other ``_SAMPLE_KEYS`` are sliced per rank when present.
+        total_lengths: token count per sample, length must be a multiple of
+            ``global_batch_size``.
         global_batch_size: samples per training step.
-        dynamic_global_batch_size: if set, stamped onto every per-rank dict so the
-            training side reads the dynamic value instead of the static
-            ``args.global_batch_size``.
 
     Returns:
-        List of ``dp_size`` dicts, each ready to be ``ray.put`` and consumed by the
-        training side. Each dict carries: ``partition`` (global sample indices for
-        that rank), the sliced ``_SAMPLE_KEYS``, the passthrough ``_PASSTHROUGH_KEYS``,
-        ``num_microbatches`` (same list on every rank), ``micro_batch_indices``
-        (rank-local), and ``dynamic_global_batch_size`` when applicable.
+        ``(partitions, micro_batch_indices, num_microbatches)``:
+          - ``partitions[r]`` — global sample indices going to rank r, concatenated
+            across all steps in mbs order.
+          - ``micro_batch_indices[r][k]`` — local indices into ``partitions[r]`` for
+            the k-th mbs of rank r (flat across all steps).
+          - ``num_microbatches[s]`` — mbs count for step s; same value on every rank.
     """
     dp_size = train_parallel_config["dp_size"]
     cp_size = train_parallel_config["cp_size"]
     vpp_size = train_parallel_config["vpp_size"]
     mb_group = train_parallel_config["microbatch_group_size_per_vp_stage"]
 
-    total_lengths = [len(t) for t in data["tokens"]]
-    data["total_lengths"] = total_lengths
     num_steps = len(total_lengths) // global_batch_size
 
     if args.use_dynamic_batch_size:
         assert args.max_tokens_per_gpu is not None
         max_per_bin = args.max_tokens_per_gpu * cp_size
 
-    # Accumulators indexed by DP rank.
-    #   partitions[r] — global sample indices going to rank r, concatenated across
-    #     all steps in mbs-order. Also becomes ``rollout_data["partition"]``.
-    #   per_rank_mbs_indices[r] — flat list of mbs (across all steps in order),
-    #     each mbs being LOCAL indices into partitions[r].
-    #   num_microbatches_per_step[s] — same value on every DP rank (PP sync).
     partitions: list[list[int]] = [[] for _ in range(dp_size)]
-    per_rank_mbs_indices: list[list[list[int]]] = [[] for _ in range(dp_size)]
-    num_microbatches_per_step: list[int] = []
+    micro_batch_indices: list[list[list[int]]] = [[] for _ in range(dp_size)]
+    num_microbatches: list[int] = []
 
-    # 1. Per step: DP split, then per-rank mbs schedule.
     for step_i in range(num_steps):
         step_start = step_i * global_batch_size
         step_lengths = total_lengths[step_start : step_start + global_batch_size]
@@ -153,30 +120,12 @@ def build_dp_rollout_data(
             for r in range(dp_size):
                 expand_bins_by_splitting(rank_mbs[r], num_mbs_per_rank, rank_lens[r])
 
-        num_microbatches_per_step.append(num_mbs_per_rank)
+        num_microbatches.append(num_mbs_per_rank)
 
-        # 2. Materialize per-rank schedule. Samples are appended in mbs order so each
-        # mbs occupies a contiguous range of positions in partitions[r].
         for r in range(dp_size):
             for mbs_local in rank_mbs[r]:
                 local_start = len(partitions[r])
                 partitions[r].extend(step_start + rank_parts[r][i] for i in mbs_local)
-                per_rank_mbs_indices[r].append(list(range(local_start, local_start + len(mbs_local))))
+                micro_batch_indices[r].append(list(range(local_start, local_start + len(mbs_local))))
 
-    # 3. Build per-rank rollout_data dicts (caller wraps in Ray Box).
-    rollout_data_list: list[dict] = []
-    for r in range(dp_size):
-        partition = partitions[r]
-        rollout_data: dict = {"partition": partition}
-        for key in _SAMPLE_KEYS:
-            if key in data:
-                rollout_data[key] = [data[key][j] for j in partition]
-        for key in _PASSTHROUGH_KEYS:
-            if key in data:
-                rollout_data[key] = data[key]
-        if dynamic_global_batch_size is not None:
-            rollout_data["dynamic_global_batch_size"] = dynamic_global_batch_size
-        rollout_data["num_microbatches"] = num_microbatches_per_step
-        rollout_data["micro_batch_indices"] = per_rank_mbs_indices[r]
-        rollout_data_list.append(rollout_data)
-    return rollout_data_list
+    return partitions, micro_batch_indices, num_microbatches

--- a/slime/utils/seqlen_balancing.py
+++ b/slime/utils/seqlen_balancing.py
@@ -177,6 +177,27 @@ def get_seqlen_balanced_partitions(seqlen_list: list[int], k_partitions: int, eq
     return _check_and_sort_partitions(partitions)
 
 
+def first_fit_pack(total_lengths, max_tokens_per_bin):
+    """First-fit bin packing.
+
+    Returns ``list[list[int]]`` — each bin is a list of indices into ``total_lengths``.
+    Bin sums are ``<= max_tokens_per_bin`` whenever every individual ``length`` fits;
+    an oversized sample lands alone in its own bin with sum equal to its length.
+    """
+    bins: list[list[int]] = []
+    bin_sums: list[int] = []
+    for idx, length in enumerate(total_lengths):
+        for j in range(len(bins)):
+            if bin_sums[j] + length <= max_tokens_per_bin:
+                bins[j].append(idx)
+                bin_sums[j] += length
+                break
+        else:
+            bins.append([idx])
+            bin_sums.append(length)
+    return bins
+
+
 def _split_bin_by_tokens(bin_indices: list[int], lengths) -> list[list[int]]:
     """Split a bin's indices into two halves balanced by total tokens (LPT heuristic).
 

--- a/slime/utils/seqlen_balancing.py
+++ b/slime/utils/seqlen_balancing.py
@@ -177,6 +177,37 @@ def get_seqlen_balanced_partitions(seqlen_list: list[int], k_partitions: int, eq
     return _check_and_sort_partitions(partitions)
 
 
+def _split_bin_by_tokens(bin_indices: list[int], lengths) -> list[list[int]]:
+    """Split a bin's indices into two halves balanced by total tokens (LPT heuristic).
+
+    Returns ``[left, right]`` where both lists together cover ``bin_indices``. Because
+    each half is a strict subset of ``bin_indices``, both have token sums ``<=`` the
+    original bin's sum — useful when you need to grow a bin packing without ever
+    creating a bin larger than the originals.
+    """
+    halves: list[list[int]] = [[], []]
+    sums = [0, 0]
+    for idx in sorted(bin_indices, key=lambda i: -lengths[i]):
+        h = 0 if sums[0] <= sums[1] else 1
+        halves[h].append(idx)
+        sums[h] += lengths[idx]
+    return halves
+
+
+def expand_bins_by_splitting(bins: list[list[int]], target_count: int, lengths) -> None:
+    """Grow ``bins`` in place to ``target_count`` by repeatedly splitting the largest
+    multi-sample bin via :func:`_split_bin_by_tokens`. Stops early if every remaining
+    bin is a singleton (no bin can be split further)."""
+    while len(bins) < target_count:
+        candidates = [(sum(lengths[i] for i in b), idx) for idx, b in enumerate(bins) if len(b) > 1]
+        if not candidates:
+            break
+        _, idx = max(candidates)
+        left, right = _split_bin_by_tokens(bins[idx], lengths)
+        bins[idx] = left
+        bins.append(right)
+
+
 def get_reverse_idx(idx_map):
     reverse_idx_map = copy.deepcopy(idx_map)
 

--- a/tests/test_dp_schedule.py
+++ b/tests/test_dp_schedule.py
@@ -1,18 +1,18 @@
-"""CPU unit tests for slime.utils.dp_schedule.build_dp_rollout_data.
+"""CPU unit tests for slime.utils.dp_schedule.build_dp_schedule.
 
-The tests assert the invariants documented at the top of dp_schedule.py against a
-range of static / dynamic / VPP / oversize / balance scenarios.
+The tests assert the invariants documented at the top of dp_schedule.py against
+a range of static / dynamic / VPP / oversize / balance scenarios.
 
-Trim and dynamic-gbs resolution live in the caller (``RolloutManager``), so these
-tests just hand ``build_dp_rollout_data`` a ``data`` dict whose ``tokens`` length
-is already a multiple of the supplied ``global_batch_size``.
+Trim, dynamic-gbs resolution, and per-rank rollout_data packaging all live in
+``RolloutManager._split_train_data_by_dp``; these tests just exercise the
+schedule itself (``partitions`` and ``micro_batch_indices``).
 """
 
 from types import SimpleNamespace
 
 import pytest
 
-from slime.utils.dp_schedule import build_dp_rollout_data, compute_dynamic_global_batch_size
+from slime.utils.dp_schedule import build_dp_schedule, compute_dynamic_global_batch_size
 
 
 def make_args(
@@ -39,33 +39,24 @@ def make_tp(dp_size=1, cp_size=1, vpp_size=1, microbatch_group_size_per_vp_stage
     }
 
 
-def make_data(lengths):
-    """``data["tokens"][i]`` is a list of ``lengths[i]`` placeholder token ids."""
-    return {"tokens": [list(range(L)) for L in lengths]}
-
-
-def assert_invariants(rollout_data_list, *, dp_size, total_lengths, max_per_bin=None):
+def assert_invariants(partitions, micro_batch_indices, num_microbatches, *, dp_size, total_lengths, max_per_bin=None):
     """Check the invariants documented at the top of dp_schedule.py."""
-    # All ranks see the same num_microbatches list (PP-sync requirement).
-    nmb = rollout_data_list[0]["num_microbatches"]
-    for r in range(1, dp_size):
-        assert rollout_data_list[r]["num_microbatches"] == nmb, "num_microbatches diverged across ranks"
-
     expected_per_rank = len(total_lengths) // dp_size
     seen_global: set[int] = set()
     for r in range(dp_size):
-        rd = rollout_data_list[r]
-        partition = rd["partition"]
+        partition = partitions[r]
+        mbi = micro_batch_indices[r]
 
         # Same sample count per rank.
         assert len(partition) == expected_per_rank, f"rank {r}: {len(partition)} samples, want {expected_per_rank}"
 
-        # Each rank has sum(nmb) micro-batches.
-        assert len(rd["micro_batch_indices"]) == sum(nmb), f"rank {r}: mbs count mismatch"
+        # Same num_mbs per rank (PP sync); num_microbatches is shared, so each rank's
+        # flat mbs count must match sum(num_microbatches).
+        assert len(mbi) == sum(num_microbatches), f"rank {r}: mbs count mismatch"
 
-        # Flattened micro_batch_indices == range(len(partition)) (each sample covered once
-        # by exactly one mbs).
-        flat = [i for mbs in rd["micro_batch_indices"] for i in mbs]
+        # Flattened micro_batch_indices == range(len(partition)) (each sample covered
+        # exactly once, by exactly one mbs).
+        flat = [i for mbs in mbi for i in mbs]
         assert flat == list(range(len(partition))), f"rank {r}: micro_batch_indices don't tile [0, n)"
 
         # Disjoint partitions whose union covers every sample.
@@ -78,9 +69,8 @@ def assert_invariants(rollout_data_list, *, dp_size, total_lengths, max_per_bin=
 
     # Every mbs <= max_per_bin tokens, EXCEPT a singleton bin holding an oversized sample.
     for r in range(dp_size):
-        rd = rollout_data_list[r]
-        partition = rd["partition"]
-        for mbs in rd["micro_batch_indices"]:
+        partition = partitions[r]
+        for mbs in micro_batch_indices[r]:
             bin_total = sum(total_lengths[partition[i]] for i in mbs)
             if bin_total > max_per_bin:
                 assert len(mbs) == 1, f"rank {r}: mbs sum {bin_total} > {max_per_bin} but contains {len(mbs)} samples"
@@ -89,79 +79,73 @@ def assert_invariants(rollout_data_list, *, dp_size, total_lengths, max_per_bin=
 @pytest.mark.unit
 def test_static_stride_single_step():
     """Static + strided DP split, single step."""
-    lengths = [10] * 16
-    data = make_data(lengths)
+    total_lengths = [10] * 16
     args = make_args(micro_batch_size=2)
     tp = make_tp(dp_size=4)
 
-    out = build_dp_rollout_data(args, tp, data, global_batch_size=16)
+    partitions, mbi, nmb = build_dp_schedule(args, tp, total_lengths, global_batch_size=16)
 
-    assert len(out) == 4
-    assert out[0]["num_microbatches"] == [2]
-    assert_invariants(out, dp_size=4, total_lengths=lengths)
+    assert nmb == [2]
+    assert_invariants(partitions, mbi, nmb, dp_size=4, total_lengths=total_lengths)
 
 
 @pytest.mark.unit
 def test_static_balance_multi_step():
     """Static + balance_data + 2 training steps. Each rank must get gbs/dp per step."""
-    lengths = [1, 2, 3, 4, 5, 6, 7, 8, 8, 7, 6, 5, 4, 3, 2, 1]  # 2 steps of 8
-    data = make_data(lengths)
+    total_lengths = [1, 2, 3, 4, 5, 6, 7, 8, 8, 7, 6, 5, 4, 3, 2, 1]  # 2 steps of 8
     args = make_args(micro_batch_size=2, balance_data=True)
     tp = make_tp(dp_size=2)
 
-    out = build_dp_rollout_data(args, tp, data, global_batch_size=8)
+    partitions, mbi, nmb = build_dp_schedule(args, tp, total_lengths, global_batch_size=8)
 
-    assert out[0]["num_microbatches"] == [2, 2]
-    assert_invariants(out, dp_size=2, total_lengths=lengths)
+    assert nmb == [2, 2]
+    assert_invariants(partitions, mbi, nmb, dp_size=2, total_lengths=total_lengths)
 
 
 @pytest.mark.unit
 def test_dynamic_uniform():
     """Dynamic mbs on uniform-length samples."""
-    lengths = [5] * 8
-    data = make_data(lengths)
+    total_lengths = [5] * 8
     args = make_args(use_dynamic_batch_size=True, max_tokens_per_gpu=10)
     tp = make_tp(dp_size=2)
 
-    out = build_dp_rollout_data(args, tp, data, global_batch_size=8)
+    partitions, mbi, nmb = build_dp_schedule(args, tp, total_lengths, global_batch_size=8)
 
-    assert_invariants(out, dp_size=2, total_lengths=lengths, max_per_bin=10)
+    assert_invariants(partitions, mbi, nmb, dp_size=2, total_lengths=total_lengths, max_per_bin=10)
 
 
 @pytest.mark.unit
 def test_dynamic_skewed_lengths():
     """Skewed lengths (the case where K-K used to over-pack a single bin)."""
-    lengths = [9, 9, 9, 9, 1, 1, 1, 1]
-    data = make_data(lengths)
+    total_lengths = [9, 9, 9, 9, 1, 1, 1, 1]
     args = make_args(use_dynamic_batch_size=True, max_tokens_per_gpu=10)
     tp = make_tp(dp_size=2)
 
-    out = build_dp_rollout_data(args, tp, data, global_batch_size=8)
+    partitions, mbi, nmb = build_dp_schedule(args, tp, total_lengths, global_batch_size=8)
 
-    assert_invariants(out, dp_size=2, total_lengths=lengths, max_per_bin=10)
+    assert_invariants(partitions, mbi, nmb, dp_size=2, total_lengths=total_lengths, max_per_bin=10)
 
 
 @pytest.mark.unit
 def test_dynamic_oversized_sample_lands_alone():
     """A single sample exceeding max_per_bin must end up alone in its mbs (with no
     other samples crammed in)."""
-    lengths = [15, 3, 3, 3, 3, 3, 3, 3]  # 15 > C=10
-    data = make_data(lengths)
+    total_lengths = [15, 3, 3, 3, 3, 3, 3, 3]  # 15 > C=10
     args = make_args(use_dynamic_batch_size=True, max_tokens_per_gpu=10)
     tp = make_tp(dp_size=2)
 
-    out = build_dp_rollout_data(args, tp, data, global_batch_size=8)
+    partitions, mbi, nmb = build_dp_schedule(args, tp, total_lengths, global_batch_size=8)
 
-    assert_invariants(out, dp_size=2, total_lengths=lengths, max_per_bin=10)
+    assert_invariants(partitions, mbi, nmb, dp_size=2, total_lengths=total_lengths, max_per_bin=10)
     # Find the rank holding the oversized sample and verify it lives alone in some mbs.
-    oversize_idx = lengths.index(15)
+    oversize_idx = total_lengths.index(15)
     found = False
     for r in range(2):
-        partition = out[r]["partition"]
+        partition = partitions[r]
         if oversize_idx not in partition:
             continue
         local = partition.index(oversize_idx)
-        for mbs in out[r]["micro_batch_indices"]:
+        for mbs in mbi[r]:
             if local in mbs:
                 assert mbs == [local], f"oversized sample shares an mbs: {mbs}"
                 found = True
@@ -171,32 +155,15 @@ def test_dynamic_oversized_sample_lands_alone():
 @pytest.mark.unit
 def test_dynamic_with_vpp_rounds_to_mb_group():
     """num_microbatches per rank should be a multiple of mb_group when vpp_size > 1."""
-    lengths = [4] * 32  # 2 steps of 16; per step, ~8 bins of 8 needed at C=8
-    data = make_data(lengths)
+    total_lengths = [4] * 32  # 2 steps of 16; per step, ~8 bins of 8 needed at C=8
     args = make_args(use_dynamic_batch_size=True, max_tokens_per_gpu=8)
     tp = make_tp(dp_size=2, vpp_size=2, microbatch_group_size_per_vp_stage=2)
 
-    out = build_dp_rollout_data(args, tp, data, global_batch_size=16)
+    partitions, mbi, nmb = build_dp_schedule(args, tp, total_lengths, global_batch_size=16)
 
-    nmb = out[0]["num_microbatches"]
     for n in nmb:
         assert n % 2 == 0, f"num_microbatches {n} is not a multiple of mb_group=2"
-    assert_invariants(out, dp_size=2, total_lengths=lengths, max_per_bin=8)
-
-
-@pytest.mark.unit
-def test_dynamic_global_batch_size_stamped_on_rollout_data():
-    """When dynamic_global_batch_size is passed it should appear on every per-rank dict."""
-    lengths = [4] * 8
-    data = make_data(lengths)
-    args = make_args(micro_batch_size=1)
-    tp = make_tp(dp_size=4)
-
-    out = build_dp_rollout_data(args, tp, data, global_batch_size=8, dynamic_global_batch_size=8)
-
-    assert out[0]["num_microbatches"] == [2]
-    for r in range(4):
-        assert out[r]["dynamic_global_batch_size"] == 8
+    assert_invariants(partitions, mbi, nmb, dp_size=2, total_lengths=total_lengths, max_per_bin=8)
 
 
 @pytest.mark.unit
@@ -206,25 +173,6 @@ def test_compute_dynamic_global_batch_size_floor_and_min():
     assert compute_dynamic_global_batch_size(16, 4) == 16
     # Fewer samples than dp_size: clamp to dp_size so we still produce a valid mbs.
     assert compute_dynamic_global_batch_size(2, 4) == 4
-
-
-@pytest.mark.unit
-def test_sample_aligned_fields_are_sliced_by_partition():
-    """``rewards`` (sample-aligned) should be sliced per rank; ``raw_reward``
-    (passthrough) should appear verbatim."""
-    lengths = [3] * 8
-    data = make_data(lengths)
-    data["rewards"] = list(range(100, 108))  # one per sample
-    data["raw_reward"] = "passthrough"  # whole-batch field
-    args = make_args(micro_batch_size=1)
-    tp = make_tp(dp_size=2)
-
-    out = build_dp_rollout_data(args, tp, data, global_batch_size=8)
-
-    for r in range(2):
-        partition = out[r]["partition"]
-        assert out[r]["rewards"] == [data["rewards"][j] for j in partition]
-        assert out[r]["raw_reward"] == "passthrough"
 
 
 if __name__ == "__main__":

--- a/tests/test_dp_schedule.py
+++ b/tests/test_dp_schedule.py
@@ -1,0 +1,270 @@
+"""CPU unit tests for slime.utils.dp_schedule.build_dp_rollout_data.
+
+The tests assert the invariants documented at the top of dp_schedule.py against a
+range of static / dynamic / VPP / oversize / trim / balance scenarios.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from slime.utils.dp_schedule import build_dp_rollout_data, compute_dynamic_global_batch_size
+
+
+def make_args(
+    *,
+    global_batch_size,
+    micro_batch_size=1,
+    use_dynamic_batch_size=False,
+    max_tokens_per_gpu=None,
+    use_dynamic_global_batch_size=False,
+    disable_rollout_trim_samples=False,
+    balance_data=False,
+):
+    return SimpleNamespace(
+        global_batch_size=global_batch_size,
+        micro_batch_size=micro_batch_size,
+        use_dynamic_batch_size=use_dynamic_batch_size,
+        max_tokens_per_gpu=max_tokens_per_gpu,
+        use_dynamic_global_batch_size=use_dynamic_global_batch_size,
+        disable_rollout_trim_samples=disable_rollout_trim_samples,
+        balance_data=balance_data,
+    )
+
+
+def make_tp(dp_size=1, cp_size=1, vpp_size=1, microbatch_group_size_per_vp_stage=1):
+    return {
+        "dp_size": dp_size,
+        "cp_size": cp_size,
+        "vpp_size": vpp_size,
+        "microbatch_group_size_per_vp_stage": microbatch_group_size_per_vp_stage,
+    }
+
+
+def make_data(lengths):
+    """``data["tokens"][i]`` is a list of ``lengths[i]`` placeholder token ids."""
+    return {"tokens": [list(range(L)) for L in lengths]}
+
+
+def assert_invariants(rollout_data_list, *, dp_size, total_lengths, max_per_bin=None):
+    """Check the invariants documented at the top of dp_schedule.py."""
+    # All ranks see the same num_microbatches list (PP-sync requirement).
+    nmb = rollout_data_list[0]["num_microbatches"]
+    for r in range(1, dp_size):
+        assert rollout_data_list[r]["num_microbatches"] == nmb, "num_microbatches diverged across ranks"
+
+    expected_per_rank = len(total_lengths) // dp_size
+    seen_global: set[int] = set()
+    for r in range(dp_size):
+        rd = rollout_data_list[r]
+        partition = rd["partition"]
+
+        # Same sample count per rank.
+        assert len(partition) == expected_per_rank, f"rank {r}: {len(partition)} samples, want {expected_per_rank}"
+
+        # Each rank has sum(nmb) micro-batches.
+        assert len(rd["micro_batch_indices"]) == sum(nmb), f"rank {r}: mbs count mismatch"
+
+        # Flattened micro_batch_indices == range(len(partition)) (each sample covered once
+        # by exactly one mbs).
+        flat = [i for mbs in rd["micro_batch_indices"] for i in mbs]
+        assert flat == list(range(len(partition))), f"rank {r}: micro_batch_indices don't tile [0, n)"
+
+        # Disjoint partitions whose union covers every sample.
+        assert seen_global.isdisjoint(partition), f"rank {r}: overlap with other ranks"
+        seen_global.update(partition)
+    assert seen_global == set(range(len(total_lengths))), "some samples not assigned to any rank"
+
+    if max_per_bin is None:
+        return
+
+    # Every mbs <= max_per_bin tokens, EXCEPT a singleton bin holding an oversized sample.
+    for r in range(dp_size):
+        rd = rollout_data_list[r]
+        partition = rd["partition"]
+        for mbs in rd["micro_batch_indices"]:
+            bin_total = sum(total_lengths[partition[i]] for i in mbs)
+            if bin_total > max_per_bin:
+                assert len(mbs) == 1, f"rank {r}: mbs sum {bin_total} > {max_per_bin} but contains {len(mbs)} samples"
+
+
+@pytest.mark.unit
+def test_static_stride_single_step():
+    """Static + strided DP split, single step."""
+    lengths = [10] * 16
+    data = make_data(lengths)
+    args = make_args(global_batch_size=16, micro_batch_size=2)
+    tp = make_tp(dp_size=4)
+
+    out = build_dp_rollout_data(args, tp, data)
+
+    assert len(out) == 4
+    assert out[0]["num_microbatches"] == [2]
+    assert_invariants(out, dp_size=4, total_lengths=lengths)
+
+
+@pytest.mark.unit
+def test_static_balance_multi_step():
+    """Static + balance_data + 2 training steps. Each rank must get gbs/dp per step."""
+    lengths = [1, 2, 3, 4, 5, 6, 7, 8, 8, 7, 6, 5, 4, 3, 2, 1]  # 2 steps of 8
+    data = make_data(lengths)
+    args = make_args(global_batch_size=8, micro_batch_size=2, balance_data=True)
+    tp = make_tp(dp_size=2)
+
+    out = build_dp_rollout_data(args, tp, data)
+
+    assert out[0]["num_microbatches"] == [2, 2]
+    assert_invariants(out, dp_size=2, total_lengths=lengths)
+
+
+@pytest.mark.unit
+def test_dynamic_uniform():
+    """Dynamic mbs on uniform-length samples."""
+    lengths = [5] * 8
+    data = make_data(lengths)
+    args = make_args(global_batch_size=8, use_dynamic_batch_size=True, max_tokens_per_gpu=10)
+    tp = make_tp(dp_size=2)
+
+    out = build_dp_rollout_data(args, tp, data)
+
+    assert_invariants(out, dp_size=2, total_lengths=lengths, max_per_bin=10)
+
+
+@pytest.mark.unit
+def test_dynamic_skewed_lengths():
+    """Skewed lengths (the case where K-K used to over-pack a single bin)."""
+    lengths = [9, 9, 9, 9, 1, 1, 1, 1]
+    data = make_data(lengths)
+    args = make_args(global_batch_size=8, use_dynamic_batch_size=True, max_tokens_per_gpu=10)
+    tp = make_tp(dp_size=2)
+
+    out = build_dp_rollout_data(args, tp, data)
+
+    assert_invariants(out, dp_size=2, total_lengths=lengths, max_per_bin=10)
+
+
+@pytest.mark.unit
+def test_dynamic_oversized_sample_lands_alone():
+    """A single sample exceeding max_per_bin must end up alone in its mbs (with no
+    other samples crammed in)."""
+    lengths = [15, 3, 3, 3, 3, 3, 3, 3]  # 15 > C=10
+    data = make_data(lengths)
+    args = make_args(global_batch_size=8, use_dynamic_batch_size=True, max_tokens_per_gpu=10)
+    tp = make_tp(dp_size=2)
+
+    out = build_dp_rollout_data(args, tp, data)
+
+    assert_invariants(out, dp_size=2, total_lengths=lengths, max_per_bin=10)
+    # Find the rank holding the oversized sample and verify it lives alone in some mbs.
+    oversize_idx = lengths.index(15)
+    found = False
+    for r in range(2):
+        partition = out[r]["partition"]
+        if oversize_idx not in partition:
+            continue
+        local = partition.index(oversize_idx)
+        for mbs in out[r]["micro_batch_indices"]:
+            if local in mbs:
+                assert mbs == [local], f"oversized sample shares an mbs: {mbs}"
+                found = True
+    assert found
+
+
+@pytest.mark.unit
+def test_dynamic_with_vpp_rounds_to_mb_group():
+    """num_microbatches per rank should be a multiple of mb_group when vpp_size > 1."""
+    lengths = [4] * 32  # 2 steps of 16; per step, ~8 bins of 8 needed at C=8
+    data = make_data(lengths)
+    args = make_args(global_batch_size=16, use_dynamic_batch_size=True, max_tokens_per_gpu=8)
+    tp = make_tp(dp_size=2, vpp_size=2, microbatch_group_size_per_vp_stage=2)
+
+    out = build_dp_rollout_data(args, tp, data)
+
+    nmb = out[0]["num_microbatches"]
+    for n in nmb:
+        assert n % 2 == 0, f"num_microbatches {n} is not a multiple of mb_group=2"
+    assert_invariants(out, dp_size=2, total_lengths=lengths, max_per_bin=8)
+
+
+@pytest.mark.unit
+def test_trim_to_global_batch_size():
+    """Surplus samples beyond a multiple of global_batch_size get trimmed."""
+    lengths = [10] * 9  # 9 -> trim to 8 with gbs=4
+    data = make_data(lengths)
+    args = make_args(global_batch_size=4, micro_batch_size=1)
+    tp = make_tp(dp_size=2)
+
+    out = build_dp_rollout_data(args, tp, data)
+
+    # 8 surviving samples * num_steps unchanged.
+    assert len(data["tokens"]) == 8
+    assert out[0]["num_microbatches"] == [2, 2]
+    assert_invariants(out, dp_size=2, total_lengths=lengths[:8])
+
+
+@pytest.mark.unit
+def test_disable_trim_passes_through_uneven_data():
+    """When disable_rollout_trim_samples is on we don't trim. With an exact multiple
+    of gbs the schedule still works; uneven input would raise downstream, which we
+    don't assert here (we just verify the no-trim case is left alone)."""
+    lengths = [10] * 8
+    data = make_data(lengths)
+    args = make_args(global_batch_size=4, micro_batch_size=1, disable_rollout_trim_samples=True)
+    tp = make_tp(dp_size=2)
+
+    out = build_dp_rollout_data(args, tp, data)
+
+    assert len(data["tokens"]) == 8  # untouched
+    assert_invariants(out, dp_size=2, total_lengths=lengths)
+
+
+@pytest.mark.unit
+def test_dynamic_global_batch_size_resolves_to_one_step():
+    """compute_dynamic_global_batch_size + caller wiring should produce one step
+    covering all dp-aligned samples."""
+    lengths = [4] * 10  # 10 samples, dp=4 -> dynamic gbs = 8, 1 step, 2 trimmed
+    data = make_data(lengths)
+    args = make_args(global_batch_size=4, micro_batch_size=1, use_dynamic_global_batch_size=True)
+    tp = make_tp(dp_size=4)
+
+    dynamic_gbs = compute_dynamic_global_batch_size(len(lengths), tp["dp_size"])
+    assert dynamic_gbs == 8
+
+    out = build_dp_rollout_data(args, tp, data, dynamic_global_batch_size=dynamic_gbs)
+
+    assert len(data["tokens"]) == 8
+    assert out[0]["num_microbatches"] == [2]
+    assert out[0]["dynamic_global_batch_size"] == 8
+    assert_invariants(out, dp_size=4, total_lengths=lengths[:8])
+
+
+@pytest.mark.unit
+def test_compute_dynamic_global_batch_size_floor_and_min():
+    """Verify both the floor-to-dp-multiple and the dp_size floor."""
+    assert compute_dynamic_global_batch_size(10, 4) == 8
+    assert compute_dynamic_global_batch_size(16, 4) == 16
+    # Fewer samples than dp_size: clamp to dp_size so we still produce a valid mbs.
+    assert compute_dynamic_global_batch_size(2, 4) == 4
+
+
+@pytest.mark.unit
+def test_sample_aligned_fields_are_sliced_by_partition():
+    """``rewards`` (sample-aligned) should be sliced per rank; ``raw_reward``
+    (passthrough) should appear verbatim."""
+    lengths = [3] * 8
+    data = make_data(lengths)
+    data["rewards"] = list(range(100, 108))  # one per sample
+    data["raw_reward"] = "passthrough"  # whole-batch field
+    args = make_args(global_batch_size=8, micro_batch_size=1)
+    tp = make_tp(dp_size=2)
+
+    out = build_dp_rollout_data(args, tp, data)
+
+    for r in range(2):
+        partition = out[r]["partition"]
+        assert out[r]["rewards"] == [data["rewards"][j] for j in partition]
+        assert out[r]["raw_reward"] == "passthrough"
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__]))

--- a/tests/test_dp_schedule.py
+++ b/tests/test_dp_schedule.py
@@ -1,7 +1,11 @@
 """CPU unit tests for slime.utils.dp_schedule.build_dp_rollout_data.
 
 The tests assert the invariants documented at the top of dp_schedule.py against a
-range of static / dynamic / VPP / oversize / trim / balance scenarios.
+range of static / dynamic / VPP / oversize / balance scenarios.
+
+Trim and dynamic-gbs resolution live in the caller (``RolloutManager``), so these
+tests just hand ``build_dp_rollout_data`` a ``data`` dict whose ``tokens`` length
+is already a multiple of the supplied ``global_batch_size``.
 """
 
 from types import SimpleNamespace
@@ -13,21 +17,15 @@ from slime.utils.dp_schedule import build_dp_rollout_data, compute_dynamic_globa
 
 def make_args(
     *,
-    global_batch_size,
     micro_batch_size=1,
     use_dynamic_batch_size=False,
     max_tokens_per_gpu=None,
-    use_dynamic_global_batch_size=False,
-    disable_rollout_trim_samples=False,
     balance_data=False,
 ):
     return SimpleNamespace(
-        global_batch_size=global_batch_size,
         micro_batch_size=micro_batch_size,
         use_dynamic_batch_size=use_dynamic_batch_size,
         max_tokens_per_gpu=max_tokens_per_gpu,
-        use_dynamic_global_batch_size=use_dynamic_global_batch_size,
-        disable_rollout_trim_samples=disable_rollout_trim_samples,
         balance_data=balance_data,
     )
 
@@ -93,10 +91,10 @@ def test_static_stride_single_step():
     """Static + strided DP split, single step."""
     lengths = [10] * 16
     data = make_data(lengths)
-    args = make_args(global_batch_size=16, micro_batch_size=2)
+    args = make_args(micro_batch_size=2)
     tp = make_tp(dp_size=4)
 
-    out = build_dp_rollout_data(args, tp, data)
+    out = build_dp_rollout_data(args, tp, data, global_batch_size=16)
 
     assert len(out) == 4
     assert out[0]["num_microbatches"] == [2]
@@ -108,10 +106,10 @@ def test_static_balance_multi_step():
     """Static + balance_data + 2 training steps. Each rank must get gbs/dp per step."""
     lengths = [1, 2, 3, 4, 5, 6, 7, 8, 8, 7, 6, 5, 4, 3, 2, 1]  # 2 steps of 8
     data = make_data(lengths)
-    args = make_args(global_batch_size=8, micro_batch_size=2, balance_data=True)
+    args = make_args(micro_batch_size=2, balance_data=True)
     tp = make_tp(dp_size=2)
 
-    out = build_dp_rollout_data(args, tp, data)
+    out = build_dp_rollout_data(args, tp, data, global_batch_size=8)
 
     assert out[0]["num_microbatches"] == [2, 2]
     assert_invariants(out, dp_size=2, total_lengths=lengths)
@@ -122,10 +120,10 @@ def test_dynamic_uniform():
     """Dynamic mbs on uniform-length samples."""
     lengths = [5] * 8
     data = make_data(lengths)
-    args = make_args(global_batch_size=8, use_dynamic_batch_size=True, max_tokens_per_gpu=10)
+    args = make_args(use_dynamic_batch_size=True, max_tokens_per_gpu=10)
     tp = make_tp(dp_size=2)
 
-    out = build_dp_rollout_data(args, tp, data)
+    out = build_dp_rollout_data(args, tp, data, global_batch_size=8)
 
     assert_invariants(out, dp_size=2, total_lengths=lengths, max_per_bin=10)
 
@@ -135,10 +133,10 @@ def test_dynamic_skewed_lengths():
     """Skewed lengths (the case where K-K used to over-pack a single bin)."""
     lengths = [9, 9, 9, 9, 1, 1, 1, 1]
     data = make_data(lengths)
-    args = make_args(global_batch_size=8, use_dynamic_batch_size=True, max_tokens_per_gpu=10)
+    args = make_args(use_dynamic_batch_size=True, max_tokens_per_gpu=10)
     tp = make_tp(dp_size=2)
 
-    out = build_dp_rollout_data(args, tp, data)
+    out = build_dp_rollout_data(args, tp, data, global_batch_size=8)
 
     assert_invariants(out, dp_size=2, total_lengths=lengths, max_per_bin=10)
 
@@ -149,10 +147,10 @@ def test_dynamic_oversized_sample_lands_alone():
     other samples crammed in)."""
     lengths = [15, 3, 3, 3, 3, 3, 3, 3]  # 15 > C=10
     data = make_data(lengths)
-    args = make_args(global_batch_size=8, use_dynamic_batch_size=True, max_tokens_per_gpu=10)
+    args = make_args(use_dynamic_batch_size=True, max_tokens_per_gpu=10)
     tp = make_tp(dp_size=2)
 
-    out = build_dp_rollout_data(args, tp, data)
+    out = build_dp_rollout_data(args, tp, data, global_batch_size=8)
 
     assert_invariants(out, dp_size=2, total_lengths=lengths, max_per_bin=10)
     # Find the rank holding the oversized sample and verify it lives alone in some mbs.
@@ -175,10 +173,10 @@ def test_dynamic_with_vpp_rounds_to_mb_group():
     """num_microbatches per rank should be a multiple of mb_group when vpp_size > 1."""
     lengths = [4] * 32  # 2 steps of 16; per step, ~8 bins of 8 needed at C=8
     data = make_data(lengths)
-    args = make_args(global_batch_size=16, use_dynamic_batch_size=True, max_tokens_per_gpu=8)
+    args = make_args(use_dynamic_batch_size=True, max_tokens_per_gpu=8)
     tp = make_tp(dp_size=2, vpp_size=2, microbatch_group_size_per_vp_stage=2)
 
-    out = build_dp_rollout_data(args, tp, data)
+    out = build_dp_rollout_data(args, tp, data, global_batch_size=16)
 
     nmb = out[0]["num_microbatches"]
     for n in nmb:
@@ -187,55 +185,18 @@ def test_dynamic_with_vpp_rounds_to_mb_group():
 
 
 @pytest.mark.unit
-def test_trim_to_global_batch_size():
-    """Surplus samples beyond a multiple of global_batch_size get trimmed."""
-    lengths = [10] * 9  # 9 -> trim to 8 with gbs=4
+def test_dynamic_global_batch_size_stamped_on_rollout_data():
+    """When dynamic_global_batch_size is passed it should appear on every per-rank dict."""
+    lengths = [4] * 8
     data = make_data(lengths)
-    args = make_args(global_batch_size=4, micro_batch_size=1)
-    tp = make_tp(dp_size=2)
-
-    out = build_dp_rollout_data(args, tp, data)
-
-    # 8 surviving samples * num_steps unchanged.
-    assert len(data["tokens"]) == 8
-    assert out[0]["num_microbatches"] == [2, 2]
-    assert_invariants(out, dp_size=2, total_lengths=lengths[:8])
-
-
-@pytest.mark.unit
-def test_disable_trim_passes_through_uneven_data():
-    """When disable_rollout_trim_samples is on we don't trim. With an exact multiple
-    of gbs the schedule still works; uneven input would raise downstream, which we
-    don't assert here (we just verify the no-trim case is left alone)."""
-    lengths = [10] * 8
-    data = make_data(lengths)
-    args = make_args(global_batch_size=4, micro_batch_size=1, disable_rollout_trim_samples=True)
-    tp = make_tp(dp_size=2)
-
-    out = build_dp_rollout_data(args, tp, data)
-
-    assert len(data["tokens"]) == 8  # untouched
-    assert_invariants(out, dp_size=2, total_lengths=lengths)
-
-
-@pytest.mark.unit
-def test_dynamic_global_batch_size_resolves_to_one_step():
-    """compute_dynamic_global_batch_size + caller wiring should produce one step
-    covering all dp-aligned samples."""
-    lengths = [4] * 10  # 10 samples, dp=4 -> dynamic gbs = 8, 1 step, 2 trimmed
-    data = make_data(lengths)
-    args = make_args(global_batch_size=4, micro_batch_size=1, use_dynamic_global_batch_size=True)
+    args = make_args(micro_batch_size=1)
     tp = make_tp(dp_size=4)
 
-    dynamic_gbs = compute_dynamic_global_batch_size(len(lengths), tp["dp_size"])
-    assert dynamic_gbs == 8
+    out = build_dp_rollout_data(args, tp, data, global_batch_size=8, dynamic_global_batch_size=8)
 
-    out = build_dp_rollout_data(args, tp, data, dynamic_global_batch_size=dynamic_gbs)
-
-    assert len(data["tokens"]) == 8
     assert out[0]["num_microbatches"] == [2]
-    assert out[0]["dynamic_global_batch_size"] == 8
-    assert_invariants(out, dp_size=4, total_lengths=lengths[:8])
+    for r in range(4):
+        assert out[r]["dynamic_global_batch_size"] == 8
 
 
 @pytest.mark.unit
@@ -255,10 +216,10 @@ def test_sample_aligned_fields_are_sliced_by_partition():
     data = make_data(lengths)
     data["rewards"] = list(range(100, 108))  # one per sample
     data["raw_reward"] = "passthrough"  # whole-batch field
-    args = make_args(global_batch_size=8, micro_batch_size=1)
+    args = make_args(micro_batch_size=1)
     tp = make_tp(dp_size=2)
 
-    out = build_dp_rollout_data(args, tp, data)
+    out = build_dp_rollout_data(args, tp, data, global_batch_size=8)
 
     for r in range(2):
         partition = out[r]["partition"]


### PR DESCRIPTION
Previously `get_data_iterator` on the actor side computed the per-step micro-batch schedule for each DP rank locally, then all-reduced `num_microbatches` with MAX to agree across ranks. With skewed sample lengths this could leave some ranks with more mbs than they actually needed, and the per-rank-local balancing also had less information to work with than a global view would.

This change moves the schedule into `_split_train_data_by_dp` on the rollout side so it can be computed once on the full global batch:

- Extend `train_parallel_config` with `cp_size`, `vpp_size`, and `microbatch_group_size_per_vp_stage` so the rollout side has enough info to reproduce the training-side mbs/VPP constraints.
- `_split_train_data_by_dp` now does per-step scheduling. Static mbs: partition each step into dp ranks (balanced or strided) so each rank gets `gbs/dp` samples per step. Dynamic mbs: compute the global minimum mbs from `max_tokens_per_gpu * cp_size`, ceil-divide by dp (with VPP rounding), bin-pack the step globally, and balance the bins across DP ranks so every rank ends up with the same `num_microbatches` and similar tokens.
- `get_data_iterator` is now a thin consumer: it reads `num_microbatches` and (for dynamic) `micro_batch_indices` straight out of `rollout_data` and builds `DataIterator`s.

Side effects:
- The DP-wide `all_reduce(num_microbatches, MAX)` is gone.
- Dynamic mbs uses a tighter global bin-pack instead of per-rank min + MAX, so skewed batches use fewer mbs.
- Static + `balance_data` + multi-step now gives each rank exactly `gbs/dp` samples per step (previously a global balanced partition could spread a rank's samples unevenly across steps).