### PR TITLE
fix: quote nvidia-modelopt requirement in build_conda.sh

### DIFF
--- a/build_conda.sh
+++ b/build_conda.sh
@@ -49,7 +49,7 @@ NVCC_APPEND_FLAGS="--threads 4" \
 
 pip install git+https://github.com/fzyzcjy/torch_memory_saver.git@dc6876905830430b5054325fa4211ff302169c6b --no-cache-dir --force-reinstall
 pip install git+https://github.com/fzyzcjy/Megatron-Bridge.git@dev_rl --no-build-isolation
-pip install nvidia-modelopt[torch]>=0.37.0 --no-build-isolation
+pip install "nvidia-modelopt[torch]>=0.37.0" --no-build-isolation
 pip install https://github.com/zhuzilin/sgl-router/releases/download/v0.3.2-5f8d397/sglang_router-0.3.2-cp38-abi3-manylinux_2_28_x86_64.whl --force-reinstall
 
 # megatron


### PR DESCRIPTION
## What

Quote the `nvidia-modelopt[torch]>=0.37.0` requirement in `build_conda.sh`.

## Why

Without quotes, the shell parses `>` as stdout redirection:

    pip install nvidia-modelopt[torch]>=0.37.0 --no-build-isolation

As a result, the version constraint is not passed to `pip` as intended, and a file named `=0.37.0` can be created/truncated in the working directory.

`pip` documentation recommends quoting requirement specifiers in the shell when using `>`, `<`, or environment markers:
https://pip.pypa.io/en/stable/reference/requirement-specifiers/#examples

## Tested

    bash -n build_conda.sh

I also verified the shell parsing behavior with:

    tmpdir="$(mktemp -d)"
    cd "$tmpdir"

    echo nvidia-modelopt[torch]>=0.37.0 --no-build-isolation
    ls -la  # creates '=0.37.0'

    rm -f '=0.37.0'
    echo "nvidia-modelopt[torch]>=0.37.0" --no-build-isolation
    ls -la  # does not create '=0.37.0'