### PR TITLE
fix: avoid applying rollout temperature to critic values

### DIFF
--- a/slime/backends/megatron_utils/loss.py
+++ b/slime/backends/megatron_utils/loss.py
@@ -39,10 +39,11 @@ def get_responses(
     total_lengths: list[int],
     response_lengths: list[int],
     max_seq_lens: list[int] | None = None,
+    apply_temperature: bool = True,
 ) -> Iterator[tuple[torch.Tensor, torch.Tensor]]:
     """Yield response-aligned `(logits_chunk, tokens_chunk)` pairs per sample.
 
-    After squeezing batch dimension and applying temperature scaling, this
+    After squeezing batch dimension and optionally applying temperature scaling, this
     function extracts the logits and tokens corresponding to response segments
     for each sample. When context parallelism is disabled, it slices directly
     from the concatenated sequence. With context parallelism enabled, it
@@ -51,10 +52,11 @@ def get_responses(
     Args:
         logits: Model outputs with shape `[1, T, V]` (policy) or `[1, T, 1]`
             (value). Must be float32.
-        args: Configuration containing `rollout_temperature` for scaling.
+        args: Configuration containing `rollout_temperature` for optional scaling.
         unconcat_tokens: List of token tensors (prompt+response) per sample.
         total_lengths: Total sequence lengths (prompt+response) per sample.
         response_lengths: Response segment lengths per sample.
+        apply_temperature: Whether to divide outputs by `rollout_temperature`.
 
     Yields:
         Tuple of `(logits_chunk, tokens_chunk)` where `logits_chunk` is shape
@@ -73,7 +75,7 @@ def get_responses(
         assert max_seq_lens is not None
         logits = logits.view(-1, logits.size(-1))
 
-    if args.rollout_temperature != 1.0:
+    if apply_temperature and args.rollout_temperature != 1.0:
         logits = logits.div(args.rollout_temperature)
 
     cp_size = mpu.get_context_parallel_world_size()
@@ -486,8 +488,8 @@ def get_values(
 
     Args:
         logits: Value head output with shape `[1, T, 1]`.
-        args: Configuration (passed to `get_responses` which uses
-            `rollout_temperature` even though values don't need temperature).
+        args: Configuration passed to `get_responses`; temperature scaling is
+            disabled for value outputs.
         unconcat_tokens: List of token tensors per sample.
         total_lengths: Total sequence lengths per sample.
         response_lengths: Response segment lengths per sample.
@@ -506,6 +508,7 @@ def get_values(
         total_lengths=total_lengths,
         response_lengths=response_lengths,
         max_seq_lens=max_seq_lens,
+        apply_temperature=False,
     ):
         assert logits_chunk.size(-1) == 1, f"{logits_chunk.shape}"
         value_list.append(logits_chunk.squeeze(-1))

--- a/tests/test_value_temperature.py
+++ b/tests/test_value_temperature.py
@@ -1,0 +1,54 @@
+import sys
+import types
+from argparse import Namespace
+
+import pytest
+import torch
+
+
+NUM_GPUS = 0
+
+
+def test_get_values_does_not_apply_rollout_temperature(monkeypatch):
+    previous_loss = sys.modules.pop("slime.backends.megatron_utils.loss", None)
+    previous_cp_utils = sys.modules.pop("slime.backends.megatron_utils.cp_utils", None)
+
+    mpu_stub = types.SimpleNamespace(
+        get_context_parallel_world_size=lambda: 1,
+        get_context_parallel_rank=lambda: 0,
+    )
+    megatron_mod = types.ModuleType("megatron")
+    core_mod = types.ModuleType("megatron.core")
+    core_mod.mpu = mpu_stub
+    monkeypatch.setitem(sys.modules, "megatron", megatron_mod)
+    monkeypatch.setitem(sys.modules, "megatron.core", core_mod)
+
+    try:
+        from slime.backends.megatron_utils.loss import get_values
+
+        args = Namespace(qkv_format="thd", rollout_temperature=0.5, allgather_cp=False)
+        logits = torch.tensor([[[1.0], [2.0], [3.0], [4.0]]], dtype=torch.float32)
+        tokens = [torch.tensor([10, 11, 12, 13], dtype=torch.long)]
+
+        _, result = get_values(
+            logits,
+            args=args,
+            unconcat_tokens=tokens,
+            total_lengths=[4],
+            response_lengths=[2],
+        )
+
+        torch.testing.assert_close(result["values"][0], torch.tensor([2.0, 3.0]))
+    finally:
+        if previous_loss is None:
+            sys.modules.pop("slime.backends.megatron_utils.loss", None)
+        else:
+            sys.modules["slime.backends.megatron_utils.loss"] = previous_loss
+        if previous_cp_utils is None:
+            sys.modules.pop("slime.backends.megatron_utils.cp_utils", None)
+        else:
+            sys.modules["slime.backends.megatron_utils.cp_utils"] = previous_cp_utils
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__]))


### PR DESCRIPTION
## What

Avoid applying `rollout_temperature` to critic value-head outputs.

`get_responses()` is shared by response-aligned policy-logit extraction and value extraction. Temperature scaling is needed for policy logits when reconstructing rollout log probabilities, but critic values are scalar predictions and should not be divided by the rollout sampling temperature.

## Changes

- Add an `apply_temperature` flag to `get_responses()`.
- Keep temperature scaling enabled by default for existing policy/logprob paths.
- Disable temperature scaling in `get_values()`.
- Add a zero-GPU unit test for non-unit `rollout_temperature`.

## Tested

- `ruff check slime/backends/megatron_utils/loss.py tests/test_value_temperature.py`
- `isort --profile=black --filter-files --check-only slime/backends/megatron_utils/loss.py tests/test_value_temperature.py`
- `black --check slime/backends/megatron_utils/loss.py tests/test_value_temperature.py`
- `PYTHONDONTWRITEBYTECODE=1 python -m py_compile slime/backends/megatron_utils/loss.py tests/test_value_temperature.py`