### PR TITLE
rollout: validate GPU placement before engine startuprollout: validate GPU placement before engine startup

### DIFF
--- a/slime/ray/rollout.py
+++ b/slime/ray/rollout.py
@@ -18,12 +18,12 @@ from slime.backends.sglang_utils.sglang_config import ModelConfig, ServerGroupCo
 from slime.backends.sglang_utils.sglang_engine import SGLangEngine
 from slime.rollout.base_types import call_rollout_fn
 from slime.utils import logging_utils
-from slime.utils.dp_schedule import build_dp_schedule, compute_dynamic_global_batch_size
 from slime.utils.health_monitor import RolloutHealthMonitor
 from slime.utils.http_utils import _wrap_ipv6, find_available_port, get_host_info, init_http_client
 from slime.utils.logging_utils import configure_logger, init_tracking
 from slime.utils.metric_utils import compute_pass_rate, compute_rollout_step, compute_statistics, dict_add_prefix
 from slime.utils.misc import Box, group_by, load_function
+from slime.utils.seqlen_balancing import get_seqlen_balanced_partitions
 from slime.utils.types import Sample
 
 from ..utils.metric_utils import has_repetition
@@ -67,6 +67,36 @@ class ServerGroup:
         """Node-0 engines only (for multi-node serving)."""
         return self.all_engines[:: self.nodes_per_engine]
 
+    def validate_gpu_placement(self, num_gpu_per_engine: int, reordered_bundle_indices: list, reordered_gpu_ids: list):
+        if num_gpu_per_engine <= 0:
+            raise ValueError(f"num_gpu_per_engine must be positive, got {num_gpu_per_engine}.")
+
+        if len(reordered_bundle_indices) != len(reordered_gpu_ids):
+            raise ValueError(
+                "Invalid rollout placement group metadata: "
+                f"len(reordered_bundle_indices)={len(reordered_bundle_indices)} does not match "
+                f"len(reordered_gpu_ids)={len(reordered_gpu_ids)}."
+            )
+
+        if not self.all_engines:
+            return
+
+        required_gpu_slots = self.gpu_offset + len(self.all_engines) * num_gpu_per_engine
+        if required_gpu_slots <= len(reordered_gpu_ids):
+            return
+
+        max_gpu_index = required_gpu_slots - 1
+        raise ValueError(
+            "Invalid rollout GPU placement: server group requires placement GPU bundle index "
+            f"{max_gpu_index}, but only {len(reordered_gpu_ids)} rollout GPU slots are available. "
+            f"worker_type={self.worker_type}, gpu_offset={self.gpu_offset}, "
+            f"num_engines={len(self.all_engines)}, num_gpus_per_engine={self.num_gpus_per_engine}, "
+            f"local_num_gpus_per_engine={num_gpu_per_engine}, "
+            f"rollout_num_gpus={self.args.rollout_num_gpus}, "
+            f"rollout_num_gpus_per_engine={self.args.rollout_num_gpus_per_engine}, "
+            f"num_gpus_per_node={self.args.num_gpus_per_node}."
+        )
+
     def start_engines(self, port_cursors: dict[int, int] | None = None) -> tuple[list, dict[int, int]]:
         """Create Ray actors, allocate ports, and fire ``engine.init()`` without waiting.
 
@@ -87,6 +117,7 @@ class ServerGroup:
         num_gpu_per_engine = min(self.num_gpus_per_engine, self.args.num_gpus_per_node)
 
         pg, reordered_bundle_indices, reordered_gpu_ids = self.pg
+        self.validate_gpu_placement(num_gpu_per_engine, reordered_bundle_indices, reordered_gpu_ids)
 
         RolloutRayActor = ray.remote(SGLangEngine)
 
@@ -488,7 +519,7 @@ class RolloutManager:
             # if debug rollout only, we don't convert samples to train data and directly return
             return
         data = self._convert_samples_to_train_data(data)
-        return self._split_train_data_by_dp(data)
+        return self._split_train_data_by_dp(data, self.train_parallel_config["dp_size"])
 
     def eval(self, rollout_id):
         if self.args.debug_train_only:
@@ -587,7 +618,51 @@ class RolloutManager:
             while isinstance(data[0], list):
                 data = list(itertools.chain.from_iterable(data))
 
+            if not self.args.disable_rollout_trim_samples and not self.args.debug_rollout_only:
+                global_batch_size = self.args.global_batch_size
+                if self.args.use_dynamic_global_batch_size:
+                    logger.info(f"Collected {len(data)} samples from rollout to train with dynamic global batch size")
+                    # TODO: this is a temporary solution, we should directly save dynamic_global_batch_size to rollout data
+                    self._dynamic_global_batch_size = self._compute_dynamic_global_batch_size(len(data))
+                    global_batch_size = self._dynamic_global_batch_size
+
+                if len(data) % global_batch_size != 0:
+                    trim_len = (len(data) // global_batch_size) * global_batch_size
+                    if trim_len == 0:
+                        raise ValueError(f"Not enough samples {len(data)} for global_batch_size {global_batch_size}")
+                    origin_data_length = len(data)
+                    data = data[:trim_len]
+                    logger.info(f"trim number of samples from {origin_data_length} to {trim_len}")
+                logger.info(f"Final collected {len(data)} samples from rollout to train")
+
         return data, metrics
+
+    def _compute_dynamic_global_batch_size(self, num_samples: int) -> int:
+        """Calculate dynamic global_batch_size to ensure only one training step.
+
+        Strategy: global_batch_size = num_samples rounded down to a multiple of dp_size
+        This ensures num_steps_per_rollout = num_samples // global_batch_size = 1
+        """
+        dp_size = self.train_parallel_config["dp_size"]
+        original_gbs = self.args.global_batch_size
+
+        # Round down to a multiple of dp_size to ensure only one training step
+        dynamic_gbs = (num_samples // dp_size) * dp_size
+
+        if dynamic_gbs == 0:
+            # Too few samples, use at least dp_size
+            dynamic_gbs = dp_size
+            logger.warning(f"num_samples={num_samples} < dp_size={dp_size}, using dp_size as global_batch_size")
+
+        # Calculate how many samples will be discarded
+        wasted = num_samples - dynamic_gbs
+
+        if dynamic_gbs != original_gbs or wasted > 0:
+            logger.info(
+                f"Dynamic global_batch_size: {original_gbs} -> {dynamic_gbs} (num_samples={num_samples}, dp_size={dp_size}, num_steps=1, wasted={wasted})"
+            )
+
+        return dynamic_gbs
 
     def _save_debug_rollout_data(self, data, rollout_id, evaluation: bool):
         # TODO to be refactored (originally Buffer._set_data)
@@ -707,52 +782,27 @@ class RolloutManager:
     def set_train_parallel_config(self, config: dict):
         self.train_parallel_config = config
 
-    def _split_train_data_by_dp(self, data):
-        """Resolve gbs, trim ``data``, compute the DP/mbs schedule, and package each
-        rank's rollout_data into a Ray Box. The schedule itself is computed by
-        :func:`build_dp_schedule` so it stays unit-testable without Ray/sglang."""
-        dp_size = self.train_parallel_config["dp_size"]
+    def _split_train_data_by_dp(self, data, dp_size):
+        """Split the train data by data parallel size."""
+        rollout_data = {}
 
-        # 1. Resolve effective global_batch_size
-        dynamic_gbs: int | None = None
-        if self.args.use_dynamic_global_batch_size and not self.args.disable_rollout_trim_samples:
-            dynamic_gbs = compute_dynamic_global_batch_size(len(data["tokens"]), dp_size)
-            if dynamic_gbs != self.args.global_batch_size:
-                logger.info(
-                    f"Dynamic global_batch_size: {self.args.global_batch_size} -> {dynamic_gbs} "
-                    f"(num_samples={len(data['tokens'])}, dp_size={dp_size}, num_steps=1)"
-                )
-            global_batch_size = dynamic_gbs
-        else:
-            global_batch_size = self.args.global_batch_size
+        if "prompt" in data:
+            rollout_data["prompt"] = data["prompt"]
 
-        # 2. Trim data to a multiple of global_batch_size
-        if not self.args.disable_rollout_trim_samples:
-            num_samples = len(data["tokens"])
-            trim_len = num_samples // global_batch_size * global_batch_size
-            if trim_len == 0:
-                raise ValueError(f"Not enough samples {num_samples} for global_batch_size {global_batch_size}")
-            if trim_len < num_samples:
-                logger.info(f"Trimmed samples from {num_samples} to {trim_len}")
-                for key, val in data.items():
-                    if isinstance(val, list):
-                        data[key] = val[:trim_len]
-
-        # 3. Compute schedule
         total_lengths = [len(t) for t in data["tokens"]]
         data["total_lengths"] = total_lengths
-        partitions, micro_batch_indices, num_microbatches = build_dp_schedule(
-            self.args,
-            self.train_parallel_config,
-            total_lengths,
-            global_batch_size=global_batch_size,
-        )
 
-        # 4. Package per-rank rollout_data
+        if self.args.balance_data:
+            partitions = get_seqlen_balanced_partitions(total_lengths, dp_size, equal_size=True)
+        else:
+            partitions = [range(i, len(total_lengths), dp_size) for i in range(dp_size)]
+
         rollout_data_refs = []
-        for r in range(dp_size):
-            partition = partitions[r]
-            rollout_data = {"partition": partition}
+
+        for i in range(dp_size):
+            rollout_data = {}
+            partition = partitions[i]
+            rollout_data["partition"] = partition
             for key in [
                 "tokens",
                 "multimodal_train_inputs",
@@ -769,16 +819,19 @@ class RolloutManager:
             ]:
                 if key not in data:
                     continue
-                rollout_data[key] = [data[key][j] for j in partition]
+                val = [data[key][j] for j in partition]
+                rollout_data[key] = val
             # keys that need to be splited at train side
-            for key in ["raw_reward", "total_lengths"]:
+            for key in [
+                "raw_reward",
+                "total_lengths",
+            ]:
                 if key not in data:
                     continue
                 rollout_data[key] = data[key]
-            if dynamic_gbs is not None:
-                rollout_data["dynamic_global_batch_size"] = dynamic_gbs
-            rollout_data["num_microbatches"] = num_microbatches
-            rollout_data["micro_batch_indices"] = micro_batch_indices[r]
+            # Pass dynamic global_batch_size to training side
+            if hasattr(self, "_dynamic_global_batch_size"):
+                rollout_data["dynamic_global_batch_size"] = self._dynamic_global_batch_size
             rollout_data_refs.append(Box(ray.put(rollout_data)))
         return rollout_data_refs
 
@@ -999,6 +1052,14 @@ def start_rollout_servers(args, pg) -> dict[str, RolloutServer]:
             nonlocal engine_offset, gpu_offset
             gpus_per_engine = group_cfg.num_gpus_per_engine
             num_gpu_per_engine_local = min(gpus_per_engine, args.num_gpus_per_node)
+            if group_cfg.num_gpus % num_gpu_per_engine_local != 0:
+                raise ValueError(
+                    "Invalid sglang server group GPU configuration: "
+                    f"num_gpus={group_cfg.num_gpus} must be divisible by "
+                    f"local_num_gpus_per_engine={num_gpu_per_engine_local}. "
+                    f"worker_type={group_cfg.worker_type}, num_gpus_per_engine={gpus_per_engine}, "
+                    f"num_gpus_per_node={args.num_gpus_per_node}, rollout_num_gpus={args.rollout_num_gpus}."
+                )
             num_engines = group_cfg.num_gpus // num_gpu_per_engine_local
 
             group_abs_start = rollout_pg_offset + gpu_offset

--- a/tests/utils/test_rollout_gpu_placement.py
+++ b/tests/utils/test_rollout_gpu_placement.py
@@ -1,0 +1,92 @@
+from argparse import Namespace
+
+import pytest
+
+from slime.ray.rollout import ServerGroup, start_rollout_servers
+
+
+def _args(**overrides):
+    defaults = {
+        "debug_train_only": False,
+        "num_gpus_per_node": 4,
+        "rollout_num_gpus": 1,
+        "rollout_num_gpus_per_engine": 1,
+    }
+    defaults.update(overrides)
+    return Namespace(**defaults)
+
+
+def test_server_group_rejects_incomplete_placement_metadata():
+    group = ServerGroup(
+        args=_args(),
+        pg=(None, [0, 1], [0]),
+        all_engines=[None],
+        num_gpus_per_engine=1,
+        num_new_engines=0,
+    )
+
+    with pytest.raises(ValueError, match="Invalid rollout placement group metadata"):
+        group.validate_gpu_placement(num_gpu_per_engine=1, reordered_bundle_indices=[0, 1], reordered_gpu_ids=[0])
+
+
+def test_server_group_rejects_non_positive_local_gpu_count():
+    group = ServerGroup(
+        args=_args(),
+        pg=(None, [0], [0]),
+        all_engines=[None],
+        num_gpus_per_engine=1,
+        num_new_engines=0,
+    )
+
+    with pytest.raises(ValueError, match="num_gpu_per_engine must be positive"):
+        group.validate_gpu_placement(num_gpu_per_engine=0, reordered_bundle_indices=[0], reordered_gpu_ids=[0])
+
+
+def test_server_group_rejects_gpu_bundle_index_out_of_range():
+    group = ServerGroup(
+        args=_args(rollout_num_gpus=3, rollout_num_gpus_per_engine=2),
+        pg=(None, [0, 1, 2], [0, 1, 2]),
+        all_engines=[None, None],
+        num_gpus_per_engine=2,
+        num_new_engines=0,
+    )
+
+    with pytest.raises(ValueError) as exc_info:
+        group.validate_gpu_placement(
+            num_gpu_per_engine=2,
+            reordered_bundle_indices=[0, 1, 2],
+            reordered_gpu_ids=[0, 1, 2],
+        )
+
+    message = str(exc_info.value)
+    assert "placement GPU bundle index 3" in message
+    assert "only 3 rollout GPU slots are available" in message
+    assert "rollout_num_gpus=3" in message
+    assert "rollout_num_gpus_per_engine=2" in message
+    assert "num_gpus_per_node=4" in message
+
+
+def test_start_rollout_servers_rejects_non_divisible_server_group():
+    args = _args(
+        rollout_num_gpus=3,
+        rollout_num_gpus_per_engine=2,
+        sglang_config=None,
+        prefill_num_servers=None,
+        debug_rollout_only=True,
+        colocate=False,
+        actor_num_nodes=1,
+        actor_num_gpus_per_node=4,
+        offload_rollout=False,
+        hf_checkpoint="/tmp/model",
+        sglang_router_ip="127.0.0.1",
+        sglang_router_port=30000,
+    )
+
+    with pytest.raises(ValueError) as exc_info:
+        start_rollout_servers(args, pg=(None, [0, 1, 2], [0, 1, 2]))
+
+    message = str(exc_info.value)
+    assert "Invalid sglang server group GPU configuration" in message
+    assert "num_gpus=3" in message
+    assert "local_num_gpus_per_engine=2" in message
+    assert "rollout_num_gpus=3" in message


### PR DESCRIPTION
## What
- Add explicit rollout GPU placement validation before creating SGLang engine actors.
- Reject incomplete placement metadata and out-of-range GPU bundle indices with actionable ValueError messages.
- Reject non-divisible server group GPU configurations before engine count calculation.
 - Add unit tests for invalid placement and server group GPU configs.

## Why
Invalid rollout GPU settings currently surface as a generic IndexError during engine startup, making configuration issues hard to diagnose.

Refs #1908, #1840.

## Test
  - python slime/ray/rollout.py tests/utils/test_rollout_gpu_placement.py