### PR TITLE
Add Trackio rollout trace logging

### DIFF
--- a/docs/en/developer_guide/trace.md
+++ b/docs/en/developer_guide/trace.md
@@ -31,6 +31,24 @@ The script generates:
 
 By default it also starts a local static server so you can open the generated HTML immediately. If you only want the files, use `--no-serve`.
 
+## Log traces to Trackio
+
+To inspect rollout traces in Trackio during a run, install Trackio and enable it in the training command:
+
+```bash
+pip install trackio
+
+python train.py \
+    ... \
+    --use-trackio \
+    --trackio-project slime-traces \
+    --trackio-run-name my-run
+```
+
+slime logs rollout and evaluation samples as `trackio.Trace` records. Each trace includes the prompt/response conversation plus metadata such as rollout id, step, sample index, group index, reward, status, and slime's internal span events.
+
+By default slime logs up to 32 samples per rollout to avoid very large trace uploads. Use `--trackio-max-traces-per-rollout 0` to log all samples.
+
 ## How to read the viewer
 
 - Each row corresponds to one sample.
@@ -116,4 +134,3 @@ with trace_span(sample, "sglang_generate") as span:
 - Save a small number of rollouts first; the viewer is easiest to read when each dump contains a manageable number of samples.
 - The viewer is built from the saved `.pt` dump, so traces can be inspected offline on another machine.
 - For GPU/kernel-level SGLang profiling traces, see [Profiling](./profiling.md).
-

--- a/slime/ray/rollout.py
+++ b/slime/ray/rollout.py
@@ -18,6 +18,7 @@ from slime.backends.sglang_utils.sglang_config import ModelConfig, ServerGroupCo
 from slime.backends.sglang_utils.sglang_engine import SGLangEngine
 from slime.rollout.base_types import call_rollout_fn
 from slime.utils import logging_utils
+from slime.utils import trackio_utils
 from slime.utils.dp_schedule import build_dp_schedule, compute_dynamic_global_batch_size
 from slime.utils.health_monitor import RolloutHealthMonitor
 from slime.utils.http_utils import _wrap_ipv6, find_available_port, get_host_info, init_http_client
@@ -1149,6 +1150,9 @@ def _log_eval_rollout_data(rollout_id, args, data, extra_metrics: dict[str, Any]
     step = compute_rollout_step(args, rollout_id)
     log_dict["eval/step"] = step
     logging_utils.log(args, log_dict, step_key="eval/step")
+    for key in data.keys():
+        if (samples := data[key].get("samples")) is not None:
+            trackio_utils.log_rollout_traces(args, rollout_id, samples, split=f"eval/{key}", step=step)
 
     return log_dict
 
@@ -1169,6 +1173,7 @@ def _log_rollout_data(rollout_id, args, samples, rollout_extra_metrics, rollout_
     step = compute_rollout_step(args, rollout_id)
     log_dict["rollout/step"] = step
     logging_utils.log(args, log_dict, step_key="rollout/step")
+    trackio_utils.log_rollout_traces(args, rollout_id, samples, split="rollout", step=step)
 
 
 def compute_metrics_from_samples(args, samples):

--- a/slime/utils/arguments.py
+++ b/slime/utils/arguments.py
@@ -1109,6 +1109,32 @@ def get_slime_extra_args_provider(add_custom_arguments=None):
 
             return parser
 
+        # trackio
+        def add_trackio_arguments(parser):
+            parser.add_argument("--use-trackio", action="store_true", default=False)
+            parser.add_argument(
+                "--trackio-project",
+                type=str,
+                default=None,
+                help="Trackio project name. Defaults to --wandb-project or 'slime'.",
+            )
+            parser.add_argument(
+                "--trackio-run-name",
+                type=str,
+                default=None,
+                help="Trackio run name. Defaults to --wandb-group or 'slime-rank-{rank}'.",
+            )
+            parser.add_argument(
+                "--trackio-max-traces-per-rollout",
+                type=int,
+                default=32,
+                help=(
+                    "Maximum rollout/eval samples to log as Trackio traces per rollout. "
+                    "Set to 0 or a negative value to log all samples."
+                ),
+            )
+            return parser
+
         # debug
         def add_debug_arguments(parser):
             parser.add_argument(
@@ -1381,6 +1407,7 @@ def get_slime_extra_args_provider(add_custom_arguments=None):
         parser = add_on_policy_distillation_arguments(parser)
         parser = add_wandb_arguments(parser)
         parser = add_tensorboard_arguments(parser)
+        parser = add_trackio_arguments(parser)
         parser = add_router_arguments(parser)
         parser = add_debug_arguments(parser)
         parser = add_network_arguments(parser)

--- a/slime/utils/logging_utils.py
+++ b/slime/utils/logging_utils.py
@@ -2,6 +2,7 @@ import logging
 
 import wandb
 
+from . import trackio_utils
 from . import wandb_utils
 from .tensorboard_utils import _TensorboardAdapter
 
@@ -29,6 +30,7 @@ def init_tracking(args, primary: bool = True, **kwargs):
         wandb_utils.init_wandb_primary(args, **kwargs)
     else:
         wandb_utils.init_wandb_secondary(args, **kwargs)
+    trackio_utils.init_trackio(args, primary=primary)
 
 
 def update_tracking_open_metrics(args, router_addr):
@@ -36,13 +38,13 @@ def update_tracking_open_metrics(args, router_addr):
 
 
 def finish_tracking(args):
-    if not args.use_wandb:
-        return
-    try:
-        if wandb.run is not None:
-            wandb.finish()
-    except Exception:
-        logging.getLogger(__name__).exception("Failed to finish wandb run")
+    if args.use_wandb:
+        try:
+            if wandb.run is not None:
+                wandb.finish()
+        except Exception:
+            logging.getLogger(__name__).exception("Failed to finish wandb run")
+    trackio_utils.finish_trackio(args)
 
 
 # TODO further refactor, e.g. put TensorBoard init to the "init" part
@@ -53,3 +55,6 @@ def log(args, metrics, step_key: str):
     if args.use_tensorboard:
         metrics_except_step = {k: v for k, v in metrics.items() if k != step_key}
         _TensorboardAdapter(args).log(data=metrics_except_step, step=metrics[step_key])
+
+    if getattr(args, "use_trackio", False):
+        trackio_utils.log_metrics(args, metrics, step=metrics.get(step_key))

--- a/slime/utils/trackio_utils.py
+++ b/slime/utils/trackio_utils.py
@@ -1,0 +1,127 @@
+import logging
+import os
+from copy import deepcopy
+from typing import Any
+
+from slime.utils.types import Sample
+
+logger = logging.getLogger(__name__)
+_INITIALIZED = False
+
+
+def _import_trackio():
+    try:
+        import trackio
+    except ImportError as exc:
+        raise ImportError("Trackio logging requires the `trackio` package. Install it with `pip install trackio` or remove `--use-trackio`.") from exc
+    return trackio
+
+
+def _trackio_project(args) -> str:
+    return args.trackio_project or args.wandb_project or "slime"
+
+
+def _trackio_run_name(args) -> str:
+    return args.trackio_run_name or args.wandb_group or f"slime-rank-{getattr(args, 'rank', 0)}"
+
+
+def init_trackio(args, primary: bool = True):
+    global _INITIALIZED
+    if not getattr(args, "use_trackio", False):
+        return
+    if _INITIALIZED:
+        return
+
+    trackio = _import_trackio()
+    trackio.init(
+        project=_trackio_project(args),
+        name=_trackio_run_name(args),
+        config=_compute_config_for_logging(args),
+    )
+    _INITIALIZED = True
+
+
+def finish_trackio(args):
+    global _INITIALIZED
+    if not getattr(args, "use_trackio", False):
+        return
+    trackio = _import_trackio()
+    try:
+        trackio.finish()
+        _INITIALIZED = False
+    except Exception:
+        logger.exception("Failed to finish Trackio run")
+
+
+def log_metrics(args, metrics: dict[str, Any], step: int | None = None):
+    if not getattr(args, "use_trackio", False):
+        return
+    init_trackio(args)
+    trackio = _import_trackio()
+    trackio.log(metrics, step=step)
+
+
+def log_rollout_traces(args, rollout_id: int, samples: list[Sample], *, split: str, step: int):
+    if not getattr(args, "use_trackio", False):
+        return
+    init_trackio(args)
+
+    max_traces = getattr(args, "trackio_max_traces_per_rollout", 32)
+    if max_traces is not None and max_traces > 0:
+        samples = samples[:max_traces]
+
+    traces = [_sample_to_trackio_trace(args, rollout_id, sample, split=split, step=step) for sample in samples]
+    traces = [trace for trace in traces if trace is not None]
+    if not traces:
+        return
+
+    trackio = _import_trackio()
+    trackio.log({f"{split}/trajectories": traces}, step=step)
+
+
+def _sample_to_trackio_trace(args, rollout_id: int, sample: Sample, *, split: str, step: int):
+    trackio = _import_trackio()
+    messages = _sample_messages(sample)
+    if not messages:
+        return None
+    return trackio.Trace(
+        messages=messages,
+        metadata={
+            "split": split,
+            "rollout_id": rollout_id,
+            "step": step,
+            "sample_index": sample.index,
+            "group_index": sample.group_index,
+            "status": sample.status.value if hasattr(sample.status, "value") else str(sample.status),
+            "reward": sample.reward,
+            "response_length": sample.response_length,
+            "effective_response_length": sample.effective_response_length,
+            "metadata": sample.metadata,
+            "trace": getattr(sample, "trace", None),
+            "trackio_max_traces_per_rollout": getattr(args, "trackio_max_traces_per_rollout", None),
+        },
+    )
+
+
+def _sample_messages(sample: Sample) -> list[dict[str, Any]]:
+    messages = _prompt_messages(sample.prompt)
+    if sample.response:
+        messages.append({"role": "assistant", "content": sample.response})
+    return messages
+
+
+def _prompt_messages(prompt: str | list[dict[str, Any]]) -> list[dict[str, Any]]:
+    if isinstance(prompt, str):
+        return [{"role": "user", "content": prompt}]
+    if isinstance(prompt, list):
+        return [dict(message) for message in prompt if isinstance(message, dict)]
+    return [{"role": "user", "content": str(prompt)}]
+
+
+def _compute_config_for_logging(args):
+    output = deepcopy(args.__dict__)
+    whitelist_env_vars = [
+        "SLURM_JOB_ID",
+    ]
+    output["env_vars"] = {key: value for key, value in os.environ.items() if key in whitelist_env_vars}
+    return output

--- a/tests/utils/test_trackio_utils.py
+++ b/tests/utils/test_trackio_utils.py
@@ -1,0 +1,106 @@
+import sys
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from slime.utils import trackio_utils
+from slime.utils.types import Sample
+
+
+def setup_function():
+    trackio_utils._INITIALIZED = False
+
+
+def _args(**overrides):
+    values = {
+        "use_trackio": True,
+        "trackio_project": "slime-trackio-test",
+        "trackio_run_name": "smoke-run",
+        "trackio_max_traces_per_rollout": 4,
+        "wandb_project": None,
+        "wandb_group": None,
+        "rank": 0,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def test_init_trackio_uses_project_run_and_config():
+    fake_trackio = MagicMock()
+
+    with patch.dict(sys.modules, {"trackio": fake_trackio}):
+        trackio_utils.init_trackio(_args())
+
+    fake_trackio.init.assert_called_once()
+    init_kwargs = fake_trackio.init.call_args.kwargs
+    assert init_kwargs["project"] == "slime-trackio-test"
+    assert init_kwargs["name"] == "smoke-run"
+    assert init_kwargs["config"]["trackio_project"] == "slime-trackio-test"
+
+
+def test_log_rollout_traces_writes_trackio_trace_records():
+    fake_trackio = MagicMock()
+    fake_trackio.Trace.side_effect = lambda messages, metadata: {
+        "_type": "trackio.trace",
+        "messages": messages,
+        "metadata": metadata,
+    }
+    sample = Sample(
+        index=7,
+        group_index=3,
+        prompt=[
+            {"role": "system", "content": "You are concise."},
+            {"role": "user", "content": "What is 2 + 2?"},
+        ],
+        response="4",
+        reward=1.0,
+        response_length=1,
+        metadata={"source": "unit-test"},
+    )
+    sample.trace = {"trace_id": "trace-1", "events": [{"name": "sglang_generate"}]}
+
+    with patch.dict(sys.modules, {"trackio": fake_trackio}):
+        trackio_utils.log_rollout_traces(_args(), rollout_id=5, samples=[sample], split="rollout", step=9)
+
+    fake_trackio.init.assert_called_once()
+    fake_trackio.Trace.assert_called_once()
+    trace_kwargs = fake_trackio.Trace.call_args.kwargs
+    assert trace_kwargs["messages"] == [
+        {"role": "system", "content": "You are concise."},
+        {"role": "user", "content": "What is 2 + 2?"},
+        {"role": "assistant", "content": "4"},
+    ]
+    assert trace_kwargs["metadata"]["split"] == "rollout"
+    assert trace_kwargs["metadata"]["rollout_id"] == 5
+    assert trace_kwargs["metadata"]["step"] == 9
+    assert trace_kwargs["metadata"]["sample_index"] == 7
+    assert trace_kwargs["metadata"]["group_index"] == 3
+    assert trace_kwargs["metadata"]["reward"] == 1.0
+    assert trace_kwargs["metadata"]["metadata"] == {"source": "unit-test"}
+    assert trace_kwargs["metadata"]["trace"] == {"trace_id": "trace-1", "events": [{"name": "sglang_generate"}]}
+    fake_trackio.log.assert_called_once()
+    log_payload = fake_trackio.log.call_args.args[0]
+    assert log_payload["rollout/trajectories"] == [
+        {
+            "_type": "trackio.trace",
+            "messages": trace_kwargs["messages"],
+            "metadata": trace_kwargs["metadata"],
+        }
+    ]
+    assert fake_trackio.log.call_args.kwargs == {"step": 9}
+
+
+def test_log_rollout_traces_respects_max_traces_per_rollout():
+    fake_trackio = MagicMock()
+    fake_trackio.Trace.side_effect = lambda messages, metadata: {"messages": messages, "metadata": metadata}
+    samples = [Sample(index=index, prompt=f"prompt {index}", response="ok") for index in range(3)]
+
+    with patch.dict(sys.modules, {"trackio": fake_trackio}):
+        trackio_utils.log_rollout_traces(
+            _args(trackio_max_traces_per_rollout=2),
+            rollout_id=1,
+            samples=samples,
+            split="rollout",
+            step=0,
+        )
+
+    assert fake_trackio.Trace.call_count == 2


### PR DESCRIPTION
Hi folks! This PR adds trace logging via Trackio, the free, local-first experiment tracking library from Hugging Face 🤗

This PR follows slime's existing rollout trace and logging patterns, specifically I did this:

- added `--use-trackio` support alongside the existing W&B/TensorBoard tracking options
- added `--trackio-project`, `--trackio-run-name`, and `--trackio-max-traces-per-rollout` configuration
- added logging rollout and evaluation samples as `trackio.Trace` records with step, rollout, sample, reward, status, metadata, and slime span-event metadata
- added Trackio metric logging through the existing `logging_utils.log(...)` path
- documented Trackio trace logging in the trace developer guide
- added tests with mocked Trackio

Here's what it looks like:

<img width="1503" height="764" alt="image" src="https://github.com/user-attachments/assets/9baa2a5c-b39d-45b3-ad8a-5dfc14af6954" />

AI assistance was used to prepare this PR, using the existing W&B/TensorBoard integrations as a template.
