### PR TITLE
fix: guard sglang_speculative_algorithm read in --debug-train-only mode

### DIFF
--- a/slime/ray/rollout.py
+++ b/slime/ray/rollout.py
@@ -1236,7 +1236,7 @@ def _compute_zero_std_metrics(args, all_samples: list[Sample]):
 
 
 def _compute_spec_metrics(args, all_samples: list[Sample]):
-    if args.sglang_speculative_algorithm is None:
+    if getattr(args, "sglang_speculative_algorithm", None) is None:
         return {}
     num_samples = len(all_samples)
     metrics = {}


### PR DESCRIPTION
## Bug

\`_compute_spec_metrics\` (in \`slime/ray/rollout.py\`) reads \`args.sglang_speculative_algorithm\` directly. With \`--debug-train-only\`, sglang argparse is skipped (\`slime/utils/arguments.py\` lines 1414-1421: \`skip_sglang = pre.debug_train_only or ...\`), so the attribute is never set on \`args\`. The first rollout completion raises:

\`\`\`
AttributeError: 'Namespace' object has no attribute 'sglang_speculative_algorithm'
  File "/root/slime/slime/ray/rollout.py", line 1265, in _compute_spec_metrics
    if args.sglang_speculative_algorithm is None:
\`\`\`

Reproduces on any SFT or train-only run that uses \`--debug-train-only\` (the documented way to run training without sglang servers).

## Fix

One line — use \`getattr(args, "sglang_speculative_algorithm", None) is None\` so the guard falls through to the empty-metrics path when the attr is missing. That path (\`return {}\`) is already the intended behavior for non-spec runs, so the fix is purely defensive — no semantic change.

## Provenance

The unguarded read was added in #640 (MTP training support, 2025-10-31). Released in v0.2.0 (2025-11-28); present in all subsequent tags.

## Test plan

- [x] Verified on Qwen3.5-35B-A3B SFT with \`--debug-train-only\` on 2x p5e.48xlarge: pre-fix crashes at first rollout completion; post-fix runs past it (currently at step 42, climbing).
- [ ] Existing tests still pass (single-line change in a defensive guard, no logic change).