### PR TITLE
[sglang_utils] flush_cache: log non-200 responses and back off before…

### DIFF
--- a/slime/backends/sglang_utils/sglang_engine.py
+++ b/slime/backends/sglang_utils/sglang_engine.py
@@ -295,6 +295,8 @@ class SGLangEngine(RayActor):
                 response = requests.get(f"http://{self.server_host}:{self.server_port}/flush_cache")
                 if response.status_code == 200:
                     break
+                logger.info(f"Error flushing cache: HTTP {response.status_code} {response.text!r}")
+                time.sleep(1)
             except NewConnectionError as e:
                 raise e
             except Exception as e:


### PR DESCRIPTION
The /flush_cache endpoint without timeout_s uses snapshot semantics: the scheduler checks is_fully_idle() once and returns 200 / 400. When there are in-flight requests, this returns 400 immediately. The existing for-loop retried on non-200 without sleeping, so it spun at ~ms cadence and silently swallowed failure modes like "Another flush_cache is already in progress" or "Timed out waiting for idle state.".

Mirror the except branch: on non-200, log the status code + body and sleep 1s before retrying. The 60 retries now provide a real ~60s wait budget instead of a tight spin, and failures are visible in the log.