### PR TITLE
[Fix] Fix FLOPs accounting for non-MLA attention

### DIFF
--- a/slime/utils/flops_utils.py
+++ b/slime/utils/flops_utils.py
@@ -6,19 +6,24 @@ def calculate_lm_head_flops(seqlen, hidden_size, vocab_size):
     return 2 * seqlen * hidden_size * vocab_size
 
 
+def _is_multi_latent_attention(args):
+    return bool(getattr(args, "multi_latent_attention", False))
+
+
 def calculate_qkv_projection_flops(args, seqlen, hidden_size, num_attention_heads, num_query_groups):
-    if args.q_lora_rank is None:
-        q_flops = 2 * seqlen * hidden_size * num_attention_heads * args.kv_channels
-    else:
+    is_mla = _is_multi_latent_attention(args)
+    if is_mla and args.q_lora_rank is not None:
         q_flops = (
             2
             * seqlen
             * args.q_lora_rank
             * (args.hidden_size + args.num_attention_heads * (args.qk_head_dim + args.qk_pos_emb_head_dim))
         )
-    if args.kv_lora_rank is None:
-        kv_flops = 2 * 2 * seqlen * hidden_size * num_query_groups * args.kv_channels
     else:
+        q_head_dim = args.qk_head_dim + args.qk_pos_emb_head_dim if is_mla else args.kv_channels
+        q_flops = 2 * seqlen * hidden_size * num_attention_heads * q_head_dim
+
+    if is_mla and args.kv_lora_rank is not None:
         kv_flops = (
             2
             * seqlen
@@ -28,18 +33,21 @@ def calculate_qkv_projection_flops(args, seqlen, hidden_size, num_attention_head
                 + args.hidden_size * args.qk_pos_emb_head_dim
             )
         )
+    else:
+        kv_flops = 2 * 2 * seqlen * hidden_size * num_query_groups * args.kv_channels
 
     return q_flops + kv_flops
 
 
 def calculate_attention_flops(args, seqlen, num_attention_heads):
+    is_mla = _is_multi_latent_attention(args)
     # QK^T with causal
-    if args.qk_pos_emb_head_dim:
+    if is_mla:
         flops = 2 * num_attention_heads * seqlen * seqlen * (args.qk_head_dim + args.qk_pos_emb_head_dim) / 2
     else:
         flops = 2 * num_attention_heads * seqlen * seqlen * args.kv_channels / 2
     # A*V
-    if args.v_head_dim:
+    if is_mla:
         flops += num_attention_heads * seqlen * seqlen * args.v_head_dim
     else:
         flops += num_attention_heads * seqlen * seqlen * args.kv_channels


### PR DESCRIPTION
## Summary

Fix FLOPs accounting so MLA projection/attention formulas are gated by `args.multi_latent_attention`, not by Megatron's MLA argument defaults.

Megatron registers MLA args globally, so non-MLA models can still have values such as `kv_lora_rank=32`, `qk_pos_emb_head_dim=64`, and `v_head_dim=128`. The previous FLOPs utility treated those non-None/default values as proof that MLA was active, which caused regular MHA/GQA models to use MLA-style accounting.

## Evidence

A local `scripts/run-qwen3-4B.sh` run with temporary branch logging showed a non-MLA GQA model entering MLA-style FLOPs branches:

```text
[FLOPS_DEBUG:qkv] rank=0 multi_latent_attention=False q_branch=standard_q kv_branch=mla_kv_lora kv_lora_rank=32 q_lora_rank=None num_query_groups=8 kv_channels=128 qk_head_dim=128 qk_pos_emb_head_dim=64 v_head_dim=128 seqlen=8391
[FLOPS_DEBUG:attention] rank=0 multi_latent_attention=False qk_branch=mla_qk_pos_emb_dim v_branch=v_head_dim kv_channels=128 qk_head_dim=128 qk_pos_emb_head_dim=64 v_head_dim=128 seqlen=8391
```

`qwen3-4B.sh` configures GQA (`--group-query-attention`, `--num-query-groups 8`, `--kv-channels 128`) and does not enable `--multi-latent-attention`, so this is a metrics-only bug, not a model forward bug.

## Changes

- Add an explicit `multi_latent_attention` gate in `slime/utils/flops_utils.py`.
- Non-MLA models now always use standard MHA/GQA QKV and attention formulas, ignoring Megatron's MLA defaults.
- MLA models continue to use MLA-specific Q LoRA, KV LoRA, positional QK dim, and V head dim formulas.

## Validation

Local-only validation, no test files added:

```text
local flops formula checks passed
python3 -m py_compile slime/utils/flops_utils.py
git diff --check
```
