### PR TITLE
fix(rollout): support non extra gpu placement when using rollout-external mode

### DIFF
--- a/slime/backends/sglang_utils/sglang_engine.py
+++ b/slime/backends/sglang_utils/sglang_engine.py
@@ -190,6 +190,25 @@ class SGLangEngine(RayActor):
         actual_server_args = _get_actual_server_args()
         _sanity_check_server_args(actual_server_args, expect_server_args)
 
+        # Register external engine with the router, same as _init_normal.
+        if self.node_rank == 0 and self.router_ip and self.router_port:
+            if parse(sglang_router.__version__) <= parse("0.2.1"):
+                response = requests.post(
+                    f"http://{self.router_ip}:{self.router_port}/add_worker?url=http://{self.server_host}:{self.server_port}",
+                )
+            else:
+                payload = {
+                    "url": f"http://{self.server_host}:{self.server_port}",
+                    "worker_type": self.worker_type,
+                }
+                if self.worker_type == "prefill":
+                    payload["bootstrap_port"] = expect_server_args["disaggregation_bootstrap_port"]
+                response = requests.post(
+                    f"http://{self.router_ip}:{self.router_port}/workers",
+                    json=payload,
+                )
+            response.raise_for_status()
+
     def _init_normal(self, server_args_dict):
         logger.info(f"Launch HttpServerEngineAdapter at: {self.server_host}:{self.server_port}")
         self.process = launch_server_process(ServerArgs(**server_args_dict))
@@ -648,4 +667,7 @@ _EXTERNAL_ENGINE_SKIP_CHECK_FIELDS = [
     "enable_draft_weights_cpu_backup",
     "enable_metrics",
     "mem_fraction_static",
+    "host",
+    "base_gpu_id",
+    "gpu_id_step",
 ]

--- a/slime/ray/placement_group.py
+++ b/slime/ray/placement_group.py
@@ -90,6 +90,9 @@ def create_placement_groups(args):
     elif args.colocate:
         num_gpus = args.actor_num_nodes * args.actor_num_gpus_per_node
         rollout_offset = 0
+    elif args.rollout_external:
+        num_gpus = args.actor_num_nodes * args.actor_num_gpus_per_node
+        rollout_offset = 0
     else:
         num_gpus = args.actor_num_nodes * args.actor_num_gpus_per_node + args.rollout_num_gpus
         rollout_offset = args.actor_num_nodes * args.actor_num_gpus_per_node

--- a/slime/ray/rollout.py
+++ b/slime/ray/rollout.py
@@ -1004,7 +1004,7 @@ def _start_router(args, *, has_pd_disaggregation: bool = False, force_new: bool 
 
 def _compute_rollout_offset(args) -> int:
     """Offset (in PG bundle slots) where rollout GPUs start."""
-    if args.debug_train_only or args.debug_rollout_only or args.colocate:
+    if args.debug_train_only or args.debug_rollout_only or args.colocate or args.rollout_external:
         return 0
     offset = args.actor_num_nodes * args.actor_num_gpus_per_node
     return offset

--- a/slime/utils/arguments.py
+++ b/slime/utils/arguments.py
@@ -1827,6 +1827,52 @@ def slime_validate_args(args):
             if args.use_critic:
                 args.rollout_num_gpus += args.critic_num_gpus_per_node * args.critic_num_nodes
 
+    # rollout_external: the inference engines are pre-launched outside slime.
+    # Local SGLangEngine Ray actors are only thin HTTP wrappers that do not
+    # own GPU memory, so they must share the actor's placement group rather
+    # than reserving extra GPU bundles. We also force offload_rollout=False
+    # because release/resume_memory_occupation would HTTP-call the external
+    # server and disturb its memory state.
+    if args.rollout_external:
+        assert not args.colocate, (
+            "--colocate is incompatible with --rollout-external: colocate forces "
+            "rollout_num_gpus to equal actor GPUs and enables offload_rollout, "
+            "both of which conflict with externally-hosted engines."
+        )
+        assert not args.debug_rollout_only, "--debug-rollout-only is incompatible with --rollout-external."
+        assert (
+            args.rollout_external_engine_addrs
+        ), "--rollout-external requires --rollout-external-engine-addrs to be set."
+        # Rollout shares the actor's placement group, which has
+        # actor_num_nodes * actor_num_gpus_per_node GPU bundles. Each external
+        # engine still occupies one bundle slot for scheduling, so the engine
+        # count cannot exceed the actor PG size.
+        num_external_engines = len(args.rollout_external_engine_addrs)
+        actor_pg_slots = args.actor_num_nodes * args.actor_num_gpus_per_node
+        assert num_external_engines <= actor_pg_slots, (
+            f"--rollout-external currently requires num_external_engines "
+            f"({num_external_engines}) <= actor_num_nodes * actor_num_gpus_per_node "
+            f"({actor_pg_slots}), because external rollout actors share the actor "
+            f"placement group bundle-for-bundle. Either reduce "
+            f"--rollout-external-engine-addrs or increase actor GPUs."
+        )
+        # When --rollout-num-gpus is omitted, derive it from the number of
+        # external engine addresses so the user doesn't have to specify a
+        # GPU count for off-host engines.
+        if args.rollout_num_gpus is None:
+            args.rollout_num_gpus = len(args.rollout_external_engine_addrs) * args.rollout_num_gpus_per_engine
+            logger.info(
+                f"rollout_external: derived rollout_num_gpus={args.rollout_num_gpus} "
+                f"from {len(args.rollout_external_engine_addrs)} external address(es) × "
+                f"rollout_num_gpus_per_engine={args.rollout_num_gpus_per_engine}."
+            )
+        if args.offload_rollout:
+            logger.info(
+                "rollout_external is set: forcing offload_rollout=False to avoid "
+                "issuing release/resume_memory_occupation to the external server."
+            )
+        args.offload_rollout = False
+
     if args.offload_train is None:
         args.offload_train = False
     if args.offload_rollout is None:


### PR DESCRIPTION
## Background

rollout-external mode is already supported in slime — it lets the training job talk to a pre-launched SGLang server instead of spawning one. While
  smoke-testing this path end-to-end (machine A hosts SGLang, machine B runs train.py) I hit a few bugs and one piece of waste that this PR cleans up.

**What this PR fixes:**
1. External engine never registers with the router.
2. Sanity check rejects fields that must differ for an external server.
3. Redundant local GPU reservation for the rollout group.
    * For non-colocate runs, slime reserves ```actor_num_gpus + rollout_num_gpus``` GPU bundles in the placement group, with rollout starting at rollout_offset =```actor_num_gpus```.
    * But under --rollout-external the local rollout actor is a thin HTTP wrapper — it doesn't touch local GPU memory, so reserving ```rollout_num_gpus``` extra bundles on the training node is pure waste (and fails outright when the training node doesn't have that many spare GPUs). Reuse the actor PG and set rollout_offset = 0 in both create_placement_groups and _compute_rollout_offset.

## How to reproduce

Two machines. Machine A hosts the pre-launched SGLang server; machine B runs the slime training job and points at it.

1. Machine A — launch the external SGLang server
```
python -m sglang.launch_server \
    --model-path /path/to/model \
    --host 0.0.0.0 \
    --port 10091
```

Verify reachable from B: curl http://<SGLANG_HOST>:10091/get_server_info.

2. Machine B — minimal GRPO smoke test driving the external server

The only --rollout-external-specific bit is the SGLANG_ARGS block:
```
SGLANG_ARGS=(
     --rollout-num-gpus-per-engine 1
     --sglang-mem-fraction-static 0.4
     --rollout-external
     --rollout-external-engine-addrs <SGLANG_HOST>:10091
  )
```

  Full script:
```
  #!/bin/bash
  set -ex

  pkill -9 sglang 2>/dev/null || true
  ray stop --force 2>/dev/null || true
  pkill -9 ray python 2>/dev/null || true
  sleep 2

  export PYTHONBUFFERED=1
  SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
  source "${SCRIPT_DIR}/models/qwen2.5-0.5B.sh"

  CKPT_ARGS=(
     --hf-checkpoint /path/to/Qwen2.5-0.5B-Instruct/
     --ref-load     /path/to/Qwen2.5-0.5B-Instruct_torch_dist/
     --save /tmp/slime_smoke_save/
     --save-interval 9999
  )

  ROLLOUT_ARGS=(
     --prompt-data /path/to/dapo-math-17k.jsonl
     --input-key prompt --label-key label
     --apply-chat-template --rollout-shuffle
     --rm-type deepscaler
     --num-rollout 3 --rollout-batch-size 2
     --n-samples-per-prompt 2 --num-steps-per-rollout 1
     --global-batch-size 4
     --rollout-max-response-len 256 --rollout-temperature 1
  )

  PERF_ARGS=(
     --tensor-model-parallel-size 1 --pipeline-model-parallel-size 1
     --context-parallel-size 1 --expert-model-parallel-size 1
     --expert-tensor-parallel-size 1
     --use-dynamic-batch-size --max-tokens-per-gpu 2048
  )

  GRPO_ARGS=(
     --advantage-estimator grpo --use-kl-loss --kl-loss-coef 0.00
     --kl-loss-type low_var_kl --entropy-coef 0.00
     --eps-clip 0.2 --eps-clip-high 0.28
  )

  OPTIMIZER_ARGS=(
     --optimizer adam --lr 1e-6 --lr-decay-style constant
     --weight-decay 0.1 --adam-beta1 0.9 --adam-beta2 0.98
  )

  SGLANG_ARGS=(
     --rollout-num-gpus-per-engine 1
     --sglang-mem-fraction-static 0.4
     --rollout-external
     --rollout-external-engine-addrs <SGLANG_HOST>:10091
  )

  MISC_ARGS=(
     --attention-dropout 0.0 --hidden-dropout 0.0
     --accumulate-allreduce-grads-in-fp32
     --attention-softmax-in-fp32
     --attention-backend flash
  )

  ray start --head --node-ip-address 127.0.0.1 --num-gpus 2 --disable-usage-stats

  ray job submit --address="http://127.0.0.1:8265" \
     --runtime-env-json='{
       "env_vars": {
          "PYTHONPATH": "/path/to/Megatron-LM/",
          "CUDA_DEVICE_MAX_CONNECTIONS": "1",
       }
     }' \
     -- python3 train.py \
     --actor-num-nodes 1 \
     --actor-num-gpus-per-node 2 \
     "${MODEL_ARGS[@]}" \
     "${CKPT_ARGS[@]}" "${ROLLOUT_ARGS[@]}" \
     "${OPTIMIZER_ARGS[@]}" "${GRPO_ARGS[@]}" \
     "${PERF_ARGS[@]}" "${SGLANG_ARGS[@]}" "${MISC_ARGS[@]}"
```