### PR TITLE
fix: clamp max_new_tokens on retry to prevent response_length overflow

### DIFF
--- a/slime/rollout/sglang_rollout.py
+++ b/slime/rollout/sglang_rollout.py
@@ -163,6 +163,15 @@ async def generate(args: Namespace, sample: Sample, sampling_params: dict[str, A
 
     prompt_ids = _prepare_prompt_ids(sample, state.tokenizer, state.processor)
 
+    # Clamp on retry: ABORTED samples carry response_length from prior attempts.
+    sampling_params = dict(sampling_params)
+    if args.rollout_max_response_len is not None:
+        remaining = args.rollout_max_response_len - sample.response_length
+        if remaining <= 0:
+            sample.status = Sample.Status.TRUNCATED
+            return sample
+        sampling_params["max_new_tokens"] = min(sampling_params["max_new_tokens"], remaining)
+
     assert (
         sampling_params["max_new_tokens"] >= 0
     ), f"max_new_tokens: {sampling_params['max_new_tokens']} should not be less than 0"


### PR DESCRIPTION
## Summary

ABORTED samples are pushed back into the data buffer by `fully_async_rollout`'s done callback and re-picked by the worker, but their `sample.tokens` / `response_length` carry over the partial output from the first attempt. Meanwhile the per-call `sampling_params` is a shallow copy of `GenerateState.sampling_params`, whose `max_new_tokens` is fixed at `args.rollout_max_response_len` and never decremented. On retry sglang sees a new context and generates up to another full `rollout_max_response_len` tokens, so `sample.response_length += new_tokens` can climb to ~2x the configured cap (or higher across retry chains), breaking the training-side per-GPU token budget.

This PR clamps `max_new_tokens` to `(rollout_max_response_len - response_length)` at the entry of `generate()`, and marks the sample `TRUNCATED` when the budget is already exhausted. Mirrors the retool multi-turn fix in #1861.
