### PR TITLE
perf(rollout): pack loss_masks as np.int8 at the ray.put boundary

### DIFF
--- a/slime/ray/rollout.py
+++ b/slime/ray/rollout.py
@@ -684,20 +684,19 @@ class RolloutManager:
             "group_ids": group_ids,
         }
 
-        # loss mask
-        # TODO: compress the loss mask
+        # loss mask: pack as np.int8 at the ray.put boundary.
         loss_masks = []
         for sample in samples:
-            # always instantiate loss_mask if not provided
-            if sample.loss_mask is None:
-                sample.loss_mask = [1] * sample.response_length
-
-            assert (
-                len(sample.loss_mask) == sample.response_length
-            ), f"loss mask length {len(sample.loss_mask)} != response length {sample.response_length}"
             if sample.remove_sample:
-                sample.loss_mask = [0] * sample.response_length
-            loss_masks.append(sample.loss_mask)
+                mask = np.zeros(sample.response_length, dtype=np.int8)
+            elif sample.loss_mask is None:
+                mask = np.ones(sample.response_length, dtype=np.int8)
+            else:
+                assert (
+                    len(sample.loss_mask) == sample.response_length
+                ), f"loss mask length {len(sample.loss_mask)} != response length {sample.response_length}"
+                mask = np.asarray(sample.loss_mask, dtype=np.int8)
+            loss_masks.append(mask)
         train_data["loss_masks"] = loss_masks
 
         # Per-group aggregate, precomputed at the step level (where we can


### PR DESCRIPTION
Address TODO at slime/ray/rollout.py:688. Per-sample loss masks are converted to np.int8 ndarrays in _convert_samples_to_train_data, right before train_data crosses into the Ray plasma store.

- Sample.loss_mask upstream still produces/mutates list[int]; this preserves the existing list contract relied on by sglang_rollout's '+= [1]*n' increment, sglang_streaming_rollout's 'base + [1]*n' splice, trajectory.write_segment_to_sample's 'list(segment.loss_mask)' copy, and sft_rollout's '[-response_length:]' slice.
- Downstream actor._get_rollout_data already does torch.tensor(t, dtype=torch.int, device=cuda) per sample, which accepts ndarray transparently.

```python
rollout_data["loss_masks"] = [
    torch.tensor(t, dtype=torch.int, device=torch.cuda.current_device()) for t in rollout_data["loss_masks"] 
] # from list[numpy(int8)] -> list[tensor(int)]
```

Effects:
- ~35x lower trainer-process Python heap after deserialization (1 B/token vs ~36 B/token in CPython list[int])
- smaller Ray plasma payload
