### PR TITLE
perf(megatron-loss): scale logits per-chunk to avoid OOM

### DIFF
--- a/slime/backends/megatron_utils/loss.py
+++ b/slime/backends/megatron_utils/loss.py
@@ -140,8 +140,8 @@ def get_responses(
 
         # Apply temperature per-chunk instead of on the full [T, V] logits to avoid
         # a single ~16GiB allocation that OOMs under fragmentation.
-        if args.rollout_temperature != 1.0:
-            logits_chunk = logits_chunk / args.rollout_temperature
+        if apply_temperature and args.rollout_temperature != 1.0:
+            logits_chunk = logits_chunk.div(args.rollout_temperature)
 
         yield logits_chunk, tokens_chunk
 

--- a/slime/backends/megatron_utils/loss.py
+++ b/slime/backends/megatron_utils/loss.py
@@ -75,9 +75,6 @@ def get_responses(
         assert max_seq_lens is not None
         logits = logits.view(-1, logits.size(-1))
 
-    if apply_temperature and args.rollout_temperature != 1.0:
-        logits = logits.div(args.rollout_temperature)
-
     cp_size = mpu.get_context_parallel_world_size()
     end = 0
     seq_start = 0
@@ -140,6 +137,11 @@ def get_responses(
             tokens_chunk = torch.cat([tokens_0, tokens_1], dim=0)
 
         seq_start += total_length
+
+        # Apply temperature per-chunk instead of on the full [T, V] logits to avoid
+        # a single ~16GiB allocation that OOMs under fragmentation.
+        if args.rollout_temperature != 1.0:
+            logits_chunk = logits_chunk / args.rollout_temperature
 
         yield logits_chunk, tokens_chunk
 


### PR DESCRIPTION
    # ⚡ Performance

    ## Move rollout_temperature division into per-chunk yield in get_responses

    - Remove full-tensor `logits.div(rollout_temperature)` that allocated a
      duplicate `[T, V]` fp32 buffer (~16 GiB on Qwen3 with long packed
      sequences), doubling loss-step peak memory and triggering OOM under
      allocator fragmentation
    - Apply the scalar division to each `logits_chunk` right before yielding,
      so allocations are bounded by per-sample response size and happen
      incrementally instead of as a single giant contiguous block
    - Numerically equivalent across all four chunking paths (cp_size==1 RL,
      SFT, allgather_cp, zigzag CP) since scalar division commutes with
      slicing and concatenation