### PR TITLE
fix(colocate): derive num_gpus_per_node from actor_num_gpus_per_node

### DIFF
--- a/slime/utils/arguments.py
+++ b/slime/utils/arguments.py
@@ -1818,6 +1818,19 @@ def slime_validate_args(args):
             args.offload_train = True
         if args.offload_rollout is None:
             args.offload_rollout = True
+        # In colocate mode the rollout engines share the actor's physical nodes, so the
+        # GPUs-per-physical-node equals actor_num_gpus_per_node. --num-gpus-per-node defaults
+        # to 8 (an 8-GPU/node assumption); on hardware with a different per-node count (e.g.
+        # 4x GB200/node) that default is wrong for MULTI-NODE colocate: the rollout-engine
+        # addr/port allocation computes node_index via num_gpus_per_node and maps every engine
+        # to node 0, so worker-node engines are handed the head node's IP and fail to bind
+        # (OSError: [Errno 99] Cannot assign requested address). Derive the real per-node count.
+        if args.num_gpus_per_node != args.actor_num_gpus_per_node:
+            logger.info(
+                f"colocate: overriding num_gpus_per_node {args.num_gpus_per_node} -> "
+                f"actor_num_gpus_per_node {args.actor_num_gpus_per_node} (per-physical-node GPU count)."
+            )
+            args.num_gpus_per_node = args.actor_num_gpus_per_node
         if args.rollout_num_gpus != args.actor_num_gpus_per_node * args.actor_num_nodes:
             logger.info(
                 f"rollout_num_gpus {args.rollout_num_gpus} != actor_num_gpus_per_node {args.actor_num_gpus_per_node} "


### PR DESCRIPTION
## Problem

In **colocate** mode the rollout engines share the actor's physical nodes, so the GPUs-per-physical-node always equals `actor_num_gpus_per_node`. But `--num-gpus-per-node` defaults to `8` (an 8-GPU/node assumption). On hardware with a different per-node GPU count (e.g. **4× GB200/node**), that default is wrong for **multi-node** colocate runs.

`_allocate_rollout_engine_addr_and_ports_normal` does:

```python
num_engines_per_node = max(1, args.num_gpus_per_node // _gpus_per_engine)
...
node_index = local_rank // num_engines_per_node
```

With `num_gpus_per_node=8` but only 4 GPUs/node and `rollout_num_gpus_per_engine=2`, `num_engines_per_node` becomes `4` instead of `2`, so **every engine maps to `node_index=0`** and is handed the head node's IP. Worker-node engines then fail to bind:

```
OSError: [Errno 99] Cannot assign requested address
  -> server exited unexpectedly
```

The help text already documents the manual workaround ("If you are going to use less than 8 gpus per node under colocate mode, you should set this number"), but it's silently easy to forget and the resulting failure is opaque.

## Fix

Since the value is fully determined in colocate mode, derive it automatically from `actor_num_gpus_per_node`:

```python
if args.num_gpus_per_node != args.actor_num_gpus_per_node:
    logger.info("colocate: overriding num_gpus_per_node ... -> actor_num_gpus_per_node ...")
    args.num_gpus_per_node = args.actor_num_gpus_per_node
```

## Scope / safety

- **Single-node 8-GPU runs**: unaffected — `actor_num_gpus_per_node == 8 == default`, so the override is a no-op.
- **Non-colocate (disaggregated) runs**: untouched (the override is inside the `if args.colocate:` block), preserving the ability to configure a rollout cluster with a different per-node GPU count than the actor.
- Consuming/allocation logic is unchanged.

## Verification

Reproduced and fixed on a 2-node, 4-GPU/node Blackwell colocate run:
- **Before**: all rollout engines report the head node's IP → worker engines `Errno 99`.
- **After**: log shows `colocate: overriding num_gpus_per_node 8 -> 4`; engines split correctly across head (engines 0,1) and worker (engines 2,3); bind succeeds.