### PR TITLE
fix(rollout): apply sample filter in rollout manager

### DIFF
--- a/slime/ray/rollout.py
+++ b/slime/ray/rollout.py
@@ -16,7 +16,7 @@ from sglang.srt.constants import GPU_MEMORY_TYPE_CUDA_GRAPH, GPU_MEMORY_TYPE_KV_
 
 from slime.backends.sglang_utils.sglang_config import ModelConfig, ServerGroupConfig, SglangConfig
 from slime.backends.sglang_utils.sglang_engine import SGLangEngine
-from slime.rollout.base_types import call_rollout_fn
+from slime.rollout.base_types import apply_rollout_sample_filter, call_rollout_fn
 from slime.utils import logging_utils
 from slime.utils.dp_schedule import build_dp_schedule
 from slime.utils.health_monitor import RolloutHealthMonitor
@@ -601,6 +601,7 @@ class RolloutManager:
             # set the same rollout_id on every sibling so the loss reducer counts
             # the rollout once instead of N times.
             _validate_rollout_id_annotated(data)
+            apply_rollout_sample_filter(self.args, data)
             # flatten the data if it is a list of lists
             while isinstance(data[0], list):
                 data = list(itertools.chain.from_iterable(data))

--- a/slime/rollout/base_types.py
+++ b/slime/rollout/base_types.py
@@ -24,3 +24,14 @@ def call_rollout_fn(fn, *args, evaluation: bool, **kwargs):
         output = RolloutFnEvalOutput(data=output) if evaluation else RolloutFnTrainOutput(samples=output)
 
     return output
+
+
+def apply_rollout_sample_filter(args, samples: list[Any]) -> None:
+    """Apply the rollout sample filter to grouped rollout samples in place."""
+    if args.rollout_sample_filter_path is None:
+        return
+
+    from slime.utils.misc import load_function
+
+    filter_func = load_function(args.rollout_sample_filter_path)
+    filter_func(args, samples)

--- a/slime/rollout/sglang_rollout.py
+++ b/slime/rollout/sglang_rollout.py
@@ -475,11 +475,9 @@ async def generate_rollout_async(
 
     # reset the global state to prevent effects on the next rollout or eval.
     state.reset()
-    if args.rollout_sample_filter_path is not None:
-        filter_func = load_function(args.rollout_sample_filter_path)
-        filter_func(args, data)
 
-    # There can be circumstances where users want to process all samples including filtered ones.
+    # RolloutManager applies rollout_sample_filter_path after rollout functions return.
+    # This hook stays here because it needs all samples, including filtered ones.
     if args.rollout_all_samples_process_path is not None:
         process_func = load_function(args.rollout_all_samples_process_path)
         process_func(args, all_samples, data_source)

--- a/tests/plugin_contracts/test_plugin_rollout_contracts.py
+++ b/tests/plugin_contracts/test_plugin_rollout_contracts.py
@@ -24,7 +24,12 @@ NUM_GPUS = 0
 DEFAULT_ROLLOUT_FUNCTION_PATH = "slime.rollout.sglang_rollout.generate_rollout"
 REFERENCE_ROLLOUT_FUNCTION_PATH = "plugin_contracts.test_plugin_rollout_contracts.valid_rollout_function"
 
-from slime.rollout.base_types import RolloutFnEvalOutput, RolloutFnTrainOutput, call_rollout_fn
+from slime.rollout.base_types import (
+    RolloutFnEvalOutput,
+    RolloutFnTrainOutput,
+    apply_rollout_sample_filter,
+    call_rollout_fn,
+)
 from slime.rollout.sglang_rollout import generate_rollout as default_generate_rollout
 from slime.utils.misc import load_function
 from slime.utils.types import Sample
@@ -79,6 +84,11 @@ def valid_rollout_function(args, rollout_id, data_source, evaluation=False):
             sample.reward = float(group_index + sample_index)
             sample.status = Sample.Status.COMPLETED
     return RolloutFnTrainOutput(samples=groups, metrics={"source": "contract"})
+
+
+def drop_last_sample_filter(args, groups: list[list[Sample]]) -> None:
+    for group in groups:
+        group[-1].remove_sample = True
 
 
 def invalid_rollout_function(args, rollout_id, data_source, evaluation=False):
@@ -178,6 +188,24 @@ def test_default_rollout_compat_wrapper_stability():
 
 def test_local_rollout_plugin_aligns_with_default_input_output_format():
     assert_rollout_function_matches_default_contract(valid_rollout_function)
+
+
+def test_rollout_sample_filter_applies_to_custom_rollout_output():
+    args = type(
+        "Args",
+        (),
+        {
+            "rollout_sample_filter_path": "plugin_contracts.test_plugin_rollout_contracts.drop_last_sample_filter",
+        },
+    )()
+    train_output = call_rollout_fn(valid_rollout_function, args, 2, ContractDataSource(), evaluation=False)
+
+    apply_rollout_sample_filter(args, train_output.samples)
+
+    assert [[sample.remove_sample for sample in group] for group in train_output.samples] == [
+        [False, True],
+        [False, True],
+    ]
 
 
 def test_misaligned_rollout_plugin_is_rejected():


### PR DESCRIPTION
## Summary

This PR fixes `--rollout-sample-filter-path` so it is applied consistently for all training rollout functions, including custom functions loaded through `--rollout-function-path`.

`--rollout-sample-filter-path` is documented as a rollout customization hook. It lets users mark generated `Sample`s with `remove_sample=True` so those samples are excluded from loss calculation. Currently, the hook is applied inside the default SGLang rollout implementation. That works for the default path, but custom rollout functions can return valid training samples through `RolloutManager` without the configured sample filter being applied.

This PR moves the sample-filter application to `RolloutManager._get_rollout_data`, after rollout output normalization and `_validate_rollout_id_annotated(data)`, and before flattening the nested rollout samples.

## Motivation

This is intended as a narrow bug fix within the contribution scope described in `CONTRIBUTING.md`: it fixes existing behavior, adds focused CPU contract-test coverage, and avoids introducing a new feature, abstraction, or broad refactor.

The behavior this PR restores is:

> If `args.rollout_sample_filter_path` is set, every training rollout function output that reaches `RolloutManager` has the same in-place `Sample.remove_sample` filter applied before conversion to train data.

Without this change, two rollout functions that both return valid `RolloutFnTrainOutput` data can behave differently depending only on whether they are the built-in SGLang provider or a custom provider.

## Why the Manager Boundary

`RolloutManager._get_rollout_data` is the smallest shared boundary that sees every training rollout output before train-data conversion:

- Every training rollout function, built-in or custom, already funnels through this method.
- The manager already normalizes legacy/custom rollout outputs via `call_rollout_fn`.
- Applying the filter after `_validate_rollout_id_annotated(data)` preserves the existing validation order: invalid compact rollout outputs fail before user filter code mutates them.
- Applying the filter before flattening preserves the grouped shape expected by the existing sample-filter contract.
- The default SGLang rollout behavior remains equivalent, while custom rollout functions now honor the same documented argument.

Keeping the hook at this shared boundary avoids requiring each rollout provider, or each custom rollout author, to repeat the same framework-level hook call and ordering.

## What Stays Unchanged

`rollout_all_samples_process_path` intentionally stays in `sglang_rollout.py`. That hook needs `all_samples`, including groups dropped by dynamic filtering before the manager receives the kept rollout data. Moving it to the manager would require passing provider-local state into the manager, so this PR leaves that behavior untouched.

## Alternatives Considered

- Keep the filter only in `sglang_rollout.py`: simple, but custom rollout functions still do not receive the documented hook behavior.
- Ask each rollout function to call the filter itself: avoids touching the manager, but duplicates sequencing across providers and makes custom rollout correctness depend on each implementation remembering the framework hook.
- Apply the filter after flattening or during train-data conversion: easier to centralize, but it would lose the grouped rollout context used by the existing hook contract.
- Move `rollout_all_samples_process_path` too: not equivalent, because the manager does not receive dropped/unused groups.

## Validation

- `uv run --no-project --with black==24.3.0 black --check slime/rollout/base_types.py slime/ray/rollout.py slime/rollout/sglang_rollout.py tests/plugin_contracts/test_plugin_rollout_contracts.py`
- `uv run --no-project --with ruff ruff check slime/rollout/base_types.py slime/ray/rollout.py slime/rollout/sglang_rollout.py tests/plugin_contracts/test_plugin_rollout_contracts.py`
- `python tests/plugin_contracts/test_plugin_rollout_contracts.py` in a Python 3.12 CPU test environment: 7 passed
- `python tests/plugin_contracts/test_plugin_path_loading_contracts.py` in the same environment: 14 passed
- `python -m py_compile slime/rollout/base_types.py slime/ray/rollout.py slime/rollout/sglang_rollout.py tests/plugin_contracts/test_plugin_rollout_contracts.py`
- `uv run --no-project --with pre-commit pre-commit run --files slime/rollout/base_types.py slime/ray/rollout.py slime/rollout/sglang_rollout.py tests/plugin_contracts/test_plugin_rollout_contracts.py`
- `git diff --check`

I did not run a GPU e2e test because the change is limited to a CPU-verifiable rollout hook contract and does not touch model execution, SGLang engine behavior, or Megatron training math.