### PR TITLE
feat: add --balance-by-flops for FLOPs-balanced micro-batching

### DIFF
--- a/slime/utils/arguments.py
+++ b/slime/utils/arguments.py
@@ -1786,23 +1786,6 @@ def slime_validate_args(args):
     if getattr(args, "balance_by_flops", False):
         assert args.use_dynamic_batch_size, "--balance-by-flops requires --use-dynamic-batch-size"
 
-        h = getattr(args, "hidden_size", None)
-        ffn = getattr(args, "ffn_hidden_size", None)
-        if h is None or ffn is None:
-            args.workload_coeff = 24576
-        else:
-            num_experts = getattr(args, "num_experts", None)
-            if num_experts is not None and num_experts > 1:
-                topk = getattr(args, "moe_router_topk", 1)
-                moe_ffn = getattr(args, "moe_ffn_hidden_size", ffn)
-                shared = getattr(args, "moe_shared_expert_intermediate_size", None) or 0
-                d_ff = moe_ffn * topk + shared
-            else:
-                d_ff = ffn
-            ffn_mul = 3 if getattr(args, "swiglu", False) else 2
-            args.workload_coeff = 2 * h + ffn_mul * d_ff // 2
-        logger.info(f"balance-by-flops: workload_coeff={args.workload_coeff}")
-
     if args.eps_clip_high is None:
         args.eps_clip_high = args.eps_clip
 

--- a/slime/utils/arguments.py
+++ b/slime/utils/arguments.py
@@ -687,17 +687,6 @@ def get_slime_extra_args_provider(add_custom_arguments=None):
             )
 
             parser.add_argument(
-                "--exact-flops-balance",
-                action="store_true",
-                default=False,
-                help=(
-                    "When used with --balance-by-flops, compute exact per-sample FLOPs via "
-                    "calculate_fwd_flops instead of the lightweight coeff*L + L² approximation. "
-                    "Useful for ablation studies comparing approximate vs exact FLOPs balancing."
-                ),
-            )
-
-            parser.add_argument(
                 "--use-dynamic-batch-size",
                 action="store_true",
                 default=False,
@@ -1793,9 +1782,6 @@ def slime_validate_args(args):
         assert args.max_tokens_per_gpu is not None, "max_tokens_per_gpu must be set when use_dynamic_batch_size is set"
         if args.log_probs_max_tokens_per_gpu is None:
             args.log_probs_max_tokens_per_gpu = args.max_tokens_per_gpu
-
-    if getattr(args, "exact_flops_balance", False):
-        assert getattr(args, "balance_by_flops", False), "--exact-flops-balance requires --balance-by-flops"
 
     if getattr(args, "balance_by_flops", False):
         assert args.use_dynamic_batch_size, "--balance-by-flops requires --use-dynamic-batch-size"

--- a/slime/utils/arguments.py
+++ b/slime/utils/arguments.py
@@ -673,6 +673,20 @@ def get_slime_extra_args_provider(add_custom_arguments=None):
             )
 
             parser.add_argument(
+                "--balance-by-flops",
+                action="store_true",
+                default=False,
+                help=(
+                    "Use FLOPs-based workload estimation (coeff*L + L²) for micro-batch "
+                    "partitioning via Karmarkar-Karp instead of first-fit token packing. "
+                    "The linear coefficient is auto-computed from model config (hidden_size, "
+                    "ffn_hidden_size, swiglu, MoE experts). Captures the quadratic cost of "
+                    "attention, producing more balanced micro-batches when sequence lengths "
+                    "vary widely. Requires --use-dynamic-batch-size."
+                ),
+            )
+
+            parser.add_argument(
                 "--use-dynamic-batch-size",
                 action="store_true",
                 default=False,
@@ -1768,6 +1782,26 @@ def slime_validate_args(args):
         assert args.max_tokens_per_gpu is not None, "max_tokens_per_gpu must be set when use_dynamic_batch_size is set"
         if args.log_probs_max_tokens_per_gpu is None:
             args.log_probs_max_tokens_per_gpu = args.max_tokens_per_gpu
+
+    if getattr(args, "balance_by_flops", False):
+        assert args.use_dynamic_batch_size, "--balance-by-flops requires --use-dynamic-batch-size"
+
+        h = getattr(args, "hidden_size", None)
+        ffn = getattr(args, "ffn_hidden_size", None)
+        if h is None or ffn is None:
+            args.workload_coeff = 24576
+        else:
+            num_experts = getattr(args, "num_experts", None)
+            if num_experts is not None and num_experts > 1:
+                topk = getattr(args, "moe_router_topk", 1)
+                moe_ffn = getattr(args, "moe_ffn_hidden_size", ffn)
+                shared = getattr(args, "moe_shared_expert_intermediate_size", None) or 0
+                d_ff = moe_ffn * topk + shared
+            else:
+                d_ff = ffn
+            ffn_mul = 3 if getattr(args, "swiglu", False) else 2
+            args.workload_coeff = 2 * h + ffn_mul * d_ff // 2
+        logger.info(f"balance-by-flops: workload_coeff={args.workload_coeff}")
 
     if args.eps_clip_high is None:
         args.eps_clip_high = args.eps_clip

--- a/slime/utils/arguments.py
+++ b/slime/utils/arguments.py
@@ -687,6 +687,17 @@ def get_slime_extra_args_provider(add_custom_arguments=None):
             )
 
             parser.add_argument(
+                "--exact-flops-balance",
+                action="store_true",
+                default=False,
+                help=(
+                    "When used with --balance-by-flops, compute exact per-sample FLOPs via "
+                    "calculate_fwd_flops instead of the lightweight coeff*L + L² approximation. "
+                    "Useful for ablation studies comparing approximate vs exact FLOPs balancing."
+                ),
+            )
+
+            parser.add_argument(
                 "--use-dynamic-batch-size",
                 action="store_true",
                 default=False,
@@ -1782,6 +1793,9 @@ def slime_validate_args(args):
         assert args.max_tokens_per_gpu is not None, "max_tokens_per_gpu must be set when use_dynamic_batch_size is set"
         if args.log_probs_max_tokens_per_gpu is None:
             args.log_probs_max_tokens_per_gpu = args.max_tokens_per_gpu
+
+    if getattr(args, "exact_flops_balance", False):
+        assert getattr(args, "balance_by_flops", False), "--exact-flops-balance requires --balance-by-flops"
 
     if getattr(args, "balance_by_flops", False):
         assert args.use_dynamic_batch_size, "--balance-by-flops requires --use-dynamic-batch-size"

--- a/slime/utils/dp_schedule.py
+++ b/slime/utils/dp_schedule.py
@@ -43,6 +43,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from slime.utils.flops_utils import calculate_fwd_flops
 from slime.utils.seqlen_balancing import (
     calculate_workload,
     expand_bins_by_splitting,
@@ -53,14 +54,21 @@ from slime.utils.seqlen_balancing import (
 logger = logging.getLogger(__name__)
 
 
+def _calculate_workloads(step_lengths, args, exact_flops_balance):
+    if exact_flops_balance:
+        return [calculate_fwd_flops([l], args) for l in step_lengths]
+    return calculate_workload(step_lengths, coeff=getattr(args, "workload_coeff", 24576))
+
+
 def _pack_step_into_mbs(
     step_lengths: list[int],
     *,
+    args: Any,
     use_dynamic_batch_size: bool,
     max_per_bin: int | None,
     micro_batch_size: int | None,
     balance_by_flops: bool = False,
-    workload_coeff: int = 24576,
+    exact_flops_balance: bool = False,
 ) -> list[list[int]]:
     """Group a step's samples into mbs. Returns ``mbs[k]`` = local indices into ``step_lengths``."""
     if use_dynamic_batch_size:
@@ -70,7 +78,7 @@ def _pack_step_into_mbs(
             num_mbs = max(1, (total_tokens + max_per_bin - 1) // max_per_bin)
             if num_mbs >= len(step_lengths):
                 return [[i] for i in range(len(step_lengths))]
-            workloads = calculate_workload(step_lengths, coeff=workload_coeff)
+            workloads = _calculate_workloads(step_lengths, args, exact_flops_balance)
             return get_seqlen_balanced_partitions(workloads, num_mbs, equal_size=False)
         return first_fit_pack(step_lengths, max_per_bin)
     assert micro_batch_size is not None
@@ -155,14 +163,15 @@ def build_dp_schedule(
         # 1. Pack samples in this step into mbs with one global pass.
         # ``step_mbs`` indices are LOCAL into ``sample_indices``.
         balance_by_flops = getattr(args, "balance_by_flops", False)
-        workload_coeff = getattr(args, "workload_coeff", 24576)
+        exact_flops_balance = getattr(args, "exact_flops_balance", False)
         step_mbs = _pack_step_into_mbs(
             step_lengths,
+            args=args,
             use_dynamic_batch_size=args.use_dynamic_batch_size,
             max_per_bin=max_per_bin,
             micro_batch_size=getattr(args, "micro_batch_size", None),
             balance_by_flops=balance_by_flops,
-            workload_coeff=workload_coeff,
+            exact_flops_balance=exact_flops_balance,
         )
 
         # 2. Align mbs count to a multiple of ``align_to``.
@@ -193,7 +202,7 @@ def build_dp_schedule(
         # or balance_by_flops is on, otherwise a strided round-robin.
         if args.balance_data or balance_by_flops:
             if balance_by_flops:
-                step_workloads = calculate_workload(step_lengths, coeff=workload_coeff)
+                step_workloads = _calculate_workloads(step_lengths, args, exact_flops_balance)
                 mbs_weights = [sum(step_workloads[i] for i in bin_) for bin_ in step_mbs]
             else:
                 mbs_weights = [sum(step_lengths[i] for i in bin_) for bin_ in step_mbs]

--- a/slime/utils/dp_schedule.py
+++ b/slime/utils/dp_schedule.py
@@ -43,8 +43,8 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from slime.utils.flops_utils import calculate_fwd_flops
 from slime.utils.seqlen_balancing import (
-    calculate_workload,
     expand_bins_by_splitting,
     first_fit_pack,
     get_seqlen_balanced_partitions,
@@ -53,14 +53,18 @@ from slime.utils.seqlen_balancing import (
 logger = logging.getLogger(__name__)
 
 
+def _calculate_workloads(step_lengths, args):
+    return [calculate_fwd_flops([l], args) for l in step_lengths]
+
+
 def _pack_step_into_mbs(
     step_lengths: list[int],
     *,
+    args: Any,
     use_dynamic_batch_size: bool,
     max_per_bin: int | None,
     micro_batch_size: int | None,
     balance_by_flops: bool = False,
-    workload_coeff: int = 24576,
 ) -> list[list[int]]:
     """Group a step's samples into mbs. Returns ``mbs[k]`` = local indices into ``step_lengths``."""
     if use_dynamic_batch_size:
@@ -70,7 +74,7 @@ def _pack_step_into_mbs(
             num_mbs = max(1, (total_tokens + max_per_bin - 1) // max_per_bin)
             if num_mbs >= len(step_lengths):
                 return [[i] for i in range(len(step_lengths))]
-            workloads = calculate_workload(step_lengths, coeff=workload_coeff)
+            workloads = _calculate_workloads(step_lengths, args)
             return get_seqlen_balanced_partitions(workloads, num_mbs, equal_size=False)
         return first_fit_pack(step_lengths, max_per_bin)
     assert micro_batch_size is not None
@@ -155,14 +159,13 @@ def build_dp_schedule(
         # 1. Pack samples in this step into mbs with one global pass.
         # ``step_mbs`` indices are LOCAL into ``sample_indices``.
         balance_by_flops = getattr(args, "balance_by_flops", False)
-        workload_coeff = getattr(args, "workload_coeff", 24576)
         step_mbs = _pack_step_into_mbs(
             step_lengths,
+            args=args,
             use_dynamic_batch_size=args.use_dynamic_batch_size,
             max_per_bin=max_per_bin,
             micro_batch_size=getattr(args, "micro_batch_size", None),
             balance_by_flops=balance_by_flops,
-            workload_coeff=workload_coeff,
         )
 
         # 2. Align mbs count to a multiple of ``align_to``.
@@ -193,7 +196,7 @@ def build_dp_schedule(
         # or balance_by_flops is on, otherwise a strided round-robin.
         if args.balance_data or balance_by_flops:
             if balance_by_flops:
-                step_workloads = calculate_workload(step_lengths, coeff=workload_coeff)
+                step_workloads = _calculate_workloads(step_lengths, args)
                 mbs_weights = [sum(step_workloads[i] for i in bin_) for bin_ in step_mbs]
             else:
                 mbs_weights = [sum(step_lengths[i] for i in bin_) for bin_ in step_mbs]

--- a/slime/utils/dp_schedule.py
+++ b/slime/utils/dp_schedule.py
@@ -43,7 +43,6 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from slime.utils.flops_utils import calculate_fwd_flops
 from slime.utils.seqlen_balancing import (
     calculate_workload,
     expand_bins_by_splitting,
@@ -54,21 +53,14 @@ from slime.utils.seqlen_balancing import (
 logger = logging.getLogger(__name__)
 
 
-def _calculate_workloads(step_lengths, args, exact_flops_balance):
-    if exact_flops_balance:
-        return [calculate_fwd_flops([l], args) for l in step_lengths]
-    return calculate_workload(step_lengths, coeff=getattr(args, "workload_coeff", 24576))
-
-
 def _pack_step_into_mbs(
     step_lengths: list[int],
     *,
-    args: Any,
     use_dynamic_batch_size: bool,
     max_per_bin: int | None,
     micro_batch_size: int | None,
     balance_by_flops: bool = False,
-    exact_flops_balance: bool = False,
+    workload_coeff: int = 24576,
 ) -> list[list[int]]:
     """Group a step's samples into mbs. Returns ``mbs[k]`` = local indices into ``step_lengths``."""
     if use_dynamic_batch_size:
@@ -78,7 +70,7 @@ def _pack_step_into_mbs(
             num_mbs = max(1, (total_tokens + max_per_bin - 1) // max_per_bin)
             if num_mbs >= len(step_lengths):
                 return [[i] for i in range(len(step_lengths))]
-            workloads = _calculate_workloads(step_lengths, args, exact_flops_balance)
+            workloads = calculate_workload(step_lengths, coeff=workload_coeff)
             return get_seqlen_balanced_partitions(workloads, num_mbs, equal_size=False)
         return first_fit_pack(step_lengths, max_per_bin)
     assert micro_batch_size is not None
@@ -163,15 +155,14 @@ def build_dp_schedule(
         # 1. Pack samples in this step into mbs with one global pass.
         # ``step_mbs`` indices are LOCAL into ``sample_indices``.
         balance_by_flops = getattr(args, "balance_by_flops", False)
-        exact_flops_balance = getattr(args, "exact_flops_balance", False)
+        workload_coeff = getattr(args, "workload_coeff", 24576)
         step_mbs = _pack_step_into_mbs(
             step_lengths,
-            args=args,
             use_dynamic_batch_size=args.use_dynamic_batch_size,
             max_per_bin=max_per_bin,
             micro_batch_size=getattr(args, "micro_batch_size", None),
             balance_by_flops=balance_by_flops,
-            exact_flops_balance=exact_flops_balance,
+            workload_coeff=workload_coeff,
         )
 
         # 2. Align mbs count to a multiple of ``align_to``.
@@ -202,7 +193,7 @@ def build_dp_schedule(
         # or balance_by_flops is on, otherwise a strided round-robin.
         if args.balance_data or balance_by_flops:
             if balance_by_flops:
-                step_workloads = _calculate_workloads(step_lengths, args, exact_flops_balance)
+                step_workloads = calculate_workload(step_lengths, coeff=workload_coeff)
                 mbs_weights = [sum(step_workloads[i] for i in bin_) for bin_ in step_mbs]
             else:
                 mbs_weights = [sum(step_lengths[i] for i in bin_) for bin_ in step_mbs]

--- a/slime/utils/dp_schedule.py
+++ b/slime/utils/dp_schedule.py
@@ -43,7 +43,12 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from slime.utils.seqlen_balancing import expand_bins_by_splitting, first_fit_pack, get_seqlen_balanced_partitions
+from slime.utils.seqlen_balancing import (
+    calculate_workload,
+    expand_bins_by_splitting,
+    first_fit_pack,
+    get_seqlen_balanced_partitions,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -54,10 +59,19 @@ def _pack_step_into_mbs(
     use_dynamic_batch_size: bool,
     max_per_bin: int | None,
     micro_batch_size: int | None,
+    balance_by_flops: bool = False,
+    workload_coeff: int = 24576,
 ) -> list[list[int]]:
     """Group a step's samples into mbs. Returns ``mbs[k]`` = local indices into ``step_lengths``."""
     if use_dynamic_batch_size:
         assert max_per_bin is not None
+        if balance_by_flops:
+            total_tokens = sum(step_lengths)
+            num_mbs = max(1, (total_tokens + max_per_bin - 1) // max_per_bin)
+            if num_mbs >= len(step_lengths):
+                return [[i] for i in range(len(step_lengths))]
+            workloads = calculate_workload(step_lengths, coeff=workload_coeff)
+            return get_seqlen_balanced_partitions(workloads, num_mbs, equal_size=False)
         return first_fit_pack(step_lengths, max_per_bin)
     assert micro_batch_size is not None
     n = len(step_lengths)
@@ -140,11 +154,15 @@ def build_dp_schedule(
 
         # 1. Pack samples in this step into mbs with one global pass.
         # ``step_mbs`` indices are LOCAL into ``sample_indices``.
+        balance_by_flops = getattr(args, "balance_by_flops", False)
+        workload_coeff = getattr(args, "workload_coeff", 24576)
         step_mbs = _pack_step_into_mbs(
             step_lengths,
             use_dynamic_batch_size=args.use_dynamic_batch_size,
             max_per_bin=max_per_bin,
             micro_batch_size=getattr(args, "micro_batch_size", None),
+            balance_by_flops=balance_by_flops,
+            workload_coeff=workload_coeff,
         )
 
         # 2. Align mbs count to a multiple of ``align_to``.
@@ -171,12 +189,15 @@ def build_dp_schedule(
         num_mbs_per_rank = K // dp_size
         num_microbatches.append(num_mbs_per_rank)
 
-        # 3. Distribute mbs across ranks: KK on mbs token sums when balance_data is on,
-        # otherwise a strided round-robin. Both produce ``num_mbs_per_rank`` mbs per
-        # rank (equal_size=True is what KK needs for PP to stay synced).
-        if args.balance_data:
-            mbs_token_sums = [sum(step_lengths[i] for i in bin_) for bin_ in step_mbs]
-            rank_mbs_idx = get_seqlen_balanced_partitions(mbs_token_sums, dp_size, equal_size=True)
+        # 3. Distribute mbs across ranks: KK on mbs workloads when balance_data
+        # or balance_by_flops is on, otherwise a strided round-robin.
+        if args.balance_data or balance_by_flops:
+            if balance_by_flops:
+                step_workloads = calculate_workload(step_lengths, coeff=workload_coeff)
+                mbs_weights = [sum(step_workloads[i] for i in bin_) for bin_ in step_mbs]
+            else:
+                mbs_weights = [sum(step_lengths[i] for i in bin_) for bin_ in step_mbs]
+            rank_mbs_idx = get_seqlen_balanced_partitions(mbs_weights, dp_size, equal_size=True)
         else:
             rank_mbs_idx = [list(range(r, K, dp_size)) for r in range(dp_size)]
 

--- a/slime/utils/dp_schedule.py
+++ b/slime/utils/dp_schedule.py
@@ -44,17 +44,13 @@ import logging
 from typing import Any
 
 from slime.utils.flops_utils import calculate_fwd_flops
-from slime.utils.seqlen_balancing import (
-    expand_bins_by_splitting,
-    first_fit_pack,
-    get_seqlen_balanced_partitions,
-)
+from slime.utils.seqlen_balancing import expand_bins_by_splitting, first_fit_pack, get_seqlen_balanced_partitions
 
 logger = logging.getLogger(__name__)
 
 
 def _calculate_workloads(step_lengths, args):
-    return [calculate_fwd_flops([l], args) for l in step_lengths]
+    return [calculate_fwd_flops([sl], args) for sl in step_lengths]
 
 
 def _pack_step_into_mbs(

--- a/slime/utils/seqlen_balancing.py
+++ b/slime/utils/seqlen_balancing.py
@@ -177,6 +177,18 @@ def get_seqlen_balanced_partitions(seqlen_list: list[int], k_partitions: int, eq
     return _check_and_sort_partitions(partitions)
 
 
+def calculate_workload(seqlen_list, coeff=24576):
+    """Estimate per-sequence transformer FLOPs proportional to ``coeff * L + L²``.
+
+    ``coeff`` is the linear coefficient that captures FFN + attention projection
+    cost, pre-computed from model config as ``2*h + ffn_mul * d_ff // 2``
+    (see ``slime_validate_args`` in arguments.py).  Default 24576 = 6*4096.
+    """
+    if isinstance(seqlen_list, list):
+        return [coeff * l + l * l for l in seqlen_list]
+    return coeff * seqlen_list + seqlen_list ** 2
+
+
 def first_fit_pack(total_lengths, max_tokens_per_bin):
     """First-fit bin packing.
 

--- a/slime/utils/seqlen_balancing.py
+++ b/slime/utils/seqlen_balancing.py
@@ -185,8 +185,8 @@ def calculate_workload(seqlen_list, coeff=24576):
     (see ``slime_validate_args`` in arguments.py).  Default 24576 = 6*4096.
     """
     if isinstance(seqlen_list, list):
-        return [coeff * l + l * l for l in seqlen_list]
-    return coeff * seqlen_list + seqlen_list ** 2
+        return [coeff * sl + sl * sl for sl in seqlen_list]
+    return coeff * seqlen_list + seqlen_list**2
 
 
 def first_fit_pack(total_lengths, max_tokens_per_bin):

--- a/tests/test_dp_schedule.py
+++ b/tests/test_dp_schedule.py
@@ -287,5 +287,53 @@ def test_rejects_when_fewer_groups_than_gbs():
         build_dp_schedule(args, tp, [3] * 6, global_batch_size=4, group_indices=[0, 0, 1, 1, 2, 2])
 
 
+@pytest.mark.unit
+def test_balance_by_flops_basic():
+    """FLOPs-balanced partitioning produces valid mbs."""
+    args = make_args(use_dynamic_batch_size=True, max_tokens_per_gpu=9000)
+    args.balance_by_flops = True
+    args.workload_coeff = 26624  # Qwen3-8B SwiGLU: 2*4096 + 3*12288//2
+    tp = make_tp(dp_size=2)
+    total_lengths = [2000, 8000, 3000, 1500, 5000, 4000, 7000, 500]
+    p, mbi, nmb, gbs = build_dp_schedule(
+        args, tp, total_lengths, global_batch_size=8, group_indices=list(range(8))
+    )
+    assert_invariants(
+        p, mbi, nmb,
+        dp_size=2,
+        expected_global_sample_indices=range(8),
+        total_lengths=total_lengths,
+    )
+
+
+@pytest.mark.unit
+def test_balance_by_flops_workload_aware():
+    """FLOPs-balanced partitioning groups by computational cost, not just token count."""
+    from slime.utils.seqlen_balancing import calculate_workload
+
+    # 4 samples: two long, two short. Total tokens similar per pair but FLOPs very different.
+    total_lengths = [8000, 2000, 2000, 8000]
+    tp = make_tp(dp_size=2)
+
+    args_fb = make_args(use_dynamic_batch_size=True, max_tokens_per_gpu=12000)
+    args_fb.balance_by_flops = True
+    args_fb.workload_coeff = 26624
+    p, mbi, nmb, _ = build_dp_schedule(
+        args_fb, tp, total_lengths, global_batch_size=4, group_indices=list(range(4))
+    )
+    assert_invariants(
+        p, mbi, nmb,
+        dp_size=2,
+        expected_global_sample_indices=range(4),
+        total_lengths=total_lengths,
+    )
+
+    # Verify each rank gets one long + one short sample for FLOPs balance
+    workloads = calculate_workload(total_lengths, coeff=26624)
+    rank_workloads = [sum(workloads[i] for i in p[r]) for r in range(2)]
+    ratio = max(rank_workloads) / min(rank_workloads) if min(rank_workloads) > 0 else float("inf")
+    assert ratio < 1.5, f"DP rank workload ratio {ratio:.2f} too unbalanced"
+
+
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__]))

--- a/tests/test_dp_schedule.py
+++ b/tests/test_dp_schedule.py
@@ -287,53 +287,5 @@ def test_rejects_when_fewer_groups_than_gbs():
         build_dp_schedule(args, tp, [3] * 6, global_batch_size=4, group_indices=[0, 0, 1, 1, 2, 2])
 
 
-@pytest.mark.unit
-def test_balance_by_flops_basic():
-    """FLOPs-balanced partitioning produces valid mbs."""
-    args = make_args(use_dynamic_batch_size=True, max_tokens_per_gpu=9000)
-    args.balance_by_flops = True
-    args.workload_coeff = 26624  # Qwen3-8B SwiGLU: 2*4096 + 3*12288//2
-    tp = make_tp(dp_size=2)
-    total_lengths = [2000, 8000, 3000, 1500, 5000, 4000, 7000, 500]
-    p, mbi, nmb, gbs = build_dp_schedule(args, tp, total_lengths, global_batch_size=8, group_indices=list(range(8)))
-    assert_invariants(
-        p,
-        mbi,
-        nmb,
-        dp_size=2,
-        expected_global_sample_indices=range(8),
-        total_lengths=total_lengths,
-    )
-
-
-@pytest.mark.unit
-def test_balance_by_flops_workload_aware():
-    """FLOPs-balanced partitioning groups by computational cost, not just token count."""
-    from slime.utils.seqlen_balancing import calculate_workload
-
-    # 4 samples: two long, two short. Total tokens similar per pair but FLOPs very different.
-    total_lengths = [8000, 2000, 2000, 8000]
-    tp = make_tp(dp_size=2)
-
-    args_fb = make_args(use_dynamic_batch_size=True, max_tokens_per_gpu=12000)
-    args_fb.balance_by_flops = True
-    args_fb.workload_coeff = 26624
-    p, mbi, nmb, _ = build_dp_schedule(args_fb, tp, total_lengths, global_batch_size=4, group_indices=list(range(4)))
-    assert_invariants(
-        p,
-        mbi,
-        nmb,
-        dp_size=2,
-        expected_global_sample_indices=range(4),
-        total_lengths=total_lengths,
-    )
-
-    # Verify each rank gets one long + one short sample for FLOPs balance
-    workloads = calculate_workload(total_lengths, coeff=26624)
-    rank_workloads = [sum(workloads[i] for i in p[r]) for r in range(2)]
-    ratio = max(rank_workloads) / min(rank_workloads) if min(rank_workloads) > 0 else float("inf")
-    assert ratio < 1.5, f"DP rank workload ratio {ratio:.2f} too unbalanced"
-
-
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__]))

--- a/tests/test_dp_schedule.py
+++ b/tests/test_dp_schedule.py
@@ -295,11 +295,11 @@ def test_balance_by_flops_basic():
     args.workload_coeff = 26624  # Qwen3-8B SwiGLU: 2*4096 + 3*12288//2
     tp = make_tp(dp_size=2)
     total_lengths = [2000, 8000, 3000, 1500, 5000, 4000, 7000, 500]
-    p, mbi, nmb, gbs = build_dp_schedule(
-        args, tp, total_lengths, global_batch_size=8, group_indices=list(range(8))
-    )
+    p, mbi, nmb, gbs = build_dp_schedule(args, tp, total_lengths, global_batch_size=8, group_indices=list(range(8)))
     assert_invariants(
-        p, mbi, nmb,
+        p,
+        mbi,
+        nmb,
         dp_size=2,
         expected_global_sample_indices=range(8),
         total_lengths=total_lengths,
@@ -318,11 +318,11 @@ def test_balance_by_flops_workload_aware():
     args_fb = make_args(use_dynamic_batch_size=True, max_tokens_per_gpu=12000)
     args_fb.balance_by_flops = True
     args_fb.workload_coeff = 26624
-    p, mbi, nmb, _ = build_dp_schedule(
-        args_fb, tp, total_lengths, global_batch_size=4, group_indices=list(range(4))
-    )
+    p, mbi, nmb, _ = build_dp_schedule(args_fb, tp, total_lengths, global_batch_size=4, group_indices=list(range(4)))
     assert_invariants(
-        p, mbi, nmb,
+        p,
+        mbi,
+        nmb,
         dp_size=2,
         expected_global_sample_indices=range(4),
         total_lengths=total_lengths,


### PR DESCRIPTION
## Summary

This PR adds `--balance-by-flops` for FLOPs-aware micro-batch partitioning in dynamic batching. Instead of balancing by token count alone, it uses `coeff * L + L²` per sample to account for the quadratic cost of attention. The linear coefficient is auto-computed from model config (hidden_size, FFN, SwiGLU, MoE experts/topk/shared).

Changes:

- Add `--balance-by-flops` flag and auto-compute `workload_coeff` in `arguments.py`.
- Replace first-fit token packing with Karmarkar-Karp FLOPs-balanced partitioning for micro-batch grouping and DP rank assignment in `dp_schedule.py`.
- Add `calculate_workload()` in `seqlen_balancing.py`.

## Motivation

Dynamic batching packs micro-batches by token count (`Σ L`), but attention FLOPs scale as `O(L²)`. When sequence lengths vary widely, a rank with a few long sequences has much higher compute cost than one with many short sequences. Since all ranks synchronize at all-reduce, the slowest rank determines step time.

`--balance-by-flops` uses `coeff * L + L²` as the balancing metric. This operates purely at the micro-batch partitioning level and does not affect downstream context-parallel splitting, so it composes directly with CP.

## Experiments

All experiments compare `--balance-by-flops` (with `--balance-data`) against a baseline using only `--balance-data` (token-sum KK balancing). Both use `--use-dynamic-batch-size`. Statistics exclude warmup steps.

### Setup

| | SFT Dense | SFT MoE | RL Dense | RL MoE |
| --- | --- | --- | --- | --- |
| **GPU** | 4×L20Z | 8×L20Z | 8×L20Z | 8×L20Z |
| **Model** | Qwen3-4B | Qwen3.5-35B-A3B | Qwen3-4B | Qwen3-30B-A3B |
| **Type** | Dense | MoE | Dense | MoE |
| **Task** | SFT | SFT | RL (GRPO) | RL (GRPO) |
| **TP / PP / EP / DP** | 1 / 1 / — / 4 | 2 / 1 / 8 / 4 | 2 / 1 / — / 4 | 4 / 1 / 8 / 2 |
| **max_tokens_per_gpu** | 9,216 | 8,192 | 9,216 | 20,480 |
| **global_batch_size** | 128 | 128 | 256 | 256 |
| **max_response_len** | — | — | 8,192 | 8,192 |

### Results

| | SFT Dense | SFT MoE | RL Dense | RL MoE |
| --- | ---: | ---: | ---: | ---: |
| **actor_train_time Δ** | −12.7% | −30.1% | −14.0% | −20.6% |
| **actor_train_tflops Δ** | +13.7% | +23.4% | +4.5% | +23.7% |
| **actor_train_tok/s Δ** | +13.7% | +23.4% | +6.0% | +24.0% |


## Notes

- `--balance-by-flops` requires `--use-dynamic-batch-size`.
- The flag is orthogonal to `--balance-data`; when both are set, FLOPs-based weights are used for both micro-batch packing and DP rank assignment.