### PR TITLE
examples: add CISPO custom loss

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -454,7 +454,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        info: [{"num_gpus": 0, "test_file": "test_megatron_argument_validation.py"}, {"num_gpus": 0, "test_file": "test_dp_schedule.py"}, {"num_gpus": 0, "test_file": "test_cp_utils.py"}, {"num_gpus": 0, "test_file": "test_metric_report.py"}, {"num_gpus": 0, "test_file": "test_metric_report_dist.py"}, {"num_gpus": 0, "test_file": "test_loss_cp_invariance.py"}, {"num_gpus": 0, "test_file": "test_value_temperature.py"}, {"num_gpus": 0, "test_file": "test_rm_f1.py"}, {"num_gpus": 0, "test_file": "test_rm_gpqa.py"}, {"num_gpus": 0, "test_file": "test_rm_math.py"}, {"num_gpus": 0, "test_file": "test_rm_math_dapo.py"}, {"num_gpus": 0, "test_file": "test_rm_deepscaler.py"}, {"num_gpus": 0, "test_file": "test_sample.py"}, {"num_gpus": 0, "test_file": "test_agent_trajectory.py"}, {"num_gpus": 0, "test_file": "test_rollout_validation.py"}, {"num_gpus": 0, "test_file": "test_placement_group.py"}, {"num_gpus": 0, "test_file": "test_external_sglang_engines.py"}, {"num_gpus": 0, "test_file": "utils/test_hf_checkpoint_saver.py"}, {"num_gpus": 0, "test_file": "plugin_contracts/test_plugin_rollout_contracts.py"}, {"num_gpus": 0, "test_file": "plugin_contracts/test_plugin_runtime_hook_contracts.py"}, {"num_gpus": 0, "test_file": "plugin_contracts/test_plugin_path_loading_contracts.py"}, {"num_gpus": 0, "test_file": "plugin_contracts/test_plugin_generate_contracts.py"}]
+        info: [{"num_gpus": 0, "test_file": "test_megatron_argument_validation.py"}, {"num_gpus": 0, "test_file": "test_dp_schedule.py"}, {"num_gpus": 0, "test_file": "test_cp_utils.py"}, {"num_gpus": 0, "test_file": "test_metric_report.py"}, {"num_gpus": 0, "test_file": "test_metric_report_dist.py"}, {"num_gpus": 0, "test_file": "test_loss_cp_invariance.py"}, {"num_gpus": 0, "test_file": "test_cispo_custom_loss.py"}, {"num_gpus": 0, "test_file": "test_value_temperature.py"}, {"num_gpus": 0, "test_file": "test_rm_f1.py"}, {"num_gpus": 0, "test_file": "test_rm_gpqa.py"}, {"num_gpus": 0, "test_file": "test_rm_math.py"}, {"num_gpus": 0, "test_file": "test_rm_math_dapo.py"}, {"num_gpus": 0, "test_file": "test_rm_deepscaler.py"}, {"num_gpus": 0, "test_file": "test_sample.py"}, {"num_gpus": 0, "test_file": "test_agent_trajectory.py"}, {"num_gpus": 0, "test_file": "test_rollout_validation.py"}, {"num_gpus": 0, "test_file": "test_placement_group.py"}, {"num_gpus": 0, "test_file": "test_external_sglang_engines.py"}, {"num_gpus": 0, "test_file": "utils/test_hf_checkpoint_saver.py"}, {"num_gpus": 0, "test_file": "plugin_contracts/test_plugin_rollout_contracts.py"}, {"num_gpus": 0, "test_file": "plugin_contracts/test_plugin_runtime_hook_contracts.py"}, {"num_gpus": 0, "test_file": "plugin_contracts/test_plugin_path_loading_contracts.py"}, {"num_gpus": 0, "test_file": "plugin_contracts/test_plugin_generate_contracts.py"}]
     defaults:
       run:
         working-directory: ${{ github.workspace }}
@@ -482,6 +482,8 @@ jobs:
         run: |
           pip install torch --index-url https://download.pytorch.org/whl/cpu
           pip install pytest numpy packaging pyyaml omegaconf tqdm httpx requests ray pybase64 pylatexenc sympy aiohttp pillow safetensors
+
+          pip install megatron-core
 
 
       - name: Install

--- a/.github/workflows/pr-test.yml.j2
+++ b/.github/workflows/pr-test.yml.j2
@@ -69,6 +69,7 @@
       'label': 'run-ci-cpu-unittest',
       'always': True,
       'cpu': True,
+      'extra_pip_deps': 'megatron-core',
       'tests': [
         {'test_file': 'test_megatron_argument_validation.py', 'num_gpus': 0},
         {'test_file': 'test_dp_schedule.py', 'num_gpus': 0},
@@ -76,6 +77,7 @@
         {'test_file': 'test_metric_report.py', 'num_gpus': 0},
         {'test_file': 'test_metric_report_dist.py', 'num_gpus': 0},
         {'test_file': 'test_loss_cp_invariance.py', 'num_gpus': 0},
+        {'test_file': 'test_cispo_custom_loss.py', 'num_gpus': 0},
         {'test_file': 'test_value_temperature.py', 'num_gpus': 0},
         {'test_file': 'test_rm_f1.py', 'num_gpus': 0},
         {'test_file': 'test_rm_gpqa.py', 'num_gpus': 0},

--- a/examples/README.md
+++ b/examples/README.md
@@ -5,6 +5,7 @@ These examples provide concrete examples to leverage slime in your own RL workfl
 ## Directory Structure
 
 - **[eval_multi_task](./eval_multi_task)**: Example for supporting evaluation multiple tasks with different configs.
+- **[cispo](./cispo)**: CISPO implemented through slime's `--loss-type custom_loss` extension point.
 - **[fully_async](./fully_async)**: Demonstrates fully asynchronous rollout generation for higher efficiency.
 - **[geo3k_vlm](./geo3k_vlm)**: Training VLMs on a single-turn reasoning task using GRPO on the GEO3K dataset.
 - **[geo3k_vlm_multi_turn](./geo3k_vlm_multi_turn)**: VLM multi-turn training on Geo3k dataset.

--- a/examples/cispo/README.md
+++ b/examples/cispo/README.md
@@ -1,0 +1,51 @@
+# CISPO Custom Loss
+
+This example implements CISPO (Clipped IS-weight Policy Optimization) with
+slime's existing custom loss interface. It keeps CISPO out of
+`--advantage-estimator`: use a normal estimator such as `grpo`, then replace the
+policy objective with this custom loss.
+
+```bash
+--advantage-estimator grpo
+--loss-type custom_loss
+--custom-loss-function-path examples.cispo.cispo_loss.cispo_loss_function
+--custom-config-path examples/cispo/cispo.yaml
+--use-rollout-logprobs
+--calculate-per-token-loss
+```
+
+The CISPO objective maximizes a detached clipped ratio times the target policy
+log-probability:
+
+```python
+ratio = torch.exp(target_logprobs - sampling_logprobs)
+clipped_ratio = torch.clamp(ratio, clip_low_threshold, clip_high_threshold)
+loss = -(clipped_ratio.detach() * advantages * target_logprobs)
+```
+
+The bundled config follows the one-sided CISPO setting:
+
+```yaml
+loss_config:
+  cispo:
+    clip_low_threshold: 0.0
+    clip_high_threshold: 4.0
+```
+
+These are Tinker-style absolute ratio thresholds, not epsilon values.
+
+`--use-rollout-logprobs` is recommended so the CISPO denominator uses the actual
+sampler log-probs from `rollout_log_probs`, matching Tinker's
+`sampling_logprobs` input.
+
+`--calculate-per-token-loss` is recommended when matching Tinker's token-level
+loss aggregation.
+
+This example intentionally does not combine CISPO with `--use-tis`. TIS applies
+an additional importance-weighting or masking pass, while CISPO's detached
+clipped ratio is already part of the objective.
+
+# References
+1. MiniMax-M1: https://arxiv.org/abs/2506.13585
+2. ScaleRL: https://arxiv.org/abs/2510.13786
+3. Tinker CISPO: https://tinker-docs.thinkingmachines.ai/tinker/losses/cispo/

--- a/examples/cispo/cispo.yaml
+++ b/examples/cispo/cispo.yaml
@@ -1,0 +1,9 @@
+# Config for examples.cispo.cispo_loss.cispo_loss_function.
+#
+# This file is loaded through --custom-config-path. slime attaches top-level
+# YAML keys to args, so the custom loss reads args.loss_config["cispo"].
+loss_config:
+  cispo:
+    # These are Tinker-style absolute ratio thresholds, not epsilon values.
+    clip_low_threshold: 0.0
+    clip_high_threshold: 4.0

--- a/examples/cispo/cispo_loss.py
+++ b/examples/cispo/cispo_loss.py
@@ -1,0 +1,252 @@
+from __future__ import annotations
+
+from argparse import Namespace
+from collections.abc import Callable, Mapping
+
+import torch
+
+from slime.backends.megatron_utils.cp_utils import all_gather_with_cp, get_sum_of_sample_mean
+from slime.backends.megatron_utils.loss import get_log_probs_and_entropy
+from slime.utils.misc import load_function
+from slime.utils.ppo_utils import compute_approx_kl, compute_opsm_mask
+from slime.utils.types import RolloutBatch
+
+
+@torch.compile(dynamic=True)
+def compute_cispo_loss(
+    ppo_kl: torch.Tensor,
+    target_log_probs: torch.Tensor,
+    advantages: torch.Tensor,
+    clip_low_threshold: float,
+    clip_high_threshold: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Compute per-token CISPO losses.
+
+    CISPO clips the importance ratio and detaches it before multiplying by
+    target log-probs, so the ratio is a bounded coefficient rather than a path
+    for gradients.
+    """
+    ratio = (-ppo_kl).exp()
+    clipped_ratio = torch.clamp(ratio, min=clip_low_threshold, max=clip_high_threshold)
+    pg_losses = -clipped_ratio.detach() * advantages * target_log_probs
+    clipfrac = (clipped_ratio != ratio).float()
+    return pg_losses, clipfrac
+
+
+def _get_cispo_config(args: Namespace) -> tuple[float, float]:
+    loss_config = getattr(args, "loss_config", None)
+    if isinstance(loss_config, Mapping):
+        config = loss_config.get("cispo", {})
+    else:
+        config = getattr(args, "cispo", {})
+    if config is None:
+        config = {}
+    if not isinstance(config, Mapping):
+        raise TypeError("CISPO config must be a mapping. Use loss_config.cispo in --custom-config-path YAML.")
+
+    try:
+        clip_low = float(config["clip_low_threshold"])
+        clip_high = float(config["clip_high_threshold"])
+    except KeyError as exc:
+        required_keys = "loss_config.cispo.clip_low_threshold and loss_config.cispo.clip_high_threshold"
+        raise KeyError(f"CISPO config requires {required_keys}.") from exc
+    if clip_low < 0:
+        raise ValueError(f"clip_low_threshold must be non-negative, got {clip_low}.")
+    if clip_high <= clip_low:
+        raise ValueError(
+            f"clip_high_threshold must be greater than clip_low_threshold, got {clip_high} <= {clip_low}."
+        )
+    return clip_low, clip_high
+
+
+def _get_sampling_log_probs(
+    args: Namespace,
+    batch: RolloutBatch,
+    target_log_probs: list[torch.Tensor],
+) -> list[torch.Tensor]:
+    if getattr(args, "use_rollout_logprobs", False):
+        rollout_log_probs = batch.get("rollout_log_probs")
+        if rollout_log_probs:
+            return rollout_log_probs
+
+    old_log_probs = batch.get("log_probs")
+    if old_log_probs:
+        return old_log_probs
+
+    return [log_prob.detach() for log_prob in target_log_probs]
+
+
+def _validate_supported_options(args: Namespace) -> None:
+    if getattr(args, "use_tis", False):
+        raise ValueError(
+            "examples.cispo.cispo_loss does not support --use-tis. "
+            "CISPO applies a detached clipped ratio inside the policy objective."
+        )
+
+
+def cispo_loss_function(
+    args: Namespace,
+    batch: RolloutBatch,
+    logits: torch.Tensor,
+    sum_of_sample_mean: Callable[[torch.Tensor], torch.Tensor],
+) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
+    """Megatron custom loss entrypoint for `--loss-type custom_loss`.
+
+    Expected CLI:
+
+        --loss-type custom_loss
+        --custom-loss-function-path examples.cispo.cispo_loss.cispo_loss_function
+        --custom-config-path examples/cispo/cispo.yaml
+    """
+    _validate_supported_options(args)
+    clip_low, clip_high = _get_cispo_config(args)
+
+    response_lengths = batch["response_lengths"]
+    total_lengths = batch["total_lengths"]
+    max_seq_lens = batch.get("max_seq_lens", None)
+
+    _, log_probs_and_entropy = get_log_probs_and_entropy(
+        logits,
+        args=args,
+        unconcat_tokens=batch["unconcat_tokens"],
+        total_lengths=total_lengths,
+        response_lengths=response_lengths,
+        with_entropy=True,
+        max_seq_lens=max_seq_lens,
+    )
+
+    target_log_probs_list = log_probs_and_entropy["log_probs"]
+    sampling_log_probs_list = _get_sampling_log_probs(args, batch, target_log_probs_list)
+    train_log_probs_for_mismatch = batch.get("log_probs")
+    if not train_log_probs_for_mismatch:
+        train_log_probs_for_mismatch = [log_prob.detach() for log_prob in target_log_probs_list]
+
+    if getattr(args, "use_opsm", False):
+        full_log_probs = [
+            all_gather_with_cp(log_prob, total_length, response_length)
+            for log_prob, total_length, response_length in zip(
+                target_log_probs_list, total_lengths, response_lengths, strict=False
+            )
+        ]
+        full_sampling_log_probs = [
+            all_gather_with_cp(log_prob, total_length, response_length)
+            for log_prob, total_length, response_length in zip(
+                sampling_log_probs_list, total_lengths, response_lengths, strict=False
+            )
+        ]
+        opsm_mask, opsm_clipfrac = compute_opsm_mask(
+            args=args,
+            full_log_probs=full_log_probs,
+            full_old_log_probs=full_sampling_log_probs,
+            advantages=batch["advantages"],
+            loss_masks=batch["loss_masks"],
+        )
+
+    target_log_probs = torch.cat(target_log_probs_list, dim=0)
+    sampling_log_probs = torch.cat(sampling_log_probs_list, dim=0)
+    advantages = torch.cat(batch["advantages"], dim=0)
+
+    if target_log_probs.shape != sampling_log_probs.shape or target_log_probs.shape != advantages.shape:
+        raise ValueError(
+            "CISPO input shapes must match: "
+            f"{target_log_probs.shape=}, {sampling_log_probs.shape=}, {advantages.shape=}."
+        )
+
+    ppo_kl = sampling_log_probs - target_log_probs
+    pg_loss, pg_clipfrac = compute_cispo_loss(ppo_kl, target_log_probs, advantages, clip_low, clip_high)
+
+    if getattr(args, "use_opsm", False):
+        pg_loss = pg_loss * opsm_mask
+
+    if getattr(args, "get_mismatch_metrics", False):
+        sum_of_sample_mean_for_mismatch_metrics = sum_of_sample_mean
+        assert "rollout_log_probs" in batch, "rollout_log_probs must be provided for mismatch metrics"
+
+        ois = (-ppo_kl).exp()
+        mismatch_func = load_function(args.custom_tis_function_path)
+        mismatch_pg_loss, modified_response_masks, mismatch_metrics = mismatch_func(
+            args=args,
+            pg_loss=pg_loss,
+            train_log_probs=train_log_probs_for_mismatch,
+            rollout_log_probs=batch["rollout_log_probs"],
+            loss_masks=batch["loss_masks"],
+            total_lengths=total_lengths,
+            response_lengths=response_lengths,
+        )
+        if mismatch_pg_loss is not None:
+            pg_loss = mismatch_pg_loss
+        sum_of_sample_mean = get_sum_of_sample_mean(
+            total_lengths,
+            response_lengths,
+            modified_response_masks,
+            batch["rollout_mask_sums"],
+            args.calculate_per_token_loss,
+            args.qkv_format,
+            max_seq_lens,
+        )
+
+    if getattr(args, "custom_pg_loss_reducer_function_path", None) is not None:
+        custom_pg_loss_reducer_func = load_function(args.custom_pg_loss_reducer_function_path)
+        pg_loss_masks = (
+            modified_response_masks if getattr(args, "get_mismatch_metrics", False) else batch["loss_masks"]
+        )
+        pg_loss_reducer = custom_pg_loss_reducer_func(
+            total_lengths, response_lengths, pg_loss_masks, args.calculate_per_token_loss
+        )
+    else:
+        pg_loss_reducer = sum_of_sample_mean
+
+    pg_loss = pg_loss_reducer(pg_loss)
+    pg_clipfrac = sum_of_sample_mean(pg_clipfrac)
+    ppo_kl = sum_of_sample_mean(ppo_kl)
+
+    entropy = torch.cat(log_probs_and_entropy["entropy"], dim=0)
+    entropy_loss = sum_of_sample_mean(entropy)
+
+    loss = pg_loss - args.entropy_coef * entropy_loss
+
+    if args.use_kl_loss:
+        ref_log_probs = torch.cat(batch["ref_log_probs"], dim=0)
+        importance_ratio = None
+        if args.use_unbiased_kl:
+            importance_ratio = torch.exp(target_log_probs - sampling_log_probs)
+        kl = compute_approx_kl(
+            target_log_probs,
+            ref_log_probs,
+            kl_loss_type=args.kl_loss_type,
+            importance_ratio=importance_ratio,
+        )
+        kl_loss = sum_of_sample_mean(kl)
+        loss = loss + args.kl_loss_coef * kl_loss
+
+    if target_log_probs.numel() == 0:
+        loss = loss + 0 * logits.sum()
+
+    train_rollout_logprob_abs_diff = None
+    rollout_log_probs = batch.get("rollout_log_probs")
+    if rollout_log_probs:
+        rollout_log_probs = torch.cat(rollout_log_probs, dim=0)
+        train_rollout_logprob_abs_diff = sum_of_sample_mean((sampling_log_probs - rollout_log_probs).abs())
+
+    reported_loss = {
+        "loss": loss.clone().detach(),
+        "pg_loss": pg_loss.clone().detach(),
+        "entropy_loss": entropy_loss.clone().detach(),
+        "pg_clipfrac": pg_clipfrac.clone().detach(),
+        "ppo_kl": ppo_kl.clone().detach(),
+    }
+    if train_rollout_logprob_abs_diff is not None:
+        reported_loss["train_rollout_logprob_abs_diff"] = train_rollout_logprob_abs_diff.clone().detach()
+    if args.use_kl_loss:
+        reported_loss["kl_loss"] = kl_loss.clone().detach()
+    if getattr(args, "get_mismatch_metrics", False):
+        reported_loss["ois"] = sum_of_sample_mean_for_mismatch_metrics(ois).clone().detach()
+        for metric_key, metric_value in mismatch_metrics.items():
+            reported_loss[metric_key] = sum_of_sample_mean_for_mismatch_metrics(metric_value)
+    if getattr(args, "use_opsm", False):
+        reported_loss["opsm_clipfrac"] = opsm_clipfrac
+    if "opd_reverse_kl" in batch:
+        opd_reverse_kl = torch.cat(batch["opd_reverse_kl"], dim=0)
+        reported_loss["opd_reverse_kl"] = sum_of_sample_mean(opd_reverse_kl).clone().detach()
+
+    return loss, reported_loss

--- a/tests/test_cispo_custom_loss.py
+++ b/tests/test_cispo_custom_loss.py
@@ -1,0 +1,313 @@
+from __future__ import annotations
+
+import sys
+from argparse import Namespace
+from pathlib import Path
+
+import pytest
+import torch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from examples.cispo.cispo_loss import (
+    _get_cispo_config,
+    _get_sampling_log_probs,
+    _validate_supported_options,
+    cispo_loss_function,
+    compute_cispo_loss,
+)
+
+NUM_GPUS = 0
+
+
+def test_cispo_loss_matches_detached_ratio_formula():
+    target_log_probs = torch.tensor([0.0, 0.5, -1.0], requires_grad=True)
+    sampling_log_probs = torch.tensor([0.0, -0.5, -1.0])
+    advantages = torch.tensor([1.0, -2.0, 0.25])
+    ppo_kl = sampling_log_probs - target_log_probs
+
+    loss, clipfrac = compute_cispo_loss(ppo_kl, target_log_probs, advantages, 0.0, 1.5)
+
+    expected_ratio = torch.exp(target_log_probs.detach() - sampling_log_probs)
+    expected_clipped_ratio = torch.clamp(expected_ratio, min=0.0, max=1.5)
+    expected_loss = -expected_clipped_ratio * advantages * target_log_probs.detach()
+
+    assert torch.allclose(loss.detach(), expected_loss)
+    assert torch.equal(clipfrac, torch.tensor([0.0, 1.0, 0.0]))
+
+    loss.sum().backward()
+    assert torch.allclose(target_log_probs.grad, -expected_clipped_ratio * advantages)
+
+
+def test_cispo_config_reads_loss_config_namespace():
+    args = Namespace(loss_config={"cispo": {"clip_low_threshold": 0.1, "clip_high_threshold": 3.0}})
+    assert _get_cispo_config(args) == pytest.approx((0.1, 3.0))
+
+
+def test_cispo_config_requires_yaml_thresholds():
+    with pytest.raises(KeyError, match="clip_low_threshold"):
+        _get_cispo_config(Namespace())
+
+
+def test_cispo_sampling_log_probs_fall_back_without_rollout_log_probs():
+    old_log_probs = [torch.tensor([0.1, 0.2])]
+    target_log_probs = [torch.tensor([0.3, 0.4])]
+
+    assert (
+        _get_sampling_log_probs(
+            Namespace(use_rollout_logprobs=True),
+            {"log_probs": old_log_probs},
+            target_log_probs,
+        )
+        is old_log_probs
+    )
+
+
+def test_cispo_validation_rejects_tis():
+    with pytest.raises(ValueError, match="use-tis"):
+        _validate_supported_options(Namespace(use_tis=True))
+
+
+def test_cispo_validation_allows_mismatch_metrics_and_opsm():
+    _validate_supported_options(Namespace(use_tis=False, get_mismatch_metrics=True, use_opsm=True))
+
+
+def test_cispo_custom_loss_reports_opd_reverse_kl(monkeypatch):
+    def fake_get_log_probs_and_entropy(*args, **kwargs):
+        return None, {
+            "log_probs": [torch.tensor([0.1, 0.2], requires_grad=True)],
+            "entropy": [torch.tensor([0.0, 0.0])],
+        }
+
+    monkeypatch.setattr("examples.cispo.cispo_loss.get_log_probs_and_entropy", fake_get_log_probs_and_entropy)
+
+    args = Namespace(
+        entropy_coef=0.0,
+        loss_config={"cispo": {"clip_low_threshold": 0.0, "clip_high_threshold": 4.0}},
+        use_kl_loss=False,
+        use_opsm=False,
+        use_rollout_logprobs=False,
+        use_tis=False,
+    )
+    batch = {
+        "advantages": [torch.tensor([1.0, 1.0])],
+        "log_probs": [torch.tensor([0.0, 0.0])],
+        "opd_reverse_kl": [torch.tensor([0.3, 0.5])],
+        "response_lengths": [2],
+        "total_lengths": [2],
+        "unconcat_tokens": [torch.tensor([1, 2])],
+    }
+
+    _, reported_loss = cispo_loss_function(args, batch, torch.zeros(1), lambda x: x.mean())
+
+    assert reported_loss["opd_reverse_kl"] == pytest.approx(torch.tensor(0.4))
+
+
+def test_cispo_custom_loss_supports_kl_loss(monkeypatch):
+    def fake_get_log_probs_and_entropy(*args, **kwargs):
+        return None, {
+            "log_probs": [torch.tensor([0.1, 0.2], requires_grad=True)],
+            "entropy": [torch.tensor([0.0, 0.0])],
+        }
+
+    monkeypatch.setattr("examples.cispo.cispo_loss.get_log_probs_and_entropy", fake_get_log_probs_and_entropy)
+
+    args = Namespace(
+        entropy_coef=0.0,
+        kl_loss_coef=2.0,
+        kl_loss_type="k1",
+        loss_config={"cispo": {"clip_low_threshold": 0.0, "clip_high_threshold": 4.0}},
+        use_kl_loss=True,
+        use_opsm=False,
+        use_rollout_logprobs=False,
+        use_tis=False,
+        use_unbiased_kl=False,
+    )
+    batch = {
+        "advantages": [torch.tensor([1.0, 1.0])],
+        "log_probs": [torch.tensor([0.0, 0.0])],
+        "ref_log_probs": [torch.tensor([0.0, 0.0])],
+        "response_lengths": [2],
+        "total_lengths": [2],
+        "unconcat_tokens": [torch.tensor([1, 2])],
+    }
+
+    _, reported_loss = cispo_loss_function(args, batch, torch.zeros(1), lambda x: x.mean())
+
+    assert reported_loss["kl_loss"].item() == pytest.approx(0.15)
+    assert reported_loss["loss"].item() == pytest.approx(
+        reported_loss["pg_loss"].item() + 2.0 * reported_loss["kl_loss"].item()
+    )
+
+
+def test_cispo_custom_loss_supports_opsm(monkeypatch):
+    def fake_get_log_probs_and_entropy(*args, **kwargs):
+        return None, {
+            "log_probs": [torch.tensor([0.1, 0.2], requires_grad=True)],
+            "entropy": [torch.tensor([0.0, 0.0])],
+        }
+
+    def fake_compute_opsm_mask(**kwargs):
+        return torch.tensor([0.0, 1.0]), torch.tensor(0.5)
+
+    monkeypatch.setattr("examples.cispo.cispo_loss.get_log_probs_and_entropy", fake_get_log_probs_and_entropy)
+    monkeypatch.setattr("examples.cispo.cispo_loss.all_gather_with_cp", lambda x, *args, **kwargs: x)
+    monkeypatch.setattr("examples.cispo.cispo_loss.compute_opsm_mask", fake_compute_opsm_mask)
+
+    args = Namespace(
+        entropy_coef=0.0,
+        loss_config={"cispo": {"clip_low_threshold": 0.0, "clip_high_threshold": 4.0}},
+        use_kl_loss=False,
+        use_opsm=True,
+        use_rollout_logprobs=False,
+        use_tis=False,
+    )
+    batch = {
+        "advantages": [torch.tensor([1.0, 1.0])],
+        "log_probs": [torch.tensor([0.0, 0.0])],
+        "loss_masks": [torch.tensor([1.0, 1.0])],
+        "response_lengths": [2],
+        "total_lengths": [2],
+        "unconcat_tokens": [torch.tensor([1, 2])],
+    }
+
+    _, reported_loss = cispo_loss_function(args, batch, torch.zeros(1), lambda x: x.mean())
+
+    expected_pg_loss = -(torch.exp(torch.tensor(0.2)) * torch.tensor(0.2)) / 2
+    assert reported_loss["pg_loss"].item() == pytest.approx(expected_pg_loss.item())
+    assert reported_loss["opsm_clipfrac"].item() == pytest.approx(0.5)
+
+
+def test_cispo_custom_loss_reports_rollout_metric_like_policy_loss(monkeypatch):
+    def fake_get_log_probs_and_entropy(*args, **kwargs):
+        return None, {
+            "log_probs": [torch.tensor([0.1, 0.2], requires_grad=True)],
+            "entropy": [torch.tensor([0.0, 0.0])],
+        }
+
+    monkeypatch.setattr("examples.cispo.cispo_loss.get_log_probs_and_entropy", fake_get_log_probs_and_entropy)
+
+    args = Namespace(
+        entropy_coef=0.0,
+        loss_config={"cispo": {"clip_low_threshold": 0.0, "clip_high_threshold": 4.0}},
+        use_kl_loss=False,
+        use_opsm=False,
+        use_rollout_logprobs=True,
+        use_tis=False,
+    )
+    batch = {
+        "advantages": [torch.tensor([1.0, 1.0])],
+        "log_probs": [torch.tensor([10.0, 10.0])],
+        "response_lengths": [2],
+        "rollout_log_probs": [torch.tensor([-0.1, -0.2])],
+        "total_lengths": [2],
+        "unconcat_tokens": [torch.tensor([1, 2])],
+    }
+
+    _, reported_loss = cispo_loss_function(args, batch, torch.zeros(1), lambda x: x.mean())
+
+    assert reported_loss["train_rollout_logprob_abs_diff"].item() == pytest.approx(0.0)
+
+
+def test_cispo_custom_loss_uses_custom_pg_loss_reducer(monkeypatch):
+    def fake_get_log_probs_and_entropy(*args, **kwargs):
+        return None, {
+            "log_probs": [torch.tensor([0.1, 0.2], requires_grad=True)],
+            "entropy": [torch.tensor([0.0, 0.0])],
+        }
+
+    def fake_load_function(path):
+        assert path == "tests.custom_reducer"
+
+        def custom_reducer(total_lengths, response_lengths, loss_masks, calculate_per_token_loss):
+            return lambda x: x.sum()
+
+        return custom_reducer
+
+    monkeypatch.setattr("examples.cispo.cispo_loss.get_log_probs_and_entropy", fake_get_log_probs_and_entropy)
+    monkeypatch.setattr("examples.cispo.cispo_loss.load_function", fake_load_function)
+
+    args = Namespace(
+        calculate_per_token_loss=False,
+        custom_pg_loss_reducer_function_path="tests.custom_reducer",
+        entropy_coef=0.0,
+        get_mismatch_metrics=False,
+        loss_config={"cispo": {"clip_low_threshold": 0.0, "clip_high_threshold": 4.0}},
+        use_kl_loss=False,
+        use_opsm=False,
+        use_rollout_logprobs=False,
+        use_tis=False,
+    )
+    batch = {
+        "advantages": [torch.tensor([1.0, 1.0])],
+        "log_probs": [torch.tensor([0.0, 0.0])],
+        "loss_masks": [torch.tensor([1.0, 1.0])],
+        "response_lengths": [2],
+        "total_lengths": [2],
+        "unconcat_tokens": [torch.tensor([1, 2])],
+    }
+
+    _, reported_loss = cispo_loss_function(args, batch, torch.zeros(1), lambda x: x.mean())
+
+    expected = -(torch.exp(torch.tensor([0.1, 0.2])) * torch.tensor([0.1, 0.2])).sum()
+    assert reported_loss["pg_loss"].item() == pytest.approx(expected.item())
+
+
+def test_cispo_custom_loss_reports_mismatch_metrics(monkeypatch):
+    def fake_get_log_probs_and_entropy(*args, **kwargs):
+        return None, {
+            "log_probs": [torch.tensor([0.1, 0.2], requires_grad=True)],
+            "entropy": [torch.tensor([0.0, 0.0])],
+        }
+
+    def fake_load_function(path):
+        assert path == "tests.mismatch"
+
+        def mismatch_func(**kwargs):
+            return None, kwargs["loss_masks"], {"mis_metric": torch.tensor([0.2, 0.4])}
+
+        return mismatch_func
+
+    def fake_get_sum_of_sample_mean(*args, **kwargs):
+        return lambda x: x.mean()
+
+    monkeypatch.setattr("examples.cispo.cispo_loss.get_log_probs_and_entropy", fake_get_log_probs_and_entropy)
+    monkeypatch.setattr("examples.cispo.cispo_loss.load_function", fake_load_function)
+    monkeypatch.setattr("examples.cispo.cispo_loss.get_sum_of_sample_mean", fake_get_sum_of_sample_mean)
+
+    args = Namespace(
+        calculate_per_token_loss=False,
+        custom_pg_loss_reducer_function_path=None,
+        custom_tis_function_path="tests.mismatch",
+        entropy_coef=0.0,
+        get_mismatch_metrics=True,
+        loss_config={"cispo": {"clip_low_threshold": 0.0, "clip_high_threshold": 4.0}},
+        qkv_format="thd",
+        use_kl_loss=False,
+        use_opsm=False,
+        use_rollout_logprobs=False,
+        use_tis=False,
+    )
+    batch = {
+        "advantages": [torch.tensor([1.0, 1.0])],
+        "log_probs": [torch.tensor([0.0, 0.0])],
+        "loss_masks": [torch.tensor([1.0, 1.0])],
+        "response_lengths": [2],
+        "rollout_log_probs": [torch.tensor([-0.1, -0.2])],
+        "rollout_mask_sums": [torch.tensor(2.0)],
+        "total_lengths": [2],
+        "unconcat_tokens": [torch.tensor([1, 2])],
+    }
+
+    _, reported_loss = cispo_loss_function(args, batch, torch.zeros(1), lambda x: x.mean())
+
+    assert reported_loss["mis_metric"].item() == pytest.approx(0.3)
+    assert "ois" in reported_loss
+
+
+def test_cispo_custom_loss_function_is_loadable():
+    assert callable(cispo_loss_function)
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__]))


### PR DESCRIPTION
## Summary

This reworks the CISPO support from #681 as an example-first custom loss instead of adding a new built-in advantage estimator.

Changes:
- add examples/cispo with a custom_loss implementation of the detached clipped-ratio CISPO objective
- read CISPO thresholds from loss_config.cispo via --custom-config-path
- document the intended --loss-type custom_loss usage and unsupported combinations such as --use-tis
- add a CPU unit test for the token loss value, clipping, config defaults, and detached-ratio gradient

## Motivation

The earlier PR #681 had user interest and included a GSM8K/Qwen3-0.6B smoke result, but slime now has a custom_loss extension point for novel RL objectives. This keeps the core PPO/GRPO/GSPO surface unchanged while making CISPO easy to try.

Previous smoke result from #681: https://api.wandb.ai/links/kekmodel/yz3rhx3x

## Usage

```bash
--advantage-estimator grpo
--loss-type custom_loss
--custom-loss-function-path examples.cispo.cispo_loss.cispo_loss_function
--custom-config-path examples/cispo/cispo.yaml
```

## Validation

- python tests/test_cispo_custom_loss.py
- python -m black --check examples/cispo/cispo_loss.py tests/test_cispo_custom_loss.py
- python .github/workflows/generate_github_workflows.py
- git diff --check
