### PR TITLE
[examples]: add qwen3.5-9b model config and fully_async example

### DIFF
--- a/examples/fully_async/README.md
+++ b/examples/fully_async/README.md
@@ -11,6 +11,8 @@ directory is just the launch script + CI test.
 * `run-qwen2.5-0.5B-fully_async.sh` — single-node, 4-GPU, three-rollout demo
   with Qwen2.5-0.5B-Instruct on dapo-math-17k. Fast enough to be the CI
   smoke test for the fully-async path.
+* `run-qwen3.5-9B-fully_async.sh` — single-node, 8-GPU, three-rollout demo
+  with Qwen3.5-9B on dapo-math-17k.
 
 The same script doubles as `tests/test_qwen2.5_0.5B_fully_async_short.py` in
 CI.

--- a/examples/fully_async/run-qwen3.5-9B-fully_async.sh
+++ b/examples/fully_async/run-qwen3.5-9B-fully_async.sh
@@ -1,0 +1,139 @@
+#!/bin/bash
+# Tiny end-to-end fully-async GRPO example using Qwen3.5-9B on the
+# dapo-math-17k dataset. Designed to run on a single 8-GPU node in a few
+# minutes.
+#
+# Prerequisites:
+#   /root/models/Qwen3.5-9B/             (HF checkpoint)
+#   /root/models/Qwen3.5-9B_torch_dist/  (from tools/convert_hf_to_torch_dist.py)
+#   /root/datasets/dapo-math-17k/dapo-math-17k.jsonl
+
+# clean any leftover ray/sglang
+pkill -9 sglang 2>/dev/null || true
+sleep 3
+ray stop --force 2>/dev/null || true
+pkill -9 ray python 2>/dev/null || true
+sleep 3
+
+set -ex
+
+export PYTHONUNBUFFERED=1
+
+NVLINK_COUNT=$(nvidia-smi topo -m 2>/dev/null | grep -o 'NV[0-9][0-9]*' | wc -l)
+HAS_NVLINK=$([ "$NVLINK_COUNT" -gt 0 ] && echo 1 || echo 0)
+echo "HAS_NVLINK: $HAS_NVLINK (detected $NVLINK_COUNT NVLink references)"
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+source "${SCRIPT_DIR}/../../scripts/models/qwen3.5-9B.sh"
+
+MODEL_DIR=${MODEL_DIR:-/root/models/Qwen3.5-9B}
+DATA_PATH=${DATA_PATH:-/root/datasets/dapo-math-17k/dapo-math-17k.jsonl}
+
+CKPT_ARGS=(
+   --hf-checkpoint "${MODEL_DIR}"
+   --ref-load "${MODEL_DIR}_torch_dist"
+   --save /tmp/slime_fully_async_demo/
+   --save-interval 9999
+)
+
+ROLLOUT_ARGS=(
+   # ↓↓↓ This is the only knob you need to flip to go fully-async ↓↓↓
+   --rollout-function-path slime.rollout.fully_async_rollout.generate_rollout_fully_async
+
+   --prompt-data "${DATA_PATH}"
+   --input-key prompt
+   --label-key label
+   --apply-chat-template
+   --rollout-shuffle
+
+   --rm-type deepscaler
+
+   --num-rollout 3
+   --rollout-batch-size 8
+   --n-samples-per-prompt 4
+   --rollout-max-response-len 2048
+   --rollout-temperature 1
+
+   --global-batch-size 32
+   --balance-data
+)
+
+PERF_ARGS=(
+   --tensor-model-parallel-size 2
+   --sequence-parallel
+   --pipeline-model-parallel-size 1
+   --context-parallel-size 1
+   --expert-model-parallel-size 1
+   --expert-tensor-parallel-size 1
+
+   --recompute-granularity full
+   --recompute-method uniform
+   --recompute-num-layers 1
+
+   --use-dynamic-batch-size
+   --max-tokens-per-gpu 4096
+)
+
+GRPO_ARGS=(
+   --advantage-estimator grpo
+   --use-kl-loss
+   --kl-loss-coef 0.00
+   --kl-loss-type low_var_kl
+   --entropy-coef 0.00
+   --eps-clip 0.2
+   --eps-clip-high 0.28
+)
+
+OPTIMIZER_ARGS=(
+   --optimizer adam
+   --lr 1e-6
+   --lr-decay-style constant
+   --weight-decay 0.1
+   --adam-beta1 0.9
+   --adam-beta2 0.98
+)
+
+SGLANG_ARGS=(
+   --rollout-num-gpus-per-engine 2
+   --sglang-mem-fraction-static 0.7
+)
+
+MISC_ARGS=(
+   --attention-dropout 0.0
+   --hidden-dropout 0.0
+   --accumulate-allreduce-grads-in-fp32
+   --attention-softmax-in-fp32
+   --attention-backend flash
+)
+
+# launch the master node of ray in container
+NUM_GPUS=${NUM_GPUS:-8}
+export MASTER_ADDR=${MASTER_ADDR:-"127.0.0.1"}
+ray start --head --node-ip-address "${MASTER_ADDR}" --num-gpus "${NUM_GPUS}" --disable-usage-stats
+
+RUNTIME_ENV_JSON="{
+  \"env_vars\": {
+    \"PYTHONPATH\": \"/root/Megatron-LM/:${SCRIPT_DIR}\",
+    \"CUDA_DEVICE_MAX_CONNECTIONS\": \"1\",
+    \"NCCL_NVLS_ENABLE\": \"${HAS_NVLINK}\"
+  }
+}"
+
+# fully-async splits actor / rollout onto disjoint GPUs (no colocation).
+ACTOR_GPUS=${ACTOR_GPUS:-4}
+ROLLOUT_GPUS=${ROLLOUT_GPUS:-$((NUM_GPUS - ACTOR_GPUS))}
+
+ray job submit --address="http://127.0.0.1:8265" \
+   --runtime-env-json="${RUNTIME_ENV_JSON}" \
+   -- python3 train_async.py \
+   --actor-num-nodes 1 \
+   --actor-num-gpus-per-node "${ACTOR_GPUS}" \
+   --rollout-num-gpus "${ROLLOUT_GPUS}" \
+   ${MODEL_ARGS[@]} \
+   "${CKPT_ARGS[@]}" \
+   "${ROLLOUT_ARGS[@]}" \
+   "${OPTIMIZER_ARGS[@]}" \
+   "${GRPO_ARGS[@]}" \
+   "${PERF_ARGS[@]}" \
+   "${SGLANG_ARGS[@]}" \
+   "${MISC_ARGS[@]}"

--- a/scripts/models/qwen3.5-9B.sh
+++ b/scripts/models/qwen3.5-9B.sh
@@ -1,0 +1,28 @@
+MODEL_ARGS=(
+   --spec "slime_plugins.models.qwen3_5" "get_qwen3_5_spec"
+
+   --disable-bias-linear
+   --qk-layernorm
+   --group-query-attention
+   --num-attention-heads 16
+   --num-query-groups 4
+   --kv-channels 256
+   --num-layers 32
+   --hidden-size 4096
+   --ffn-hidden-size 12288
+   --use-gated-attention
+
+   --normalization RMSNorm
+   --apply-layernorm-1p
+   --position-embedding-type rope
+   --norm-epsilon 1e-6
+   --rotary-percent 0.25
+   --swiglu
+   --untie-embeddings-and-output-weights
+   --vocab-size 248320
+
+   --rotary-base 10000000
+
+   # Qwen3.5 specific
+   --attention-output-gate
+)


### PR DESCRIPTION
## Summary

Add qwen3.5-9b model config and fully_async example

Changes:
- add scripts/models/qwen3.5-9B.sh as qwen3.5-9b MODEL_ARGS
- add examples/fully_async/run-qwen3.5-9B-fully_async.sh with single node 8 GPUs training demo

## Motivation

9B is commonly used, but it is currently missing

## Usage

```bash
bash examples/fully_async/run-qwen3.5-9B-fully_async.sh
```

## Pass
<img width="1273" height="469" alt="image" src="https://github.com/user-attachments/assets/e74d12b8-cc1c-44db-b33f-756393be01e3" />
