### PR TITLE
Support OPD when teacher tokenization differs

### DIFF
--- a/docs/en/advanced/on-policy-distillation.md
+++ b/docs/en/advanced/on-policy-distillation.md
@@ -11,6 +11,8 @@ On-policy distillation (OPD) enables a student model to learn from a larger teac
 | `--opd-kl-coef` | OPD KL penalty coefficient (default: 1.0). Controls the weight of the distillation signal relative to the RL advantage. |
 | `--opd-teacher-load` | Path to teacher Megatron checkpoint. **Required** when `--opd-type=megatron`, **must not be set** when `--opd-type=sglang`. |
 | `--opd-teacher-ckpt-step` | Optional checkpoint step for teacher model. |
+| `--teacher-tokenizer-path` | Teacher tokenizer path for cross-vocabulary SGLang OPD. |
+| `--opd-prompt-messages-key` | Metadata key used to preserve raw chat messages so the teacher can render the prompt with its own chat template. |
 
 ## How It Works
 
@@ -47,6 +49,20 @@ The teacher runs on an external SGLang server. Teacher log-probs are obtained du
 --custom-reward-post-process-path slime.rollout.on_policy_distillation.post_process_rewards
 --rm-url http://<TEACHER_IP>:<TEACHER_PORT>/generate
 ```
+
+For a teacher with a different tokenizer, keep `--opd-type sglang` and use the cross-vocabulary hooks:
+```bash
+--use-opd
+--opd-type sglang
+--opd-kl-coef 1.0
+--custom-rm-path slime.rollout.on_policy_distillation.reward_func_cross_vocab
+--custom-reward-post-process-path slime.rollout.on_policy_distillation.post_process_rewards_cross_vocab
+--teacher-tokenizer-path /path/to/teacher_hf_checkpoint
+--opd-prompt-messages-key opd_messages
+--rm-url http://<TEACHER_IP>:<TEACHER_PORT>/generate
+```
+
+When `--opd-prompt-messages-key` is set and the dataset prompt is chat messages, slime stores the raw messages in `sample.metadata[opd_messages]` before applying the student chat template. The teacher request renders those messages with the teacher tokenizer, then applies OPD only to response tokens whose decoded token text matches at the same text position. Non-matching tokenizer boundaries fall back to the student rollout log-prob, making the OPD delta zero there.
 
 ### Megatron Mode (`--opd-type megatron`)
 

--- a/docs/zh/advanced/on-policy-distillation.md
+++ b/docs/zh/advanced/on-policy-distillation.md
@@ -11,6 +11,8 @@
 | `--opd-kl-coef` | OPD KL 惩罚系数（默认值：1.0）。控制蒸馏信号相对于 RL advantage 的权重。 |
 | `--opd-teacher-load` | 教师模型的 Megatron checkpoint 路径。`--opd-type=megatron` 时**必须**设置，`--opd-type=sglang` 时**不可**设置。 |
 | `--opd-teacher-ckpt-step` | 可选的教师模型 checkpoint 步数。 |
+| `--teacher-tokenizer-path` | cross-vocabulary SGLang OPD 使用的教师 tokenizer 路径。 |
+| `--opd-prompt-messages-key` | 保存原始 chat messages 的 metadata key，用于让教师 tokenizer 用自己的 chat template 重新渲染 prompt。 |
 
 ## 原理
 
@@ -47,6 +49,20 @@ $$
 --custom-reward-post-process-path slime.rollout.on_policy_distillation.post_process_rewards
 --rm-url http://<TEACHER_IP>:<TEACHER_PORT>/generate
 ```
+
+如果教师和学生使用不同 tokenizer，仍然使用 `--opd-type sglang`，但切换到 cross-vocabulary hooks：
+```bash
+--use-opd
+--opd-type sglang
+--opd-kl-coef 1.0
+--custom-rm-path slime.rollout.on_policy_distillation.reward_func_cross_vocab
+--custom-reward-post-process-path slime.rollout.on_policy_distillation.post_process_rewards_cross_vocab
+--teacher-tokenizer-path /path/to/teacher_hf_checkpoint
+--opd-prompt-messages-key opd_messages
+--rm-url http://<TEACHER_IP>:<TEACHER_PORT>/generate
+```
+
+设置 `--opd-prompt-messages-key` 后，如果数据集 prompt 是 chat messages，slime 会在应用学生 chat template 前把原始 messages 保存到 `sample.metadata[opd_messages]`。教师请求会用教师 tokenizer 重新渲染这些 messages，并且只在 response 中 decoded token text 和文本位置都能 1:1 对齐的 token 上应用 OPD；无法对齐的位置使用 student rollout log-prob，使 OPD delta 为零。
 
 ### Megatron 模式 (`--opd-type megatron`)
 

--- a/examples/on_policy_distillation/README.md
+++ b/examples/on_policy_distillation/README.md
@@ -18,6 +18,8 @@ This example shows how to run **on-policy distillation (OPD)** using slime. A sm
 | `--opd-kl-coef` | OPD KL penalty coefficient (default: 1.0). |
 | `--opd-teacher-load` | Path to teacher checkpoint. **Required** when `--opd-type=megatron`, **must not be set** when `--opd-type=sglang`. |
 | `--opd-teacher-ckpt-step` | Optional checkpoint step for teacher model. |
+| `--teacher-tokenizer-path` | Teacher tokenizer path for cross-vocabulary SGLang OPD. |
+| `--opd-prompt-messages-key` | Metadata key used to preserve raw chat messages so the teacher can render them with its own chat template. |
 
 ## Mode Comparison
 
@@ -31,7 +33,9 @@ This example shows how to run **on-policy distillation (OPD)** using slime. A sm
 - `slime/rollout/on_policy_distillation.py` implements (for SGLang mode):
   - `reward_func` calls the teacher server (via `args.rm_url`) with every sample to obtain token-level logprobs.
   - `post_process_rewards` trims the teacher logprobs to the generated response span and writes the tensors back to each `Sample` to compute advantages.
+  - `reward_func_cross_vocab` / `post_process_rewards_cross_vocab` support teachers with a different tokenizer by rendering the original chat messages with the teacher chat template and applying OPD only on exactly aligned response tokens.
 - `run-qwen3-8B-opd.sh` launches an SGLang teacher server, then submits a Ray job that runs `train.py`.
+- `run-qwen3-8B-qwen3.5-35B-A3B-cross-vocab-opd.sh` shows cross-vocabulary SGLang OPD with a Qwen3-8B student and a Qwen3.5-35B-A3B teacher.
 - `run-qwen3-8B-opd-megatron.sh` uses Megatron-loaded teacher model (no external server needed).
 
 ## Running the example
@@ -60,6 +64,16 @@ PYTHONPATH=/root/Megatron-LM python tools/convert_hf_to_torch_dist.py \
 ```bash
 bash examples/on_policy_distillation/run-qwen3-8B-opd.sh
 ```
+
+For a teacher with a different tokenizer, keep `--opd-type sglang` and switch the hooks:
+```bash
+--custom-rm-path slime.rollout.on_policy_distillation.reward_func_cross_vocab
+--custom-reward-post-process-path slime.rollout.on_policy_distillation.post_process_rewards_cross_vocab
+--teacher-tokenizer-path /path/to/teacher_hf_checkpoint
+--opd-prompt-messages-key opd_messages
+```
+
+When `--opd-prompt-messages-key` is set and the dataset prompt is chat messages, slime stores the raw messages in `sample.metadata[opd_messages]` before applying the student chat template. The cross-vocabulary hook then renders those messages with the teacher tokenizer. If raw messages are unavailable, it falls back to the already-rendered string prompt.
 
 ### Using Megatron Teacher (No External Server)
 

--- a/examples/on_policy_distillation/run-qwen3-8B-qwen3.5-35B-A3B-cross-vocab-opd.sh
+++ b/examples/on_policy_distillation/run-qwen3-8B-qwen3.5-35B-A3B-cross-vocab-opd.sh
@@ -1,0 +1,191 @@
+#!/bin/bash
+
+# usage:
+#   bash examples/on_policy_distillation/run-qwen3-8B-qwen3.5-35B-A3B-cross-vocab-opd.sh
+#
+# This example trains a Qwen3-8B student with a Qwen3.5-35B-A3B SGLang teacher.
+# The teacher and student prompts are rendered with their own chat templates, so
+# the OPD hooks use cross-vocabulary alignment instead of sending student token IDs
+# to the teacher.
+
+set -ex
+
+SLIME_ROOT=${SLIME_ROOT:-/root/slime}
+MEGATRON_ROOT=${MEGATRON_ROOT:-/root/Megatron-LM}
+DATA_PATH=${DATA_PATH:-/root/dapo-math-17k/dapo-math-17k.jsonl}
+
+STUDENT_HF_PATH=${STUDENT_HF_PATH:-/root/Qwen3-8B}
+STUDENT_TORCH_DIST_PATH=${STUDENT_TORCH_DIST_PATH:-/root/Qwen3-8B_torch_dist}
+STUDENT_SLIME_CKPT_PATH=${STUDENT_SLIME_CKPT_PATH:-/root/Qwen3-8B_slime}
+TEACHER_HF_PATH=${TEACHER_HF_PATH:-/root/Qwen3.5-35B-A3B}
+
+TEACHER_IP=${TEACHER_IP:-127.0.0.1}
+TEACHER_PORT=${TEACHER_PORT:-13141}
+TEACHER_CUDA_VISIBLE_DEVICES=${TEACHER_CUDA_VISIBLE_DEVICES:-6,7}
+TEACHER_TP=${TEACHER_TP:-2}
+TEACHER_MEM_FRACTION_STATIC=${TEACHER_MEM_FRACTION_STATIC:-0.75}
+TEACHER_CHUNKED_PREFILL_SIZE=${TEACHER_CHUNKED_PREFILL_SIZE:-4096}
+LOG_FILE=${LOG_FILE:-/tmp/sglang_qwen35_teacher_$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 6).log}
+
+SLIME_CUDA_VISIBLE_DEVICES=${SLIME_CUDA_VISIBLE_DEVICES:-0,1,2,3,4,5}
+SLIME_NUM_GPUS=${SLIME_NUM_GPUS:-6}
+
+CUDA_VISIBLE_DEVICES=${TEACHER_CUDA_VISIBLE_DEVICES} python3 -m sglang.launch_server \
+    --model-path ${TEACHER_HF_PATH} \
+    --host 0.0.0.0 \
+    --port ${TEACHER_PORT} \
+    --tp ${TEACHER_TP} \
+    --chunked-prefill-size ${TEACHER_CHUNKED_PREFILL_SIZE} \
+    --mem-fraction-static ${TEACHER_MEM_FRACTION_STATIC} \
+    > "${LOG_FILE}" 2>&1 &
+
+echo "Starting Qwen3.5-35B-A3B teacher model server..."
+until curl -sf http://${TEACHER_IP}:${TEACHER_PORT}/health_generate > /dev/null; do
+    echo "Waiting for the teacher model server to start..."
+    tail -n 10 "${LOG_FILE}"
+    sleep 5
+done
+
+curl http://${TEACHER_IP}:${TEACHER_PORT}/get_model_info
+echo "Teacher model server is up at ${TEACHER_IP}:${TEACHER_PORT}."
+sleep 10
+
+export PYTHONUNBUFFERED=1
+
+NVLINK_COUNT=$(nvidia-smi topo -m 2>/dev/null | grep -o 'NV[0-9][0-9]*' | wc -l)
+if [ "${NVLINK_COUNT}" -gt 0 ]; then
+    HAS_NVLINK=1
+else
+    HAS_NVLINK=0
+fi
+echo "HAS_NVLINK: ${HAS_NVLINK} (detected ${NVLINK_COUNT} NVLink references)"
+
+source "${SLIME_ROOT}/scripts/models/qwen3-8B.sh"
+
+CKPT_ARGS=(
+   --hf-checkpoint ${STUDENT_HF_PATH}
+   --ref-load ${STUDENT_TORCH_DIST_PATH}
+   --load ${STUDENT_SLIME_CKPT_PATH}
+   --save ${STUDENT_SLIME_CKPT_PATH}
+   --save-interval 20
+)
+
+ROLLOUT_ARGS=(
+   --prompt-data ${DATA_PATH}
+   --input-key prompt
+   --apply-chat-template
+   --opd-prompt-messages-key opd_messages
+   --rollout-shuffle
+   --num-rollout 300
+   --rollout-batch-size 6
+   --n-samples-per-prompt 2
+   --rollout-max-response-len 4096
+   --rollout-temperature 1
+
+   --global-batch-size 12
+   --balance-data
+)
+
+RM_ARGS=(
+   --custom-rm-path slime.rollout.on_policy_distillation.reward_func_cross_vocab
+   --custom-reward-post-process-path slime.rollout.on_policy_distillation.post_process_rewards_cross_vocab
+   --rm-url http://${TEACHER_IP}:${TEACHER_PORT}/generate
+   --teacher-tokenizer-path ${TEACHER_HF_PATH}
+   --opd-teacher-timeout 300
+   --opd-teacher-retries 2
+)
+
+EVAL_ARGS=(
+   # --eval-interval 20
+   # --eval-prompt-data aime ${DATA_DIR}/aime-2024/aime-2024.jsonl
+   # --n-samples-per-eval-prompt 8
+   # --eval-max-response-len 4096
+   # --eval-top-p 1
+)
+
+PERF_ARGS=(
+   --tensor-model-parallel-size 1
+   --pipeline-model-parallel-size 1
+   --context-parallel-size 1
+   --expert-model-parallel-size 1
+   --expert-tensor-parallel-size 1
+
+   --recompute-granularity full
+   --recompute-method uniform
+   --recompute-num-layers 1
+
+   --use-dynamic-batch-size
+   --max-tokens-per-gpu 4096
+)
+
+GRPO_ARGS=(
+   --advantage-estimator grpo
+   --use-opd
+   --opd-type sglang
+   --opd-kl-coef 1.0
+   --use-kl-loss
+   --kl-loss-coef 0.00
+   --kl-loss-type low_var_kl
+   --entropy-coef 0.00
+)
+
+OPTIMIZER_ARGS=(
+   --optimizer adam
+   --lr 1e-6
+   --lr-decay-style constant
+   --weight-decay 0.1
+   --adam-beta1 0.9
+   --adam-beta2 0.98
+)
+
+WANDB_ARGS=(
+   # --use-wandb
+   # --wandb-project slime-dev
+   # --wandb-group qwen3-8B-qwen35-35B-A3B-cross-vocab-opd
+   # --wandb-key ${WANDB_KEY}
+)
+
+SGLANG_ARGS=(
+   --colocate
+   --num-gpus-per-node ${SLIME_NUM_GPUS}
+   --rollout-num-gpus-per-engine 1
+   --sglang-mem-fraction-static 0.4
+)
+
+MISC_ARGS=(
+   --attention-dropout 0.0
+   --hidden-dropout 0.0
+   --accumulate-allreduce-grads-in-fp32
+   --attention-softmax-in-fp32
+   --attention-backend flash
+)
+
+export MASTER_ADDR=${MASTER_ADDR:-"127.0.0.1"}
+CUDA_VISIBLE_DEVICES=${SLIME_CUDA_VISIBLE_DEVICES} ray start --head --node-ip-address ${MASTER_ADDR} --num-gpus ${SLIME_NUM_GPUS} --disable-usage-stats --dashboard-host=0.0.0.0 --dashboard-port=8265
+
+ray job submit --address="http://127.0.0.1:8265" \
+   --runtime-env-json='{
+     "env_vars": {
+        "PYTHONPATH": "'${MEGATRON_ROOT}'/",
+        "CUDA_VISIBLE_DEVICES": "'${SLIME_CUDA_VISIBLE_DEVICES}'",
+        "CUDA_DEVICE_MAX_CONNECTIONS": "1"
+     }
+   }' \
+   -- python3 train.py \
+   --actor-num-nodes 1 \
+   --actor-num-gpus-per-node ${SLIME_NUM_GPUS} \
+   --rollout-num-gpus ${SLIME_NUM_GPUS} \
+   ${MODEL_ARGS[@]} \
+   ${CKPT_ARGS[@]} \
+   ${ROLLOUT_ARGS[@]} \
+   ${OPTIMIZER_ARGS[@]} \
+   ${GRPO_ARGS[@]} \
+   ${WANDB_ARGS[@]} \
+   ${PERF_ARGS[@]} \
+   ${EVAL_ARGS[@]} \
+   ${SGLANG_ARGS[@]} \
+   ${MISC_ARGS[@]} \
+   ${RM_ARGS[@]}
+
+pkill -9 sglang
+sleep 3

--- a/slime/rollout/data_source.py
+++ b/slime/rollout/data_source.py
@@ -80,6 +80,7 @@ class RolloutDataSource(DataSource):
                 tool_key=args.tool_key,
                 apply_chat_template=args.apply_chat_template,
                 apply_chat_template_kwargs=args.apply_chat_template_kwargs,
+                prompt_messages_key=getattr(args, "opd_prompt_messages_key", None),
                 seed=args.rollout_seed,
             )
             if self.args.rollout_shuffle:

--- a/slime/rollout/on_policy_distillation.py
+++ b/slime/rollout/on_policy_distillation.py
@@ -1,11 +1,196 @@
+import asyncio
+import logging
+
 import aiohttp
 import torch
 
 from slime.utils.processing_utils import encode_image_for_rollout_engine
 from slime.utils.types import Sample
 
+logger = logging.getLogger(__name__)
+
+
+def _get_teacher_semaphore(args):
+    loop = asyncio.get_running_loop()
+    loop_key = id(loop)
+    semaphores_by_loop = getattr(args, "_opd_teacher_semaphores", None)
+    if semaphores_by_loop is None:
+        semaphores_by_loop = {}
+        args._opd_teacher_semaphores = semaphores_by_loop
+
+    concurrency = int(getattr(args, "opd_teacher_concurrency", 0))
+    if concurrency <= 0:
+        return None
+
+    semaphore = semaphores_by_loop.get(loop_key)
+    if semaphore is None:
+        semaphore = asyncio.Semaphore(concurrency)
+        semaphores_by_loop[loop_key] = semaphore
+    return semaphore
+
+
+def _teacher_payload_summary(payload):
+    if "input_ids" in payload:
+        return f"input_tokens={len(payload['input_ids'])}"
+    if "text" in payload:
+        return f"text_chars={len(payload['text'])}"
+    return "payload_size=unknown"
+
+
+async def _post_teacher_once(session, teacher_url, payload):
+    async with session.post(teacher_url, json=payload) as resp:
+        if resp.status >= 400:
+            body = (await resp.text())[:500]
+            raise aiohttp.ClientResponseError(
+                request_info=resp.request_info,
+                history=resp.history,
+                status=resp.status,
+                message=f"{resp.reason}; body={body}",
+                headers=resp.headers,
+            )
+        return await resp.json()
+
+
+async def _post_teacher_json(args, teacher_url, payload, sample, warning_prefix):
+    retries = max(0, int(getattr(args, "opd_teacher_retries", 2)))
+    timeout = aiohttp.ClientTimeout(total=float(getattr(args, "opd_teacher_timeout", 300.0)))
+    semaphore = _get_teacher_semaphore(args)
+    last_exc = None
+
+    for attempt in range(retries + 1):
+        try:
+            async with aiohttp.ClientSession(timeout=timeout) as session:
+                if semaphore is None:
+                    return await _post_teacher_once(session, teacher_url, payload)
+                async with semaphore:
+                    return await _post_teacher_once(session, teacher_url, payload)
+        except (TimeoutError, asyncio.TimeoutError, aiohttp.ClientError) as exc:
+            last_exc = exc
+            if attempt < retries:
+                await asyncio.sleep(min(0.2 * (2**attempt), 2.0))
+                continue
+
+    logger.warning(
+        "%s failed after %s attempt(s); using student rollout logprobs as teacher logprobs "
+        "for sample index=%s (%s): %s: %s",
+        warning_prefix,
+        retries + 1,
+        getattr(sample, "index", None),
+        _teacher_payload_summary(payload),
+        type(last_exc).__name__,
+        last_exc,
+    )
+    return {"_opd_teacher_fallback": True, "_opd_teacher_fallback_reason": type(last_exc).__name__}
+
+
+def _use_student_log_probs_for_teacher(sample: Sample, reason: str) -> None:
+    resp_len = sample.response_length
+    if resp_len == 0:
+        sample.teacher_log_probs = torch.empty(0, dtype=torch.float32)
+    else:
+        rollout_lps = sample.rollout_log_probs
+        if rollout_lps is None:
+            values = torch.zeros(resp_len, dtype=torch.float32)
+        else:
+            values = torch.as_tensor(rollout_lps, dtype=torch.float32).flatten()
+            if values.numel() >= resp_len:
+                values = values[-resp_len:]
+            else:
+                values = torch.cat([torch.zeros(resp_len - values.numel(), dtype=torch.float32), values])
+        sample.teacher_log_probs = values
+
+    if sample.metadata is None:
+        sample.metadata = {}
+    sample.metadata["opd_teacher_fallback"] = True
+    sample.metadata["opd_teacher_fallback_reason"] = reason
+
+
+def _load_student_tokenizer(args):
+    if not hasattr(args, "_opd_student_tok"):
+        from transformers import AutoTokenizer
+
+        args._opd_student_tok = AutoTokenizer.from_pretrained(args.hf_checkpoint, trust_remote_code=True)
+    return args._opd_student_tok
+
+
+def _get_opd_mask_token_sequences(args) -> list[list[int]]:
+    token_strings = getattr(args, "opd_mask_teacher_logprob_tokens", None)
+    if not token_strings:
+        return []
+
+    cached = getattr(args, "_opd_mask_teacher_logprob_token_ids", None)
+    if cached is not None:
+        return cached
+
+    tokenizer = _load_student_tokenizer(args)
+    sequences = []
+    for token_string in token_strings:
+        token_ids = tokenizer.encode(token_string, add_special_tokens=False)
+        if not token_ids:
+            logger.warning("Skipping empty OPD teacher-logprob mask token string: %r", token_string)
+            continue
+        sequences.append(token_ids)
+
+    args._opd_mask_teacher_logprob_token_ids = sequences
+    return sequences
+
+
+def _iter_matching_token_positions(tokens: list[int], sequences: list[list[int]]):
+    for sequence in sequences:
+        seq_len = len(sequence)
+        if seq_len == 0 or seq_len > len(tokens):
+            continue
+        for start in range(0, len(tokens) - seq_len + 1):
+            if tokens[start : start + seq_len] == sequence:
+                yield from range(start, start + seq_len)
+
+
+def _mask_teacher_logprobs_with_student(args, sample: Sample, teacher_log_probs):
+    sequences = _get_opd_mask_token_sequences(args)
+    if not sequences or sample.response_length == 0:
+        return teacher_log_probs
+
+    student_log_probs = sample.rollout_log_probs
+    if not student_log_probs:
+        logger.warning(
+            "Cannot mask OPD teacher log-probs for sample index=%s because rollout_log_probs is missing.",
+            getattr(sample, "index", None),
+        )
+        return teacher_log_probs
+
+    resp_len = sample.response_length
+    prompt_len = len(sample.tokens) - resp_len
+    response_tokens = sample.tokens[prompt_len:]
+    student_log_probs = list(student_log_probs)[-resp_len:]
+    masked_positions = sorted(set(_iter_matching_token_positions(response_tokens, sequences)))
+    if not masked_positions:
+        return teacher_log_probs
+
+    if isinstance(teacher_log_probs, torch.Tensor):
+        masked = teacher_log_probs.clone()
+        for pos in masked_positions:
+            if pos < masked.numel() and pos < len(student_log_probs):
+                masked[pos] = float(student_log_probs[pos])
+        return masked
+
+    masked = list(teacher_log_probs)
+    for pos in masked_positions:
+        if pos < len(masked) and pos < len(student_log_probs):
+            masked[pos] = float(student_log_probs[pos])
+    return masked
+
 
 async def reward_func(args, sample, **kwargs):
+    if kwargs.get("evaluation"):
+        from slime.rollout.rm_hub import async_rm as default_async_rm
+
+        saved = args.custom_rm_path
+        args.custom_rm_path = None
+        try:
+            return await default_async_rm(args, sample, **kwargs)
+        finally:
+            args.custom_rm_path = saved
+
     payload = {
         # "text": sample.prompt + sample.response,
         "input_ids": sample.tokens,
@@ -22,11 +207,7 @@ async def reward_func(args, sample, **kwargs):
         image_data = sample.multimodal_inputs["images"]
         payload["image_data"] = [encode_image_for_rollout_engine(image) for image in image_data]
 
-    session_kwargs = {}
-    async with aiohttp.ClientSession(**session_kwargs) as session:
-        async with session.post(args.rm_url, json=payload) as resp:
-            resp.raise_for_status()
-            return await resp.json()
+    return await _post_teacher_json(args, args.rm_url, payload, sample, "OPD teacher request")
 
 
 def post_process_rewards(args, samples: list[Sample], **kwargs):
@@ -42,20 +223,46 @@ def post_process_rewards(args, samples: list[Sample], **kwargs):
     For pure on-policy distillation without task rewards, we return 0.0 for each sample.
     The actual learning signal comes from the OPD KL penalty applied in compute_advantages_and_returns.
     """
-    raw_rewards = [sample.get_reward_value(args) for sample in samples]
+    raw_rewards = [
+        (
+            sample.reward
+            if isinstance(sample.reward, dict) and sample.reward.get("_opd_teacher_fallback")
+            else sample.get_reward_value(args)
+        )
+        for sample in samples
+    ]
     response_lengths = [sample.response_length for sample in samples]
+
+    for sample, reward in zip(samples, raw_rewards, strict=False):
+        if isinstance(reward, dict) and reward.get("_opd_teacher_fallback"):
+            _use_student_log_probs_for_teacher(sample, reward.get("_opd_teacher_fallback_reason", "teacher_failed"))
 
     # Extract teacher log-probs from the sglang response
     teacher_log_probs = [
         torch.tensor([item[0] for item in reward["meta_info"]["input_token_logprobs"][1:]], dtype=torch.float32)
         for reward in raw_rewards
+        if not (isinstance(reward, dict) and reward.get("_opd_teacher_fallback"))
     ]
     teacher_log_probs = [
         t_log_prob[-response_length:]
-        for t_log_prob, response_length in zip(teacher_log_probs, response_lengths, strict=False)
+        for t_log_prob, response_length in zip(
+            teacher_log_probs,
+            [
+                length
+                for reward, length in zip(raw_rewards, response_lengths, strict=False)
+                if not (isinstance(reward, dict) and reward.get("_opd_teacher_fallback"))
+            ],
+            strict=False,
+        )
     ]
 
-    for sample, t_log_probs in zip(samples, teacher_log_probs, strict=False):
+    samples_with_teacher = [
+        sample
+        for sample, reward in zip(samples, raw_rewards, strict=False)
+        if not (isinstance(reward, dict) and reward.get("_opd_teacher_fallback"))
+    ]
+    for sample, t_log_probs in zip(samples_with_teacher, teacher_log_probs, strict=False):
+        t_log_probs = _mask_teacher_logprobs_with_student(args, sample, t_log_probs)
         sample.teacher_log_probs = t_log_probs
 
     # Return scalar rewards for GRPO/PPO advantage estimator
@@ -64,4 +271,215 @@ def post_process_rewards(args, samples: list[Sample], **kwargs):
     # If you have task rewards, you can add them here.
     scalar_rewards = [0.0] * len(samples)
 
+    return scalar_rewards, scalar_rewards
+
+
+def _load_cross_vocab_tokenizers(args):
+    """Lazy-load teacher and student tokenizers, caching them on args."""
+    if hasattr(args, "_cross_vocab_student_tok"):
+        return
+
+    teacher_path = getattr(args, "teacher_tokenizer_path", None)
+    if not teacher_path:
+        raise ValueError(
+            "--teacher-tokenizer-path is required for cross-vocabulary OPD. "
+            "It must point to the teacher model tokenizer."
+        )
+
+    from transformers import AutoTokenizer
+
+    args._cross_vocab_student_tok = AutoTokenizer.from_pretrained(args.hf_checkpoint, trust_remote_code=True)
+    args._cross_vocab_teacher_tok = AutoTokenizer.from_pretrained(teacher_path, trust_remote_code=True)
+
+
+def _get_nested_metadata(metadata: dict, key: str | None):
+    if not key:
+        return None
+    current = metadata
+    for part in key.split("."):
+        if not isinstance(current, dict) or part not in current:
+            return None
+        current = current[part]
+    return current
+
+
+def _render_teacher_prompt(args, sample: Sample, teacher_tok):
+    """Render the rollout prompt with the teacher tokenizer when messages are available."""
+    metadata = sample.metadata or {}
+    messages_key = getattr(args, "opd_prompt_messages_key", None)
+    prompt_messages = _get_nested_metadata(metadata, messages_key)
+    if prompt_messages is None and isinstance(sample.prompt, list):
+        prompt_messages = sample.prompt
+
+    if prompt_messages is not None:
+        if isinstance(prompt_messages, str):
+            prompt_text = prompt_messages
+            prompt_ids = teacher_tok.encode(prompt_text, add_special_tokens=False)
+            return prompt_text, prompt_ids
+        if not isinstance(prompt_messages, list):
+            raise TypeError(
+                f"OPD prompt messages from key {messages_key!r} must be a list of chat messages or a string, "
+                f"got {type(prompt_messages).__name__}."
+            )
+
+        tools = metadata.get("tools")
+        template_kwargs = {"tokenize": False, "add_generation_prompt": True}
+        if tools is not None:
+            template_kwargs["tools"] = tools
+        try:
+            prompt_text = teacher_tok.apply_chat_template(prompt_messages, **template_kwargs)
+        except TypeError:
+            template_kwargs.pop("tools", None)
+            prompt_text = teacher_tok.apply_chat_template(prompt_messages, **template_kwargs)
+
+        token_kwargs = dict(template_kwargs)
+        token_kwargs["tokenize"] = True
+        try:
+            prompt_ids = teacher_tok.apply_chat_template(prompt_messages, **token_kwargs)
+        except TypeError:
+            token_kwargs.pop("tools", None)
+            prompt_ids = teacher_tok.apply_chat_template(prompt_messages, **token_kwargs)
+        return prompt_text, prompt_ids
+
+    if not isinstance(sample.prompt, str):
+        raise TypeError(
+            "Cross-vocabulary OPD requires a string prompt or chat messages in sample.prompt/metadata. "
+            f"Got sample.prompt={type(sample.prompt).__name__}."
+        )
+    return sample.prompt, teacher_tok.encode(sample.prompt, add_special_tokens=False)
+
+
+def _decode_token_texts(tokenizer, token_ids: list[int]) -> list[str]:
+    return [
+        tokenizer.decode([token_id], skip_special_tokens=False, clean_up_tokenization_spaces=False) or ""
+        for token_id in token_ids
+    ]
+
+
+def _align_common_tokens_1to1(teacher_texts, teacher_lps, student_texts, student_rollout_lps):
+    """Align teacher logprobs to student positions using exact 1:1 decoded-token matches.
+
+    Positions without an exact match keep the student rollout logprob. The downstream
+    reverse-KL delta is therefore zero for tokenizer-boundary mismatches.
+    """
+    aligned = list(student_rollout_lps)
+
+    i = j = 0
+    teacher_prefix = ""
+    student_prefix = ""
+    num_matched = 0
+
+    while i < len(teacher_texts) and j < len(student_texts):
+        teacher_text = teacher_texts[i] or ""
+        student_text = student_texts[j] or ""
+
+        if teacher_prefix == student_prefix and teacher_text == student_text:
+            aligned[j] = teacher_lps[i]
+            num_matched += 1
+            teacher_prefix += teacher_text
+            student_prefix += student_text
+            i += 1
+            j += 1
+        elif len(teacher_prefix) > len(student_prefix):
+            student_prefix += student_text
+            j += 1
+        elif len(teacher_prefix) < len(student_prefix):
+            teacher_prefix += teacher_text
+            i += 1
+        else:
+            teacher_prefix += teacher_text
+            student_prefix += student_text
+            i += 1
+            j += 1
+
+    return aligned, num_matched
+
+
+async def reward_func_cross_vocab(args, sample: Sample, **kwargs):
+    """Ask an SGLang teacher for logprobs after rendering the prompt with teacher chat template."""
+    if kwargs.get("evaluation"):
+        from slime.rollout.rm_hub import async_rm as default_async_rm
+
+        saved = args.custom_rm_path
+        args.custom_rm_path = None
+        try:
+            return await default_async_rm(args, sample, **kwargs)
+        finally:
+            args.custom_rm_path = saved
+
+    _load_cross_vocab_tokenizers(args)
+    teacher_tok = args._cross_vocab_teacher_tok
+    teacher_prompt, teacher_prompt_ids = _render_teacher_prompt(args, sample, teacher_tok)
+
+    payload = {
+        "text": teacher_prompt + sample.response,
+        "sampling_params": {
+            "temperature": 0,
+            "max_new_tokens": 0,
+            "skip_special_tokens": False,
+        },
+        "return_logprob": True,
+        "logprob_start_len": 0,
+    }
+
+    result = await _post_teacher_json(args, args.rm_url, payload, sample, "Cross-vocab OPD teacher request")
+    if isinstance(result, dict) and result.get("_opd_teacher_fallback"):
+        return result
+
+    result["_cross_vocab_meta"] = {"teacher_prompt_len": len(teacher_prompt_ids)}
+    return result
+
+
+def post_process_rewards_cross_vocab(args, samples: list[Sample], **kwargs):
+    """Store teacher logprobs on student response positions that share a 1:1 token boundary."""
+    raw_rewards = [
+        (
+            sample.reward
+            if isinstance(sample.reward, dict) and sample.reward.get("_opd_teacher_fallback")
+            else sample.get_reward_value(args)
+        )
+        for sample in samples
+    ]
+    has_teacher_rewards = any(
+        not (isinstance(reward, dict) and reward.get("_opd_teacher_fallback")) for reward in raw_rewards
+    )
+    if has_teacher_rewards:
+        _load_cross_vocab_tokenizers(args)
+        student_tok = args._cross_vocab_student_tok
+        teacher_tok = args._cross_vocab_teacher_tok
+
+    for sample, reward in zip(samples, raw_rewards, strict=True):
+        resp_len = sample.response_length
+        if resp_len == 0:
+            sample.teacher_log_probs = torch.empty(0, dtype=torch.float32)
+            continue
+
+        if isinstance(reward, dict) and reward.get("_opd_teacher_fallback"):
+            _use_student_log_probs_for_teacher(sample, reward.get("_opd_teacher_fallback_reason", "teacher_failed"))
+            continue
+
+        all_info = reward["meta_info"]["input_token_logprobs"]
+        teacher_prompt_len = reward["_cross_vocab_meta"]["teacher_prompt_len"]
+
+        teacher_resp_info = all_info[teacher_prompt_len:]
+        teacher_lps = [item[0] for item in teacher_resp_info]
+        teacher_ids = [item[1] for item in teacher_resp_info]
+
+        prompt_len = len(sample.tokens) - resp_len
+        student_resp_ids = sample.tokens[prompt_len:]
+        student_texts = _decode_token_texts(student_tok, student_resp_ids)
+        teacher_texts = _decode_token_texts(teacher_tok, teacher_ids)
+        student_rollout_lps = list(sample.rollout_log_probs or [0.0] * resp_len)[-resp_len:]
+
+        aligned_lps, num_matched = _align_common_tokens_1to1(
+            teacher_texts, teacher_lps, student_texts, student_rollout_lps
+        )
+        aligned_lps = _mask_teacher_logprobs_with_student(args, sample, aligned_lps)
+
+        sample.teacher_log_probs = torch.tensor(aligned_lps, dtype=torch.float32)
+        if sample.metadata is None:
+            sample.metadata = {}
+        sample.metadata["cross_vocab_token_overlap"] = num_matched / resp_len if resp_len > 0 else 0.0
+
+    scalar_rewards = [0.0] * len(samples)
     return scalar_rewards, scalar_rewards

--- a/slime/rollout/sglang_rollout.py
+++ b/slime/rollout/sglang_rollout.py
@@ -515,7 +515,8 @@ async def eval_rollout_single_dataset(
 
     global EVAL_PROMPT_DATASET
 
-    cache_key = dataset_cfg.cache_key + (args.hf_checkpoint, args.apply_chat_template)
+    opd_prompt_messages_key = getattr(args, "opd_prompt_messages_key", None)
+    cache_key = dataset_cfg.cache_key + (args.hf_checkpoint, args.apply_chat_template, opd_prompt_messages_key)
     if cache_key not in EVAL_PROMPT_DATASET:
         tokenizer = load_tokenizer(args.hf_checkpoint, trust_remote_code=True)
         processor = load_processor(args.hf_checkpoint, trust_remote_code=True)
@@ -531,6 +532,7 @@ async def eval_rollout_single_dataset(
             tool_key=dataset_cfg.tool_key,
             apply_chat_template=args.apply_chat_template,
             apply_chat_template_kwargs=args.apply_chat_template_kwargs,
+            prompt_messages_key=opd_prompt_messages_key,
         )
     dataset = EVAL_PROMPT_DATASET[cache_key]
 

--- a/slime/utils/arguments.py
+++ b/slime/utils/arguments.py
@@ -1108,6 +1108,53 @@ def get_slime_extra_args_provider(add_custom_arguments=None):
             parser.add_argument(
                 "--opd-teacher-ckpt-step", type=int, default=None, help="The checkpoint step for OPD teacher model."
             )
+            parser.add_argument(
+                "--teacher-tokenizer-path",
+                type=str,
+                default=None,
+                help=(
+                    "Path to the teacher tokenizer for cross-vocabulary SGLang OPD. "
+                    "Required when using slime.rollout.on_policy_distillation.reward_func_cross_vocab."
+                ),
+            )
+            parser.add_argument(
+                "--opd-prompt-messages-key",
+                type=str,
+                default=None,
+                help=(
+                    "Metadata key used to preserve the raw chat messages for cross-vocabulary OPD. "
+                    "When set, Dataset stores the pre-template prompt messages in sample.metadata under this key, "
+                    "and reward_func_cross_vocab renders those messages with the teacher chat template."
+                ),
+            )
+            parser.add_argument(
+                "--opd-mask-teacher-logprob-tokens",
+                type=str,
+                nargs="+",
+                default=None,
+                help=(
+                    "Student-tokenizer strings whose OPD teacher log-probs should be replaced with student rollout "
+                    "log-probs, making the OPD delta zero on protected format tokens."
+                ),
+            )
+            parser.add_argument(
+                "--opd-teacher-timeout",
+                type=float,
+                default=300.0,
+                help="Total timeout in seconds for each SGLang OPD teacher HTTP request.",
+            )
+            parser.add_argument(
+                "--opd-teacher-retries",
+                type=int,
+                default=2,
+                help="Number of retries for transient SGLang OPD teacher HTTP failures before falling back.",
+            )
+            parser.add_argument(
+                "--opd-teacher-concurrency",
+                type=int,
+                default=0,
+                help="Maximum concurrent SGLang OPD teacher HTTP requests per rollout worker. 0 disables this limit.",
+            )
             return parser
 
         def add_router_arguments(parser):
@@ -1764,6 +1811,13 @@ def slime_validate_args(args):
 
     # Validate on-policy distillation (OPD) arguments
     if args.use_opd:
+        if args.opd_teacher_timeout <= 0:
+            raise ValueError("--opd-teacher-timeout must be positive.")
+        if args.opd_teacher_retries < 0:
+            raise ValueError("--opd-teacher-retries must be non-negative.")
+        if args.opd_teacher_concurrency < 0:
+            raise ValueError("--opd-teacher-concurrency must be non-negative.")
+
         if args.opd_type is None:
             raise ValueError("--opd-type must be specified when --use-opd is enabled. Choose 'sglang' or 'megatron'.")
 

--- a/slime/utils/data.py
+++ b/slime/utils/data.py
@@ -208,6 +208,7 @@ class Dataset:
         seed=42,
         apply_chat_template=False,
         apply_chat_template_kwargs=None,
+        prompt_messages_key=None,
     ):
         origin_samples = []
         for data in read_file(path):
@@ -216,6 +217,9 @@ class Dataset:
             prompt = _build_messages(data, prompt_key, as_conversation, multimodal_keys)
 
             metadata = data.get(metadata_key) or {}
+            if prompt_messages_key is not None and isinstance(prompt, list):
+                metadata = dict(metadata)
+                metadata[prompt_messages_key] = prompt
             tools = None
             if tool_key is not None and tool_key in data:
                 tools = data[tool_key]

--- a/tests/test_on_policy_distillation.py
+++ b/tests/test_on_policy_distillation.py
@@ -1,0 +1,202 @@
+import json
+import os
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from slime.rollout.on_policy_distillation import (
+    _align_common_tokens_1to1,
+    _render_teacher_prompt,
+    post_process_rewards_cross_vocab,
+    reward_func_cross_vocab,
+)
+from slime.utils.data import Dataset
+from slime.utils.types import Sample
+
+
+class FakeTokenizer:
+    def __init__(self, decoded=None):
+        self.decoded = decoded or {}
+        self.rendered_messages = None
+
+    def apply_chat_template(self, messages, tokenize=False, add_generation_prompt=True, **kwargs):
+        self.rendered_messages = messages
+        rendered = "<teacher>" + "|".join(message["content"] for message in messages) + "<assistant>"
+        if tokenize:
+            return list(range(len(messages) + 1))
+        return rendered
+
+    def encode(self, text, add_special_tokens=False):
+        return list(range(len(text)))
+
+    def decode(self, token_ids, skip_special_tokens=False, clean_up_tokenization_spaces=False):
+        return "".join(self.decoded[token_id] for token_id in token_ids)
+
+
+def test_cross_vocab_render_prefers_metadata_messages():
+    tokenizer = FakeTokenizer()
+    args = SimpleNamespace(opd_prompt_messages_key="opd_messages")
+    messages = [{"role": "user", "content": "solve"}]
+    sample = Sample(prompt="<student>solve<assistant>", response="42", metadata={"opd_messages": messages})
+
+    prompt_text, prompt_ids = _render_teacher_prompt(args, sample, tokenizer)
+
+    assert prompt_text == "<teacher>solve<assistant>"
+    assert prompt_ids == [0, 1]
+    assert tokenizer.rendered_messages == messages
+
+
+def test_dataset_preserves_raw_messages_for_cross_vocab_opd(tmp_path):
+    data_path = tmp_path / "data.jsonl"
+    messages = [{"role": "user", "content": "solve"}]
+    data_path.write_text(json.dumps({"messages": messages, "metadata": {"source": "unit"}}) + "\n")
+
+    dataset = Dataset(
+        str(data_path),
+        tokenizer=FakeTokenizer(),
+        processor=None,
+        max_length=None,
+        prompt_key="messages",
+        metadata_key="metadata",
+        apply_chat_template=True,
+        prompt_messages_key="opd_messages",
+    )
+
+    sample = dataset[0]
+    assert sample.prompt == "<teacher>solve<assistant>"
+    assert sample.metadata["source"] == "unit"
+    assert sample.metadata["opd_messages"] == messages
+
+
+def test_align_common_tokens_uses_student_logprob_for_tokenizer_mismatch():
+    aligned, matched = _align_common_tokens_1to1(
+        teacher_texts=["A", "BC"],
+        teacher_lps=[-1.0, -2.0],
+        student_texts=["A", "B", "C"],
+        student_rollout_lps=[-0.1, -0.2, -0.3],
+    )
+
+    assert matched == 1
+    assert aligned == [-1.0, -0.2, -0.3]
+
+
+def test_cross_vocab_post_process_aligns_teacher_response_logprobs():
+    args = SimpleNamespace(
+        reward_key=None,
+        teacher_tokenizer_path="unused",
+        opd_mask_teacher_logprob_tokens=None,
+        _cross_vocab_teacher_tok=FakeTokenizer({1: "A", 2: "B"}),
+        _cross_vocab_student_tok=FakeTokenizer({3: "A", 4: "B"}),
+    )
+    sample = Sample(
+        tokens=[99, 3, 4],
+        response_length=2,
+        rollout_log_probs=[-0.3, -0.4],
+        reward={
+            "_cross_vocab_meta": {"teacher_prompt_len": 2},
+            "meta_info": {
+                "input_token_logprobs": [
+                    [None, 10],
+                    [-0.1, 11],
+                    [-1.0, 1],
+                    [-2.0, 2],
+                ]
+            },
+        },
+    )
+
+    rewards, raw_rewards = post_process_rewards_cross_vocab(args, [sample])
+
+    assert rewards == [0.0]
+    assert raw_rewards == [0.0]
+    assert torch.equal(sample.teacher_log_probs, torch.tensor([-1.0, -2.0]))
+    assert sample.metadata["cross_vocab_token_overlap"] == 1.0
+
+
+def test_cross_vocab_fallback_does_not_require_tokenizers():
+    args = SimpleNamespace(reward_key=None)
+    sample = Sample(
+        response_length=2,
+        rollout_log_probs=[-4.0, -5.0],
+        reward={"_opd_teacher_fallback": True, "_opd_teacher_fallback_reason": "TimeoutError"},
+    )
+
+    rewards, raw_rewards = post_process_rewards_cross_vocab(args, [sample])
+
+    assert rewards == [0.0]
+    assert raw_rewards == [0.0]
+    assert torch.equal(sample.teacher_log_probs, torch.tensor([-4.0, -5.0]))
+    assert sample.metadata["opd_teacher_fallback"] is True
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(
+    not (
+        os.getenv("SLIME_OPD_TEACHER_RM_URL")
+        and os.getenv("SLIME_OPD_STUDENT_TOKENIZER_PATH")
+        and os.getenv("SLIME_OPD_TEACHER_TOKENIZER_PATH")
+    ),
+    reason=(
+        "set SLIME_OPD_TEACHER_RM_URL, SLIME_OPD_STUDENT_TOKENIZER_PATH, "
+        "and SLIME_OPD_TEACHER_TOKENIZER_PATH to run live cross-vocab OPD teacher API test"
+    ),
+)
+@pytest.mark.asyncio
+async def test_cross_vocab_reward_func_with_live_teacher_api():
+    """Optional live check for a running SGLang teacher /generate endpoint.
+
+    Example:
+        SLIME_OPD_TEACHER_RM_URL=http://127.0.0.1:30000/generate \
+        SLIME_OPD_STUDENT_TOKENIZER_PATH=/path/to/student \
+        SLIME_OPD_TEACHER_TOKENIZER_PATH=/path/to/teacher \
+        pytest tests/test_on_policy_distillation.py::test_cross_vocab_reward_func_with_live_teacher_api
+    """
+    from transformers import AutoTokenizer
+
+    messages = [{"role": "user", "content": os.getenv("SLIME_OPD_LIVE_PROMPT", "What is 2+2?")}]
+    response = os.getenv("SLIME_OPD_LIVE_RESPONSE", "4")
+    student_tokenizer_path = os.environ["SLIME_OPD_STUDENT_TOKENIZER_PATH"]
+    teacher_tokenizer_path = os.environ["SLIME_OPD_TEACHER_TOKENIZER_PATH"]
+    rm_url = os.environ["SLIME_OPD_TEACHER_RM_URL"]
+
+    student_tok = AutoTokenizer.from_pretrained(student_tokenizer_path, trust_remote_code=True)
+    student_prompt = student_tok.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
+    student_prompt_ids = student_tok.encode(student_prompt, add_special_tokens=False)
+    response_ids = student_tok.encode(response, add_special_tokens=False)
+    response_length = len(response_ids)
+    assert response_length > 0
+
+    sample = Sample(
+        prompt=student_prompt,
+        tokens=student_prompt_ids + response_ids,
+        response=response,
+        response_length=response_length,
+        rollout_log_probs=[-1.0] * response_length,
+        metadata={"opd_messages": messages},
+    )
+    args = SimpleNamespace(
+        hf_checkpoint=student_tokenizer_path,
+        teacher_tokenizer_path=teacher_tokenizer_path,
+        rm_url=rm_url,
+        reward_key=None,
+        custom_rm_path=None,
+        opd_prompt_messages_key="opd_messages",
+        opd_mask_teacher_logprob_tokens=None,
+        opd_teacher_timeout=float(os.getenv("SLIME_OPD_TEACHER_TIMEOUT", "300")),
+        opd_teacher_retries=int(os.getenv("SLIME_OPD_TEACHER_RETRIES", "0")),
+        opd_teacher_concurrency=0,
+    )
+
+    sample.reward = await reward_func_cross_vocab(args, sample)
+    if isinstance(sample.reward, dict) and sample.reward.get("_opd_teacher_fallback"):
+        pytest.fail(f"teacher request fell back: {sample.reward.get('_opd_teacher_fallback_reason')}")
+
+    rewards, raw_rewards = post_process_rewards_cross_vocab(args, [sample])
+
+    assert rewards == [0.0]
+    assert raw_rewards == [0.0]
+    assert sample.teacher_log_probs is not None
+    assert len(sample.teacher_log_probs) == response_length
+    assert torch.isfinite(sample.teacher_log_probs).all()
+    assert 0.0 <= sample.metadata["cross_vocab_token_overlap"] <= 1.0


### PR DESCRIPTION
SGLang OPD previously assumed that teacher and student shared token IDs, so it could send student token IDs directly to the teacher server and trim returned logprobs by student response length. Cross-vocabulary distillation needs the teacher to render the original chat messages with its own chat template, then align teacher response logprobs back to student response positions only where token boundaries match exactly.

This adds explicit cross-vocabulary hooks, preserves raw prompt messages in dataset metadata when requested, and documents the SGLang configuration. Non-aligned response positions keep the student rollout logprob so the OPD delta is zero there.

Constraint: Official Sample.prompt may already be a student-rendered string after --apply-chat-template, so raw messages are preserved through an opt-in metadata key instead of relying on local origin_prompt fields.
Rejected: Send student token IDs to cross-vocabulary teachers | token IDs are tokenizer-local and cannot represent the same prompt across vocabularies.
Rejected: Apply teacher logprobs to every decoded-text span | many-to-one token spans do not map to a single student logprob position cleanly.
Confidence: medium
Scope-risk: moderate
Directive: Do not replace the metadata messages path with origin_prompt-style private fields; official datasets need an explicit portable way to carry raw messages.
Tested: python -m py_compile on modified Python files; manual execution of tests/test_on_policy_distillation.py test functions; git diff --check.
Not-tested: Full pytest suite unavailable because pytest is not installed; parser smoke blocked by missing sglang_router dependency; live SGLang teacher request not exercised.