### PR TITLE
[draft] Add support for multi teacher OPD and memory-efficient topk level OPD

### DIFF
--- a/examples/on_policy_distillation/README.md
+++ b/examples/on_policy_distillation/README.md
@@ -112,6 +112,8 @@ python3 examples/on_policy_distillation/topkopd_train.py \
 
 Teachers must be homogeneous with the student model. Multiple teacher checkpoints are averaged in probability space before computing the top-k OPD loss.
 
+The top-k example uses `examples.on_policy_distillation.topk_opd_helpers` to provide zero rewards and placeholder advantages. This keeps the rollout reward path runnable for pure top-k OPD; the actual training signal still comes from `topk_opd_loss`, which compares the current policy with the Megatron teacher distribution on the student's top-k tokens plus tail mass.
+
 
 # Preliminary Results
 Using Qwen3-8B-Base model sfted on part of the [OpenThoughts3-1.2M](https://huggingface.co/datasets/open-thoughts/OpenThoughts3-1.2M) dataset, we performed on-policy distillation with a Qwen3-32B teacher on the remaining data. Evaluation on Math500 shows:

--- a/examples/on_policy_distillation/README.md
+++ b/examples/on_policy_distillation/README.md
@@ -8,6 +8,7 @@ This example shows how to run **on-policy distillation (OPD)** using slime. A sm
 - **Two teacher modes**:
   - **sglang**: Teacher runs on an external SGLang server, teacher log-probs are obtained during rollout.
   - **megatron**: Teacher is loaded directly into Megatron via `--opd-teacher-load`, teacher log-probs are computed during training forward pass.
+  - **top-k megatron**: Homogeneous Megatron teacher(s) are loaded during training and matched on the student's top-k logits plus tail mass via `topkopd_train.py`.
 
 ## Key Arguments
 
@@ -16,7 +17,10 @@ This example shows how to run **on-policy distillation (OPD)** using slime. A sm
 | `--use-opd` | Enable on-policy distillation. Required flag to use OPD. |
 | `--opd-type` | Type of OPD: `sglang` or `megatron`. Required when `--use-opd` is set. |
 | `--opd-kl-coef` | OPD KL penalty coefficient (default: 1.0). |
-| `--opd-teacher-load` | Path to teacher checkpoint. **Required** when `--opd-type=megatron`, **must not be set** when `--opd-type=sglang`. |
+| `--opd-teacher-load` | Path to a single teacher checkpoint. **Required** when `--opd-type=megatron` unless `--opd-teacher-loads` is set; **must not be set** when `--opd-type=sglang`. |
+| `--opd-teacher-loads` | One or more homogeneous Megatron teacher checkpoints for top-k OPD. |
+| `--topk-level-opd` | Enable top-k level Megatron OPD. Use the `examples/on_policy_distillation/topkopd_train.py` entry. |
+| `--opd-top-k` | Number of student top-k logits retained for top-k OPD. |
 | `--opd-teacher-ckpt-step` | Optional checkpoint step for teacher model. |
 
 ## Mode Comparison
@@ -33,6 +37,7 @@ This example shows how to run **on-policy distillation (OPD)** using slime. A sm
   - `post_process_rewards` trims the teacher logprobs to the generated response span and writes the tensors back to each `Sample` to compute advantages.
 - `run-qwen3-8B-opd.sh` launches an SGLang teacher server, then submits a Ray job that runs `train.py`.
 - `run-qwen3-8B-opd-megatron.sh` uses Megatron-loaded teacher model (no external server needed).
+- `run-qwen3-8B-topk-opd-megatron.sh` uses the explicit `topkopd_train.py` entry to train with top-k level OPD and optional multi-teacher checkpoints.
 
 ## Running the example
 
@@ -86,6 +91,26 @@ PYTHONPATH=/root/Megatron-LM python tools/convert_hf_to_torch_dist.py \
 ```bash
 bash examples/on_policy_distillation/run-qwen3-8B-opd-megatron.sh
 ```
+
+### Using Top-k Megatron Teacher(s)
+
+Top-k level OPD uses a dedicated train entry so the top-k actor subclass is only used when explicitly requested:
+```bash
+bash examples/on_policy_distillation/run-qwen3-8B-topk-opd-megatron.sh
+```
+
+The example submits:
+```bash
+python3 examples/on_policy_distillation/topkopd_train.py \
+  --use-opd \
+  --opd-type megatron \
+  --topk-level-opd \
+  --loss-type topk_opd_loss \
+  --opd-top-k 100 \
+  --opd-teacher-loads /path/to/teacher_a /path/to/teacher_b
+```
+
+Teachers must be homogeneous with the student model. Multiple teacher checkpoints are averaged in probability space before computing the top-k OPD loss.
 
 
 # Preliminary Results

--- a/examples/on_policy_distillation/run-qwen3-8B-topk-opd-megatron.sh
+++ b/examples/on_policy_distillation/run-qwen3-8B-topk-opd-megatron.sh
@@ -1,0 +1,169 @@
+#!/bin/bash
+
+# Top-k level On-Policy Distillation with Megatron-based teacher model(s)
+# This example uses the original model as the teacher (self-distillation for demonstration).
+#
+# IMPORTANT: This is just an example configuration!
+# In practice, you should:
+# 1. Use one or more different stronger models as teachers
+# 2. Adjust --opd-kl-coef and --opd-top-k based on your task
+# 3. Configure proper evaluation metrics
+
+set -ex
+
+export PYTHONUNBUFFERED=1
+
+NVLINK_COUNT=$(nvidia-smi topo -m 2>/dev/null | grep -o 'NV[0-9][0-9]*' | wc -l)
+if [ "$NVLINK_COUNT" -gt 0 ]; then
+    HAS_NVLINK=1
+else
+    HAS_NVLINK=0
+fi
+echo "HAS_NVLINK: $HAS_NVLINK (detected $NVLINK_COUNT NVLink references)"
+
+source "/root/slime/scripts/models/qwen3-8B.sh"
+
+
+CKPT_ARGS=(
+   --hf-checkpoint /root/Qwen3-8B
+   --ref-load /root/Qwen3-8B_torch_dist
+   --load /root/Qwen3-8B_slime/
+   --save /root/Qwen3-8B_slime/
+   --save-interval 20
+)
+
+ROLLOUT_ARGS=(
+   --prompt-data /root/dapo-math-17k/dapo-math-17k.jsonl
+   --input-key prompt
+   --apply-chat-template
+   --rollout-shuffle
+   --num-rollout 300
+   --rollout-batch-size 16
+   --n-samples-per-prompt 4
+   --rollout-max-response-len 16384
+   --rollout-temperature 1
+
+   --global-batch-size 64
+   --balance-data
+)
+
+RM_ARGS=(
+   --rm-type math
+)
+
+EVAL_ARGS=(
+   # --eval-interval 20
+   # --eval-prompt-data aime ${DATA_DIR}/aime-2024/aime-2024.jsonl
+   # --n-samples-per-eval-prompt 16
+   # --eval-max-response-len 16384
+   # --eval-top-p 1
+)
+
+PERF_ARGS=(
+   --tensor-model-parallel-size 2
+   --sequence-parallel
+   --pipeline-model-parallel-size 1
+   --context-parallel-size 1
+   --expert-model-parallel-size 1
+   --expert-tensor-parallel-size 1
+
+   --recompute-granularity full
+   --recompute-method uniform
+   --recompute-num-layers 1
+
+   # --micro-batch-size 1
+   --use-dynamic-batch-size
+   --max-tokens-per-gpu 16384
+)
+
+GRPO_ARGS=(
+   --advantage-estimator grpo                        # Base advantage estimator (can be ppo, grpo, etc.)
+
+   # Top-k OPD Configuration
+   --use-opd                                          # Enable on-policy distillation
+   --opd-type megatron                                # Use Megatron forward for teacher
+   --topk-level-opd                                   # Use the top-k OPD actor entry path
+   --loss-type topk_opd_loss                          # Train with top-k/tail OPD loss
+   --opd-top-k ${OPD_TOP_K:-100}                      # Top-k vocabulary mass retained per response token
+   --opd-kl-coef 1.0                                  # CHANGE THIS: OPD loss coefficient
+   # Teacher model configuration. Multiple paths are supported here.
+   --opd-teacher-loads ${OPD_TEACHER_LOADS:-/root/Qwen3-8B_torch_dist}
+
+   --use-kl-loss
+   --kl-loss-coef 0.00
+   --kl-loss-type low_var_kl
+   --entropy-coef 0.00
+)
+
+OPTIMIZER_ARGS=(
+   --optimizer adam
+   --lr 1e-6
+   --lr-decay-style constant
+   --weight-decay 0.1
+   --adam-beta1 0.9
+   --adam-beta2 0.98
+)
+
+WANDB_ARGS=(
+   #--use-wandb
+   # --wandb-project slime-dev
+   # --wandb-group qwen3-8B-topk-opd-megatron
+   # --wandb-key ${WANDB_KEY}
+)
+
+SGLANG_ARGS=(
+   --rollout-num-gpus-per-engine 1
+   --sglang-mem-fraction-static 0.4
+)
+
+
+MISC_ARGS=(
+   --attention-dropout 0.0
+   --hidden-dropout 0.0
+   --accumulate-allreduce-grads-in-fp32
+   --attention-softmax-in-fp32
+   --attention-backend flash
+)
+
+
+
+
+# launch the master node of ray in container
+export MASTER_ADDR=${MASTER_ADDR:-"127.0.0.1"}
+ray start --head --node-ip-address ${MASTER_ADDR} --num-gpus 8 --disable-usage-stats --dashboard-host=0.0.0.0 --dashboard-port=8265
+
+
+ray job submit --address="http://127.0.0.1:8265" \
+   --runtime-env-json='{
+     "env_vars": {
+        "PYTHONPATH": "/root/Megatron-LM/",
+        "CUDA_DEVICE_MAX_CONNECTIONS": "1"
+     }
+   }' \
+   -- python3 examples/on_policy_distillation/topkopd_train.py \
+   --actor-num-nodes 1 \
+   --actor-num-gpus-per-node 2 \
+   --rollout-num-gpus 4 \
+   ${MODEL_ARGS[@]} \
+   ${CKPT_ARGS[@]} \
+   ${ROLLOUT_ARGS[@]} \
+   ${OPTIMIZER_ARGS[@]} \
+   ${GRPO_ARGS[@]} \
+   ${WANDB_ARGS[@]} \
+   ${PERF_ARGS[@]} \
+   ${EVAL_ARGS[@]} \
+   ${SGLANG_ARGS[@]} \
+   ${MISC_ARGS[@]} \
+   ${RM_ARGS[@]}
+
+
+
+####clear after training
+pkill -9 sglang
+sleep 3
+ray stop --force
+pkill -9 ray
+pkill -9 python
+sleep 3
+pkill -9 ray
+pkill -9 python

--- a/examples/on_policy_distillation/run-qwen3-8B-topk-opd-megatron.sh
+++ b/examples/on_policy_distillation/run-qwen3-8B-topk-opd-megatron.sh
@@ -48,7 +48,9 @@ ROLLOUT_ARGS=(
 )
 
 RM_ARGS=(
-   --rm-type math
+   --custom-rm-path examples.on_policy_distillation.topk_opd_helpers.zero_reward_func
+   --custom-reward-post-process-path examples.on_policy_distillation.topk_opd_helpers.zero_reward_post_process
+   --custom-advantage-function-path examples.on_policy_distillation.topk_opd_helpers.placeholder_advantage_function
 )
 
 EVAL_ARGS=(

--- a/examples/on_policy_distillation/topk_opd_helpers.py
+++ b/examples/on_policy_distillation/topk_opd_helpers.py
@@ -1,0 +1,39 @@
+"""Minimal reward plumbing for top-k Megatron OPD examples.
+
+Top-k OPD gets its training signal from teacher/student top-k and tail
+distributions computed during Megatron training. These helpers keep the rollout
+reward path runnable when no task reward is needed.
+"""
+
+from __future__ import annotations
+
+import torch
+
+from slime.utils.types import Sample
+
+
+async def zero_reward_func(args, sample_or_samples: Sample | list[Sample], **kwargs):
+    if isinstance(sample_or_samples, list):
+        return [0.0 for _ in sample_or_samples]
+    return {"score": 0.0}
+
+
+def zero_reward_post_process(args, samples: list[Sample]):
+    rewards = [0.0 for _ in samples]
+    return rewards, rewards
+
+
+def placeholder_advantage_function(args, rollout_data):
+    values_sources = (
+        rollout_data.get("log_probs"),
+        rollout_data.get("rollout_log_probs"),
+        rollout_data.get("values"),
+    )
+    device = next((values[0].device for values in values_sources if values), torch.device("cpu"))
+
+    advantages = [
+        torch.zeros(response_length, dtype=torch.float32, device=device)
+        for response_length in rollout_data["response_lengths"]
+    ]
+    rollout_data["advantages"] = advantages
+    rollout_data["returns"] = [advantage.clone() for advantage in advantages]

--- a/examples/on_policy_distillation/topkopd_train.py
+++ b/examples/on_policy_distillation/topkopd_train.py
@@ -1,14 +1,15 @@
-from pathlib import Path
 import sys
+from pathlib import Path
 
 SLIME_ROOT = Path(__file__).resolve().parents[2]
 if str(SLIME_ROOT) not in sys.path:
     sys.path.insert(0, str(SLIME_ROOT))
 
+from train import train
+
 from slime.backends.megatron_utils.topk_opd_actor import TopKOPDMegatronTrainRayActor
 from slime.ray.actor_group import set_train_actor_cls
 from slime.utils.arguments import parse_args
-from train import train
 
 
 def main():

--- a/examples/on_policy_distillation/topkopd_train.py
+++ b/examples/on_policy_distillation/topkopd_train.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+import sys
+
+SLIME_ROOT = Path(__file__).resolve().parents[2]
+if str(SLIME_ROOT) not in sys.path:
+    sys.path.insert(0, str(SLIME_ROOT))
+
+from slime.backends.megatron_utils.topk_opd_actor import TopKOPDMegatronTrainRayActor
+from slime.ray.actor_group import set_train_actor_cls
+from slime.utils.arguments import parse_args
+from train import train
+
+
+def main():
+    args = parse_args()
+    if not args.topk_level_opd:
+        raise ValueError("topkopd_train.py requires --topk-level-opd.")
+    if args.train_backend != "megatron" or args.opd_type != "megatron":
+        raise ValueError("topkopd_train.py requires Megatron OPD: --train-backend megatron --opd-type megatron.")
+    set_train_actor_cls(TopKOPDMegatronTrainRayActor)
+    train(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/slime/backends/megatron_utils/actor.py
+++ b/slime/backends/megatron_utils/actor.py
@@ -120,9 +120,14 @@ class MegatronTrainRayActor(TrainRayActor):
         if with_ref:
             self.load_other_checkpoint("ref", args.ref_load)
 
-        # Load teacher model for Megatron-based on-policy distillation
+        # Load teacher model(s) for Megatron-based on-policy distillation.
         if with_opd_teacher:
-            self.load_other_checkpoint("teacher", args.opd_teacher_load)
+            teacher_loads = getattr(args, "opd_teacher_loads", None) or [args.opd_teacher_load]
+            if len(teacher_loads) == 1:
+                self.load_other_checkpoint("teacher", teacher_loads[0])
+            else:
+                for teacher_idx, teacher_load in enumerate(teacher_loads):
+                    self.load_other_checkpoint(f"teacher_{teacher_idx}", teacher_load)
 
         if self.args.keep_old_actor:
             # Load old_actor checkpoint
@@ -674,7 +679,7 @@ class MegatronTrainRayActor(TrainRayActor):
         if model_tag == "ref" and self.args.ref_ckpt_step is not None:
             old_ckpt_step = self.args.ckpt_step
             self.args.ckpt_step = self.args.ref_ckpt_step
-        elif model_tag == "teacher" and self.args.opd_teacher_ckpt_step is not None:
+        elif model_tag.startswith("teacher") and self.args.opd_teacher_ckpt_step is not None:
             old_ckpt_step = self.args.ckpt_step
             self.args.ckpt_step = self.args.opd_teacher_ckpt_step
 

--- a/slime/backends/megatron_utils/data.py
+++ b/slime/backends/megatron_utils/data.py
@@ -299,6 +299,11 @@ def log_rollout_data(
                 "rollout_ids",
                 "rollout_mask_sums",
                 "rollout_routed_experts",
+                "student_topk_indices",
+                "old_topk_log_probs",
+                "old_tail_log_probs",
+                "teacher_topk_log_probs",
+                "teacher_tail_log_probs",
                 "max_seq_lens",
                 "global_batch_sizes",
                 "num_microbatches",
@@ -322,6 +327,7 @@ def log_rollout_data(
                         "values",
                         "teacher_log_probs",
                         "opd_reverse_kl",
+                        "topk_opd_reverse_kl",
                     ]:
                         tensor = torch.cat(val).clone().detach()
                         sum_of_sample_mean = get_sum_of_sample_mean(

--- a/slime/backends/megatron_utils/loss.py
+++ b/slime/backends/megatron_utils/loss.py
@@ -2,6 +2,7 @@ from argparse import Namespace
 from collections.abc import Callable, Iterator
 from typing import Any
 
+import math
 import torch
 import torch.distributed as dist
 import torch.nn.functional as F
@@ -1028,6 +1029,390 @@ def policy_loss_function(
     return loss, reported_loss
 
 
+
+class TPLogSumExp(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, logits_chunk: torch.Tensor, tp_group):
+        logits_max_chunks = []
+        r_local = logits_chunk.size(0)
+        for r_start in range(0, r_local, 2048):
+            r_end = min(r_start + 2048, r_local)
+            logits_max_chunks.append(logits_chunk[r_start:r_end].detach().max(dim=-1, keepdim=True).values)
+        logits_max = torch.cat(logits_max_chunks, dim=0) if r_local > 0 else logits_chunk.new_empty((0, 1))
+
+        tp_size = dist.get_world_size(tp_group) if tp_group is not None else 1
+        if tp_size > 1:
+            dist.all_reduce(logits_max, op=dist.ReduceOp.MAX, group=tp_group)
+
+        sum_exp_chunks = []
+        for r_start in range(0, r_local, 2048):
+            r_end = min(r_start + 2048, r_local)
+            chunk_norm = logits_chunk[r_start:r_end].detach() - logits_max[r_start:r_end]
+            sum_exp_chunks.append(chunk_norm.exp().sum(dim=-1, keepdim=True))
+        sum_exp = torch.cat(sum_exp_chunks, dim=0) if r_local > 0 else logits_chunk.new_empty((0, 1))
+        if tp_size > 1:
+            dist.all_reduce(sum_exp, op=dist.ReduceOp.SUM, group=tp_group)
+
+        log_sum_exp = sum_exp.log()
+        ctx.save_for_backward(logits_chunk, logits_max, sum_exp)
+        return log_sum_exp, logits_max
+
+    @staticmethod
+    def backward(ctx, grad_log_sum_exp: torch.Tensor, grad_logits_max: torch.Tensor):
+        logits_chunk, logits_max, sum_exp = ctx.saved_tensors
+        grad_logits = None
+        if ctx.needs_input_grad[0]:
+            grad_logits = torch.empty_like(logits_chunk)
+            r_local = logits_chunk.size(0)
+            for r_start in range(0, r_local, 2048):
+                r_end = min(r_start + 2048, r_local)
+                chunk_norm = logits_chunk[r_start:r_end].detach() - logits_max[r_start:r_end]
+                chunk_prob = chunk_norm.exp() / sum_exp[r_start:r_end]
+                grad_logits[r_start:r_end] = chunk_prob * grad_log_sum_exp[r_start:r_end]
+        return grad_logits, None
+
+
+class TPTopKLogProbs(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, logits_chunk, log_sum_exp, logits_max, vocab_offset, local_vocab_size, tp_group, top_k):
+        with torch.no_grad():
+            r_local = logits_chunk.size(0)
+            tp_size = dist.get_world_size(tp_group) if tp_group is not None else 1
+            topk_vals_list = []
+            topk_idx_list = []
+            for r_start in range(0, r_local, 2048):
+                r_end = min(r_start + 2048, r_local)
+                normalized = logits_chunk[r_start:r_end] - logits_max[r_start:r_end] - log_sum_exp[r_start:r_end]
+                if tp_size > 1:
+                    gathered = [torch.zeros_like(normalized) for _ in range(tp_size)]
+                    dist.all_gather(gathered, normalized, group=tp_group)
+                    full_vocab_log_probs = torch.cat(gathered, dim=-1)
+                    vals, idx = full_vocab_log_probs.topk(top_k, dim=-1)
+                else:
+                    vals, idx = normalized.topk(top_k, dim=-1)
+                topk_vals_list.append(vals)
+                topk_idx_list.append(idx)
+            topk_log_probs = (
+                torch.cat(topk_vals_list, dim=0)
+                if r_local > 0
+                else torch.empty(0, top_k, dtype=logits_chunk.dtype, device=logits_chunk.device)
+            )
+            topk_indices = (
+                torch.cat(topk_idx_list, dim=0)
+                if r_local > 0
+                else torch.empty(0, top_k, dtype=torch.long, device=logits_chunk.device)
+            )
+
+        ctx.save_for_backward(topk_indices)
+        ctx.vocab_offset = vocab_offset
+        ctx.local_vocab_size = local_vocab_size
+        return topk_log_probs, topk_indices
+
+    @staticmethod
+    def backward(ctx, grad_topk_log_probs, grad_topk_indices):
+        (topk_indices,) = ctx.saved_tensors
+        vocab_offset = ctx.vocab_offset
+        local_vocab_size = ctx.local_vocab_size
+        grad_logits_chunk = torch.zeros(
+            topk_indices.size(0),
+            local_vocab_size,
+            dtype=grad_topk_log_probs.dtype,
+            device=grad_topk_log_probs.device,
+        )
+        in_local_mask = (topk_indices >= vocab_offset) & (topk_indices < vocab_offset + local_vocab_size)
+        local_indices = (topk_indices - vocab_offset).clamp(0, local_vocab_size - 1)
+        grad_logits_chunk.scatter_add_(
+            -1, local_indices, grad_topk_log_probs * in_local_mask.to(grad_topk_log_probs.dtype)
+        )
+        grad_log_sum_exp = -grad_topk_log_probs.sum(dim=-1, keepdim=True)
+        grad_logits_max = torch.zeros_like(grad_log_sum_exp)
+        return grad_logits_chunk, grad_log_sum_exp, grad_logits_max, None, None, None, None
+
+
+def _compute_log_probs_at_indices(
+    indices: torch.Tensor,
+    logits_chunk: torch.Tensor,
+    logits_max: torch.Tensor,
+    log_sum_exp: torch.Tensor,
+    vocab_offset: int,
+    local_vocab_size: int,
+    tp_group,
+) -> torch.Tensor:
+    in_local_vocab = (indices >= vocab_offset) & (indices < vocab_offset + local_vocab_size)
+    local_indices = (indices - vocab_offset).clamp(0, local_vocab_size - 1)
+    local_log_probs_list = []
+    for r_start in range(0, logits_chunk.size(0), 2048):
+        r_end = min(r_start + 2048, logits_chunk.size(0))
+        chunk_local_logits = logits_chunk[r_start:r_end].gather(-1, local_indices[r_start:r_end])
+        chunk_log_probs = chunk_local_logits - logits_max[r_start:r_end] - log_sum_exp[r_start:r_end]
+        chunk_log_probs = chunk_log_probs * in_local_vocab[r_start:r_end].to(chunk_log_probs.dtype)
+        local_log_probs_list.append(chunk_log_probs)
+    if logits_chunk.size(0) > 0:
+        local_log_probs_at_idx = torch.cat(local_log_probs_list, dim=0)
+    else:
+        local_log_probs_at_idx = torch.empty(0, indices.size(-1), dtype=logits_chunk.dtype, device=logits_chunk.device)
+    if tp_group is not None and dist.get_world_size(tp_group) > 1:
+        dist.all_reduce(local_log_probs_at_idx, group=tp_group)
+    return local_log_probs_at_idx
+
+
+def get_topk_log_probs(
+    logits: torch.Tensor,
+    *,
+    args: Namespace,
+    unconcat_tokens: list[torch.Tensor],
+    total_lengths: list[int],
+    response_lengths: list[int],
+    top_k: int = 100,
+    max_seq_lens: list[int] | None = None,
+    target_indices: list[torch.Tensor] | None = None,
+    **kwargs: Any,
+) -> tuple[torch.Tensor, dict[str, list[torch.Tensor]]]:
+    tp_group = mpu.get_tensor_model_parallel_group()
+    tp_rank = mpu.get_tensor_model_parallel_rank()
+    cp_size = mpu.get_context_parallel_world_size()
+    cp_group = mpu.get_context_parallel_group() if cp_size > 1 else None
+    qkv_format = args.qkv_format
+
+    topk_log_probs_list = []
+    topk_indices_list = []
+    tail_log_probs_list = []
+    entropy_list = []
+
+    for i, (logits_chunk, tokens_chunk) in enumerate(
+        get_responses(
+            logits,
+            args=args,
+            unconcat_tokens=unconcat_tokens,
+            total_lengths=total_lengths,
+            response_lengths=response_lengths,
+            max_seq_lens=max_seq_lens,
+        )
+    ):
+        r_local = logits_chunk.size(0)
+        assert tokens_chunk.size(0) == r_local
+        local_vocab_size = logits_chunk.size(-1)
+        vocab_offset = tp_rank * local_vocab_size
+        total_length = total_lengths[i]
+        response_length = response_lengths[i]
+        prompt_length = total_length - response_length
+
+        if r_local == 0:
+            top_k_i = top_k if target_indices is None or i >= len(target_indices) else target_indices[i].size(-1)
+            device = logits.device
+            if cp_size > 1 and target_indices is not None and i < len(target_indices):
+                full_log_probs = torch.zeros(response_length, top_k_i, dtype=logits.dtype, device=device)
+                dist.all_reduce(full_log_probs, group=cp_group)
+                topk_log_probs_list.append(full_log_probs)
+                topk_indices_list.append(target_indices[i])
+                tail_log_probs_list.append((1.0 - full_log_probs.exp().sum(dim=-1)).clamp(min=1e-10).log())
+            elif cp_size > 1:
+                full_indices = torch.zeros(response_length, top_k_i, dtype=torch.long, device=device)
+                dist.all_reduce(full_indices, group=cp_group)
+                topk_log_probs_list.append(torch.empty(0, top_k_i, dtype=logits.dtype, device=device))
+                topk_indices_list.append(full_indices)
+                tail_log_probs_list.append(torch.empty(0, dtype=logits.dtype, device=device))
+            else:
+                topk_log_probs_list.append(torch.empty(0, top_k_i, dtype=logits.dtype, device=device))
+                topk_indices_list.append(torch.empty(0, top_k_i, dtype=torch.long, device=device))
+                tail_log_probs_list.append(torch.empty(0, dtype=logits.dtype, device=device))
+            entropy_list.append(torch.empty(0, dtype=logits.dtype, device=device))
+            continue
+
+        log_sum_exp, logits_max = TPLogSumExp.apply(logits_chunk, tp_group)
+
+        if target_indices is not None and i < len(target_indices):
+            full_target_idx = target_indices[i]
+            k_i = full_target_idx.size(-1)
+            if cp_size > 1:
+                max_seq_len = max_seq_lens[i] if max_seq_lens is not None else None
+                _, _, logits_offset, tokens_offset = get_logits_and_tokens_offset_with_cp(
+                    total_length, response_length, qkv_format, max_seq_len
+                )
+                start_0 = tokens_offset[0][0] - prompt_length
+                end_0 = tokens_offset[0][1] - prompt_length
+                start_1 = tokens_offset[1][0] - prompt_length
+                end_1 = tokens_offset[1][1] - prompt_length
+                local_idx_0 = (
+                    full_target_idx[start_0:end_0]
+                    if end_0 > start_0
+                    else torch.empty(0, k_i, dtype=full_target_idx.dtype, device=full_target_idx.device)
+                )
+                local_idx_1 = (
+                    full_target_idx[start_1:end_1]
+                    if end_1 > start_1
+                    else torch.empty(0, k_i, dtype=full_target_idx.dtype, device=full_target_idx.device)
+                )
+                local_target_idx = torch.cat([local_idx_0, local_idx_1], dim=0)
+                local_log_probs = _compute_log_probs_at_indices(
+                    local_target_idx, logits_chunk, logits_max, log_sum_exp, vocab_offset, local_vocab_size, tp_group
+                )
+                full_log_probs = torch.zeros(
+                    response_length, k_i, dtype=local_log_probs.dtype, device=local_log_probs.device
+                )
+                r0 = logits_offset[0][1] - logits_offset[0][0]
+                if r0 > 0:
+                    pos0 = logits_offset[0][0] + 1 - prompt_length
+                    full_log_probs[pos0 : pos0 + r0] = local_log_probs[:r0]
+                r1 = logits_offset[1][1] - logits_offset[1][0]
+                if r1 > 0:
+                    pos1 = logits_offset[1][0] + 1 - prompt_length
+                    full_log_probs[pos1 : pos1 + r1] = local_log_probs[r0 : r0 + r1]
+                dist.all_reduce(full_log_probs, group=cp_group)
+                topk_log_probs = full_log_probs
+                topk_indices = full_target_idx
+            else:
+                topk_log_probs = _compute_log_probs_at_indices(
+                    full_target_idx, logits_chunk, logits_max, log_sum_exp, vocab_offset, local_vocab_size, tp_group
+                )
+                topk_indices = full_target_idx
+        else:
+            topk_log_probs, topk_indices_local = TPTopKLogProbs.apply(
+                logits_chunk, log_sum_exp, logits_max, vocab_offset, local_vocab_size, tp_group, top_k
+            )
+            if cp_size > 1:
+                _, _, logits_offset, _ = get_logits_and_tokens_offset_with_cp(
+                    total_length,
+                    response_length,
+                    qkv_format,
+                    max_seq_lens[i] if max_seq_lens is not None else None,
+                )
+                full_indices = torch.zeros(
+                    response_length, top_k, dtype=topk_indices_local.dtype, device=topk_indices_local.device
+                )
+                r0 = logits_offset[0][1] - logits_offset[0][0]
+                if r0 > 0:
+                    start0 = logits_offset[0][0] + 1 - prompt_length
+                    full_indices[start0 : start0 + r0] = topk_indices_local[:r0]
+                r1 = logits_offset[1][1] - logits_offset[1][0]
+                if r1 > 0:
+                    start1 = logits_offset[1][0] + 1 - prompt_length
+                    full_indices[start1 : start1 + r1] = topk_indices_local[r0 : r0 + r1]
+                dist.all_reduce(full_indices, group=cp_group)
+                topk_indices = full_indices
+            else:
+                topk_indices = topk_indices_local
+
+        topk_probs = topk_log_probs.exp()
+        tail_prob = (1.0 - topk_probs.sum(dim=-1)).clamp(min=1e-10)
+        tail_log_prob = tail_prob.log()
+        entropy = -(topk_probs * topk_log_probs).sum(dim=-1) - tail_prob * tail_log_prob
+        topk_log_probs_list.append(topk_log_probs)
+        topk_indices_list.append(topk_indices)
+        tail_log_probs_list.append(tail_log_prob)
+        entropy_list.append(entropy)
+
+    return torch.empty((0,), device=logits.device), {
+        "topk_log_probs": topk_log_probs_list,
+        "topk_indices": topk_indices_list,
+        "tail_log_probs": tail_log_probs_list,
+        "entropy": entropy_list,
+    }
+
+
+def _slice_full_response_data_by_cp(
+    values: list[torch.Tensor],
+    total_lengths: list[int],
+    response_lengths: list[int],
+    qkv_format: str,
+    max_seq_lens: list[int] | None,
+) -> list[torch.Tensor]:
+    if mpu.get_context_parallel_world_size() == 1:
+        return values
+    sliced = []
+    for i, (value, total_length, response_length) in enumerate(
+        zip(values, total_lengths, response_lengths, strict=False)
+    ):
+        if value.size(0) != response_length:
+            sliced.append(value)
+            continue
+        prompt_length = total_length - response_length
+        max_seq_len = max_seq_lens[i] if max_seq_lens is not None else None
+        _, _, _, tokens_offset = get_logits_and_tokens_offset_with_cp(
+            total_length, response_length, qkv_format, max_seq_len
+        )
+        part0 = value[tokens_offset[0][0] - prompt_length : tokens_offset[0][1] - prompt_length]
+        part1 = value[tokens_offset[1][0] - prompt_length : tokens_offset[1][1] - prompt_length]
+        sliced.append(torch.cat([part0, part1], dim=0))
+    return sliced
+
+
+def topk_opd_loss_function(
+    args: Namespace,
+    batch: RolloutBatch,
+    logits: torch.Tensor,
+    sum_of_sample_mean: Callable[[torch.Tensor], torch.Tensor],
+) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
+    if batch.get("student_topk_indices") is None:
+        raise ValueError("topk_opd_loss requires student_topk_indices in the batch.")
+    for key in ["old_topk_log_probs", "old_tail_log_probs", "teacher_topk_log_probs", "teacher_tail_log_probs"]:
+        if batch.get(key) is None:
+            raise ValueError(f"topk_opd_loss requires {key} in the batch.")
+
+    _, current_topk_data = get_topk_log_probs(
+        logits,
+        args=args,
+        unconcat_tokens=batch["unconcat_tokens"],
+        total_lengths=batch["total_lengths"],
+        response_lengths=batch["response_lengths"],
+        top_k=args.opd_top_k,
+        max_seq_lens=batch.get("max_seq_lens", None),
+        target_indices=batch["student_topk_indices"],
+    )
+
+    total_lengths = batch["total_lengths"]
+    response_lengths = batch["response_lengths"]
+    max_seq_lens = batch.get("max_seq_lens", None)
+    current_topk_log_probs = _slice_full_response_data_by_cp(
+        current_topk_data["topk_log_probs"], total_lengths, response_lengths, args.qkv_format, max_seq_lens
+    )
+    current_tail_log_probs = _slice_full_response_data_by_cp(
+        current_topk_data["tail_log_probs"], total_lengths, response_lengths, args.qkv_format, max_seq_lens
+    )
+    teacher_topk_log_probs = _slice_full_response_data_by_cp(
+        batch["teacher_topk_log_probs"], total_lengths, response_lengths, args.qkv_format, max_seq_lens
+    )
+    teacher_tail_log_probs = _slice_full_response_data_by_cp(
+        batch["teacher_tail_log_probs"], total_lengths, response_lengths, args.qkv_format, max_seq_lens
+    )
+    old_topk_log_probs = batch["old_topk_log_probs"]
+    old_tail_log_probs = batch["old_tail_log_probs"]
+
+    current_topk = torch.cat(current_topk_log_probs, dim=0)
+    current_tail = torch.cat(current_tail_log_probs, dim=0)
+    old_topk = torch.cat(old_topk_log_probs, dim=0)
+    old_tail = torch.cat(old_tail_log_probs, dim=0)
+    teacher_topk = torch.cat(teacher_topk_log_probs, dim=0)
+    teacher_tail = torch.cat(teacher_tail_log_probs, dim=0)
+
+    old_probs = old_topk.exp()
+    old_tail_probs = old_tail.exp()
+    topk_ratio = torch.exp(current_topk - old_topk)
+    tail_ratio = torch.exp(current_tail - old_tail)
+    topk_advantages = teacher_topk - old_topk
+    tail_advantages = teacher_tail - old_tail
+
+    per_token_loss = -(
+        (old_probs * topk_ratio * topk_advantages).sum(dim=-1)
+        + old_tail_probs * tail_ratio * tail_advantages
+    )
+    opd_loss = args.opd_kl_coef * sum_of_sample_mean(per_token_loss)
+
+    reverse_kl = (old_probs * (old_topk - teacher_topk)).sum(dim=-1) + old_tail_probs * (old_tail - teacher_tail)
+    topk_ratio_abs = (topk_ratio - 1).abs().mean(dim=-1)
+    tail_ratio_abs = (tail_ratio - 1).abs()
+    avg_ratio_abs = 0.5 * (topk_ratio_abs + tail_ratio_abs)
+
+    if current_topk.numel() == 0:
+        opd_loss = opd_loss + 0 * logits.sum()
+
+    return opd_loss, {
+        "loss": opd_loss.clone().detach(),
+        "topk_opd_loss": opd_loss.clone().detach(),
+        "topk_opd_reverse_kl": sum_of_sample_mean(reverse_kl).clone().detach(),
+        "topk_opd_ratio_abs": sum_of_sample_mean(avg_ratio_abs).clone().detach(),
+    }
+
 def value_loss_function(
     args: Namespace,
     batch: RolloutBatch,
@@ -1190,6 +1575,8 @@ def loss_function(
             func = value_loss_function
         case "sft_loss":
             func = sft_loss_function
+        case "topk_opd_loss":
+            func = topk_opd_loss_function
         case "custom_loss":
             func = load_function(args.custom_loss_function_path)
         case _:

--- a/slime/backends/megatron_utils/loss.py
+++ b/slime/backends/megatron_utils/loss.py
@@ -2,7 +2,6 @@ from argparse import Namespace
 from collections.abc import Callable, Iterator
 from typing import Any
 
-import math
 import torch
 import torch.distributed as dist
 import torch.nn.functional as F
@@ -1029,7 +1028,6 @@ def policy_loss_function(
     return loss, reported_loss
 
 
-
 class TPLogSumExp(torch.autograd.Function):
     @staticmethod
     def forward(ctx, logits_chunk: torch.Tensor, tp_group):
@@ -1393,8 +1391,7 @@ def topk_opd_loss_function(
     tail_advantages = teacher_tail - old_tail
 
     per_token_loss = -(
-        (old_probs * topk_ratio * topk_advantages).sum(dim=-1)
-        + old_tail_probs * tail_ratio * tail_advantages
+        (old_probs * topk_ratio * topk_advantages).sum(dim=-1) + old_tail_probs * tail_ratio * tail_advantages
     )
     opd_loss = args.opd_kl_coef * sum_of_sample_mean(per_token_loss)
 
@@ -1412,6 +1409,7 @@ def topk_opd_loss_function(
         "topk_opd_reverse_kl": sum_of_sample_mean(reverse_kl).clone().detach(),
         "topk_opd_ratio_abs": sum_of_sample_mean(avg_ratio_abs).clone().detach(),
     }
+
 
 def value_loss_function(
     args: Namespace,

--- a/slime/backends/megatron_utils/model.py
+++ b/slime/backends/megatron_utils/model.py
@@ -6,6 +6,7 @@ import os
 from argparse import Namespace
 from collections.abc import Callable, Sequence
 from functools import partial
+from typing import Any
 from pathlib import Path
 
 import torch
@@ -265,6 +266,7 @@ def forward_only(
     data_iterator: Sequence[DataIterator],
     num_microbatches: Sequence[int],
     store_prefix: str = "",
+    extra_kwargs: dict[str, Any] | None = None,
 ) -> dict[str, list[torch.Tensor]]:
     """Run forward passes only and collect non-loss outputs (e.g., logprobs).
 
@@ -322,6 +324,7 @@ def forward_only(
                 "total_lengths",
                 "response_lengths",
                 "max_seq_lens",
+                "student_topk_indices",
             ],
             args.data_pad_size_multiplier,
             args.qkv_format,
@@ -344,6 +347,10 @@ def forward_only(
             forward_kwargs.update(batch["multimodal_train_inputs"])
         output_tensor = model(**forward_kwargs)
 
+        output_kwargs = dict(extra_kwargs or {})
+        if batch.get("student_topk_indices", None) is not None:
+            output_kwargs["target_indices"] = batch["student_topk_indices"]
+
         return output_tensor, partial(
             f,
             args=args,
@@ -352,6 +359,7 @@ def forward_only(
             response_lengths=response_lengths,
             with_entropy=args.use_rollout_entropy,
             max_seq_lens=batch.get("max_seq_lens", None),
+            **output_kwargs,
         )
 
     # Turn on evaluation mode which disables dropout.
@@ -501,6 +509,11 @@ def train_one_step(
                 "rollout_log_probs",
                 "max_seq_lens",
                 "teacher_log_probs",
+                "student_topk_indices",
+                "old_topk_log_probs",
+                "old_tail_log_probs",
+                "teacher_topk_log_probs",
+                "teacher_tail_log_probs",
                 "rollout_mask_sums",
             ],
             args.data_pad_size_multiplier,

--- a/slime/backends/megatron_utils/model.py
+++ b/slime/backends/megatron_utils/model.py
@@ -6,8 +6,8 @@ import os
 from argparse import Namespace
 from collections.abc import Callable, Sequence
 from functools import partial
-from typing import Any
 from pathlib import Path
+from typing import Any
 
 import torch
 from megatron.core import mpu
@@ -28,6 +28,7 @@ try:
     from megatron.core.pipeline_parallel.utils import unwrap_model
 except ImportError:
     from megatron.core.utils import unwrap_model
+
 from slime.utils import logging_utils
 from slime.utils.memory_utils import clear_memory
 

--- a/slime/backends/megatron_utils/topk_opd_actor.py
+++ b/slime/backends/megatron_utils/topk_opd_actor.py
@@ -1,0 +1,154 @@
+import logging
+import math
+import os
+
+import torch
+from slime.utils import train_dump_utils
+from slime.utils.routing_replay import RoutingReplay
+from slime.utils.timer import inverse_timer, timer
+from slime.utils.types import RolloutBatch
+
+from .actor import MegatronTrainRayActor
+from .data import get_data_iterator, log_perf_data, log_rollout_data
+from .initialize import is_megatron_main_rank
+from .loss import get_topk_log_probs
+from .model import forward_only, train
+
+logger = logging.getLogger(__name__)
+
+
+class TopKOPDMegatronTrainRayActor(MegatronTrainRayActor):
+    """Megatron actor variant for top-k level OPD.
+
+    The base actor keeps token-level OPD integrated through advantages. This
+    subclass prepares top-k/tail distributions from old actor and one or more
+    homogeneous teachers, then trains with ``topk_opd_loss``.
+    """
+
+    def _teacher_tags(self) -> list[str]:
+        tags = [
+            tag for tag in self.weights_backuper.backup_tags if tag == "teacher" or tag.startswith("teacher_")
+        ]
+        return sorted(tags, key=lambda tag: (-1 if tag == "teacher" else int(tag.rsplit("_", 1)[1])))
+
+    def compute_topk_log_prob(
+        self,
+        data_iterator,
+        num_microbatches,
+        store_prefix: str = "",
+    ) -> dict[str, list[torch.Tensor]]:
+        with timer(f"{store_prefix}topk_log_probs"):
+            return forward_only(
+                get_topk_log_probs,
+                self.args,
+                self.model,
+                data_iterator,
+                num_microbatches,
+                store_prefix=store_prefix,
+                extra_kwargs={"top_k": self.args.opd_top_k},
+            )
+
+    def _compute_old_topk_data(self, data_iterator, num_microbatches, rollout_data: RolloutBatch) -> None:
+        self._switch_model("old_actor" if self.args.keep_old_actor else "actor")
+        if self.args.use_routing_replay:
+            if self.args.use_rollout_routing_replay:
+                os.environ["ROUTING_REPLAY_STAGE"] = "replay_forward"
+            else:
+                os.environ["ROUTING_REPLAY_STAGE"] = "record"
+        topk_data = self.compute_topk_log_prob(data_iterator, num_microbatches)
+        rollout_data["student_topk_indices"] = topk_data["topk_indices"]
+        rollout_data["old_topk_log_probs"] = topk_data["topk_log_probs"]
+        rollout_data["old_tail_log_probs"] = topk_data["tail_log_probs"]
+        if self.args.use_rollout_routing_replay:
+            RoutingReplay.clear_all_forward()
+
+    def _compute_teacher_topk_data(self, data_iterator, num_microbatches, rollout_data: RolloutBatch) -> None:
+        teacher_tags = self._teacher_tags()
+        if not teacher_tags:
+            raise ValueError("--topk-level-opd requires at least one Megatron teacher checkpoint.")
+
+        teacher_outputs = []
+        for teacher_tag in teacher_tags:
+            if self.args.use_routing_replay:
+                os.environ["ROUTING_REPLAY_STAGE"] = "fallthrough"
+            self._switch_model(teacher_tag)
+            teacher_outputs.append(
+                self.compute_topk_log_prob(data_iterator, num_microbatches, store_prefix=f"{teacher_tag}_")
+            )
+
+        topk_keys = [f"{teacher_tag}_topk_log_probs" for teacher_tag in teacher_tags]
+        tail_keys = [f"{teacher_tag}_tail_log_probs" for teacher_tag in teacher_tags]
+        n_teachers = len(teacher_tags)
+
+        rollout_data["teacher_topk_log_probs"] = [
+            torch.logsumexp(
+                torch.stack([out[key][sample_idx] for out, key in zip(teacher_outputs, topk_keys, strict=True)]),
+                dim=0,
+            )
+            - math.log(n_teachers)
+            for sample_idx in range(len(teacher_outputs[0][topk_keys[0]]))
+        ]
+        rollout_data["teacher_tail_log_probs"] = [
+            torch.logsumexp(
+                torch.stack([out[key][sample_idx] for out, key in zip(teacher_outputs, tail_keys, strict=True)]),
+                dim=0,
+            )
+            - math.log(n_teachers)
+            for sample_idx in range(len(teacher_outputs[0][tail_keys[0]]))
+        ]
+
+    def _prepare_topk_opd_data(self, data_iterator, num_microbatches, rollout_data: RolloutBatch) -> None:
+        self._compute_old_topk_data(data_iterator, num_microbatches, rollout_data)
+        self._compute_teacher_topk_data(data_iterator, num_microbatches, rollout_data)
+        if self._active_model_tag != "actor":
+            self._switch_model("actor")
+
+    def train_actor(self, rollout_id: int, rollout_data: RolloutBatch, external_data=None) -> None:
+        data_iterator = get_data_iterator(rollout_data)
+        num_microbatches = rollout_data["num_microbatches"]
+        global_batch_sizes = rollout_data["global_batch_sizes"]
+
+        if self.args.use_rollout_routing_replay:
+            self.fill_routing_replay(data_iterator, num_microbatches, rollout_data)
+
+        with inverse_timer("train_wait"), timer("train"):
+            self._prepare_topk_opd_data(data_iterator, num_microbatches, rollout_data)
+
+            if self.rollout_data_postprocess is not None:
+                self.rollout_data_postprocess(self.args, rollout_id, rollout_data)
+
+            log_rollout_data(rollout_id, self.args, rollout_data)
+
+            if self.args.use_routing_replay:
+                os.environ["ROUTING_REPLAY_STAGE"] = "replay_backward"
+            with timer("actor_train"):
+                train(
+                    rollout_id,
+                    self.model,
+                    self.optimizer,
+                    self.opt_param_scheduler,
+                    data_iterator,
+                    num_microbatches,
+                    global_batch_sizes,
+                )
+
+            self.prof.step(rollout_id=rollout_id)
+
+        train_dump_utils.save_debug_train_data(self.args, rollout_id=rollout_id, rollout_data=rollout_data)
+
+        if self.args.use_routing_replay:
+            RoutingReplay.clear_all()
+
+        self.weights_backuper.backup("actor")
+
+        if (
+            self.args.ref_update_interval is not None
+            and (rollout_id + 1) % self.args.ref_update_interval == 0
+            and "ref" in self.weights_backuper.backup_tags
+        ):
+            with timer("ref_model_update"):
+                if is_megatron_main_rank():
+                    logger.info(f"Updating ref model at rollout_id {rollout_id}")
+                self.weights_backuper.backup("ref")
+
+        log_perf_data(rollout_id, self.args, extra_metrics=self.weight_updater.pop_metrics())

--- a/slime/backends/megatron_utils/topk_opd_actor.py
+++ b/slime/backends/megatron_utils/topk_opd_actor.py
@@ -26,9 +26,7 @@ class TopKOPDMegatronTrainRayActor(MegatronTrainRayActor):
     """
 
     def _teacher_tags(self) -> list[str]:
-        tags = [
-            tag for tag in self.weights_backuper.backup_tags if tag == "teacher" or tag.startswith("teacher_")
-        ]
+        tags = [tag for tag in self.weights_backuper.backup_tags if tag == "teacher" or tag.startswith("teacher_")]
         return sorted(tags, key=lambda tag: (-1 if tag == "teacher" else int(tag.rsplit("_", 1)[1])))
 
     def compute_topk_log_prob(

--- a/slime/ray/actor_group.py
+++ b/slime/ray/actor_group.py
@@ -7,6 +7,14 @@ from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 from slime.ray.utils import NOSET_VISIBLE_DEVICES_ENV_VARS_LIST
 
 
+_TRAIN_ACTOR_CLS = None
+
+
+def set_train_actor_cls(actor_cls):
+    global _TRAIN_ACTOR_CLS
+    _TRAIN_ACTOR_CLS = actor_cls
+
+
 class RayTrainGroup:
     """
     A group of ray actors
@@ -85,9 +93,12 @@ class RayTrainGroup:
         if self.args.use_routing_replay and self.role == "actor":
             env_vars["ENABLE_ROUTING_REPLAY"] = "1"
 
-        from slime.backends.megatron_utils.actor import MegatronTrainRayActor
+        if self.role == "actor" and _TRAIN_ACTOR_CLS is not None:
+            actor_impl = _TRAIN_ACTOR_CLS
+        else:
+            from slime.backends.megatron_utils.actor import MegatronTrainRayActor
 
-        actor_impl = MegatronTrainRayActor
+            actor_impl = MegatronTrainRayActor
 
         TrainRayActor = ray.remote(num_gpus=1, runtime_env={"env_vars": env_vars})(actor_impl)
 

--- a/slime/utils/arguments.py
+++ b/slime/utils/arguments.py
@@ -877,10 +877,10 @@ def get_slime_extra_args_provider(add_custom_arguments=None):
             parser.add_argument(
                 "--loss-type",
                 type=str,
-                choices=["policy_loss", "sft_loss", "custom_loss"],
+                choices=["policy_loss", "sft_loss", "topk_opd_loss", "custom_loss"],
                 default="policy_loss",
                 help=(
-                    "Choose loss type, currently support ppo policy_loss or sft_loss, "
+                    "Choose loss type, currently support ppo policy_loss, top-k OPD loss, or sft_loss, "
                     "if custom_loss is set, we will use the function path from `--custom-loss-function-path`."
                 ),
             )
@@ -1104,6 +1104,28 @@ def get_slime_extra_args_provider(add_custom_arguments=None):
                     "The checkpoint for OPD teacher model. Required when --opd-type=megatron. "
                     "The teacher model should have the same architecture as policy/ref model."
                 ),
+            )
+            parser.add_argument(
+                "--opd-teacher-loads",
+                type=str,
+                nargs="+",
+                default=None,
+                help=(
+                    "Checkpoint paths for one or more Megatron OPD teacher models. "
+                    "When set, this overrides --opd-teacher-load. Teachers must be homogeneous with the student."
+                ),
+            )
+            parser.add_argument(
+                "--topk-level-opd",
+                action="store_true",
+                default=False,
+                help="Enable top-k level OPD for Megatron teachers.",
+            )
+            parser.add_argument(
+                "--opd-top-k",
+                type=int,
+                default=100,
+                help="Top-k vocabulary size used by --topk-level-opd.",
             )
             parser.add_argument(
                 "--opd-teacher-ckpt-step", type=int, default=None, help="The checkpoint step for OPD teacher model."
@@ -1763,36 +1785,52 @@ def slime_validate_args(args):
             )
 
     # Validate on-policy distillation (OPD) arguments
+    if args.opd_top_k <= 0:
+        raise ValueError("--opd-top-k must be positive.")
+
+    if args.opd_teacher_loads is None:
+        args.opd_teacher_loads = [args.opd_teacher_load] if args.opd_teacher_load is not None else None
+
+    if args.topk_level_opd and (not args.use_opd or args.opd_type != "megatron"):
+        raise ValueError("--topk-level-opd requires --use-opd --opd-type=megatron.")
+    if args.topk_level_opd and args.loss_type != "topk_opd_loss":
+        raise ValueError("--topk-level-opd requires --loss-type=topk_opd_loss.")
+    if args.topk_level_opd and args.allgather_cp:
+        raise ValueError("--topk-level-opd currently supports the default zigzag CP layout, not --allgather-cp.")
+    if args.loss_type == "topk_opd_loss" and not args.topk_level_opd:
+        raise ValueError("--loss-type=topk_opd_loss requires --topk-level-opd.")
+    if args.opd_teacher_loads is not None and len(args.opd_teacher_loads) > 1 and not args.topk_level_opd:
+        raise ValueError("--opd-teacher-loads with multiple teachers requires --topk-level-opd.")
+
     if args.use_opd:
         if args.opd_type is None:
             raise ValueError("--opd-type must be specified when --use-opd is enabled. Choose 'sglang' or 'megatron'.")
 
         if args.opd_type == "megatron":
-            if args.opd_teacher_load is None:
+            if not args.opd_teacher_loads:
                 raise ValueError(
-                    "--opd-teacher-load is required when --opd-type=megatron. "
-                    "Please provide the path to the teacher model checkpoint."
+                    "--opd-teacher-load or --opd-teacher-loads is required when --opd-type=megatron. "
+                    "Please provide the path to at least one teacher model checkpoint."
                 )
-            if not os.path.exists(args.opd_teacher_load):
-                raise FileNotFoundError(
-                    f"opd_teacher_load {args.opd_teacher_load} does not exist, please check the path."
-                )
-            if not os.path.exists(os.path.join(args.opd_teacher_load, "latest_checkpointed_iteration.txt")):
-                logger.info(
-                    f"opd_teacher_load {args.opd_teacher_load} does not have latest_checkpointed_iteration.txt, "
-                    "please make sure it is a valid megatron checkpoint directory."
-                )
+            for teacher_load in args.opd_teacher_loads:
+                if not os.path.exists(teacher_load):
+                    raise FileNotFoundError(f"opd teacher load {teacher_load} does not exist, please check the path.")
+                if not os.path.exists(os.path.join(teacher_load, "latest_checkpointed_iteration.txt")):
+                    logger.info(
+                        f"opd teacher load {teacher_load} does not have latest_checkpointed_iteration.txt, "
+                        "please make sure it is a valid megatron checkpoint directory."
+                    )
 
         elif args.opd_type == "sglang":
-            if args.opd_teacher_load is not None:
+            if args.opd_teacher_load is not None or args.opd_teacher_loads is not None:
                 raise ValueError(
-                    "--opd-teacher-load should not be set when --opd-type=sglang. "
+                    "--opd-teacher-load/--opd-teacher-loads should not be set when --opd-type=sglang. "
                     "In sglang mode, teacher log-probs are obtained from external server during rollout."
                 )
     else:
-        # If OPD is not enabled, opd_teacher_load should not be set
-        if args.opd_teacher_load is not None:
-            raise ValueError("--opd-teacher-load is set but --use-opd is not enabled. Please add --use-opd flag.")
+        # If OPD is not enabled, teacher checkpoints should not be set.
+        if args.opd_teacher_load is not None or args.opd_teacher_loads is not None:
+            raise ValueError("OPD teacher checkpoints are set but --use-opd is not enabled. Please add --use-opd flag.")
 
     if args.megatron_to_hf_mode == "bridge":
         if (

--- a/slime/utils/arguments.py
+++ b/slime/utils/arguments.py
@@ -1830,7 +1830,9 @@ def slime_validate_args(args):
     else:
         # If OPD is not enabled, teacher checkpoints should not be set.
         if args.opd_teacher_load is not None or args.opd_teacher_loads is not None:
-            raise ValueError("OPD teacher checkpoints are set but --use-opd is not enabled. Please add --use-opd flag.")
+            raise ValueError(
+                "OPD teacher checkpoints are set but --use-opd is not enabled. Please add --use-opd flag."
+            )
 
     if args.megatron_to_hf_mode == "bridge":
         if (


### PR DESCRIPTION
Top-k OPD needs a separate actor flow because it prepares old-policy top-k indices, teacher log-probs on those indices, and a top-k/tail loss before normal Megatron training. The normal train.py path now stays on the existing actor unless a dedicated entry registers the top-k actor subclass.

Constraint: Teachers are assumed homogeneous with the student so top-k token ids are shared.

Constraint: The top-k CP implementation follows the existing zigzag CP layout and rejects --allgather-cp.

Rejected: Trigger top-k actor selection implicitly from generic train.py | user requested an explicit topkopd_train.py entry for the actor subclass.

Confidence: medium

Scope-risk: moderate

Directive: Keep top-k actor selection explicit through topkopd_train.py unless generic train.py gains a documented actor plugin API.

Tested: python3 -m py_compile on modified Python files

Tested: bash -n examples/on_policy_distillation/run-qwen3-8B-topk-opd-megatron.sh

Tested: git diff --check

Not-tested: Distributed Megatron runtime with TP/CP GPUs and real teacher checkpoints

Not-tested: --allgather-cp top-k OPD, intentionally rejected by argument validation