### PR TITLE
fix(search-r1): stop generation at </search> and </answer>

### DIFF
--- a/examples/search-r1/generate_with_search.py
+++ b/examples/search-r1/generate_with_search.py
@@ -157,6 +157,21 @@ async def generate(args, sample: Sample, sampling_params) -> Sample:
     loss_mask = []
     rollout_log_probs = [] if SEARCH_R1_CONFIGS["return_logprob"] else None
 
+    # BUGFIX: make the inference engine STOP at the tool/answer boundary.
+    # Without a stop, sglang keeps emitting tokens after </search> / </answer>
+    # (junk, even fabricated new "Question:"s). The example only trimmed that junk
+    # via postprocess_responses when return_logprob=False; with return_logprob=True
+    # (TIS) trimming is disabled to keep token/logp aligned, so the junk stayed in
+    # the trajectory and got trained on (loss_mask=1) AND broke is_valid_sequence
+    # (trailing content after </answer> -> format invalid -> lower reward).
+    # Stopping at the tag avoids all of that and keeps token/logp aligned natively.
+    # slime already sets no_stop_trim=True, so the closing tag is kept in the output.
+    _stop_tags = ["</search>", "</answer>"]
+    _existing_stop = sampling_params.get("stop") or []
+    if isinstance(_existing_stop, str):
+        _existing_stop = [_existing_stop]
+    sampling_params = {**sampling_params, "stop": list(dict.fromkeys([*_existing_stop, *_stop_tags]))}
+
     for _turn_idx in range(SEARCH_R1_CONFIGS["max_turns"]):
         payload = {
             "text": prompt_text + response,


### PR DESCRIPTION
### Problem
In `examples/search-r1/generate_with_search.py`, the multi-turn rollout never tells the inference engine to stop at the tool/answer boundary. So the model keeps generating after `</search>` / `</answer>` (junk, sometimes fabricating new `Question:`s).

The example only trims that via `postprocess_responses` (string split), which is **disabled when `return_logprob=True`** (needed to keep token/logp aligned for TIS). So with logprob collection on, the trailing junk:
- stays in the trajectory and is trained on (`loss_mask=1`), and
- breaks `is_valid_sequence` (content after `</answer>` → format invalid → lower reward).

### Fix
Pass `stop=["</search>", "</answer>"]` in `sampling_params`. slime already sets `no_stop_trim=True`, so the closing tag is kept and token/logp stay aligned natively — no string post-processing needed, and it works whether `return_logprob` is on or off.
