### PR TITLE
feat(rollout): add rollout-side torch profiler trigger via sglang

### DIFF
--- a/slime/ray/rollout.py
+++ b/slime/ray/rollout.py
@@ -493,14 +493,58 @@ class RolloutManager:
         self.health_monitoring_resume()
         if self.args.ci_test and self.args.use_fault_tolerance and rollout_id >= 2:
             self._try_ci_fault_injection()
-        data, metrics = self._get_rollout_data(rollout_id=rollout_id)
-        self._save_debug_rollout_data(data, rollout_id=rollout_id, evaluation=False)
-        _log_rollout_data(rollout_id, self.args, data, metrics, time.time() - start_time)
-        if self.args.debug_rollout_only:
-            # if debug rollout only, we don't convert samples to train data and directly return
+        need_stop_profile = self._maybe_start_rollout_profile(rollout_id)
+        try:
+            data, metrics = self._get_rollout_data(rollout_id=rollout_id)
+            self._save_debug_rollout_data(data, rollout_id=rollout_id, evaluation=False)
+            _log_rollout_data(rollout_id, self.args, data, metrics, time.time() - start_time)
+            if self.args.debug_rollout_only:
+                # if debug rollout only, we don't convert samples to train data and directly return
+                return
+            data = self._convert_samples_to_train_data(data)
+            return self._split_train_data_by_dp(data)
+        finally:
+            if need_stop_profile:
+                self._stop_rollout_profile()
+
+    def _maybe_start_rollout_profile(self, rollout_id):
+        if self.args.rollout_profile_start_rollout_id is None:
+            return False
+        if rollout_id != self.args.rollout_profile_start_rollout_id:
+            return False
+        engines = self.rollout_engines
+        if not engines:
+            return False
+        logger.info(
+            f"Start rollout profile at rollout_id={rollout_id} "
+            f"num_steps={self.args.rollout_profile_num_steps} "
+            f"activities={self.args.rollout_profile_activities} "
+            f"output_dir={self.args.rollout_profile_output_dir}"
+        )
+        ray.get(
+            [
+                engine.start_profile.remote(
+                    output_dir=self.args.rollout_profile_output_dir,
+                    start_step=self.args.rollout_profile_start_step,
+                    num_steps=self.args.rollout_profile_num_steps,
+                    activities=self.args.rollout_profile_activities,
+                    profile_by_stage=self.args.rollout_profile_by_stage,
+                    with_stack=self.args.rollout_profile_with_stack or None,
+                    record_shapes=self.args.rollout_profile_record_shapes or None,
+                )
+                for engine in engines
+            ]
+        )
+        # When num_steps is set, sglang auto-stops once it reaches the target;
+        # otherwise we must stop it ourselves at the end of this rollout.
+        return self.args.rollout_profile_num_steps is None
+
+    def _stop_rollout_profile(self):
+        engines = self.rollout_engines
+        if not engines:
             return
-        data = self._convert_samples_to_train_data(data)
-        return self._split_train_data_by_dp(data)
+        logger.info("Stop rollout profile.")
+        ray.get([engine.stop_profile.remote() for engine in engines])
 
     def eval(self, rollout_id):
         if self.args.debug_train_only:

--- a/slime/utils/arguments.py
+++ b/slime/utils/arguments.py
@@ -1255,6 +1255,63 @@ def get_slime_extra_args_provider(add_custom_arguments=None):
                 default=["train_overall"],
                 nargs="+",
             )
+            # Rollout (sglang) side torch profiler. Triggered via sglang's
+            # /start_profile HTTP endpoint; trace is written under
+            # --rollout-profile-output-dir (falls back to SGLANG_TORCH_PROFILER_DIR
+            # env, default /tmp).
+            parser.add_argument(
+                "--rollout-profile-start-rollout-id",
+                type=int,
+                default=None,
+                help="If set, start the sglang torch profiler at this rollout_id. Disabled when None.",
+            )
+            parser.add_argument(
+                "--rollout-profile-num-steps",
+                type=int,
+                default=None,
+                help=(
+                    "Number of sglang forward steps to profile. "
+                    "If set, sglang auto-stops the profiler; otherwise it is stopped "
+                    "at the end of the starting rollout."
+                ),
+            )
+            parser.add_argument(
+                "--rollout-profile-start-step",
+                type=int,
+                default=None,
+                help="Skip this many sglang forward steps before recording.",
+            )
+            parser.add_argument(
+                "--rollout-profile-by-stage",
+                action="store_true",
+                default=False,
+                help="Split prefill / decode into separate trace files inside sglang.",
+            )
+            parser.add_argument(
+                "--rollout-profile-activities",
+                type=str,
+                nargs="+",
+                default=["CPU", "GPU"],
+                help="Activities forwarded to sglang /start_profile. Subset of CPU, GPU, MEM, CUDA_PROFILER, RPD.",
+            )
+            parser.add_argument(
+                "--rollout-profile-output-dir",
+                type=str,
+                default=None,
+                help="Trace output dir. If None, sglang uses SGLANG_TORCH_PROFILER_DIR env var (default /tmp).",
+            )
+            parser.add_argument(
+                "--rollout-profile-with-stack",
+                action="store_true",
+                default=False,
+                help="Record python stacks in the rollout trace.",
+            )
+            parser.add_argument(
+                "--rollout-profile-record-shapes",
+                action="store_true",
+                default=False,
+                help="Record tensor shapes in the rollout trace.",
+            )
             parser.add_argument(
                 "--memory-recorder",
                 type=str,


### PR DESCRIPTION
Add CLI-driven torch profiler support for the rollout (sglang) side, complementing the existing train-side --profile-target.

Currently, profiling sglang engines during rollout requires manually calling the /start_profile HTTP endpoint. This PR exposes the 
existing SGLangEngine.start_profile() / stop_profile() API through RolloutManager, triggered at a user-specified rollout_id.

Changes:

- slime/ray/rollout.py — add _maybe_start_rollout_profile() / _stop_rollout_profile() in generate(), calling 
 engine.start_profile.remote() / engine.stop_profile.remote() on all rollout engines
- slime/utils/arguments.py — add --rollout-profile-* arguments:
  - --rollout-profile-start-rollout-id: rollout id to trigger profiling (disabled when unset)
  - --rollout-profile-num-steps: number of sglang forward steps to profile
  - --rollout-profile-start-step: warmup steps to skip before recording
  - --rollout-profile-activities: CPU/GPU/MEM activities to capture
  - --rollout-profile-output-dir: trace output directory
  - --rollout-profile-by-stage: split prefill/decode into separate traces
  - --rollout-profile-with-stack: record Python stacks
  - --rollout-profile-record-shapes: record tensor shapes
 
 Usage:
--rollout-profile-start-rollout-id 1 \
--rollout-profile-num-steps 10 \
--rollout-profile-output-dir /tmp/rollout_traces
  
Validation:
Tested with tests/test_qwen2.5_0.5B_async_short.py on 4×H20:
- Default disabled: no profile logs, training completes normally, no performance regression
- Enabled at rollout_id=1: profiler starts at correct rollout, each engine generates a trace.json.gz, profiler stops cleanly
- All engines log Start profile / Profiling done as expected