### PR TITLE
Support num workers when dataset loading.

### DIFF
--- a/slime/rollout/data_source.py
+++ b/slime/rollout/data_source.py
@@ -81,6 +81,7 @@ class RolloutDataSource(DataSource):
                 apply_chat_template=args.apply_chat_template,
                 apply_chat_template_kwargs=args.apply_chat_template_kwargs,
                 seed=args.rollout_seed,
+                num_workers=args.num_workers),
             )
             if self.args.rollout_shuffle:
                 self.dataset.shuffle(self.epoch_id)

--- a/slime/rollout/data_source.py
+++ b/slime/rollout/data_source.py
@@ -81,7 +81,7 @@ class RolloutDataSource(DataSource):
                 apply_chat_template=args.apply_chat_template,
                 apply_chat_template_kwargs=args.apply_chat_template_kwargs,
                 seed=args.rollout_seed,
-                num_workers=args.num_workers),
+                num_workers=args.num_workers,
             )
             if self.args.rollout_shuffle:
                 self.dataset.shuffle(self.epoch_id)

--- a/slime/utils/arguments.py
+++ b/slime/utils/arguments.py
@@ -630,6 +630,15 @@ def get_slime_extra_args_provider(add_custom_arguments=None):
             )
             parser.add_argument("--metadata-key", type=str, default="metadata", help="JSON dataset key")
             parser.add_argument(
+                "--num-workers",
+                type=int,
+                default=1,
+                help=(
+                    "Number of threads for parallel dataset loading. "
+                    "Set to 1 to disable threading and load sequentially."
+                ),
+            )
+            parser.add_argument(
                 "--tool-key",
                 type=str,
                 default="tools",

--- a/slime/utils/arguments.py
+++ b/slime/utils/arguments.py
@@ -630,15 +630,6 @@ def get_slime_extra_args_provider(add_custom_arguments=None):
             )
             parser.add_argument("--metadata-key", type=str, default="metadata", help="JSON dataset key")
             parser.add_argument(
-                "--num-workers",
-                type=int,
-                default=1,
-                help=(
-                    "Number of threads for parallel dataset loading. "
-                    "Set to 1 to disable threading and load sequentially."
-                ),
-            )
-            parser.add_argument(
                 "--tool-key",
                 type=str,
                 default="tools",

--- a/slime/utils/data.py
+++ b/slime/utils/data.py
@@ -4,6 +4,8 @@ import logging
 import os
 import random
 import re
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
 
 import numpy as np
 import ray
@@ -161,7 +163,11 @@ def _build_messages(data: dict, prompt_key: str, as_conversation: bool, multimod
                             f"Not enough {mt.name} data: more '{mt.placeholder}' placeholders in prompt "
                             f"than {mt.name}s provided in data"
                         )
-                        content_list.append({"type": mt.name, mt.name: content.pop(0)})
+                        item = content.pop(0)
+                        if isinstance(item, dict):
+                            content_list.append(item)
+                        else:
+                            content_list.append({"type": mt.name, mt.name: item})
                     else:
                         content_list.append({"type": "text", "text": segment})
                 message["content"] = content_list
@@ -208,11 +214,15 @@ class Dataset:
         seed=42,
         apply_chat_template=False,
         apply_chat_template_kwargs=None,
+        num_workers=1,
     ):
-        origin_samples = []
-        for data in read_file(path):
-            # Both chat templates and multimodal inputs require conversation format (list of message dicts)
-            as_conversation = apply_chat_template or (multimodal_keys is not None)
+        rows = list(read_file(path))
+        logger.info("Read %d rows from %s", len(rows), path)
+
+        as_conversation = apply_chat_template or (multimodal_keys is not None)
+
+        # Per-row processing function
+        def _process_row(data):
             prompt = _build_messages(data, prompt_key, as_conversation, multimodal_keys)
 
             metadata = data.get(metadata_key) or {}
@@ -247,14 +257,53 @@ class Dataset:
             else:
                 multimodal_inputs = None
 
-            origin_samples.append(
-                Sample(
-                    prompt=output_prompt,
-                    label=data[label_key] if label_key is not None else None,
-                    metadata=metadata,
-                    multimodal_inputs=multimodal_inputs,
-                )
+            return Sample(
+                prompt=output_prompt,
+                label=data[label_key] if label_key is not None else None,
+                metadata=metadata,
+                multimodal_inputs=multimodal_inputs,
             )
+
+        # Parallel loading
+        t0 = time.time()
+        if num_workers > 1:
+            logger.info(
+                "Loading dataset with %d workers (%d rows) ...",
+                num_workers,
+                len(rows),
+            )
+            origin_samples = [None] * len(rows)
+            with ThreadPoolExecutor(max_workers=num_workers) as executor:
+                future_to_idx = {executor.submit(_process_row, row): i for i, row in enumerate(rows)}
+                done = 0
+                for future in as_completed(future_to_idx):
+                    idx = future_to_idx[future]
+                    origin_samples[idx] = future.result()
+                    done += 1
+                    if done % 1000 == 0 or done == len(rows):
+                        elapsed = time.time() - t0
+                        logger.info(
+                            "  loading: %d/%d rows done, %.1fs elapsed, %.2f rows/s",
+                            done,
+                            len(rows),
+                            elapsed,
+                            done / elapsed,
+                        )
+        # Fallback to single-threaded loading
+        else:
+            origin_samples = []
+            for row in rows:
+                origin_samples.append(_process_row(row))
+
+        elapsed = time.time() - t0
+        has_mm = processor is not None
+        logger.info(
+            "Dataset loaded: %d samples, multimodal=%s, %.1fs total (%.2f rows/s)",
+            len(origin_samples),
+            has_mm,
+            elapsed,
+            len(origin_samples) / elapsed if elapsed > 0 else float("inf"),
+        )
 
         if max_length is not None:
             self.origin_samples = filter_long_prompt(origin_samples, tokenizer, processor, max_length)


### PR DESCRIPTION

Motivation in #2037 

# Modified
- slime/rollout/data_source.py: pass num_workers to Dataset.
- slime/utils/data.py: Add parallel logic to load data.

# Results
old, equal to num-workers=1:
```bash
(RolloutManager pid=1111890) [2026-06-09 18:03:14] data.py:220 - Read 100 rows from xxxx/train.parquet
(RolloutManager pid=1111890) [2026-06-09 18:05:05] data.py:300 - Dataset loaded: 100 samples, multimodal=True, 110.2s total (0.91 rows/s)
```
```bash
num-workers=64:
(RolloutManager pid=1079380) [2026-06-09 18:00:19] data.py:220 - Read 100 rows from xxxx/train.parquet
(RolloutManager pid=1079380) [2026-06-09 18:00:19] data.py:270 - Loading dataset with 64 workers (100 rows) ...
(RolloutManager pid=1079380) [2026-06-09 18:00:22] data.py:285 -   loading: 100/100 rows done, 3.5s elapsed, 28.85 rows/s
(RolloutManager pid=1079380) [2026-06-09 18:00:22] data.py:300 - Dataset loaded: 100 samples, multimodal=True, 3.5s total (28.81 rows/s)
```

# Usage
```
--num-workers 64
```