### PR TITLE
Support rich image config for vlm

### DIFF
--- a/slime/utils/data.py
+++ b/slime/utils/data.py
@@ -161,7 +161,16 @@ def _build_messages(data: dict, prompt_key: str, as_conversation: bool, multimod
                             f"Not enough {mt.name} data: more '{mt.placeholder}' placeholders in prompt "
                             f"than {mt.name}s provided in data"
                         )
-                        content_list.append({"type": mt.name, mt.name: content.pop(0)})
+                        item = content.pop(0)
+                        # Support rich image config from https://github.com/QwenLM/Qwen3-VL/blob/main/README.md:
+                        # Define min_pixels and max_pixels: Images will be resized to maintain 
+                        # their aspect ratio within the range of min_pixels and max_pixels
+                        # "images": [{"type": "image", "image": "path/to/img/01.jpeg", "max_pixels": 50176, "min_pixels": 50176}, {...}]
+                        if isinstance(item, dict):
+                            content_list.append(item)
+                        # "images": ["path/to/img/01.jpeg", "url", "base64enc"]
+                        else:
+                            content_list.append({"type": mt.name, mt.name: item})
                     else:
                         content_list.append({"type": "text", "text": segment})
                 message["content"] = content_list

--- a/slime/utils/data.py
+++ b/slime/utils/data.py
@@ -162,7 +162,7 @@ def _build_messages(data: dict, prompt_key: str, as_conversation: bool, multimod
                             f"than {mt.name}s provided in data"
                         )
                         item = content.pop(0)
-                        # Support rich image config from https://github.com/QwenLM/Qwen3-VL/blob/main/README.md:
+                        # Support rich image config from https://github.com/QwenLM/Qwen3-VL/blob/main/README.md
                         # define min_pixels and max_pixels: Images will be resized to maintain 
                         # their aspect ratio within the range of min_pixels and max_pixels
                         # "images": [{"type": "image", "image": "path/to/img/01.jpeg", "max_pixels": 50176, "min_pixels": 50176}, {...}]

--- a/slime/utils/data.py
+++ b/slime/utils/data.py
@@ -163,7 +163,7 @@ def _build_messages(data: dict, prompt_key: str, as_conversation: bool, multimod
                         )
                         item = content.pop(0)
                         # Support rich image config from https://github.com/QwenLM/Qwen3-VL/blob/main/README.md:
-                        # Define min_pixels and max_pixels: Images will be resized to maintain 
+                        # define min_pixels and max_pixels: Images will be resized to maintain 
                         # their aspect ratio within the range of min_pixels and max_pixels
                         # "images": [{"type": "image", "image": "path/to/img/01.jpeg", "max_pixels": 50176, "min_pixels": 50176}, {...}]
                         if isinstance(item, dict):


### PR DESCRIPTION
## Summary

Support rich image config for vlm

Changes:
- Modify slime/utils/data.py to support rich image config from [Qwen3-VL · README](https://github.com/QwenLM/Qwen3-VL/blob/main/README.md) 

## Motivation

General image config is needed, which is missing now. 

## Usage

```bash
<no need to change>
```

## Pass
Every image in `sample.multimodal_input["images"]` now can be changed to a fixed size:
<img width="1178" height="190" alt="image" src="https://github.com/user-attachments/assets/8d2425f5-23ff-4b7f-b1ac-a464c78d42ca" />
