### PR TITLE
Allow zero-GPU rollout router startup

### DIFF
--- a/docs/en/get_started/quick_start.md
+++ b/docs/en/get_started/quick_start.md
@@ -306,7 +306,7 @@ SGLANG_ARGS=(
 
 ### Colocated Actor and Rollout
 
-Under the default configuration, training (Actor) and inference (Rollout) resources are specified separately. Ray allocates `actor_num_nodes * actor_num_gpus_per_node` GPUs to the training part and `rollout_num_gpus` GPUs to inference, that is, training and inference are separated.
+Under the default configuration, training (Actor) and inference (Rollout) resources are specified separately. Ray allocates `actor_num_nodes * actor_num_gpus_per_node` GPUs to the training part and `rollout_num_gpus` GPUs to inference, that is, training and inference are separated. When `--rollout-num-gpus` is explicitly set to `0`, slime still parses SGLang arguments and launches the router, but does not launch local SGLang servers.
 
 **Standard (Disaggregated) Configuration**:
 ```bash
@@ -320,7 +320,7 @@ ray job submit ... \
 In the above configuration, Actor uses 4 cards, and Rollout also uses 4 cards, running in parallel.
 
 **Training-Inference Integration (Colocated) Configuration**:
-To deploy training and inference on the same group of GPUs, please add the `--colocate` parameter. After enabling, `--rollout-num-gpus` will be ignored to make the number of cards for training and inference equal.
+To deploy training and inference on the same group of GPUs, please add the `--colocate` parameter. By default, this makes the number of cards for training and inference equal. You can explicitly set a different positive `--rollout-num-gpus`, for example to use more rollout GPUs than actor GPUs; the extra GPUs are used as rollout-only resources. If `--rollout-num-gpus 0` is set explicitly, slime launches only the router and no local SGLang servers.
 
 ```bash
 ray job submit ... \

--- a/docs/en/get_started/usage.md
+++ b/docs/en/get_started/usage.md
@@ -18,7 +18,7 @@ There are four main parameters for cluster resource allocation:
 
   - `--actor-num-nodes`: The number of nodes required for RL actor training.
   - `--actor-num-gpus-per-node`: The number of GPUs per node for RL actor training.
-  - `--rollout-num-gpus`: The total number of GPUs required for rollout (inference).
+  - `--rollout-num-gpus`: The total number of GPUs required for rollout (inference). Set it to `0` to still parse SGLang arguments and launch the router without launching local SGLang servers.
   - `--rollout-num-gpus-per-engine`: The number of GPUs per inference engine. This parameter is similar to SGLang's `tp_size`. When performing multi-node serving, this value should be the total number of GPUs. For example, if serving one model with 2 nodes and 16 GPUs, this value should be 16.
     The reason for not using a parameter like `--sglang-tp-size` is that we might consider supporting SGLang's `dp_size` parameter in the future, which means an engine could contain multiple SGLang servers (currently, only `--sglang-dp-size` under the `--sglang-enable-dp-attention` condition is supported).
 
@@ -26,7 +26,7 @@ With the default configuration, we use these parameters to allocate `actor_num_n
 
 For co-located training and inference, you also need to configure:
 
-  - `--colocate`: Enables co-located training and inference. When enabled, it ignores `--rollout-num-gpus` and makes the number of GPUs for training and inference equal.
+  - `--colocate`: Enables co-located training and inference. By default, this makes the number of GPUs for training and inference equal. You can explicitly set a different positive `--rollout-num-gpus`, for example to use more rollout GPUs than actor GPUs; the extra GPUs are used as rollout-only resources. If `--rollout-num-gpus 0` is set explicitly, slime launches only the router and no local SGLang servers.
 
 Additionally, slime supports Prefill and Decode disaggregation (PD Disaggregation). You can set the number of servers used for Prefill by setting the `--prefill-num-servers` argument.
 

--- a/docs/zh/get_started/quick_start.md
+++ b/docs/zh/get_started/quick_start.md
@@ -305,7 +305,7 @@ SGLANG_ARGS=(
 
 ### Colocated Actor and Rollout
 
-在默认的配置下，训练（Actor）和推理（Rollout）的资源是分开指定的，通过 ray 给训练部分分配 `actor_num_nodes * actor_num_gpus_per_node` 张 GPU，给推理分配 `rollout_num_gpus` 张 GPU，也即训推分离。
+在默认的配置下，训练（Actor）和推理（Rollout）的资源是分开指定的，通过 ray 给训练部分分配 `actor_num_nodes * actor_num_gpus_per_node` 张 GPU，给推理分配 `rollout_num_gpus` 张 GPU，也即训推分离。将 `--rollout-num-gpus` 显式设置为 `0` 时，slime 仍会解析 SGLang 参数并启动 router，但不会启动本地 SGLang server。
 
 **标准（分离）配置**：
 ```bash
@@ -319,7 +319,7 @@ ray job submit ... \
 上述配置中，Actor 使用 4 张卡，Rollout 也使用 4 张卡，两者并行运行。
 
 **训推一体化（Colocated）配置**：
-要将训练和推理部署在同一组 GPU 上，请添加 `--colocate` 参数，开启后会忽略 `--rollout-num-gpus` 让训练和推理的卡数相等。
+要将训练和推理部署在同一组 GPU 上，请添加 `--colocate` 参数，开启后默认会让训练和推理的卡数相等；也可以显式设置一个不同的正数，例如让 rollout 卡数多于 actor，多出的 GPU 会作为 rollout-only 资源使用。如果显式设置 `--rollout-num-gpus 0`，则只启动 router，不启动本地 SGLang server。
 
 
 ```bash

--- a/docs/zh/get_started/usage.md
+++ b/docs/zh/get_started/usage.md
@@ -19,7 +19,7 @@
 
 - `--actor-num-gpus-per-node`：RL 的 actor 训练的每个节点有卡；
 
-- `--rollout-num-gpus`：rollout （inference）一共需要多少卡；
+- `--rollout-num-gpus`：rollout （inference）一共需要多少卡。设置为 `0` 时，slime 仍会解析 SGLang 参数并启动 router，但不会启动本地 SGLang server；
 
 - `--rollout-num-gpus-per-engine`：每个 inference engine 有多少卡，这个参数会比较像 sglang 的 `tp_size`，也就是在进行多机 serving 的时候，这个数值应该是总卡数，例如 2 机 16 卡 serving 一个模型，这里的值应该是 16。
 
@@ -29,7 +29,7 @@
 
 当需要训推一体的时候，还需要配置上：
 
-- `--colocate`：开启训推一体。开启后会忽略 `--rollout-num-gpus` 让训练和推理的卡数相等。
+- `--colocate`：开启训推一体。开启后默认会让训练和推理的卡数相等；也可以显式设置一个不同的正数，例如让 rollout 卡数多于 actor，多出的 GPU 会作为 rollout-only 资源使用。如果显式设置 `--rollout-num-gpus 0`，则只启动 router，不启动本地 SGLang server。
 
 此外，slime 支持 Prefill 和 Decode 的分离部署 (PD Disaggregation)，可以通过设置 `--prefill-num-servers` 参数来指定用于 Prefill 的服务器数量。
 

--- a/slime/backends/megatron_utils/actor.py
+++ b/slime/backends/megatron_utils/actor.py
@@ -616,12 +616,12 @@ class MegatronTrainRayActor(TrainRayActor):
             self.rollout_manager.get_updatable_engines_and_lock.remote()
         )
 
-        if not rollout_engines:
+        reconnect_rollout_engines = self.args.offload_train and self.args.use_critic and not self.args.colocate
+
+        if not rollout_engines and not reconnect_rollout_engines:
             if dist.get_rank() == 0:
                 logger.info("No updatable SGLang engines are running; skip weight update.")
             return
-
-        reconnect_rollout_engines = self.args.offload_train and self.args.use_critic and not self.args.colocate
 
         if reconnect_rollout_engines:
             self.wake_up()

--- a/slime/backends/megatron_utils/actor.py
+++ b/slime/backends/megatron_utils/actor.py
@@ -616,6 +616,11 @@ class MegatronTrainRayActor(TrainRayActor):
             self.rollout_manager.get_updatable_engines_and_lock.remote()
         )
 
+        if not rollout_engines:
+            if dist.get_rank() == 0:
+                logger.info("No updatable SGLang engines are running; skip weight update.")
+            return
+
         reconnect_rollout_engines = self.args.offload_train and self.args.use_critic and not self.args.colocate
 
         if reconnect_rollout_engines:

--- a/slime/ray/placement_group.py
+++ b/slime/ray/placement_group.py
@@ -112,7 +112,7 @@ def _get_placement_group_layout(args) -> tuple[int, int]:
         return args.rollout_num_gpus, 0
 
     if args.colocate:
-        return actor_num_gpus, 0
+        return max(actor_num_gpus, args.rollout_num_gpus), 0
 
     return actor_num_gpus + args.rollout_num_gpus, actor_num_gpus
 

--- a/slime/ray/rollout.py
+++ b/slime/ray/rollout.py
@@ -1182,6 +1182,9 @@ def _resolve_sglang_config(args) -> SglangConfig:
         assert actual == expected, f"sglang_config total GPUs ({actual}) != rollout_num_gpus ({expected})"
         return config
 
+    if args.rollout_num_gpus == 0:
+        return SglangConfig(models=[ModelConfig(name="default", server_groups=[])])
+
     if args.prefill_num_servers is not None:
         return SglangConfig.from_prefill_num_servers(args)
 

--- a/slime/utils/arguments.py
+++ b/slime/utils/arguments.py
@@ -49,8 +49,9 @@ def get_slime_extra_args_provider(add_custom_arguments=None):
                 default=None,
                 help=(
                     "Number of GPUs for inference. Note that when using --colocate, "
-                    "i.e. the training and the inference engines are on the same gpus, this param will be ignored and will be set as "
-                    "actor_num_gpus_per_node * actor_num_nodes."
+                    "i.e. the training and the inference engines are on the same gpus, this param will be set as "
+                    "actor_num_gpus_per_node * actor_num_nodes unless it is explicitly set. "
+                    "Set it to 0 to launch routers without local SGLang engines."
                 ),
             )
             parser.add_argument(
@@ -1890,8 +1891,11 @@ def slime_validate_args(args):
     del args.offload
 
     if args.debug_rollout_only:
-        if args.colocate and (not args.rollout_num_gpus):
+        if args.colocate and args.rollout_num_gpus is None:
             args.rollout_num_gpus = args.actor_num_gpus_per_node * args.actor_num_nodes
+        elif args.rollout_num_gpus == 0:
+            args.actor_num_gpus_per_node = 0
+            args.actor_num_nodes = 0
         else:
             args.actor_num_gpus_per_node = min(8, args.rollout_num_gpus)
             args.actor_num_nodes = args.rollout_num_gpus // args.actor_num_gpus_per_node
@@ -1911,12 +1915,10 @@ def slime_validate_args(args):
             args.offload_train = True
         if args.offload_rollout is None:
             args.offload_rollout = True
-        if args.rollout_num_gpus != args.actor_num_gpus_per_node * args.actor_num_nodes:
-            logger.info(
-                f"rollout_num_gpus {args.rollout_num_gpus} != actor_num_gpus_per_node {args.actor_num_gpus_per_node} "
-                f"* actor_num_nodes {args.actor_num_nodes}, overriding rollout_num_gpus to match actor_num_gpus_per_node * actor_num_nodes."
-            )
+        if args.rollout_num_gpus is None:
             args.rollout_num_gpus = args.actor_num_gpus_per_node * args.actor_num_nodes
+        elif args.rollout_num_gpus == 0:
+            logger.info("rollout_num_gpus is 0 under colocate; no local SGLang engines will be launched.")
 
     if args.offload_train is None:
         args.offload_train = False

--- a/tests/test_megatron_argument_validation.py
+++ b/tests/test_megatron_argument_validation.py
@@ -224,6 +224,135 @@ def test_update_weight_disk_dir_rejects_conflicting_alias(monkeypatch):
         module._resolve_update_weight_disk_dir(args)
 
 
+def make_slime_validate_args(**overrides):
+    values = dict(
+        eval_config=None,
+        eval_prompt_data=None,
+        use_slime_router=False,
+        kl_coef=0,
+        use_kl_loss=False,
+        ref_load=None,
+        use_opd=False,
+        opd_type=None,
+        opd_teacher_load=None,
+        megatron_to_hf_mode="raw",
+        load=None,
+        hf_checkpoint="/tmp/hf",
+        ref_ckpt_step=None,
+        ckpt_step=None,
+        no_load_optim=False,
+        no_load_rng=False,
+        finetune=False,
+        start_rollout_id=None,
+        eval_interval=None,
+        save_interval=None,
+        save=None,
+        kl_loss_coef=0,
+        advantage_estimator="grpo",
+        normalize_advantages=False,
+        use_rollout_logprobs=False,
+        use_tis=False,
+        get_mismatch_metrics=False,
+        custom_tis_function_path=None,
+        use_dynamic_batch_size=False,
+        max_tokens_per_gpu=None,
+        log_probs_max_tokens_per_gpu=None,
+        balance_by_flops=False,
+        balance_data=False,
+        eps_clip_high=None,
+        eps_clip=0.2,
+        eval_reward_key=None,
+        reward_key="reward",
+        dump_details=None,
+        save_debug_rollout_data=None,
+        save_debug_train_data=None,
+        load_debug_rollout_data=None,
+        rollout_external_engine_addrs=None,
+        debug_train_only=False,
+        actor_num_gpus_per_node=8,
+        actor_num_nodes=1,
+        offload=False,
+        offload_train=None,
+        offload_rollout=None,
+        debug_rollout_only=False,
+        colocate=False,
+        rollout_num_gpus=8,
+        train_memory_margin_bytes=0,
+        eval_function_path=None,
+        rollout_function_path="custom.rollout",
+        num_steps_per_rollout=None,
+        rollout_batch_size=1,
+        n_samples_per_prompt=1,
+        global_batch_size=None,
+        grpo_std_normalization=True,
+        over_sampling_batch_size=None,
+        num_epoch=None,
+        num_rollout=1,
+        rollout_global_dataset=False,
+        enable_mtp_training=False,
+        mtp_num_layers=None,
+        use_rollout_routing_replay=False,
+        use_routing_replay=False,
+        custom_config_path=None,
+        eval_max_context_len=None,
+        rollout_max_context_len=None,
+        rollout_max_prompt_len=None,
+        qkv_format="thd",
+        train_backend="megatron",
+        only_train_params_name_list=None,
+        freeze_params_name_list=None,
+        update_weight_transport="nccl",
+        update_weight_disk_dir=None,
+        update_weight_delta_dir=None,
+        update_weight_mode="full",
+    )
+    values.update(overrides)
+    return types.SimpleNamespace(**values)
+
+
+@pytest.mark.unit
+def test_slime_validate_args_preserves_zero_rollout_gpus_under_colocate(monkeypatch):
+    module = load_slime_arguments_module(monkeypatch)
+    args = make_slime_validate_args(colocate=True, rollout_num_gpus=0)
+
+    module.slime_validate_args(args)
+
+    assert args.rollout_num_gpus == 0
+    assert args.offload_train is True
+    assert args.offload_rollout is True
+
+
+@pytest.mark.unit
+def test_slime_validate_args_preserves_larger_rollout_gpus_under_colocate(monkeypatch):
+    module = load_slime_arguments_module(monkeypatch)
+    args = make_slime_validate_args(
+        colocate=True,
+        actor_num_gpus_per_node=8,
+        actor_num_nodes=1,
+        rollout_num_gpus=12,
+    )
+
+    module.slime_validate_args(args)
+
+    assert args.rollout_num_gpus == 12
+    assert args.offload_train is True
+    assert args.offload_rollout is True
+
+
+@pytest.mark.unit
+def test_slime_validate_args_preserves_zero_rollout_gpus_without_colocate(monkeypatch):
+    module = load_slime_arguments_module(monkeypatch)
+    args = make_slime_validate_args(colocate=False, rollout_num_gpus=0)
+
+    module.slime_validate_args(args)
+
+    assert args.rollout_num_gpus == 0
+    assert args.actor_num_gpus_per_node == 8
+    assert args.actor_num_nodes == 1
+    assert args.offload_train is False
+    assert args.offload_rollout is False
+
+
 @pytest.mark.unit
 def test_update_weight_delta_rejects_colocate(monkeypatch):
     module = load_slime_arguments_module(monkeypatch)

--- a/tests/test_placement_group.py
+++ b/tests/test_placement_group.py
@@ -10,7 +10,6 @@ if str(REPO_ROOT) not in sys.path:
 
 from slime.ray.placement_group import _create_placement_group, _get_placement_group_layout
 
-
 NUM_GPUS = 0
 
 
@@ -34,7 +33,11 @@ def _args(**overrides):
         pytest.param({}, (48, 16), id="normal_non_colocate"),
         pytest.param({"debug_train_only": True}, (16, 0), id="debug_train_only"),
         pytest.param({"debug_rollout_only": True}, (32, 0), id="debug_rollout_only"),
-        pytest.param({"colocate": True}, (16, 0), id="colocate"),
+        pytest.param({"colocate": True, "rollout_num_gpus": 8}, (16, 0), id="colocate_rollout_less_than_actor"),
+        pytest.param({"colocate": True, "rollout_num_gpus": 16}, (16, 0), id="colocate_rollout_equals_actor"),
+        pytest.param({"colocate": True, "rollout_num_gpus": 32}, (32, 0), id="colocate_rollout_more_than_actor"),
+        pytest.param({"rollout_num_gpus": 0}, (16, 16), id="zero_rollout_gpus"),
+        pytest.param({"colocate": True, "rollout_num_gpus": 0}, (16, 0), id="colocate_zero_rollout_gpus"),
         pytest.param({"rollout_external": True}, (16, 16), id="external"),
         pytest.param({"rollout_external": True, "debug_rollout_only": True}, (0, 0), id="external_debug_rollout"),
     ],

--- a/tests/utils/test_sglang_config.py
+++ b/tests/utils/test_sglang_config.py
@@ -1,9 +1,16 @@
 """Unit tests for SglangConfig multi-model parsing with update_weights."""
 
+import sys
 import tempfile
+from argparse import Namespace
+from pathlib import Path
 
 import pytest
 import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
 
 
 def _write_yaml(data: dict) -> str:
@@ -29,6 +36,7 @@ class TestSglangConfigUpdateWeights:
             }
         )
         config = SglangConfig.from_yaml(path)
+        config.models[0].resolve(Namespace(hf_checkpoint="/tmp/hf", rollout_num_gpus_per_engine=1))
         assert len(config.models) == 1
         assert config.models[0].update_weights is True
 
@@ -82,6 +90,80 @@ class TestSglangConfigUpdateWeights:
         )
         config = SglangConfig.from_yaml(path)
         assert config.total_num_gpus == 12
+
+    def test_config_allows_model_with_no_server_groups(self):
+        """A model with no server groups can expose a router without local engines."""
+        from slime.backends.sglang_utils.sglang_config import SglangConfig
+
+        path = _write_yaml({"sglang": [{"name": "default", "server_groups": []}]})
+
+        config = SglangConfig.from_yaml(path)
+
+        assert len(config.models) == 1
+        assert config.models[0].name == "default"
+        assert config.models[0].server_groups == []
+        assert config.total_num_gpus == 0
+
+
+class TestZeroGpuRolloutConfig:
+    def test_resolve_default_zero_gpu_config_has_no_server_groups(self):
+        from slime.ray.rollout import _resolve_sglang_config
+
+        args = Namespace(sglang_config=None, prefill_num_servers=None, rollout_num_gpus=0)
+
+        config = _resolve_sglang_config(args)
+
+        assert len(config.models) == 1
+        assert config.models[0].name == "default"
+        assert config.models[0].server_groups == []
+        assert config.total_num_gpus == 0
+
+    def test_zero_gpu_config_takes_precedence_over_prefill_num_servers(self):
+        from slime.ray.rollout import _resolve_sglang_config
+
+        args = Namespace(sglang_config=None, prefill_num_servers=1, rollout_num_gpus=0)
+
+        config = _resolve_sglang_config(args)
+
+        assert config.models[0].server_groups == []
+        assert config.total_num_gpus == 0
+
+    def test_start_rollout_servers_zero_gpu_starts_router_without_engines(self, monkeypatch):
+        from slime.ray import rollout as rollout_module
+
+        def fake_start_router(args, *, has_pd_disaggregation=False, force_new=False):
+            assert has_pd_disaggregation is False
+            assert force_new is False
+            return "127.0.0.1", 3456
+
+        monkeypatch.setattr(rollout_module, "_start_router", fake_start_router)
+        args = Namespace(
+            rollout_external=False,
+            sglang_config=None,
+            prefill_num_servers=None,
+            rollout_num_gpus=0,
+            rollout_num_gpus_per_engine=1,
+            num_gpus_per_node=8,
+            debug_train_only=False,
+            debug_rollout_only=False,
+            colocate=False,
+            actor_num_nodes=1,
+            actor_num_gpus_per_node=8,
+            offload_rollout=False,
+            hf_checkpoint="/tmp/hf",
+        )
+
+        servers = rollout_module.start_rollout_servers(args, pg=(None, [], []))
+
+        assert list(servers) == ["default"]
+        server = servers["default"]
+        assert server.router_ip == "127.0.0.1"
+        assert server.router_port == 3456
+        assert server.server_groups == []
+        assert server.engines == []
+        assert args.sglang_router_ip == "127.0.0.1"
+        assert args.sglang_router_port == 3456
+        assert args.sglang_model_routers == {"default": ("127.0.0.1", 3456)}
 
 
 class TestGetModelUrl:


### PR DESCRIPTION
Treat --rollout-num-gpus 0 as an explicit router-only rollout mode, including under colocate. Build an empty default SGLang deployment so custom rollout functions can still use router args while no local SGLang servers are launched.

Skip weight sync when no updatable rollout engines are running, and cover the zero-GPU config, placement group, and argument normalization paths in CPU tests. Update get started docs for the new behavior.