### PR TITLE
feat(coding_agent_rl): add SWE-bench harness evaluation path

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -128,9 +128,6 @@ RUN cd /root/slime/slime/backends/megatron_utils/kernels/int4_qat && \
 
 # ====================================== Agentic rollout dependencies ================================
 
-# uni-agent: agent loop + reward specs (swe_bench.py) used by coding_agent_rl
+# uni-agent: reward specs (swe_bench.py) used by coding_agent_rl
 ARG UNIAGENT_COMMIT=main
-RUN pip install --no-deps "git+https://github.com/verl-project/uni-agent.git@${UNIAGENT_COMMIT}"
-
-# swebench: harness constants, log parsers, grading (used by _run_swebench_eval)
-RUN pip install swebench
+RUN pip install "git+https://github.com/verl-project/uni-agent.git@${UNIAGENT_COMMIT}"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -125,3 +125,12 @@ RUN git clone https://github.com/THUDM/slime.git /root/slime && \
 
 RUN cd /root/slime/slime/backends/megatron_utils/kernels/int4_qat && \
     pip install . --no-build-isolation
+
+# ====================================== Agentic rollout dependencies ================================
+
+# uni-agent: agent loop + reward specs (swe_bench.py) used by coding_agent_rl
+ARG UNIAGENT_COMMIT=main
+RUN pip install --no-deps "git+https://github.com/verl-project/uni-agent.git@${UNIAGENT_COMMIT}"
+
+# swebench: harness constants, log parsers, grading (used by _run_swebench_eval)
+RUN pip install swebench

--- a/examples/coding_agent_rl/generate.py
+++ b/examples/coding_agent_rl/generate.py
@@ -246,6 +246,7 @@ async def generate(args, sample: Sample, sampling_params: dict[str, Any]):
                 diff_text=diff_text,
                 swepro=md["swepro"],
                 eval_cmd=md["eval_cmd"],
+                swebench_metadata=md.get("swebench_metadata"),
                 pre_commands=md["pre_commands"],
                 timeout_sec=SWE_EVAL_TIMEOUT_SEC,
             )
@@ -329,6 +330,7 @@ def _metadata(sample: Sample) -> dict[str, Any]:
         "problem_statement": m.get("problem_statement") or _coerce_prompt(sample.prompt),
         "swepro": m.get("swepro"),
         "eval_cmd": m.get("eval_cmd") or _wrap_f2p_script(rem.get("f2p_script")),
+        "swebench_metadata": m.get("swebench_metadata"),
         "pre_commands": m.get("pre_commands") or rem.get("pre_commands"),
     }
 

--- a/examples/coding_agent_rl/sandbox.py
+++ b/examples/coding_agent_rl/sandbox.py
@@ -301,6 +301,7 @@ async def evaluate(
     diff_text: str,
     swepro: dict | None = None,
     eval_cmd: str | None = None,
+    swebench_metadata: dict | None = None,
     pre_commands: list[str] | str | None = None,
     timeout_sec: int = 600,
 ) -> tuple[float, bool, bool]:
@@ -308,8 +309,8 @@ async def evaluate(
 
     No-test-cheating guarantee: the eval sandbox is built from the same image
     but starts CLEAN, so only the model-produced diff affects reward."""
-    if not (swepro or eval_cmd):
-        logger.warning("[e2b.evaluate] no swepro/eval_cmd; reward=0")
+    if not (swepro or eval_cmd or swebench_metadata):
+        logger.warning("[e2b.evaluate] no swepro/eval_cmd/swebench_metadata; reward=0")
         return 0.0, False, True
 
     async with E2BSandbox(image) as ev:
@@ -326,6 +327,9 @@ async def evaluate(
 
         if swepro:
             r, s = await _run_swepro(ev, workdir, swepro, timeout_sec)
+            return r, s, True
+        if swebench_metadata:
+            r, s = await _run_swebench_eval(ev, workdir, swebench_metadata, timeout_sec)
             return r, s, True
         r, s = await _run_eval_cmd(ev, workdir, eval_cmd, timeout_sec)
         return r, s, True
@@ -392,6 +396,45 @@ async def _run_swepro(ev: Sandbox, workdir: str, swepro: dict, timeout: int) -> 
     passed = {t["name"] for t in parsed.get("tests", []) if t.get("status") == "PASSED"}
     required = set(swepro.get("fail_to_pass") or []) | set(swepro.get("pass_to_pass") or [])
     solved = bool(required) and required.issubset(passed)
+    return (1.0 if solved else 0.0), solved
+
+
+async def _run_swebench_eval(ev: Sandbox, workdir: str, metadata: dict, timeout: int) -> tuple[float, bool]:
+    """SWE-bench harness grading — reuses uni_agent.reward.swe_bench for script gen."""
+    import re as _re
+    from swebench.harness.constants import (
+        END_TEST_OUTPUT, FAIL_ONLY_REPOS, MAP_REPO_VERSION_TO_SPECS,
+        START_TEST_OUTPUT, EvalType, ResolvedStatus,
+    )
+    from swebench.harness.grading import get_eval_tests_report, get_resolution_status
+    from swebench.harness.log_parsers import MAP_REPO_TO_PARSER
+    from uni_agent.reward.swe_bench import _make_eval_script_list
+
+    repo, version = metadata["repo"], metadata["version"]
+    specs = MAP_REPO_VERSION_TO_SPECS[repo][version]
+    eval_script_list = _make_eval_script_list(
+        instance=metadata, specs=specs, env_name="testbed",
+        repo_directory=workdir, base_commit=metadata.get("base_commit", ""),
+        test_patch=metadata["test_patch"],
+    )
+    eval_script = "\n".join(["#!/bin/bash", "set -uxo pipefail"] + eval_script_list) + "\n"
+
+    await ev.write_file("/tmp/_swebench_eval.sh", eval_script, user="root")
+    _, stdout, _ = await ev.exec("bash /tmp/_swebench_eval.sh 2>&1", user="root", check=False, timeout=timeout)
+    output = _re.sub(r"\x1b\[[0-9;]*m|\r", "", stdout or "")
+
+    if START_TEST_OUTPUT not in output or END_TEST_OUTPUT not in output:
+        return 0.0, False
+    test_content = output.split(START_TEST_OUTPUT)[1].split(END_TEST_OUTPUT)[0]
+    status_map = MAP_REPO_TO_PARSER[repo](test_content, None)
+    eval_ref = {
+        "instance_id": metadata["instance_id"],
+        "FAIL_TO_PASS": json.loads(metadata.get("FAIL_TO_PASS", "[]")),
+        "PASS_TO_PASS": json.loads(metadata.get("PASS_TO_PASS", "[]")),
+    }
+    eval_type = EvalType.FAIL_ONLY if repo in FAIL_ONLY_REPOS else EvalType.PASS_AND_FAIL
+    report = get_eval_tests_report(status_map, eval_ref, eval_type=eval_type)
+    solved = get_resolution_status(report) == ResolvedStatus.FULL.value
     return (1.0 if solved else 0.0), solved
 
 

--- a/examples/coding_agent_rl/sandbox.py
+++ b/examples/coding_agent_rl/sandbox.py
@@ -400,41 +400,15 @@ async def _run_swepro(ev: Sandbox, workdir: str, swepro: dict, timeout: int) -> 
 
 
 async def _run_swebench_eval(ev: Sandbox, workdir: str, metadata: dict, timeout: int) -> tuple[float, bool]:
-    """SWE-bench harness grading — reuses uni_agent.reward.swe_bench for script gen."""
+    """SWE-bench harness grading — delegates to uni_agent.reward.swe_bench."""
     import re as _re
-    from swebench.harness.constants import (
-        END_TEST_OUTPUT, FAIL_ONLY_REPOS, MAP_REPO_VERSION_TO_SPECS,
-        START_TEST_OUTPUT, EvalType, ResolvedStatus,
-    )
-    from swebench.harness.grading import get_eval_tests_report, get_resolution_status
-    from swebench.harness.log_parsers import MAP_REPO_TO_PARSER
-    from uni_agent.reward.swe_bench import _make_eval_script_list
+    from uni_agent.reward.swe_bench import make_eval_script, parse_eval_output
 
-    repo, version = metadata["repo"], metadata["version"]
-    specs = MAP_REPO_VERSION_TO_SPECS[repo][version]
-    eval_script_list = _make_eval_script_list(
-        instance=metadata, specs=specs, env_name="testbed",
-        repo_directory=workdir, base_commit=metadata.get("base_commit", ""),
-        test_patch=metadata["test_patch"],
-    )
-    eval_script = "\n".join(["#!/bin/bash", "set -uxo pipefail"] + eval_script_list) + "\n"
-
+    eval_script = make_eval_script(metadata, workdir)
     await ev.write_file("/tmp/_swebench_eval.sh", eval_script, user="root")
     _, stdout, _ = await ev.exec("bash /tmp/_swebench_eval.sh 2>&1", user="root", check=False, timeout=timeout)
     output = _re.sub(r"\x1b\[[0-9;]*m|\r", "", stdout or "")
-
-    if START_TEST_OUTPUT not in output or END_TEST_OUTPUT not in output:
-        return 0.0, False
-    test_content = output.split(START_TEST_OUTPUT)[1].split(END_TEST_OUTPUT)[0]
-    status_map = MAP_REPO_TO_PARSER[repo](test_content, None)
-    eval_ref = {
-        "instance_id": metadata["instance_id"],
-        "FAIL_TO_PASS": json.loads(metadata.get("FAIL_TO_PASS", "[]")),
-        "PASS_TO_PASS": json.loads(metadata.get("PASS_TO_PASS", "[]")),
-    }
-    eval_type = EvalType.FAIL_ONLY if repo in FAIL_ONLY_REPOS else EvalType.PASS_AND_FAIL
-    report = get_eval_tests_report(status_map, eval_ref, eval_type=eval_type)
-    solved = get_resolution_status(report) == ResolvedStatus.FULL.value
+    solved, _ = parse_eval_output(metadata, output)
     return (1.0 if solved else 0.0), solved
 
 


### PR DESCRIPTION
## Summary

Add `swebench_metadata` as a third evaluation route in `sandbox.evaluate()`, alongside the existing `swepro` and `eval_cmd` paths. This allows `coding_agent_rl` to grade SWE-bench Verified instances directly using the official swebench harness.

### Changes

- **`docker/Dockerfile`**: add `uni-agent` (source install, `--no-deps`) and `swebench` Python packages
- **`examples/coding_agent_rl/sandbox.py`**: add `swebench_metadata` param to `evaluate()`, add `_run_swebench_eval()` — reuses `uni_agent.reward.swe_bench._make_eval_script_list` for eval script generation, standard swebench grading API for result parsing
- **`examples/coding_agent_rl/generate.py`**: pass `swebench_metadata` through `_metadata()` and the `evaluate()` call site

### Evaluation priority

```
swepro           → SWEPro custom scripts (existing, unchanged)
swebench_metadata → SWE-bench official harness (new)
eval_cmd         → shell command fallback (existing, unchanged)
```

### Context

Validated on 500-instance SWE-bench Verified eval with Qwen3.6-35B-A3B: uniagent mode 71.3% (355/498), matching the official 71.6%.

## Test plan

- [ ] \`docker build\` completes
- [ ] \`python -c "from uni_agent.reward.swe_bench import _make_eval_script_list; print('ok')"\` inside container
- [ ] Run a small SWE-bench eval with \`swebench_metadata\` in sample metadata

🤖 Generated with [Claude Code](https://claude.ai/code)