### PR TITLE
docs: drop dangling Dr.GRPO custom-reducer example reference

### DIFF
--- a/docs/en/get_started/customization.md
+++ b/docs/en/get_started/customization.md
@@ -298,8 +298,6 @@ def get_pg_loss_reducer(
 - Dr.GRPO: Divide by a constant instead of effective token count
 - Custom loss normalization strategies
 
-**Example**: `examples/DrGRPO/custom_reducer.py:get_pg_loss_reducer`
-
 ---
 
 ### 12. Reward Post-Processing (`--custom-reward-post-process-path`)

--- a/docs/zh/get_started/customization.md
+++ b/docs/zh/get_started/customization.md
@@ -298,8 +298,6 @@ def get_pg_loss_reducer(
 - Dr.GRPO：除以常数而非有效 token 数
 - 自定义损失归一化策略
 
-**示例**: `examples/DrGRPO/custom_reducer.py:get_pg_loss_reducer`
-
 ---
 
 ### 12. 奖励后处理 (`--custom-reward-post-process-path`)

--- a/slime/utils/arguments.py
+++ b/slime/utils/arguments.py
@@ -1050,7 +1050,7 @@ def get_slime_extra_args_provider(add_custom_arguments=None):
                 "--custom-pg-loss-reducer-function-path",
                 type=str,
                 default=None,
-                help="Path to a custom reducer function for pg_loss only. When set, pg_loss will use this custom reducer while other metrics (pg_clipfrac, ppo_kl, entropy_loss, etc.) still use the default sum_of_sample_mean. (e.g., examples/Dr.GRPO/custom_reducer.py:get_pg_loss_reducer).",
+                help="Path to a custom reducer function for pg_loss only. When set, pg_loss will use this custom reducer while other metrics (pg_clipfrac, ppo_kl, entropy_loss, etc.) still use the default sum_of_sample_mean.",
             )
 
             parser.add_argument(


### PR DESCRIPTION
## Problem

`--custom-pg-loss-reducer-function-path`'s help and the customization docs (en + zh) reference a Dr.GRPO reducer example that **does not exist** in the repo:

- `slime/utils/arguments.py` help: `(e.g., examples/Dr.GRPO/custom_reducer.py:get_pg_loss_reducer)`
- `docs/en/get_started/customization.md` §11 and `docs/zh/...`: `**Example**: examples/DrGRPO/custom_reducer.py:get_pg_loss_reducer`

`git ls-tree -r` confirms there is no `examples/DrGRPO/` (or `examples/Dr.GRPO/`) and no `custom_reducer.py` anywhere — so anyone following the pointer hits a dead path. (The help also misspells the directory as `Dr.GRPO`.)

## This PR

Removes the three dead references. The §11 walkthrough is unaffected — it still documents the hook, its full signature, and the Dr.GRPO use case inline.

## Maintainer's choice

If you'd rather **keep an example**, the alternative is to add `examples/DrGRPO/custom_reducer.py` instead of removing the pointers — happy to send that version. (Note: a first-class built-in for this exact use case — `--loss-aggregation constant` for Dr.GRPO — is proposed in #2090, which would make a standalone custom-reducer example redundant.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
