### PR TITLE
feat(tracking): add MLflow tracking support alongside W&B

### DIFF
--- a/slime/utils/arguments.py
+++ b/slime/utils/arguments.py
@@ -1208,6 +1208,53 @@ def get_slime_extra_args_provider(add_custom_arguments=None):
 
             return parser
 
+        # mlflow
+        def add_mlflow_arguments(parser):
+            parser.add_argument("--use-mlflow", action="store_true", default=False)
+            parser.add_argument(
+                "--mlflow-tracking-uri",
+                type=str,
+                default=None,
+                help="MLflow tracking server URI.",
+            )
+            parser.add_argument(
+                "--mlflow-experiment-name",
+                type=str,
+                default=None,
+                help="MLflow experiment name.",
+            )
+            parser.add_argument(
+                "--mlflow-run-name",
+                type=str,
+                default=None,
+                help="MLflow run name.",
+            )
+            parser.add_argument(
+                "--mlflow-log-samples-per-step",
+                type=int,
+                default=5,
+                help="Number of rollout samples to log as MLflow artifacts per step.",
+            )
+            parser.add_argument(
+                "--mlflow-eval-log-samples-per-step",
+                type=int,
+                default=0,
+                help="Number of eval samples to log as MLflow artifacts per step.",
+            )
+            parser.add_argument(
+                "--mlflow-log-max-chars",
+                type=int,
+                default=2000,
+                help="Max characters per prompt/response in MLflow rollout artifacts.",
+            )
+            parser.add_argument(
+                "--mlflow-eval-log-max-chars",
+                type=int,
+                default=2000,
+                help="Max characters per prompt/response in MLflow eval artifacts.",
+            )
+            return parser
+
         # debug
         def add_debug_arguments(parser):
             parser.add_argument(
@@ -1483,6 +1530,7 @@ def get_slime_extra_args_provider(add_custom_arguments=None):
         parser = add_on_policy_distillation_arguments(parser)
         parser = add_wandb_arguments(parser)
         parser = add_tensorboard_arguments(parser)
+        parser = add_mlflow_arguments(parser)
         parser = add_debug_arguments(parser)
         parser = add_network_arguments(parser)
         parser = add_reward_model_arguments(parser)

--- a/slime/utils/logging_utils.py
+++ b/slime/utils/logging_utils.py
@@ -2,7 +2,7 @@ import logging
 
 import wandb
 
-from . import wandb_utils
+from . import mlflow_utils, wandb_utils
 from .tensorboard_utils import _TensorboardAdapter
 
 _LOGGER_CONFIGURED = False
@@ -27,24 +27,37 @@ def configure_logger(prefix: str = ""):
 def init_tracking(args, primary: bool = True, **kwargs):
     if primary:
         wandb_utils.init_wandb_primary(args, **kwargs)
+        mlflow_utils.init_mlflow_primary(args)
     else:
         wandb_utils.init_wandb_secondary(args, **kwargs)
+        mlflow_utils.init_mlflow_secondary(args)
+
+
+def update_tracking_open_metrics(args, router_addr):
+    wandb_utils.reinit_wandb_primary_with_open_metrics(args, router_addr)
 
 
 def finish_tracking(args):
     if not args.use_wandb:
-        return
-    try:
-        if wandb.run is not None:
-            wandb.finish()
-    except Exception:
-        logging.getLogger(__name__).exception("Failed to finish wandb run")
+        pass
+    else:
+        try:
+            if wandb.run is not None:
+                wandb.finish()
+        except Exception:
+            logging.getLogger(__name__).exception("Failed to finish wandb run")
+
+    mlflow_utils.finish_mlflow()
 
 
 # TODO further refactor, e.g. put TensorBoard init to the "init" part
 def log(args, metrics, step_key: str):
     if args.use_wandb:
         wandb.log(metrics)
+
+    if args.use_mlflow:
+        step = metrics.get(step_key, 0)
+        mlflow_utils.log_metrics(metrics, step=int(step))
 
     if args.use_tensorboard:
         metrics_except_step = {k: v for k, v in metrics.items() if k != step_key}

--- a/slime/utils/mlflow_utils.py
+++ b/slime/utils/mlflow_utils.py
@@ -1,0 +1,131 @@
+"""MLflow tracking utilities for SLIME RL training."""
+
+import logging
+import numbers
+import os
+from copy import deepcopy
+
+logger = logging.getLogger(__name__)
+
+_mlflow_initialized = False
+_mlflow_is_primary = False
+
+
+def _sanitize_metric_name(name: str) -> str:
+    return name.replace("@", "_at_")
+
+
+def _flatten_dict(d, parent_key="", sep="/"):
+    items = []
+    for k, v in d.items():
+        new_key = f"{parent_key}{sep}{k}" if parent_key else k
+        if isinstance(v, dict):
+            items.extend(_flatten_dict(v, new_key, sep=sep).items())
+        else:
+            items.append((new_key, str(v)[:500]))
+    return dict(items)
+
+
+def init_mlflow_primary(args):
+    global _mlflow_initialized, _mlflow_is_primary
+
+    if not args.use_mlflow:
+        logger.info("MLflow disabled (--use-mlflow not set), skipping initialization")
+        return
+
+    import mlflow
+
+    tracking_uri = args.mlflow_tracking_uri
+    logger.info(f"MLflow primary init: connecting to tracking server at {tracking_uri}")
+    mlflow.set_tracking_uri(tracking_uri)
+
+    experiment_name = args.mlflow_experiment_name or "default"
+    logger.info(f"MLflow primary init: setting experiment={experiment_name}")
+    experiment = mlflow.set_experiment(experiment_name)
+
+    run_name = args.mlflow_run_name
+    logger.info(f"MLflow primary init: starting run={run_name} " f"(experiment_id={experiment.experiment_id})")
+
+    mlflow.start_run(
+        experiment_id=experiment.experiment_id,
+        run_name=run_name,
+        log_system_metrics=True,
+    )
+
+    try:
+        raw = deepcopy(args.__dict__)
+        allowed_env_vars = ["SLURM_JOB_ID"]
+        raw["env_vars"] = {k: v for k, v in os.environ.items() if k in allowed_env_vars}
+        params = _flatten_dict(raw)
+        logger.info(f"MLflow primary init: logging {len(params)} params")
+        mlflow.log_params(params)
+    except Exception as e:
+        logger.warning(f"Failed to log params to MLflow: {e}")
+
+    args.mlflow_run_id = mlflow.active_run().info.run_id
+
+    _mlflow_initialized = True
+    _mlflow_is_primary = True
+    logger.info(
+        f"MLflow primary init complete: experiment={experiment_name}, " f"run={run_name}, run_id={args.mlflow_run_id}"
+    )
+
+    import atexit
+
+    atexit.register(finish_mlflow)
+
+
+def init_mlflow_secondary(args):
+    global _mlflow_initialized
+
+    if not getattr(args, "use_mlflow", False):
+        return
+
+    mlflow_run_id = getattr(args, "mlflow_run_id", None)
+    if mlflow_run_id is None:
+        return
+
+    import mlflow
+
+    tracking_uri = args.mlflow_tracking_uri
+    logger.info(f"MLflow secondary init: connecting to {tracking_uri}, " f"joining run_id={mlflow_run_id}")
+    mlflow.set_tracking_uri(tracking_uri)
+    mlflow.start_run(run_id=mlflow_run_id, log_system_metrics=False)
+
+    _mlflow_initialized = True
+    logger.info(f"MLflow secondary init complete: joined run_id={mlflow_run_id}")
+
+
+def log_metrics(metrics: dict, step: int):
+    global _mlflow_initialized
+    if not _mlflow_initialized:
+        return
+
+    import mlflow
+
+    sanitized = {}
+    for k, v in metrics.items():
+        if isinstance(v, numbers.Number) and not isinstance(v, bool):
+            sanitized[_sanitize_metric_name(k)] = float(v)
+
+    if sanitized:
+        try:
+            mlflow.log_metrics(metrics=sanitized, step=step)
+        except Exception as e:
+            logger.warning(f"Failed to log metrics to MLflow: {e}")
+
+
+def finish_mlflow():
+    global _mlflow_initialized, _mlflow_is_primary
+    if not _mlflow_initialized:
+        return
+
+    if _mlflow_is_primary:
+        import mlflow
+
+        logger.info("MLflow finishing: ending primary run")
+        mlflow.end_run()
+        logger.info("MLflow run ended successfully")
+
+    _mlflow_initialized = False
+    _mlflow_is_primary = False


### PR DESCRIPTION
Add MLflow as an optional experiment tracking backend, mirroring the existing W&B integration:

- New slime/utils/mlflow_utils.py with primary/secondary init, metric logging, and graceful shutdown
- CLI arguments: --use-mlflow, --mlflow-tracking-uri, --mlflow-experiment-name, --mlflow-run-name, etc.
- Updated logging_utils.py to call MLflow hooks in init/finish/log paths

MLflow is lazily imported so it remains an optional dependency.