### PR TITLE
fix(examples/tau-bench): use RunConfig.agent_strategy in TAU_CONFIGS

### DIFF
--- a/examples/tau-bench/README.md
+++ b/examples/tau-bench/README.md
@@ -47,7 +47,7 @@ You need to configure your litellm API in `generate_with_tau.py` for user simula
 ```python
 TAU_CONFIGS = {
     "env": "retail",  # Select between ["retail", "airline"]
-    "agent": "tool-calling",  # Select between ["tool-calling", "act", "react", "few-shot"], only tool-calling implemented for now
+    "agent_strategy": "tool-calling",  # Select between ["tool-calling", "act", "react", "few-shot"], only tool-calling implemented for now
     "user_model": "gemini-2.0-flash-lite",  # Cheap Model for user simulator
     "user_model_provider": "gemini",
     "task_split": "train",  # Select between ["train", "test", "dev"] for retail, ["test"] for airline

--- a/examples/tau-bench/generate_with_tau.py
+++ b/examples/tau-bench/generate_with_tau.py
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 # Tau-bench configuration
 TAU_CONFIGS = {
     "env": "retail",  # Select between ["retail", "airline"]
-    "agent": "tool-calling",  # Select between ["tool-calling", "act", "react", "few-shot"]
+    "agent_strategy": "tool-calling",  # Select between ["tool-calling", "act", "react", "few-shot"]
     "user_model": "gemini-2.5-flash-lite",  # Cheap Model for user simulator
     "task_split": "train",  # Select between ["train", "test", "dev"] for retail
     "user_strategy": "llm",  # Select between ["llm", "react", "verify", "reflection"]


### PR DESCRIPTION
## Summary

- Fix `TAU_CONFIGS` in the tau-bench example to use `agent_strategy` instead of `agent`.
- Update the README snippet to match.

tau-bench's `RunConfig` defines `agent_strategy`, not `agent`. The previous key was silently ignored by Pydantic, so changing the agent type in `TAU_CONFIGS` had no effect (the default `tool-calling` was always used). `trainable_agents.agent_factory` already reads `config.agent_strategy`.

## Test plan

- [x] `RunConfig(**TAU_CONFIGS)` accepts the config without extra/ignored fields
- [x] Setting `agent_strategy` to a non-default value is reflected on the resulting `RunConfig` object
- [x] Smoke: `examples/tau-bench/run_qwen3_4B.sh` still launches (tool-calling default unchanged)
