### PR TITLE
Fix(rollout): Fail closed on unknown SGLang model names

### DIFF
--- a/slime/rollout/sglang_rollout.py
+++ b/slime/rollout/sglang_rollout.py
@@ -71,14 +71,18 @@ def get_model_url(args: Namespace, model_name: str, endpoint: str = "/generate")
         url = get_model_url(args, "ref", "/generate")
         resp = await post(url, json=payload)
 
-    Falls back to the default router if *model_name* is not found or
-    ``sglang_model_routers`` is not set.
+    Falls back to the default router only when ``sglang_model_routers`` is
+    not set or empty. If routers are registered, an unknown model name is a
+    configuration error.
     """
     routers = getattr(args, "sglang_model_routers", None)
-    if routers and model_name in routers:
-        ip, port = routers[model_name]
-        return f"http://{ip}:{port}{endpoint}"
-    return f"http://{args.sglang_router_ip}:{args.sglang_router_port}{endpoint}"
+    if not routers:
+        return f"http://{args.sglang_router_ip}:{args.sglang_router_port}{endpoint}"
+    if model_name not in routers:
+        available = ", ".join(sorted(routers))
+        raise ValueError(f"Unknown SGLang model '{model_name}'. Available models: {available}")
+    ip, port = routers[model_name]
+    return f"http://{ip}:{port}{endpoint}"
 
 
 class GenerateState(metaclass=SingletonMeta):

--- a/tests/utils/test_sglang_config.py
+++ b/tests/utils/test_sglang_config.py
@@ -304,8 +304,8 @@ class TestGetModelUrl:
         assert get_model_url(args, "ref") == "http://10.0.0.1:3001/generate"
         assert get_model_url(args, "ref", "/v1/chat/completions") == "http://10.0.0.1:3001/v1/chat/completions"
 
-    def test_get_model_url_fallback(self):
-        """get_model_url should fall back to default router if model not found."""
+    def test_get_model_url_unknown_model_raises(self):
+        """get_model_url should fail closed when a router map exists."""
         from argparse import Namespace
 
         from slime.rollout.sglang_rollout import get_model_url
@@ -315,7 +315,8 @@ class TestGetModelUrl:
             sglang_router_port=3000,
             sglang_model_routers={"actor": ("10.0.0.1", 3000)},
         )
-        assert get_model_url(args, "unknown") == "http://10.0.0.1:3000/generate"
+        with pytest.raises(ValueError, match="Unknown SGLang model 'unknown'.*actor"):
+            get_model_url(args, "unknown")
 
     def test_get_model_url_no_routers(self):
         """get_model_url should work when sglang_model_routers is not set."""


### PR DESCRIPTION
## Summary

`get_model_url()` currently falls back to the default router when a requested model name is missing from `args.sglang_model_routers`. In multi-model SGLang configs, this can silently route requests intended for a reference, reward, teacher, or judge model to the default model router.

This PR keeps the legacy fallback only when no router map is registered. If a router map exists and the requested model name is unknown, `get_model_url()` now raises a clear `ValueError` listing the available model names.

## Tests

- `python -m pytest tests/utils/test_sglang_config.py::TestGetModelUrl -q`
- `pre-commit run --files slime/rollout/sglang_rollout.py tests/utils/test_sglang_config.py --show-diff-on-failure --color=always`