### PR TITLE
fix(gpt-oss): update _patch_bridge_expert_cache_to_cpu to match Megatron-Bridge API

### DIFF
--- a/slime/backends/megatron_utils/update_weight/hf_weight_iterator_bridge.py
+++ b/slime/backends/megatron_utils/update_weight/hf_weight_iterator_bridge.py
@@ -26,9 +26,9 @@ def _patch_bridge_expert_cache_to_cpu():
 
     _orig = GPTOSSBridge.maybe_modify_converted_hf_weight
 
-    def _patched(self, task, converted_weights_dict):
+    def _patched(self, task, converted_weights_dict, hf_state_dict=None):
         cpu_dict = {k: v.cpu() for k, v in converted_weights_dict.items()}
-        result = _orig(self, task, cpu_dict)
+        result = _orig(self, task, cpu_dict, hf_state_dict)
         # Move merged result back to GPU for CUDA IPC serialization
         return {k: v.cuda() for k, v in result.items()} if result else result
 


### PR DESCRIPTION
## Summary

`radixark/Megatron-Bridge@bridge` added a fourth parameter `hf_state_dict` to `ModelBridge.maybe_modify_converted_hf_weight`. The monkey-patch in `_patch_bridge_expert_cache_to_cpu` still uses the old 3-arg signature, causing a crash during GPT-OSS colocated weight sync:

```
TypeError: _patch_bridge_expert_cache_to_cpu.<locals>._patched() takes 3 positional arguments but 4 were given
```

The fix accepts and forwards the new optional `hf_state_dict` argument.

## Root cause

`Megatron-Bridge` updated `ModelBridge.maybe_modify_converted_hf_weight` to:
```python
def maybe_modify_converted_hf_weight(
    self,
    task: WeightConversionTask,
    converted_weights_dict: Dict[str, torch.Tensor],
    hf_state_dict: Mapping[str, torch.Tensor],   # ← new param
) -> Dict[str, torch.Tensor]:
```

The patch only handled 3 args.

## Fix

```python
# before
def _patched(self, task, converted_weights_dict):
    cpu_dict = {k: v.cpu() for k, v in converted_weights_dict.items()}
    result = _orig(self, task, cpu_dict)

# after
def _patched(self, task, converted_weights_dict, hf_state_dict=None):
    cpu_dict = {k: v.cpu() for k, v in converted_weights_dict.items()}
    result = _orig(self, task, cpu_dict, hf_state_dict)
```

🤖 Generated with [Claude Code](https://claude.ai/claude-code)