### PR TITLE
fix(rm_hub): guard deepscaler reward against a missing response

### DIFF
--- a/slime/rollout/rm_hub/deepscaler.py
+++ b/slime/rollout/rm_hub/deepscaler.py
@@ -2,6 +2,12 @@ from .math_utils import extract_answer, grade_answer_mathd, grade_answer_sympy
 
 
 def get_deepscaler_rule_based_reward(response, label):
+    # Guard against a missing response, mirroring the gpqa / f1 reward
+    # functions in this package. async_rm passes sample.response straight
+    # through, so a None response would otherwise raise a TypeError here
+    # instead of scoring 0.
+    if not response:
+        return 0
     if "</think>" in response:
         model_solution = response.split("</think>")[-1]
     elif "###Response" in response:

--- a/tests/test_rm_deepscaler.py
+++ b/tests/test_rm_deepscaler.py
@@ -81,6 +81,16 @@ def test_label_with_boxed_marker_is_extracted_too():
 
 
 @pytest.mark.unit
+def test_missing_response_returns_zero():
+    """A None/empty response scores 0 instead of raising. ``async_rm``
+    feeds ``sample.response`` straight in, and the sibling gpqa / f1 reward
+    functions already guard this; without the guard ``None`` raised
+    ``TypeError: argument of type 'NoneType' is not iterable``."""
+    assert get_deepscaler_rule_based_reward(None, "42") == 0
+    assert get_deepscaler_rule_based_reward("", "42") == 0
+
+
+@pytest.mark.unit
 def test_wrong_answer_returns_zero():
     """Sanity-check the negative side of the contract."""
     assert get_deepscaler_rule_based_reward(r"</think>\boxed{43}", "42") == 0


### PR DESCRIPTION
## Summary

`get_deepscaler_rule_based_reward` (`slime/rollout/rm_hub/deepscaler.py`) starts with `if "</think>" in response:` without first checking `response`. The dispatcher `async_rm` (`slime/rollout/rm_hub/__init__.py`) passes `sample.response` straight through:

```python
elif rm_type == "deepscaler":
    return get_deepscaler_rule_based_reward(response, label)
```

The sibling rule-based rewards in this same package already guard a missing response and return 0 — `gpqa.py` (`if not response: return 0.0`) and `f1.py` (`if prediction is None: return ZERO_METRIC`) — but `deepscaler` did not, so a `None` response raised:

```
TypeError: argument of type 'NoneType' is not iterable
```

instead of scoring 0 like its siblings.

## Fix

Return `0` for a falsy response at the top of the function, matching the gpqa/f1 contract. An empty-string response already returned 0 (no marker match), so only the crash path changes.

## Test Plan

Added `test_missing_response_returns_zero` to `tests/test_rm_deepscaler.py` (the `cpu-unittest` suite):

- **Before:** `get_deepscaler_rule_based_reward(None, "42")` → `TypeError` ❌
- **After:** `None` and `""` → `0` ✅; all existing cases unchanged.

```
tests/test_rm_deepscaler.py ...........  [100%]
11 passed
```
`ruff check` passes on both files.

---
*Prepared with AI assistance (Claude Code); the change was reviewed and tested by a human before submitting.*
