### PR TITLE
fix(rm_hub): grade the final ###Response segment in deepscaler reward

### DIFF
--- a/slime/rollout/rm_hub/deepscaler.py
+++ b/slime/rollout/rm_hub/deepscaler.py
@@ -5,7 +5,7 @@ def get_deepscaler_rule_based_reward(response, label):
     if "</think>" in response:
         model_solution = response.split("</think>")[-1]
     elif "###Response" in response:
-        model_solution = response.split("###Response")[1]
+        model_solution = response.split("###Response")[-1]
     else:
         return 0
 

--- a/tests/test_rm_deepscaler.py
+++ b/tests/test_rm_deepscaler.py
@@ -36,6 +36,30 @@ def test_response_split_on_response_marker_grades_tail():
 
 
 @pytest.mark.unit
+def test_response_split_on_response_marker_grades_last_segment():
+    """When ``###Response`` appears more than once, the *final* segment is the
+    answer — same rule the ``</think>`` branch already follows with ``[-1]``.
+    A model that echoes the ``###Response`` marker inside its scratch work
+    (then emits the real answer after the last one) must still be graded on
+    that last segment. The earlier ``[1]`` indexing graded the *second*
+    segment instead, silently scoring a correct answer as 0."""
+    response = r"reasoning \boxed{1}###Response\boxed{2}###Response\boxed{42}"
+    assert get_deepscaler_rule_based_reward(response, "42") == 1
+    # The wrong intermediate answer in the second segment must not be graded.
+    assert get_deepscaler_rule_based_reward(response, "2") == 0
+
+
+@pytest.mark.unit
+def test_think_and_response_markers_agree_on_last_segment():
+    """The two marker branches must pick the same (final) segment so the
+    reward does not depend on which separator the chat template emits."""
+    think = r"junk \boxed{0}</think>mid \boxed{1}</think>\boxed{42}"
+    resp = r"junk \boxed{0}###Response mid \boxed{1}###Response\boxed{42}"
+    assert get_deepscaler_rule_based_reward(think, "42") == 1
+    assert get_deepscaler_rule_based_reward(resp, "42") == 1
+
+
+@pytest.mark.unit
 def test_response_without_any_marker_returns_zero():
     """No ``</think>`` AND no ``###Response`` → fall through to 0
     immediately (deepscaler.py:9-10). This is the silent-failure pole —


### PR DESCRIPTION
### What

`get_deepscaler_rule_based_reward` splits the model response on the answer
marker and grades the segment that follows it. The two marker branches were
inconsistent:

```python
if "</think>" in response:
    model_solution = response.split("</think>")[-1]   # last segment
elif "###Response" in response:
    model_solution = response.split("###Response")[1]  # second segment
```

The `</think>` branch takes the **last** segment (`[-1]`), but the
`###Response` branch takes the **second** segment (`[1]`). When a response
contains more than one `###Response` marker — e.g. the model echoes the
marker inside its reasoning before emitting the final answer — `[1]` grades a
middle segment instead of the final answer. A correct answer in the last
segment is then silently scored `0`, i.e. a wrong RL reward signal that no
other CI check would surface.

### Reproduction

```python
from slime.rollout.rm_hub.deepscaler import get_deepscaler_rule_based_reward

resp = r"reasoning \boxed{1}###Response\boxed{2}###Response\boxed{42}"
get_deepscaler_rule_based_reward(resp, "42")   # -> 0  (expected 1)
```

### Fix

Take `[-1]` for the `###Response` branch as well, so both branches grade the
final segment. This matches the `</think>` branch and the contract already
documented in `tests/test_rm_deepscaler.py` ("only what comes after is
graded"). The single-marker case is unchanged (`split(...)[1] == split(...)[-1]`
when there is exactly one marker), so existing behavior is preserved.

### Tests

Added two regression tests to the existing CPU unit suite
(`tests/test_rm_deepscaler.py`, already in the `cpu-unittest` CI matrix):

- `test_response_split_on_response_marker_grades_last_segment` — multiple
  `###Response` markers grade the final segment; the wrong intermediate answer
  is not graded. (Red before this change, green after.)
- `test_think_and_response_markers_agree_on_last_segment` — the two marker
  branches pick the same final segment regardless of which separator the chat
  template emits.

All 12 tests in the file pass; `ruff check`, `ruff format`, and `isort` are
clean.

This change is orthogonal to the missing-response guard in #2115 (which adds a
check above these branches and does not touch the split index), so the two do
not conflict.