### PR TITLE
fix(agent): add drop_session for cleanup paths; require base_sample in finish_session

### DIFF
--- a/examples/coding_agent_rl/generate.py
+++ b/examples/coding_agent_rl/generate.py
@@ -242,7 +242,7 @@ async def generate(args, base_sample: Sample, sampling_params: dict[str, Any]):
         )
         return _abort_result(base_sample, f"exception:{type(e).__name__}", instance_id)
     finally:
-        await state.adapter.finish_session(session_id)  # idempotent
+        await state.adapter.drop_session(session_id)  # cleanup only, idempotent
 
 
 def _log_timeout_diagnostic(t0: float, instance_id: str) -> None:

--- a/slime/agent/adapters/common.py
+++ b/slime/agent/adapters/common.py
@@ -265,12 +265,6 @@ class BaseAdapter:
         return samples
 
     async def drop_session(self, sid: str, *, wait_timeout: float = 5.0) -> None:
-        """Discard a session without producing Samples (cleanup paths).
-
-        Drains in-flight turns and frees all per-sid state, like finish_session
-        but without linearizing the trajectory — for rollouts that ended before
-        the trajectory could be consumed. Idempotent.
-        """
         await self.shutdown_session(sid, wait_timeout=wait_timeout)
         self.store.pop(sid, None)
         self.manager.drop_session(sid)

--- a/slime/agent/adapters/common.py
+++ b/slime/agent/adapters/common.py
@@ -237,7 +237,7 @@ class BaseAdapter:
         self,
         sid: str,
         *,
-        base_sample=None,
+        base_sample,
         reward: float = 0.0,
         extra_metadata: dict | None = None,
         wait_timeout: float = 5.0,
@@ -263,6 +263,17 @@ class BaseAdapter:
                 self.tokenizer.decode(s.tokens[-rlen:], skip_special_tokens=False) if rlen and s.tokens else ""
             )
         return samples
+
+    async def drop_session(self, sid: str, *, wait_timeout: float = 5.0) -> None:
+        """Discard a session without producing Samples (cleanup paths).
+
+        Drains in-flight turns and frees all per-sid state, like finish_session
+        but without linearizing the trajectory — for rollouts that ended before
+        the trajectory could be consumed. Idempotent.
+        """
+        await self.shutdown_session(sid, wait_timeout=wait_timeout)
+        self.store.pop(sid, None)
+        self.manager.drop_session(sid)
 
     # -- shared request pipeline ---------------------------------------------
 

--- a/slime/agent/harness/common.py
+++ b/slime/agent/harness/common.py
@@ -151,8 +151,10 @@ async def run_command(sb: Sandbox, *, workdir: str, start_cmd: str, env: dict[st
             check=False,
         )
         if ec == 0:
-            exit_code = int((out or "").strip())
-            break
+            exit_code_text = (out or "").strip()
+            if exit_code_text:
+                exit_code = int(exit_code_text)
+                break
     return exit_code
 
 

--- a/slime/agent/trajectory.py
+++ b/slime/agent/trajectory.py
@@ -328,6 +328,15 @@ class TrajectoryManager:
         self._turn_count.pop(sid, None)
         return samples
 
+    def drop_session(self, sid: str) -> None:
+        """Discard a session's tree without linearizing it into Samples.
+
+        For cleanup paths (e.g. a rollout that raised before consuming its
+        trajectory) where the tree must be freed but nothing should be trained.
+        """
+        self._trees.pop(sid, None)
+        self._turn_count.pop(sid, None)
+
     # -------------------- internals ----------------------------------------
 
     def _find_mount_point(self, root: MessageNode, messages: list[dict[str, Any]]) -> tuple[MessageNode, int]:

--- a/slime/agent/trajectory.py
+++ b/slime/agent/trajectory.py
@@ -329,11 +329,6 @@ class TrajectoryManager:
         return samples
 
     def drop_session(self, sid: str) -> None:
-        """Discard a session's tree without linearizing it into Samples.
-
-        For cleanup paths (e.g. a rollout that raised before consuming its
-        trajectory) where the tree must be freed but nothing should be trained.
-        """
         self._trees.pop(sid, None)
         self._turn_count.pop(sid, None)
 


### PR DESCRIPTION
## What

In the SWE coding-agent rollout, `generate()` calls `adapter.finish_session(session_id)` in its `finally` block as a catch-all cleanup. Since this path passes no `base_sample`, `finish_session` / `get_trajectory` defaulted `base_sample=None`.

On the normal path the trajectory is already consumed (the `finally` call is a no-op), but when the rollout raises **before** consuming the trajectory (e.g. sandbox boot, `evaluate`, or the wall-clock timeout guard fires), the session tree is still in the manager. The cleanup call then reaches `to_sample(base_sample=None)` and crashes on `None.index`.

Overloading `base_sample=None` to mean "cleanup only" also hid the intent: a reader can't tell from the call site whether it consumes the trajectory into trainable Samples or just frees state.

## Changes

- **`TrajectoryManager.drop_session(sid)`** / **`BaseAdapter.drop_session(sid)`** — free a session's state (drain in-flight turns, pop the tree) **without** linearizing it into `Sample`s. For paths that must release the session but produce nothing trainable.
- **`finish_session`**: `base_sample` is now required (was `=None`). The consume path can never silently build Samples from a `None` base; misuse fails loudly.
- **`generate.py`** `finally`: use `drop_session(session_id)` instead of `finish_session(session_id)` — the cleanup path now states its intent and can't crash.
- **`run_command`** (`harness/common.py`): the `done` marker holds the exit code as text, but `echo N > done` truncates the file before writing, so a poll landing in that window reads `""` and `int("")` raised. Skip empty reads and keep polling instead.

## Behavior

- Success path: unchanged — `finish_session(base_sample=...)` consumes and returns Samples; the `finally` `drop_session` is a no-op (tree already popped).
- Abort/timeout path: `drop_session` releases the session cleanly, no crash, nothing trained.