### PR TITLE
fix(retool): coerce list prompt to str in reward_func

### DIFF
--- a/examples/retool/generate_with_retool.py
+++ b/examples/retool/generate_with_retool.py
@@ -410,7 +410,8 @@ async def reward_func(args, sample, **kwargs):
         raise TypeError("Sample must be an instance of Sample class.")
 
     # Build complete solution string
-    solution_str = sample.prompt + sample.response
+    prompt_str = sample.prompt if isinstance(sample.prompt, str) else str(sample.prompt)
+    solution_str = prompt_str + sample.response
 
     # Get ground truth answer - label is a string, not a dict
     ground_truth = sample.label if sample.label is not None else ""


### PR DESCRIPTION
## Summary
In `examples/retool/generate_with_retool.py`, `reward_func` did `sample.prompt + sample.response`. With `--apply-chat-template`, `sample.prompt` is a `list[dict]`, so the concatenation raised `TypeError: can only concatenate list (not "str") to list`.

## Changes
Coerce the prompt to `str` before concatenation, matching slime's own `str(sample.prompt)` idiom in `sglang_rollout`.

Fixes #1829

AI was used for assistance.
