### PR TITLE
fix(partial-rollout): cap max_new_tokens by prior response length

### DIFF
--- a/slime/rollout/sglang_rollout.py
+++ b/slime/rollout/sglang_rollout.py
@@ -163,6 +163,9 @@ async def generate(args: Namespace, sample: Sample, sampling_params: dict[str, A
     ), f"Sample status is {sample.status}"
 
     prompt_ids = _prepare_prompt_ids(sample, state.tokenizer, state.processor)
+    # partial-rollout reuses the sample; subtract prior progress so total <= rollout_max_response_len
+    if args.partial_rollout and sample.response_length > 0:
+        sampling_params["max_new_tokens"] = max(0, args.rollout_max_response_len - sample.response_length)
 
     assert (
         sampling_params["max_new_tokens"] >= 0

--- a/slime/rollout/sglang_streaming_rollout.py
+++ b/slime/rollout/sglang_streaming_rollout.py
@@ -58,6 +58,9 @@ async def generate_streaming(args: Namespace, sample: Sample, sampling_params: d
     ), f"Sample status is {sample.status}"
 
     prompt_ids = _prepare_prompt_ids(sample, state.tokenizer, state.processor)
+    # partial-rollout reuses the sample; subtract prior progress so total <= rollout_max_response_len
+    if args.partial_rollout and sample.response_length > 0:
+        sampling_params["max_new_tokens"] = max(0, args.rollout_max_response_len - sample.response_length)
 
     assert (
         sampling_params["max_new_tokens"] >= 0


### PR DESCRIPTION
## Summary
In partial rollout, an aborted sample is resubmitted with its previously
generated tokens already attached (`sample.response_length > 0`). However,
`sampling_params["max_new_tokens"]` was still set to the full
`rollout_max_response_len`, allowing the engine to generate another full
budget of tokens. As a result, the total response length could exceed
`rollout_max_response_len` (nothing downstream clamps it).

This subtracts the already-generated length so the cumulative response stays
within `rollout_max_response_len`. When the budget is already exhausted,
`max_new_tokens` becomes 0 and the sample is marked `TRUNCATED` by the
existing guard.

## Changes
- `rollout/sglang_rollout.py` (`generate`)
- `rollout/sglang_streaming_rollout.py` (`generate_streaming`)

Only affects runs with `--partial-rollout` and samples that already have
response tokens; fresh samples are unchanged.
