### PR TITLE
fix(agent) SWE coding-agent RL stability bugs (abort handling, session cleanup)

### DIFF
--- a/examples/coding_agent_rl/generate.py
+++ b/examples/coding_agent_rl/generate.py
@@ -242,7 +242,7 @@ async def generate(args, base_sample: Sample, sampling_params: dict[str, Any]):
         )
         return _abort_result(base_sample, f"exception:{type(e).__name__}", instance_id)
     finally:
-        await state.adapter.finish_session(session_id)  # idempotent
+        await state.adapter.drop_session(session_id)  # cleanup only, idempotent
 
 
 def _log_timeout_diagnostic(t0: float, instance_id: str) -> None:
@@ -282,7 +282,9 @@ def _abort_result(sample: Sample, reason: str, instance_id: str) -> list[Sample]
     sample.response = ""
     sample.response_length = 1
     sample.loss_mask = [0]
+    sample.rollout_log_probs = [0.0]
     sample.reward = 0.0
+    sample.remove_sample = True
     sample.status = Sample.Status.ABORTED
     sample.metadata = {**(sample.metadata or {}), "abort_reason": reason}
     logger.warning("[coding_agent_rl] %s aborted: %s", instance_id, reason)

--- a/examples/coding_agent_rl/run_qwen36_35b_a3b_swe_8nodes.sh
+++ b/examples/coding_agent_rl/run_qwen36_35b_a3b_swe_8nodes.sh
@@ -152,13 +152,13 @@ PERF_ARGS=(
 )
 
 ALGO_ARGS=(
-   --advantage-estimator gspo
+   --advantage-estimator grpo
    --kl-loss-coef 0.00
    --kl-loss-type low_var_kl
    --kl-coef 0.00
    --entropy-coef 0.00
-   --eps-clip 1e-4
-   --eps-clip-high 2e-4
+   --eps-clip 0.2
+   --eps-clip-high 0.28
 )
 
 OPTIMIZER_ARGS=(

--- a/slime/agent/adapters/common.py
+++ b/slime/agent/adapters/common.py
@@ -237,7 +237,7 @@ class BaseAdapter:
         self,
         sid: str,
         *,
-        base_sample=None,
+        base_sample,
         reward: float = 0.0,
         extra_metadata: dict | None = None,
         wait_timeout: float = 5.0,
@@ -263,6 +263,11 @@ class BaseAdapter:
                 self.tokenizer.decode(s.tokens[-rlen:], skip_special_tokens=False) if rlen and s.tokens else ""
             )
         return samples
+
+    async def drop_session(self, sid: str, *, wait_timeout: float = 5.0) -> None:
+        await self.shutdown_session(sid, wait_timeout=wait_timeout)
+        self.store.pop(sid, None)
+        self.manager.drop_session(sid)
 
     # -- shared request pipeline ---------------------------------------------
 

--- a/slime/agent/harness/common.py
+++ b/slime/agent/harness/common.py
@@ -151,8 +151,10 @@ async def run_command(sb: Sandbox, *, workdir: str, start_cmd: str, env: dict[st
             check=False,
         )
         if ec == 0:
-            exit_code = int((out or "").strip())
-            break
+            exit_code_text = (out or "").strip()
+            if exit_code_text:
+                exit_code = int(exit_code_text)
+                break
     return exit_code
 
 

--- a/slime/agent/trajectory.py
+++ b/slime/agent/trajectory.py
@@ -328,6 +328,10 @@ class TrajectoryManager:
         self._turn_count.pop(sid, None)
         return samples
 
+    def drop_session(self, sid: str) -> None:
+        self._trees.pop(sid, None)
+        self._turn_count.pop(sid, None)
+
     # -------------------- internals ----------------------------------------
 
     def _find_mount_point(self, root: MessageNode, messages: list[dict[str, Any]]) -> tuple[MessageNode, int]:


### PR DESCRIPTION
- generate.py: an aborted sample now sets rollout_log_probs=[0.0] and remove_sample=True so it contributes no gradient and is excluded from the GRPO/GSPO group baseline; finally now calls drop_session instead of finish_session.
- adapters/common.py: add drop_session() for cleanup-only teardown; make finish_session's base_sample a required arg.
- harness/common.py: run_command tolerates an empty done-marker (truncate-then -write window) instead of crashing on int('').
- trajectory.py: add TrajectoryManager.drop_session() to drop trees/turn-count idempotently.
- run_qwen36_35b_a3b_swe_8nodes.sh: switch algo args to grpo eps-clip 0.2/0.28.