### PR TITLE
feat(coding_agent_rl): select claude_code/codex harness+adapter pair via SWE_AGENT

### DIFF
--- a/examples/coding_agent_rl/generate.py
+++ b/examples/coding_agent_rl/generate.py
@@ -2,14 +2,16 @@
 
     --custom-generate-function-path examples.coding_agent_rl.generate.generate
 
-generate() is a four-stage orchestrator: swe.prepare_workspace + ClaudeCodeHarness.run
--> swe.git_diff -> swe.evaluate -> adapter.finish_session. Sandbox-side work is
-split across three layers: the provider-agnostic sandbox contract
-(slime.agent.sandbox), the swappable harness lifecycle (slime.agent.harness), and
-the SWE task layer (examples.coding_agent_rl.swe -- dataset parsing, workspace
-prep, diff, eval). LLM plumbing (Anthropic <-> SGLang /generate, token capture,
-segment split) is slime.agent.adapters.AnthropicAdapter. swe.get_metadata documents
-the dataset row schema and produces the md dict consumed below.
+generate() is a four-stage orchestrator: swe.prepare_workspace + harness.run
+-> swe.git_diff -> swe.evaluate -> adapter.finish_session. The (harness, adapter)
+pair is chosen by the SWE_AGENT env var (claude_code | codex); see _AGENTS below.
+Sandbox-side work is split across three layers: the provider-agnostic sandbox
+contract (slime.agent.sandbox), the swappable harness lifecycle
+(slime.agent.harness), and the SWE task layer (examples.coding_agent_rl.swe --
+dataset parsing, workspace prep, diff, eval). LLM plumbing (Anthropic / OpenAI
+<-> SGLang /generate, token capture, segment split) is the matching
+slime.agent.adapters adapter. swe.get_metadata documents the dataset row schema
+and produces the md dict consumed below.
 """
 
 from __future__ import annotations
@@ -25,9 +27,9 @@ from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from typing import Any
 
-from slime.agent.adapters import AnthropicAdapter
+from slime.agent.adapters import AnthropicAdapter, OpenAIAdapter
 from slime.agent.aiohttp_threaded import FilteredAccessLogger, run_app_in_thread
-from slime.agent.harness import ClaudeCodeHarness
+from slime.agent.harness import ClaudeCodeHarness, CodexHarness
 from slime.agent.sandbox import E2BSandbox
 from slime.utils.misc import SingletonMeta
 from slime.utils.processing_utils import load_tokenizer
@@ -37,6 +39,15 @@ from . import swe
 
 logger = logging.getLogger(__name__)
 logging.getLogger("e2b").setLevel(logging.WARNING)
+
+_AGENTS = {
+    "claude_code": (ClaudeCodeHarness, AnthropicAdapter),
+    "codex": (CodexHarness, OpenAIAdapter),
+}
+AGENT_NAME = os.environ.get("SWE_AGENT", "claude_code")
+if AGENT_NAME not in _AGENTS:
+    raise ValueError(f"SWE_AGENT={AGENT_NAME!r} not in {sorted(_AGENTS)}")
+HARNESS_CLS, ADAPTER_CLS = _AGENTS[AGENT_NAME]
 
 
 @dataclass(frozen=True)
@@ -77,7 +88,7 @@ _BOOT_SEM = asyncio.Semaphore(CONFIG.boot_concurrency)
 
 @asynccontextmanager
 async def boot_agent_sandbox(image: str, instance_id: str) -> AsyncIterator[E2BSandbox]:
-    """Boot a fresh E2B sandbox and install the Claude Code toolchain.
+    """Boot a fresh E2B sandbox and install the selected harness toolchain.
 
     Create the sandbox from the dataset image, install Node 22 + the harness CLI
     from host tarballs, retry transient boot/install failures, and close the
@@ -91,7 +102,7 @@ async def boot_agent_sandbox(image: str, instance_id: str) -> AsyncIterator[E2BS
             async with _BOOT_SEM:
                 await cand.__aenter__()
                 try:
-                    await ClaudeCodeHarness().install_cli(cand)
+                    await HARNESS_CLS().install_cli(cand)
                 except BaseException:
                     await cand.__aexit__(None, None, None)
                     raise
@@ -130,7 +141,7 @@ class _AdapterService(metaclass=SingletonMeta):
                 "sandboxes can reach for reverse-connection to the adapter; "
                 "without it the sandbox cannot dial back and the rollout aborts."
             )
-        self.adapter = AnthropicAdapter(
+        self.adapter = ADAPTER_CLS(
             tokenizer=self.tokenizer,
             sglang_url=sglang_url,
             tool_parser=self.tool_parser,
@@ -181,7 +192,7 @@ async def generate(args, base_sample: Sample, sampling_params: dict[str, Any]):
         async with asyncio.timeout(CONFIG.rollout_guard_sec):
             async with boot_agent_sandbox(md["image"], instance_id) as sb:
                 await swe.prepare_workspace(sb, md["workdir"], md)
-                agent_exit_code = await ClaudeCodeHarness().run(
+                agent_exit_code = await HARNESS_CLS().run(
                     sb,
                     workdir=md["workdir"],
                     session_id=session_id,

--- a/examples/coding_agent_rl/run_qwen36_35b_a3b_swe_8nodes.sh
+++ b/examples/coding_agent_rl/run_qwen36_35b_a3b_swe_8nodes.sh
@@ -206,6 +206,7 @@ export NCCL_SOCKET_IFNAME="${NCCL_SOCKET_IFNAME:-${MLP_SOCKET_IFNAME:-eth0}}"
 
 # ============ SWE / claude-code rollout knobs ============
 
+export SWE_AGENT="${SWE_AGENT:-claude_code}"
 export E2B_API_KEY="${E2B_API_KEY:-e2b_0000000000000000000000000000000000000000}"
 # Metadata key your gateway routes images by; `image` is the neutral default.
 export SLIME_AGENT_SANDBOX_IMAGE_METADATA_KEY="${SLIME_AGENT_SANDBOX_IMAGE_METADATA_KEY:-image}"
@@ -268,6 +269,7 @@ RUNTIME_ENV_JSON=$(python3 - <<PY
 import json, os
 keys = (
     "no_proxy", "NO_PROXY",
+    "SWE_AGENT",
     "E2B_API_KEY", "ADAPTER_PUBLIC_HOST",
     "SLIME_AGENT_NODE_TARBALL", "SLIME_AGENT_CC_TARBALL",
     "SWE_AGENT_TIME_BUDGET_SEC", "SWE_EVAL_TIMEOUT_SEC", "SWE_BOOT_CONCURRENCY",


### PR DESCRIPTION
## What

Make the SWE rollout in `examples/coding_agent_rl` agent-agnostic. The `generate()` orchestrator no longer hard-codes the Claude Code harness + Anthropic adapter; instead the `(harness, adapter)` pair is selected at import time by the `SWE_AGENT` env var.

## Changes

- `generate.py`:
  - Add an `_AGENTS` registry mapping the agent name to its `(harness, adapter)` pair:
    - `claude_code` -> `(ClaudeCodeHarness, AnthropicAdapter)`
    - `codex` -> `(CodexHarness, OpenAIAdapter)`
  - Resolve `SWE_AGENT` (default `claude_code`) into `HARNESS_CLS` / `ADAPTER_CLS`, with an explicit `ValueError` on an unknown value.
  - Use `HARNESS_CLS` / `ADAPTER_CLS` everywhere the concrete classes were previously referenced (CLI install, adapter service, rollout run).
  - Update the module docstring to describe the selector.
- `run_qwen36_35b_a3b_swe_8nodes.sh`:
  - Export `SWE_AGENT` (default `claude_code`) and propagate it into the Ray `RUNTIME_ENV_JSON` so workers see the same selection.

## Behavior

- Default is unchanged (`claude_code`), so existing runs are not affected.
- Set `SWE_AGENT=codex` to switch the rollout to the Codex harness + OpenAI adapter.
