### PR TITLE
docs(examples): list coding_agent_rl in examples/README

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -4,6 +4,7 @@ These examples provide concrete examples to leverage slime in your own RL workfl
 
 ## Directory Structure
 
+- **[coding_agent_rl](./coding_agent_rl)**: End-to-end SWE coding-agent RL — a real coding agent (claude-code / codex) edits code in a per-sample sandbox, and the resulting `git diff` is graded against the dataset's test harness.
 - **[eval_multi_task](./eval_multi_task)**: Example for supporting evaluation multiple tasks with different configs.
 - **[fully_async](./fully_async)**: Demonstrates fully asynchronous rollout generation for higher efficiency.
 - **[geo3k_vlm](./geo3k_vlm)**: Training VLMs on a single-turn reasoning task using GRPO on the GEO3K dataset.

--- a/examples/fully_async/README.md
+++ b/examples/fully_async/README.md
@@ -57,7 +57,7 @@ work unchanged under fully-async:
 --custom-rm-path                your.module.reward      # (args, sample | list[Sample]) -> float | list[float]
 ```
 
-See `examples/swe_codex/` for a non-trivial example that plugs in a
+See `examples/coding_agent_rl/` for a non-trivial example that plugs in a
 multi-turn agent (Claude Code in a Docker-Proxy sandbox) this way.
 
 ## Worker Internals (Very Short)


### PR DESCRIPTION
## What

`examples/coding_agent_rl/` (end-to-end SWE coding-agent RL, landed via #2124/#2125) exists in the tree but is not listed in `examples/README.md`'s Directory Structure. This adds the entry so the example is discoverable alongside the others.

## Change

One line added to `examples/README.md`:

```
- **[coding_agent_rl](./coding_agent_rl)**: End-to-end SWE coding-agent RL — a real coding agent (claude-code / codex) edits code in a per-sample sandbox, and the resulting `git diff` is graded against the dataset's test harness.
```

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)