### PR TITLE
fix(examples): correct geo3k VLM default env

### DIFF
--- a/examples/geo3k_vlm_multi_turn/rollout.py
+++ b/examples/geo3k_vlm_multi_turn/rollout.py
@@ -9,13 +9,13 @@ from typing import Any
 import torch
 from examples.geo3k_vlm_multi_turn.base_env import BaseInteractionEnv
 
-# When executed as a module: python -m examples.vlm_multi_turn.rollout
+# When executed as a module: python -m examples.geo3k_vlm_multi_turn.rollout
 from slime.rollout.sglang_rollout import GenerateState
 from slime.utils.http_utils import post
 from slime.utils.processing_utils import encode_image_for_rollout_engine
 from slime.utils.types import Sample
 
-DEFAULT_ENV_MODULE = "examples.vlm_multi_turn.env_geo3k"
+DEFAULT_ENV_MODULE = "examples.geo3k_vlm_multi_turn.env_geo3k"
 
 # Dummy messages used for calculating trim length in chat template encoding
 DUMMY_MESSAGES = [

--- a/tests/test_geo3k_vlm_multi_turn_paths.py
+++ b/tests/test_geo3k_vlm_multi_turn_paths.py
@@ -1,0 +1,27 @@
+import ast
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+ROLLOUT_PATH = REPO_ROOT / "examples" / "geo3k_vlm_multi_turn" / "rollout.py"
+
+
+def _module_constant(path: Path, name: str) -> str:
+    module = ast.parse(path.read_text())
+    for node in module.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if any(isinstance(target, ast.Name) and target.id == name for target in node.targets):
+            return ast.literal_eval(node.value)
+    raise AssertionError(f"{name} not found in {path}")
+
+
+@pytest.mark.unit
+def test_geo3k_vlm_multi_turn_default_env_module_points_to_existing_file():
+    module_name = _module_constant(ROLLOUT_PATH, "DEFAULT_ENV_MODULE")
+    module_path = REPO_ROOT.joinpath(*module_name.split(".")).with_suffix(".py")
+
+    assert module_path.exists()
+    assert module_path.relative_to(REPO_ROOT).as_posix() == "examples/geo3k_vlm_multi_turn/env_geo3k.py"


### PR DESCRIPTION
## Summary
- Correct the geo3k VLM multi-turn default env module path to the existing example package.
- Update the module execution comment to match the actual package name.
- Add a lightweight static regression test so the default env module keeps pointing to an existing file.

## Tests
- uvx --from pytest pytest tests/test_geo3k_vlm_multi_turn_paths.py
- uvx ruff check examples/geo3k_vlm_multi_turn/rollout.py tests/test_geo3k_vlm_multi_turn_paths.py
- git diff --check