### PR TITLE
perf: fuse PPO logprob entropy computation

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -40,7 +40,25 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        info: [{"num_gpus": 8, "test_file": "test_qwen2.5_0.5B_sglang_config.py"}, {"num_gpus": 8, "test_file": "test_qwen2.5_0.5B_sglang_config_distributed.py"}, {"num_gpus": 8, "test_file": "test_sglang_config_mixed_offload.py"}, {"num_gpus": 8, "test_file": "test_sglang_config_mixed_offload_ft.py"}]
+        info:
+          [
+            {
+              "num_gpus": 8,
+              "test_file": "test_qwen2.5_0.5B_sglang_config.py"
+            },
+            {
+              "num_gpus": 8,
+              "test_file": "test_qwen2.5_0.5B_sglang_config_distributed.py"
+            },
+            {
+              "num_gpus": 8,
+              "test_file": "test_sglang_config_mixed_offload.py"
+            },
+            {
+              "num_gpus": 8,
+              "test_file": "test_sglang_config_mixed_offload_ft.py"
+            }
+          ]
     defaults:
       run:
         working-directory: ${{ github.workspace }}
@@ -123,7 +141,135 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        info: [{"num_gpus": 4, "test_file": "test_full_disk_weight_update.py"}, {"enable_eval": "0", "num_gpus": 8, "test_file": "test_quick_start_glm4_9B.py"}, {"num_gpus": 8, "test_file": "test_glm4.7_30B_A3B_pd_mooncake.py"}, {"enable_eval": "0", "num_gpus": 8, "test_file": "test_qwen3_30B_A3B.py", "use_deepep": "1", "use_fp8_rollout": "1"}, {"num_gpus": 8, "test_file": "test_qwen3.6_35B_A3B_pd_mooncake.py", "use_deepep": "1"}, {"enable_eval": "0", "num_gpus": 8, "test_file": "test_qwen3_30B_A3B_r3.py", "use_deepep": "1", "use_fp8_rollout": "1"}, {"enable_eval": "0", "num_gpus": 8, "test_file": "test_qwen3_4B_ppo.py"}, {"enable_eval": "0", "num_gpus": 8, "test_file": "test_qwen3_4B_ppo_disaggregate.py"}, {"enable_eval": "0", "num_gpus": 8, "test_file": "test_qwen3_4B_ppo_train_critic_only.py"}, {"enable_eval": "0", "num_gpus": 8, "test_file": "test_moonlight_16B_A3B.py"}, {"enable_eval": "0", "num_gpus": 8, "test_file": "test_moonlight_16B_A3B_r3.py"}, {"num_gpus": 8, "test_file": "test_mimo_7B_mtp_only_grad.py"}, {"num_gpus": 8, "test_file": "test_qwen3_0.6B_parallel_check.py"}, {"num_gpus": 8, "test_file": "test_qwen2.5_0.5B_debug_rollout_then_train.py"}, {"num_gpus": 8, "test_file": "test_qwen2.5_0.5B_opd_sglang.py"}, {"num_gpus": 6, "test_file": "test_qwen3_4B_external_pd.py"}, {"num_gpus": 4, "test_file": "test_qwen2.5_0.5B_fully_async_short.py"}, {"num_gpus": 4, "test_file": "test_qwen2.5_0.5B_fanout_short.py"}, {"num_gpus": 8, "test_file": "test_qwen3_4B_streaming_partial_rollout.py"}, {"num_gpus": 4, "test_file": "test_qwen3.5_0.8B_gsm8k_short.py"}, {"num_gpus": 4, "test_file": "test_qwen3.5_0.8B_gsm8k_async_short.py"}, {"num_gpus": 8, "test_args": "--save-optimizer gpu --load-optimizer gpu", "test_file": "test_qwen3_4B_ckpt.py"}, {"num_gpus": 8, "test_args": "--save-optimizer gpu --load-optimizer cpu", "test_file": "test_qwen3_4B_ckpt.py"}, {"num_gpus": 8, "test_args": "--save-optimizer cpu --load-optimizer cpu", "test_file": "test_qwen3_4B_ckpt.py"}, {"num_gpus": 8, "test_args": "--save-optimizer cpu --load-optimizer gpu", "test_file": "test_qwen3_4B_ckpt.py"}, {"num_gpus": 8, "test_args": "--async-save", "test_file": "test_qwen3_4B_ckpt.py"}]
+        info:
+          [
+            {
+              "num_gpus": 4,
+              "test_file": "test_full_disk_weight_update.py"
+            },
+            {
+              "enable_eval": "0",
+              "num_gpus": 8,
+              "test_file": "test_quick_start_glm4_9B.py"
+            },
+            {
+              "num_gpus": 8,
+              "test_file": "test_glm4.7_30B_A3B_pd_mooncake.py"
+            },
+            {
+              "enable_eval": "0",
+              "num_gpus": 8,
+              "test_file": "test_qwen3_30B_A3B.py",
+              "use_deepep": "1",
+              "use_fp8_rollout": "1"
+            },
+            {
+              "num_gpus": 8,
+              "test_file": "test_qwen3.6_35B_A3B_pd_mooncake.py",
+              "use_deepep": "1"
+            },
+            {
+              "enable_eval": "0",
+              "num_gpus": 8,
+              "test_file": "test_qwen3_30B_A3B_r3.py",
+              "use_deepep": "1",
+              "use_fp8_rollout": "1"
+            },
+            {
+              "enable_eval": "0",
+              "num_gpus": 8,
+              "test_file": "test_qwen3_4B_ppo.py"
+            },
+            {
+              "enable_eval": "0",
+              "num_gpus": 8,
+              "test_file": "test_qwen3_4B_ppo_disaggregate.py"
+            },
+            {
+              "enable_eval": "0",
+              "num_gpus": 8,
+              "test_file": "test_qwen3_4B_ppo_train_critic_only.py"
+            },
+            {
+              "num_gpus": 2,
+              "test_file": "test_ppo_logprob_entropy_gpu.py"
+            },
+            {
+              "enable_eval": "0",
+              "num_gpus": 8,
+              "test_file": "test_moonlight_16B_A3B.py"
+            },
+            {
+              "enable_eval": "0",
+              "num_gpus": 8,
+              "test_file": "test_moonlight_16B_A3B_r3.py"
+            },
+            {
+              "num_gpus": 8,
+              "test_file": "test_mimo_7B_mtp_only_grad.py"
+            },
+            {
+              "num_gpus": 8,
+              "test_file": "test_qwen3_0.6B_parallel_check.py"
+            },
+            {
+              "num_gpus": 8,
+              "test_file": "test_qwen2.5_0.5B_debug_rollout_then_train.py"
+            },
+            {
+              "num_gpus": 8,
+              "test_file": "test_qwen2.5_0.5B_opd_sglang.py"
+            },
+            {
+              "num_gpus": 6,
+              "test_file": "test_qwen3_4B_external_pd.py"
+            },
+            {
+              "num_gpus": 4,
+              "test_file": "test_qwen2.5_0.5B_fully_async_short.py"
+            },
+            {
+              "num_gpus": 4,
+              "test_file": "test_qwen2.5_0.5B_fanout_short.py"
+            },
+            {
+              "num_gpus": 8,
+              "test_file": "test_qwen3_4B_streaming_partial_rollout.py"
+            },
+            {
+              "num_gpus": 4,
+              "test_file": "test_qwen3.5_0.8B_gsm8k_short.py"
+            },
+            {
+              "num_gpus": 4,
+              "test_file": "test_qwen3.5_0.8B_gsm8k_async_short.py"
+            },
+            {
+              "num_gpus": 8,
+              "test_args": "--save-optimizer gpu --load-optimizer gpu",
+              "test_file": "test_qwen3_4B_ckpt.py"
+            },
+            {
+              "num_gpus": 8,
+              "test_args": "--save-optimizer gpu --load-optimizer cpu",
+              "test_file": "test_qwen3_4B_ckpt.py"
+            },
+            {
+              "num_gpus": 8,
+              "test_args": "--save-optimizer cpu --load-optimizer cpu",
+              "test_file": "test_qwen3_4B_ckpt.py"
+            },
+            {
+              "num_gpus": 8,
+              "test_args": "--save-optimizer cpu --load-optimizer gpu",
+              "test_file": "test_qwen3_4B_ckpt.py"
+            },
+            {
+              "num_gpus": 8,
+              "test_args": "--async-save",
+              "test_file": "test_qwen3_4B_ckpt.py"
+            }
+          ]
     defaults:
       run:
         working-directory: ${{ github.workspace }}
@@ -206,7 +352,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        info: [{"num_gpus": 8, "test_file": "test_qwen3_0.6B_parallel_check.py"}]
+        info:
+          [
+            {
+              "num_gpus": 8,
+              "test_file": "test_qwen3_0.6B_parallel_check.py"
+            }
+          ]
     defaults:
       run:
         working-directory: ${{ github.workspace }}
@@ -289,7 +441,34 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        info: [{"num_gpus": 8, "test_args": "--save-optimizer gpu --load-optimizer gpu", "test_file": "test_qwen3_4B_ckpt.py"}, {"num_gpus": 8, "test_args": "--save-optimizer gpu --load-optimizer cpu", "test_file": "test_qwen3_4B_ckpt.py"}, {"num_gpus": 8, "test_args": "--save-optimizer cpu --load-optimizer cpu", "test_file": "test_qwen3_4B_ckpt.py"}, {"num_gpus": 8, "test_args": "--save-optimizer cpu --load-optimizer gpu", "test_file": "test_qwen3_4B_ckpt.py"}, {"num_gpus": 8, "test_args": "--async-save", "test_file": "test_qwen3_4B_ckpt.py"}]
+        info:
+          [
+            {
+              "num_gpus": 8,
+              "test_args": "--save-optimizer gpu --load-optimizer gpu",
+              "test_file": "test_qwen3_4B_ckpt.py"
+            },
+            {
+              "num_gpus": 8,
+              "test_args": "--save-optimizer gpu --load-optimizer cpu",
+              "test_file": "test_qwen3_4B_ckpt.py"
+            },
+            {
+              "num_gpus": 8,
+              "test_args": "--save-optimizer cpu --load-optimizer cpu",
+              "test_file": "test_qwen3_4B_ckpt.py"
+            },
+            {
+              "num_gpus": 8,
+              "test_args": "--save-optimizer cpu --load-optimizer gpu",
+              "test_file": "test_qwen3_4B_ckpt.py"
+            },
+            {
+              "num_gpus": 8,
+              "test_args": "--async-save",
+              "test_file": "test_qwen3_4B_ckpt.py"
+            }
+          ]
     defaults:
       run:
         working-directory: ${{ github.workspace }}
@@ -372,7 +551,113 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        info: [{"num_gpus": 0, "test_file": "test_megatron_argument_validation.py"}, {"num_gpus": 0, "test_file": "utils/test_megatron_server_arguments.py"}, {"num_gpus": 0, "test_file": "test_dp_schedule.py"}, {"num_gpus": 0, "test_file": "test_cp_utils.py"}, {"num_gpus": 0, "test_file": "test_metric_report.py"}, {"num_gpus": 0, "test_file": "test_metric_report_dist.py"}, {"num_gpus": 0, "test_file": "test_loss_cp_invariance.py"}, {"num_gpus": 0, "test_file": "test_logprob_response_spans.py"}, {"num_gpus": 0, "test_file": "test_value_temperature.py"}, {"num_gpus": 0, "test_file": "test_cispo_loss.py"}, {"num_gpus": 0, "test_file": "test_rm_f1.py"}, {"num_gpus": 0, "test_file": "test_rm_gpqa.py"}, {"num_gpus": 0, "test_file": "test_rm_math.py"}, {"num_gpus": 0, "test_file": "test_rm_math_dapo.py"}, {"num_gpus": 0, "test_file": "test_rm_deepscaler.py"}, {"num_gpus": 0, "test_file": "test_sample.py"}, {"num_gpus": 0, "test_file": "test_rollout_validation.py"}, {"num_gpus": 0, "test_file": "test_placement_group.py"}, {"num_gpus": 0, "test_file": "test_external_sglang_engines.py"}, {"num_gpus": 0, "test_file": "test_empty_colocated_weight_bucket.py"}, {"num_gpus": 0, "test_file": "utils/test_hf_checkpoint_saver.py"}, {"num_gpus": 0, "test_file": "plugin_contracts/test_plugin_rollout_contracts.py"}, {"num_gpus": 0, "test_file": "plugin_contracts/test_plugin_runtime_hook_contracts.py"}, {"num_gpus": 0, "test_file": "plugin_contracts/test_plugin_path_loading_contracts.py"}, {"num_gpus": 0, "test_file": "plugin_contracts/test_plugin_generate_contracts.py"}]
+        info:
+          [
+            {
+              "num_gpus": 0,
+              "test_file": "test_megatron_argument_validation.py"
+            },
+            {
+              "num_gpus": 0,
+              "test_file": "utils/test_megatron_server_arguments.py"
+            },
+            {
+              "num_gpus": 0,
+              "test_file": "test_dp_schedule.py"
+            },
+            {
+              "num_gpus": 0,
+              "test_file": "test_cp_utils.py"
+            },
+            {
+              "num_gpus": 0,
+              "test_file": "test_metric_report.py"
+            },
+            {
+              "num_gpus": 0,
+              "test_file": "test_metric_report_dist.py"
+            },
+            {
+              "num_gpus": 0,
+              "test_file": "test_loss_cp_invariance.py"
+            },
+            {
+              "num_gpus": 0,
+              "test_file": "test_logprob_response_spans.py"
+            },
+            {
+              "num_gpus": 0,
+              "test_file": "test_value_temperature.py"
+            },
+            {
+              "num_gpus": 0,
+              "test_file": "test_cispo_loss.py"
+            },
+            {
+              "num_gpus": 0,
+              "test_file": "test_ppo_logprob_entropy.py"
+            },
+            {
+              "num_gpus": 0,
+              "test_file": "test_rm_f1.py"
+            },
+            {
+              "num_gpus": 0,
+              "test_file": "test_rm_gpqa.py"
+            },
+            {
+              "num_gpus": 0,
+              "test_file": "test_rm_math.py"
+            },
+            {
+              "num_gpus": 0,
+              "test_file": "test_rm_math_dapo.py"
+            },
+            {
+              "num_gpus": 0,
+              "test_file": "test_rm_deepscaler.py"
+            },
+            {
+              "num_gpus": 0,
+              "test_file": "test_sample.py"
+            },
+            {
+              "num_gpus": 0,
+              "test_file": "test_rollout_validation.py"
+            },
+            {
+              "num_gpus": 0,
+              "test_file": "test_placement_group.py"
+            },
+            {
+              "num_gpus": 0,
+              "test_file": "test_external_sglang_engines.py"
+            },
+            {
+              "num_gpus": 0,
+              "test_file": "test_empty_colocated_weight_bucket.py"
+            },
+            {
+              "num_gpus": 0,
+              "test_file": "utils/test_hf_checkpoint_saver.py"
+            },
+            {
+              "num_gpus": 0,
+              "test_file": "plugin_contracts/test_plugin_rollout_contracts.py"
+            },
+            {
+              "num_gpus": 0,
+              "test_file": "plugin_contracts/test_plugin_runtime_hook_contracts.py"
+            },
+            {
+              "num_gpus": 0,
+              "test_file": "plugin_contracts/test_plugin_path_loading_contracts.py"
+            },
+            {
+              "num_gpus": 0,
+              "test_file": "plugin_contracts/test_plugin_generate_contracts.py"
+            }
+          ]
     defaults:
       run:
         working-directory: ${{ github.workspace }}
@@ -438,7 +723,25 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        info: [{"num_gpus": 0, "test_file": "test_agent/test_trajectory_manager_branching.py"}, {"num_gpus": 0, "test_file": "test_agent/test_adapters.py"}, {"num_gpus": 0, "test_file": "test_agent/test_harness.py"}, {"num_gpus": 0, "test_file": "test_agent/test_agent_rollout_cpu.py"}]
+        info:
+          [
+            {
+              "num_gpus": 0,
+              "test_file": "test_agent/test_trajectory_manager_branching.py"
+            },
+            {
+              "num_gpus": 0,
+              "test_file": "test_agent/test_adapters.py"
+            },
+            {
+              "num_gpus": 0,
+              "test_file": "test_agent/test_harness.py"
+            },
+            {
+              "num_gpus": 0,
+              "test_file": "test_agent/test_agent_rollout_cpu.py"
+            }
+          ]
     defaults:
       run:
         working-directory: ${{ github.workspace }}
@@ -504,7 +807,135 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        info: [{"num_gpus": 4, "test_file": "test_full_disk_weight_update.py"}, {"enable_eval": "0", "num_gpus": 8, "test_file": "test_quick_start_glm4_9B.py"}, {"num_gpus": 8, "test_file": "test_glm4.7_30B_A3B_pd_mooncake.py"}, {"enable_eval": "0", "num_gpus": 8, "test_file": "test_qwen3_30B_A3B.py", "use_deepep": "1", "use_fp8_rollout": "1"}, {"num_gpus": 8, "test_file": "test_qwen3.6_35B_A3B_pd_mooncake.py", "use_deepep": "1"}, {"enable_eval": "0", "num_gpus": 8, "test_file": "test_qwen3_30B_A3B_r3.py", "use_deepep": "1", "use_fp8_rollout": "1"}, {"enable_eval": "0", "num_gpus": 8, "test_file": "test_qwen3_4B_ppo.py"}, {"enable_eval": "0", "num_gpus": 8, "test_file": "test_qwen3_4B_ppo_disaggregate.py"}, {"enable_eval": "0", "num_gpus": 8, "test_file": "test_qwen3_4B_ppo_train_critic_only.py"}, {"enable_eval": "0", "num_gpus": 8, "test_file": "test_moonlight_16B_A3B.py"}, {"enable_eval": "0", "num_gpus": 8, "test_file": "test_moonlight_16B_A3B_r3.py"}, {"num_gpus": 8, "test_file": "test_mimo_7B_mtp_only_grad.py"}, {"num_gpus": 8, "test_file": "test_qwen3_0.6B_parallel_check.py"}, {"num_gpus": 8, "test_file": "test_qwen2.5_0.5B_debug_rollout_then_train.py"}, {"num_gpus": 8, "test_file": "test_qwen2.5_0.5B_opd_sglang.py"}, {"num_gpus": 6, "test_file": "test_qwen3_4B_external_pd.py"}, {"num_gpus": 4, "test_file": "test_qwen2.5_0.5B_fully_async_short.py"}, {"num_gpus": 4, "test_file": "test_qwen2.5_0.5B_fanout_short.py"}, {"num_gpus": 8, "test_file": "test_qwen3_4B_streaming_partial_rollout.py"}, {"num_gpus": 4, "test_file": "test_qwen3.5_0.8B_gsm8k_short.py"}, {"num_gpus": 4, "test_file": "test_qwen3.5_0.8B_gsm8k_async_short.py"}, {"num_gpus": 8, "test_args": "--save-optimizer gpu --load-optimizer gpu", "test_file": "test_qwen3_4B_ckpt.py"}, {"num_gpus": 8, "test_args": "--save-optimizer gpu --load-optimizer cpu", "test_file": "test_qwen3_4B_ckpt.py"}, {"num_gpus": 8, "test_args": "--save-optimizer cpu --load-optimizer cpu", "test_file": "test_qwen3_4B_ckpt.py"}, {"num_gpus": 8, "test_args": "--save-optimizer cpu --load-optimizer gpu", "test_file": "test_qwen3_4B_ckpt.py"}, {"num_gpus": 8, "test_args": "--async-save", "test_file": "test_qwen3_4B_ckpt.py"}]
+        info:
+          [
+            {
+              "num_gpus": 4,
+              "test_file": "test_full_disk_weight_update.py"
+            },
+            {
+              "enable_eval": "0",
+              "num_gpus": 8,
+              "test_file": "test_quick_start_glm4_9B.py"
+            },
+            {
+              "num_gpus": 8,
+              "test_file": "test_glm4.7_30B_A3B_pd_mooncake.py"
+            },
+            {
+              "enable_eval": "0",
+              "num_gpus": 8,
+              "test_file": "test_qwen3_30B_A3B.py",
+              "use_deepep": "1",
+              "use_fp8_rollout": "1"
+            },
+            {
+              "num_gpus": 8,
+              "test_file": "test_qwen3.6_35B_A3B_pd_mooncake.py",
+              "use_deepep": "1"
+            },
+            {
+              "enable_eval": "0",
+              "num_gpus": 8,
+              "test_file": "test_qwen3_30B_A3B_r3.py",
+              "use_deepep": "1",
+              "use_fp8_rollout": "1"
+            },
+            {
+              "enable_eval": "0",
+              "num_gpus": 8,
+              "test_file": "test_qwen3_4B_ppo.py"
+            },
+            {
+              "enable_eval": "0",
+              "num_gpus": 8,
+              "test_file": "test_qwen3_4B_ppo_disaggregate.py"
+            },
+            {
+              "enable_eval": "0",
+              "num_gpus": 8,
+              "test_file": "test_qwen3_4B_ppo_train_critic_only.py"
+            },
+            {
+              "num_gpus": 2,
+              "test_file": "test_ppo_logprob_entropy_gpu.py"
+            },
+            {
+              "enable_eval": "0",
+              "num_gpus": 8,
+              "test_file": "test_moonlight_16B_A3B.py"
+            },
+            {
+              "enable_eval": "0",
+              "num_gpus": 8,
+              "test_file": "test_moonlight_16B_A3B_r3.py"
+            },
+            {
+              "num_gpus": 8,
+              "test_file": "test_mimo_7B_mtp_only_grad.py"
+            },
+            {
+              "num_gpus": 8,
+              "test_file": "test_qwen3_0.6B_parallel_check.py"
+            },
+            {
+              "num_gpus": 8,
+              "test_file": "test_qwen2.5_0.5B_debug_rollout_then_train.py"
+            },
+            {
+              "num_gpus": 8,
+              "test_file": "test_qwen2.5_0.5B_opd_sglang.py"
+            },
+            {
+              "num_gpus": 6,
+              "test_file": "test_qwen3_4B_external_pd.py"
+            },
+            {
+              "num_gpus": 4,
+              "test_file": "test_qwen2.5_0.5B_fully_async_short.py"
+            },
+            {
+              "num_gpus": 4,
+              "test_file": "test_qwen2.5_0.5B_fanout_short.py"
+            },
+            {
+              "num_gpus": 8,
+              "test_file": "test_qwen3_4B_streaming_partial_rollout.py"
+            },
+            {
+              "num_gpus": 4,
+              "test_file": "test_qwen3.5_0.8B_gsm8k_short.py"
+            },
+            {
+              "num_gpus": 4,
+              "test_file": "test_qwen3.5_0.8B_gsm8k_async_short.py"
+            },
+            {
+              "num_gpus": 8,
+              "test_args": "--save-optimizer gpu --load-optimizer gpu",
+              "test_file": "test_qwen3_4B_ckpt.py"
+            },
+            {
+              "num_gpus": 8,
+              "test_args": "--save-optimizer gpu --load-optimizer cpu",
+              "test_file": "test_qwen3_4B_ckpt.py"
+            },
+            {
+              "num_gpus": 8,
+              "test_args": "--save-optimizer cpu --load-optimizer cpu",
+              "test_file": "test_qwen3_4B_ckpt.py"
+            },
+            {
+              "num_gpus": 8,
+              "test_args": "--save-optimizer cpu --load-optimizer gpu",
+              "test_file": "test_qwen3_4B_ckpt.py"
+            },
+            {
+              "num_gpus": 8,
+              "test_args": "--async-save",
+              "test_file": "test_qwen3_4B_ckpt.py"
+            }
+          ]
     defaults:
       run:
         working-directory: ${{ github.workspace }}

--- a/.github/workflows/pr-test.yml.j2
+++ b/.github/workflows/pr-test.yml.j2
@@ -8,6 +8,7 @@
     {'test_file': 'test_qwen3_4B_ppo.py', 'num_gpus': 8, 'enable_eval': '0'},
     {'test_file': 'test_qwen3_4B_ppo_disaggregate.py', 'num_gpus': 8, 'enable_eval': '0'},
     {'test_file': 'test_qwen3_4B_ppo_train_critic_only.py', 'num_gpus': 8, 'enable_eval': '0'},
+    {'test_file': 'test_ppo_logprob_entropy_gpu.py', 'num_gpus': 2},
     {'test_file': 'test_moonlight_16B_A3B.py', 'num_gpus': 8, 'enable_eval': '0'},
     {'test_file': 'test_moonlight_16B_A3B_r3.py', 'num_gpus': 8, 'enable_eval': '0'},
     {'test_file': 'test_mimo_7B_mtp_only_grad.py', 'num_gpus': 8},
@@ -72,6 +73,7 @@
         {'test_file': 'test_logprob_response_spans.py', 'num_gpus': 0},
         {'test_file': 'test_value_temperature.py', 'num_gpus': 0},
         {'test_file': 'test_cispo_loss.py', 'num_gpus': 0},
+        {'test_file': 'test_ppo_logprob_entropy.py', 'num_gpus': 0},
         {'test_file': 'test_rm_f1.py', 'num_gpus': 0},
         {'test_file': 'test_rm_gpqa.py', 'num_gpus': 0},
         {'test_file': 'test_rm_math.py', 'num_gpus': 0},
@@ -149,7 +151,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        info: << config.tests | tojson >>
+        info:
+<< config.tests | tojson(indent=2) | indent(10, true) >>
     defaults:
       run:
         working-directory: ${{ github.workspace }}

--- a/slime/backends/megatron_utils/loss.py
+++ b/slime/backends/megatron_utils/loss.py
@@ -485,8 +485,8 @@ def get_log_probs_and_entropy(
     per-sample slicing) so backward traverses ``[T, V]`` only once, then
     extracts per-sample response portions.
 
-    When ``entropy_coef == 0``, entropy is computed under ``torch.no_grad()``
-    to avoid retaining the computation graph and to skip cloning.
+    If rollout top-p replay is provided, the keep-mask is applied only to
+    log-probabilities; entropy is always computed from the unmasked logits.
     """
     assert non_loss_data
     assert logits.dtype == torch.float32, f"{logits.dtype}"

--- a/slime/utils/ppo_utils.py
+++ b/slime/utils/ppo_utils.py
@@ -171,74 +171,157 @@ def compute_cispo_loss(
     return pg_losses, clipfrac
 
 
-def compute_log_probs(
+def _maybe_all_reduce(tensor: torch.Tensor, op: dist.ReduceOp, process_group) -> None:
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(tensor, op=op, group=process_group)
+
+
+def _get_vocab_parallel_rank_size(process_group) -> tuple[int, int]:
+    if process_group is not None and hasattr(process_group, "rank") and hasattr(process_group, "size"):
+        return process_group.rank(), process_group.size()
+    if dist.is_available() and dist.is_initialized():
+        return dist.get_rank(group=process_group), dist.get_world_size(group=process_group)
+    return 0, 1
+
+
+class _VocabParallelLogProbEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(
+        ctx,
+        vocab_parallel_logits: torch.Tensor,
+        target: torch.Tensor,
+        log_prob_keep_mask: torch.Tensor | None,
+        process_group,
+        with_entropy: bool,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        vocab_parallel_logits = vocab_parallel_logits.float()
+        seq_len, vocab_parallel_size = vocab_parallel_logits.shape
+        rank, _world_size = _get_vocab_parallel_rank_size(process_group)
+        vocab_start_index = rank * vocab_parallel_size
+        vocab_end_index = vocab_start_index + vocab_parallel_size
+
+        target_mask = (target < vocab_start_index) | (target >= vocab_end_index)
+        masked_target_1d = (target - vocab_start_index).clone()
+        masked_target_1d[target_mask] = 0
+        arange_1d = torch.arange(seq_len, device=vocab_parallel_logits.device)
+
+        def vocab_parallel_softmax(
+            logits: torch.Tensor,
+        ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+            logits_max = logits.max(dim=-1, keepdim=True).values
+            _maybe_all_reduce(logits_max, dist.ReduceOp.MAX, process_group)
+            normalized_logits = logits - logits_max
+            exp_logits = normalized_logits.exp()
+            sum_exp_logits = exp_logits.sum(dim=-1, keepdim=True)
+            _maybe_all_reduce(sum_exp_logits, dist.ReduceOp.SUM, process_group)
+            softmax = exp_logits / sum_exp_logits
+            return normalized_logits, sum_exp_logits, softmax, logits_max
+
+        entropy = vocab_parallel_logits.new_zeros((0,))
+        entropy_softmax = vocab_parallel_logits.new_empty((0,))
+        sum_softmax_times_logits = vocab_parallel_logits.new_empty((0,))
+
+        if log_prob_keep_mask is None:
+            normalized_log_prob_logits, log_prob_sum_exp_logits, log_prob_softmax, log_prob_logits_max = (
+                vocab_parallel_softmax(vocab_parallel_logits)
+            )
+            if with_entropy:
+                entropy_softmax = log_prob_softmax
+                sum_softmax_times_logits = (entropy_softmax * vocab_parallel_logits).sum(dim=-1, keepdim=True)
+                _maybe_all_reduce(sum_softmax_times_logits, dist.ReduceOp.SUM, process_group)
+                entropy = log_prob_logits_max + log_prob_sum_exp_logits.log() - sum_softmax_times_logits
+                entropy = entropy.squeeze(dim=-1)
+        else:
+            if with_entropy:
+                _entropy_normalized_logits, entropy_sum_exp_logits, entropy_softmax, entropy_logits_max = (
+                    vocab_parallel_softmax(vocab_parallel_logits)
+                )
+                sum_softmax_times_logits = (entropy_softmax * vocab_parallel_logits).sum(dim=-1, keepdim=True)
+                _maybe_all_reduce(sum_softmax_times_logits, dist.ReduceOp.SUM, process_group)
+                entropy = entropy_logits_max + entropy_sum_exp_logits.log() - sum_softmax_times_logits
+                entropy = entropy.squeeze(dim=-1)
+
+            log_prob_logits = vocab_parallel_logits.masked_fill(~log_prob_keep_mask, float("-inf"))
+            local_target_rows = torch.nonzero(~target_mask, as_tuple=False).squeeze(-1)
+            if local_target_rows.numel() > 0:
+                log_prob_logits[local_target_rows, masked_target_1d[local_target_rows]] = vocab_parallel_logits[
+                    local_target_rows, masked_target_1d[local_target_rows]
+                ]
+            normalized_log_prob_logits, log_prob_sum_exp_logits, log_prob_softmax, _log_prob_logits_max = (
+                vocab_parallel_softmax(log_prob_logits)
+            )
+
+        predicted_logits = normalized_log_prob_logits.view(-1, vocab_parallel_size)[arange_1d, masked_target_1d]
+        predicted_logits = predicted_logits.masked_fill(target_mask, 0.0).unsqueeze(-1)
+        _maybe_all_reduce(predicted_logits, dist.ReduceOp.SUM, process_group)
+        log_prob = predicted_logits - log_prob_sum_exp_logits.log()
+
+        ctx.with_entropy = with_entropy
+        ctx.cast_log_prob_grad_to_bfloat16 = vocab_parallel_logits.is_cuda
+        ctx.save_for_backward(
+            log_prob_softmax,
+            target_mask,
+            masked_target_1d,
+            entropy_softmax,
+            sum_softmax_times_logits,
+            vocab_parallel_logits,
+        )
+        return log_prob, entropy
+
+    @staticmethod
+    def backward(
+        ctx, grad_log_prob: torch.Tensor, grad_entropy: torch.Tensor
+    ) -> tuple[torch.Tensor, None, None, None, None]:
+        (
+            log_prob_softmax,
+            target_mask,
+            masked_target_1d,
+            entropy_softmax,
+            sum_softmax_times_logits,
+            vocab_parallel_logits,
+        ) = ctx.saved_tensors
+
+        grad_input = None
+        if grad_log_prob is not None:
+            vocab_parallel_size = log_prob_softmax.size(-1)
+            grad_log_prob_input = -log_prob_softmax
+            grad_2d = grad_log_prob_input.view(-1, vocab_parallel_size)
+            arange_1d = torch.arange(grad_2d.size(0), device=grad_2d.device)
+            target_update = (~target_mask).to(dtype=grad_2d.dtype)
+            grad_2d[arange_1d, masked_target_1d] += target_update
+            grad_log_prob_input = grad_log_prob_input * grad_log_prob.reshape(-1, 1)
+            if ctx.cast_log_prob_grad_to_bfloat16:
+                # Match Megatron's fused vocab-parallel CE backward, which
+                # returns the log-prob branch gradient in bfloat16.
+                grad_log_prob_input = grad_log_prob_input.to(torch.bfloat16)
+            grad_input = grad_log_prob_input
+
+        if ctx.with_entropy and grad_entropy is not None and grad_entropy.numel() > 0:
+            grad_entropy_input = entropy_softmax * (sum_softmax_times_logits - vocab_parallel_logits)
+            grad_entropy_input = grad_entropy_input * grad_entropy.reshape(-1, 1)
+            grad_input = grad_entropy_input if grad_input is None else grad_input + grad_entropy_input
+
+        return grad_input, None, None, None, None
+
+
+def _calculate_log_probs_and_entropy_chunk(
     logits: torch.Tensor,
     tokens: torch.Tensor,
-    process_group: dist.ProcessGroup | None,
-    keep_mask: torch.Tensor | None = None,
-):
-    # TODO: when megatron is not installed, fall back to naive implementation
-    from megatron.core.fusions.fused_cross_entropy import fused_vocab_parallel_cross_entropy
-
-    if keep_mask is not None:
-        from megatron.core import mpu
-
-        # Force-keep the sampled token on its TP shard so replay remains finite
-        # even if an engine-side path records a nucleus that misses the target.
-        keep_mask = keep_mask.clone()
-        vocab_local = keep_mask.size(-1)
-        vocab_start = mpu.get_tensor_model_parallel_rank() * vocab_local
-        local_tokens = tokens - vocab_start
-        on_shard = (local_tokens >= 0) & (local_tokens < vocab_local)
-        rows = torch.nonzero(on_shard, as_tuple=False).squeeze(-1)
-        if rows.numel() > 0:
-            keep_mask[rows, local_tokens[rows]] = True
-        logits = logits.masked_fill(~keep_mask, float("-inf"))
-
-    # convert to [seq_len, batch_size, vocab_size] as expected by fused_vocab_parallel_cross_entropy
-    logits = logits.unsqueeze(1)
-    tokens = tokens.unsqueeze(1)
-    return -fused_vocab_parallel_cross_entropy(logits, tokens, process_group)
-
-
-# from https://github.com/volcengine/verl/blob/0bdf7f469854815177e73dcfe9e420836c952e6e/verl/utils/megatron/tensor_parallel.py#L99
-class _VocabParallelEntropy(torch.autograd.Function):
-
-    @staticmethod
-    def forward(ctx, vocab_parallel_logits: torch.Tensor, process_group: dist.ProcessGroup) -> torch.Tensor:
-
-        @torch.compile(dynamic=True)
-        def mul_reduce(a, b):
-            return (a * b).sum(dim=-1, keepdim=True)
-
-        logits_max = vocab_parallel_logits.max(dim=-1, keepdim=True).values
-        dist.all_reduce(logits_max, op=dist.ReduceOp.MAX, group=process_group)
-        normalized_vocab_parallel_logits = vocab_parallel_logits - logits_max
-        normalized_exp_logits = normalized_vocab_parallel_logits.exp_()
-        normalized_sum_exp_logits = normalized_exp_logits.sum(dim=-1, keepdim=True)
-        dist.all_reduce(normalized_sum_exp_logits, group=process_group)
-        softmax_logits = normalized_exp_logits.div_(normalized_sum_exp_logits)
-        sum_softmax_times_logits = mul_reduce(softmax_logits, vocab_parallel_logits)
-        dist.all_reduce(sum_softmax_times_logits, group=process_group)
-        entropy = logits_max + normalized_sum_exp_logits.log() - sum_softmax_times_logits
-        ctx.save_for_backward(vocab_parallel_logits, softmax_logits, sum_softmax_times_logits)
-        return entropy.squeeze(dim=-1)
-
-    @staticmethod
-    def backward(ctx, grad_output: torch.Tensor) -> torch.Tensor:
-        vocab_parallel_logits, softmax_logits, sum_softmax_times_logits = ctx.saved_tensors
-        # reuse softmax_logits as grad
-        vocab_parallel_logits.sub_(sum_softmax_times_logits)
-        softmax_logits.mul_(vocab_parallel_logits)
-        softmax_logits.mul_(grad_output.unsqueeze(dim=-1))
-        # recover vocab_parallel_logits
-        vocab_parallel_logits.add_(sum_softmax_times_logits)
-        softmax_logits.mul_(-1)
-        return softmax_logits, None
-
-
-def compute_entropy_from_logits(logits: torch.Tensor, process_group) -> torch.Tensor:
-    return _VocabParallelEntropy.apply(logits, process_group)
+    tp_group,
+    *,
+    with_entropy: bool,
+    log_prob_keep_mask: torch.Tensor | None,
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    log_prob, entropy = _VocabParallelLogProbEntropy.apply(
+        logits,
+        tokens,
+        log_prob_keep_mask,
+        tp_group,
+        with_entropy,
+    )
+    if not with_entropy:
+        entropy = None
+    return log_prob, entropy
 
 
 def get_grpo_returns(
@@ -703,24 +786,30 @@ def calculate_log_probs_and_entropy(
                 log_prob_keep_mask.chunk(num_chunks, dim=0) if log_prob_keep_mask is not None else [None] * num_chunks
             )
 
-            if with_entropy:
-                entropys = []
-                for logits_chunk in logits_chunks:
-                    entropy_input = logits_chunk.clone()
-                    entropys.append(compute_entropy_from_logits(entropy_input, tp_group))
-                entropy = torch.cat(entropys, dim=0)
-
             log_probs = []
+            entropy_chunks = []
             for tokens_chunk, logits_chunk, mask_chunk in zip(tokens_chunks, logits_chunks, mask_chunks, strict=True):
-                log_prob = compute_log_probs(logits_chunk.clone(), tokens_chunk, tp_group, keep_mask=mask_chunk)
+                log_prob, entropy_chunk = _calculate_log_probs_and_entropy_chunk(
+                    logits_chunk,
+                    tokens_chunk,
+                    tp_group,
+                    with_entropy=with_entropy,
+                    log_prob_keep_mask=mask_chunk,
+                )
                 log_probs.append(log_prob)
+                if entropy_chunk is not None:
+                    entropy_chunks.append(entropy_chunk)
             log_prob = torch.cat(log_probs, dim=0)
+            if entropy_chunks:
+                entropy = torch.cat(entropy_chunks, dim=0)
         else:
-            if with_entropy:
-                entropy_input = logits.clone()
-                entropy = compute_entropy_from_logits(entropy_input, tp_group)
-
-            log_prob = compute_log_probs(logits.clone(), tokens, tp_group, keep_mask=log_prob_keep_mask)
+            log_prob, entropy = _calculate_log_probs_and_entropy_chunk(
+                logits,
+                tokens,
+                tp_group,
+                with_entropy=with_entropy,
+                log_prob_keep_mask=log_prob_keep_mask,
+            )
     else:
         log_prob = logits.new_zeros((0,))
         if with_entropy:

--- a/tests/test_ppo_logprob_entropy.py
+++ b/tests/test_ppo_logprob_entropy.py
@@ -1,0 +1,420 @@
+"""CPU tests for fused PPO log-probability and entropy calculation."""
+
+from __future__ import annotations
+
+import os
+import socket
+
+import pytest
+import torch
+
+from slime.utils.ppo_utils import calculate_log_probs_and_entropy
+
+
+NUM_GPUS = 0
+
+STRICT_ATOL = 1e-8
+STRICT_RTOL = 0.0
+
+
+def _free_port() -> int:
+    sock = socket.socket()
+    sock.bind(("", 0))
+    port = sock.getsockname()[1]
+    sock.close()
+    return port
+
+
+def _unfused_reference_logprob_entropy(
+    logits: torch.Tensor,
+    tokens: torch.Tensor,
+    keep_mask: torch.Tensor | None,
+    *,
+    with_entropy: bool,
+    num_partitions: int = 1,
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    """Reference for the pre-fused behavior, preserving its reduction order."""
+    logprob_logits = logits
+    if keep_mask is not None:
+        logprob_logits = logits.masked_fill(~keep_mask, float("-inf"))
+        # Match replay behavior: the sampled token must stay finite even
+        # when an engine-side top-p mask omitted it.
+        rows = torch.arange(tokens.numel(), device=logits.device)
+        logprob_logits[rows, tokens] = logits[rows, tokens]
+
+    log_probs = _reference_log_probs_with_partition_order(logprob_logits, tokens, num_partitions=num_partitions)
+    entropy = None
+    if with_entropy:
+        entropy = _reference_entropy_with_partition_order(logits, num_partitions=num_partitions)
+    return log_probs, entropy
+
+
+def _sum_in_partition_order(chunks: list[torch.Tensor]) -> torch.Tensor:
+    total = chunks[0]
+    for chunk in chunks[1:]:
+        total = total + chunk
+    return total
+
+
+def _reference_log_probs_with_partition_order(
+    logits: torch.Tensor,
+    tokens: torch.Tensor,
+    *,
+    num_partitions: int,
+) -> torch.Tensor:
+    rows = torch.arange(tokens.numel(), device=logits.device)
+    chunks = list(logits.chunk(num_partitions, dim=-1))
+    vocab_per_partition = chunks[0].size(-1)
+
+    logits_max = torch.stack([chunk.max(dim=-1, keepdim=True).values for chunk in chunks], dim=0).max(dim=0).values
+    normalized_chunks = [chunk - logits_max for chunk in chunks]
+    exp_chunks = [chunk.exp() for chunk in normalized_chunks]
+    sum_exp_logits = _sum_in_partition_order([chunk.sum(dim=-1, keepdim=True) for chunk in exp_chunks])
+
+    predicted_logits = logits.new_zeros((tokens.numel(), 1))
+    for partition, normalized_chunk in enumerate(normalized_chunks):
+        vocab_start = partition * vocab_per_partition
+        local_tokens = tokens - vocab_start
+        on_partition = (local_tokens >= 0) & (local_tokens < vocab_per_partition)
+        local_tokens = local_tokens.clamp(0, vocab_per_partition - 1)
+        partition_predicted_logits = normalized_chunk[rows, local_tokens].unsqueeze(-1)
+        partition_predicted_logits = partition_predicted_logits.masked_fill(~on_partition.unsqueeze(-1), 0.0)
+        predicted_logits = predicted_logits + partition_predicted_logits
+
+    return predicted_logits - sum_exp_logits.log()
+
+
+def _reference_entropy_with_partition_order(logits: torch.Tensor, *, num_partitions: int) -> torch.Tensor:
+    chunks = list(logits.chunk(num_partitions, dim=-1))
+    logits_max = torch.stack([chunk.max(dim=-1, keepdim=True).values for chunk in chunks], dim=0).max(dim=0).values
+    normalized_chunks = [chunk - logits_max for chunk in chunks]
+    exp_chunks = [chunk.exp() for chunk in normalized_chunks]
+    sum_exp_logits = _sum_in_partition_order([chunk.sum(dim=-1, keepdim=True) for chunk in exp_chunks])
+    softmax_chunks = [chunk / sum_exp_logits for chunk in exp_chunks]
+    sum_softmax_times_logits = _sum_in_partition_order(
+        [(softmax * chunk).sum(dim=-1, keepdim=True) for softmax, chunk in zip(softmax_chunks, chunks, strict=True)]
+    )
+    return (logits_max + sum_exp_logits.log() - sum_softmax_times_logits).squeeze(dim=-1)
+
+
+def _reference_grad_with_partition_order(
+    logits: torch.Tensor,
+    tokens: torch.Tensor,
+    keep_mask: torch.Tensor | None,
+    *,
+    with_entropy: bool,
+    logprob_weights: torch.Tensor,
+    entropy_weights: torch.Tensor,
+    num_partitions: int = 1,
+) -> torch.Tensor:
+    logprob_logits = logits
+    if keep_mask is not None:
+        logprob_logits = logits.masked_fill(~keep_mask, float("-inf"))
+        rows = torch.arange(tokens.numel(), device=logits.device)
+        logprob_logits[rows, tokens] = logits[rows, tokens]
+
+    logprob_softmax_chunks = _reference_softmax_chunks_with_partition_order(
+        logprob_logits,
+        num_partitions=num_partitions,
+    )
+    grad_chunks = []
+    vocab_per_partition = logprob_softmax_chunks[0].size(-1)
+    for partition, softmax_chunk in enumerate(logprob_softmax_chunks):
+        vocab_start = partition * vocab_per_partition
+        local_tokens = tokens - vocab_start
+        on_partition = (local_tokens >= 0) & (local_tokens < vocab_per_partition)
+        local_tokens = local_tokens.clamp(0, vocab_per_partition - 1)
+
+        grad_chunk = -softmax_chunk
+        rows = torch.arange(tokens.numel(), device=logits.device)
+        grad_2d = grad_chunk.view(-1, vocab_per_partition)
+        grad_2d[rows, local_tokens] += on_partition.to(dtype=grad_2d.dtype)
+        grad_chunk = grad_chunk * logprob_weights.reshape(-1, 1)
+        grad_chunks.append(grad_chunk)
+
+    grad = torch.cat(grad_chunks, dim=-1)
+
+    if with_entropy:
+        entropy_softmax_chunks = _reference_softmax_chunks_with_partition_order(
+            logits,
+            num_partitions=num_partitions,
+        )
+        logits_chunks = list(logits.chunk(num_partitions, dim=-1))
+        sum_softmax_times_logits = _sum_in_partition_order(
+            [
+                (softmax * logits_chunk).sum(dim=-1, keepdim=True)
+                for softmax, logits_chunk in zip(entropy_softmax_chunks, logits_chunks, strict=True)
+            ]
+        )
+        entropy_grad = torch.cat(
+            [
+                softmax * (sum_softmax_times_logits - logits_chunk) * entropy_weights.reshape(-1, 1)
+                for softmax, logits_chunk in zip(entropy_softmax_chunks, logits_chunks, strict=True)
+            ],
+            dim=-1,
+        )
+        grad = grad + entropy_grad
+
+    return grad
+
+
+def _reference_softmax_chunks_with_partition_order(
+    logits: torch.Tensor,
+    *,
+    num_partitions: int,
+) -> list[torch.Tensor]:
+    chunks = list(logits.chunk(num_partitions, dim=-1))
+    logits_max = torch.stack([chunk.max(dim=-1, keepdim=True).values for chunk in chunks], dim=0).max(dim=0).values
+    normalized_chunks = [chunk - logits_max for chunk in chunks]
+    exp_chunks = [chunk.exp() for chunk in normalized_chunks]
+    sum_exp_logits = _sum_in_partition_order([chunk.sum(dim=-1, keepdim=True) for chunk in exp_chunks])
+    return [chunk / sum_exp_logits for chunk in exp_chunks]
+
+
+def _single_rank_logits() -> torch.Tensor:
+    return torch.tensor(
+        [
+            [1.0, 2.0, 3.0, 4.0],
+            [4.0, 1.0, 0.5, 2.0],
+            [-1.0, 3.0, 2.0, 0.0],
+        ],
+        dtype=torch.float32,
+    )
+
+
+def _single_rank_keep_mask() -> torch.Tensor:
+    return torch.tensor(
+        [
+            [False, True, True, False],  # target 3 is deliberately absent.
+            [False, True, False, True],  # target 0 is deliberately absent.
+            [True, True, False, False],
+        ],
+        dtype=torch.bool,
+    )
+
+
+def _weighted_loss(
+    log_probs: torch.Tensor,
+    entropy: torch.Tensor | None,
+    *,
+    logprob_weights: torch.Tensor,
+    entropy_weights: torch.Tensor,
+) -> torch.Tensor:
+    loss = (log_probs.squeeze(-1) * logprob_weights).sum()
+    if entropy is not None:
+        loss = loss + (entropy * entropy_weights).sum()
+    return loss
+
+
+@pytest.mark.parametrize("chunk_size", [-1, 1, 2, 8])
+@pytest.mark.parametrize("with_mask", [False, True])
+@pytest.mark.parametrize("with_entropy", [False, True])
+def test_calculate_log_probs_and_entropy_matches_unfused_reference_single_rank(
+    chunk_size: int,
+    with_mask: bool,
+    with_entropy: bool,
+):
+    logits = _single_rank_logits().requires_grad_()
+    tokens = torch.tensor([3, 0, 1], dtype=torch.long)
+    keep_mask = _single_rank_keep_mask() if with_mask else None
+
+    log_probs, entropy = calculate_log_probs_and_entropy(
+        logits,
+        tokens,
+        tp_group=None,
+        with_entropy=with_entropy,
+        chunk_size=chunk_size,
+        log_prob_keep_mask=keep_mask,
+    )
+
+    ref_logits = logits.detach().clone().requires_grad_()
+    expected_log_probs, expected_entropy = _unfused_reference_logprob_entropy(
+        ref_logits,
+        tokens,
+        keep_mask,
+        with_entropy=with_entropy,
+    )
+
+    torch.testing.assert_close(log_probs, expected_log_probs, rtol=STRICT_RTOL, atol=STRICT_ATOL)
+    if with_entropy:
+        torch.testing.assert_close(entropy, expected_entropy, rtol=STRICT_RTOL, atol=STRICT_ATOL)
+    else:
+        assert entropy is None
+        assert expected_entropy is None
+
+    logprob_weights = torch.tensor([0.25, -0.5, 1.5], dtype=torch.float32)
+    entropy_weights = torch.tensor([0.55, -0.2, 1.8], dtype=torch.float32)
+    loss = _weighted_loss(
+        log_probs,
+        entropy,
+        logprob_weights=logprob_weights,
+        entropy_weights=entropy_weights,
+    )
+    loss.backward()
+    expected_grad = _reference_grad_with_partition_order(
+        ref_logits,
+        tokens,
+        keep_mask,
+        with_entropy=with_entropy,
+        logprob_weights=logprob_weights,
+        entropy_weights=entropy_weights,
+    )
+
+    torch.testing.assert_close(logits.grad, expected_grad, rtol=STRICT_RTOL, atol=STRICT_ATOL)
+
+
+@pytest.mark.parametrize("with_entropy", [False, True])
+def test_calculate_log_probs_and_entropy_handles_empty_input(with_entropy: bool):
+    logits = torch.empty((0, 4), dtype=torch.float32, requires_grad=True)
+    tokens = torch.empty((0,), dtype=torch.long)
+    keep_mask = torch.empty((0, 4), dtype=torch.bool)
+
+    log_probs, entropy = calculate_log_probs_and_entropy(
+        logits,
+        tokens,
+        tp_group=None,
+        with_entropy=with_entropy,
+        chunk_size=2,
+        log_prob_keep_mask=keep_mask,
+    )
+
+    assert log_probs.shape == (0,)
+    if with_entropy:
+        assert entropy is not None
+        assert entropy.shape == (0,)
+    else:
+        assert entropy is None
+
+
+def _distributed_full_logits() -> torch.Tensor:
+    return torch.tensor(
+        [
+            [1.0, 2.0, 3.0, 4.0, 0.5, -1.0],
+            [4.0, 1.0, 0.5, 2.0, 3.0, 0.0],
+            [-1.0, 3.0, 2.0, 0.0, 1.0, 5.0],
+            [0.2, -0.4, 1.7, -2.0, 3.3, 0.0],
+        ],
+        dtype=torch.float32,
+    )
+
+
+def _distributed_keep_mask() -> torch.Tensor:
+    return torch.tensor(
+        [
+            [False, True, False, True, False, False],  # target 5 is absent.
+            [False, True, False, False, True, False],  # target 0 is absent.
+            [True, False, True, False, False, True],  # target 3 is absent.
+            [False, True, False, True, False, False],  # target 2 is absent.
+        ],
+        dtype=torch.bool,
+    )
+
+
+def _distributed_vocab_worker(
+    rank: int,
+    world_size: int,
+    with_mask: bool,
+    with_entropy: bool,
+    chunk_size: int,
+    master_port: int,
+) -> None:
+    import torch.distributed as dist
+
+    torch.set_num_threads(1)
+    os.environ["MASTER_ADDR"] = "127.0.0.1"
+    os.environ["MASTER_PORT"] = str(master_port)
+    dist.init_process_group(backend="gloo", rank=rank, world_size=world_size)
+    try:
+        full_logits = _distributed_full_logits()
+        tokens = torch.tensor([5, 0, 3, 2], dtype=torch.long)
+        full_keep_mask = _distributed_keep_mask() if with_mask else None
+
+        vocab_per_rank = full_logits.size(-1) // world_size
+        vocab_start = rank * vocab_per_rank
+        vocab_end = vocab_start + vocab_per_rank
+        local_logits = full_logits[:, vocab_start:vocab_end].detach().clone().requires_grad_()
+        local_keep_mask = None
+        if full_keep_mask is not None:
+            local_keep_mask = full_keep_mask[:, vocab_start:vocab_end]
+
+        log_probs, entropy = calculate_log_probs_and_entropy(
+            local_logits,
+            tokens,
+            tp_group=None,
+            with_entropy=with_entropy,
+            chunk_size=chunk_size,
+            log_prob_keep_mask=local_keep_mask,
+        )
+
+        ref_logits = full_logits.detach().clone().requires_grad_()
+        expected_log_probs, expected_entropy = _unfused_reference_logprob_entropy(
+            ref_logits,
+            tokens,
+            full_keep_mask,
+            with_entropy=with_entropy,
+            num_partitions=world_size,
+        )
+
+        torch.testing.assert_close(log_probs, expected_log_probs, rtol=STRICT_RTOL, atol=STRICT_ATOL)
+        if with_entropy:
+            torch.testing.assert_close(entropy, expected_entropy, rtol=STRICT_RTOL, atol=STRICT_ATOL)
+        else:
+            assert entropy is None
+            assert expected_entropy is None
+
+        logprob_weights = torch.tensor([0.25, -0.5, 1.5, -0.75], dtype=torch.float32)
+        entropy_weights = torch.tensor([0.55, -0.2, 1.8, 0.4], dtype=torch.float32)
+        loss = _weighted_loss(
+            log_probs,
+            entropy,
+            logprob_weights=logprob_weights,
+            entropy_weights=entropy_weights,
+        )
+        loss.backward()
+        expected_grad = _reference_grad_with_partition_order(
+            ref_logits,
+            tokens,
+            full_keep_mask,
+            with_entropy=with_entropy,
+            logprob_weights=logprob_weights,
+            entropy_weights=entropy_weights,
+            num_partitions=world_size,
+        )
+
+        torch.testing.assert_close(
+            local_logits.grad,
+            expected_grad[:, vocab_start:vocab_end],
+            rtol=STRICT_RTOL,
+            atol=STRICT_ATOL,
+        )
+    finally:
+        dist.destroy_process_group()
+
+
+@pytest.mark.parametrize(
+    "with_mask,with_entropy,chunk_size",
+    [
+        pytest.param(False, True, -1, id="unmasked_entropy_no_chunks"),
+        pytest.param(True, True, 2, id="masked_entropy_chunks"),
+        pytest.param(True, False, -1, id="masked_logprob_only_no_chunks"),
+        pytest.param(False, False, 2, id="unmasked_logprob_only_chunks"),
+    ],
+)
+def test_calculate_log_probs_and_entropy_matches_unfused_reference_vocab_parallel(
+    with_mask: bool,
+    with_entropy: bool,
+    chunk_size: int,
+):
+    import torch.multiprocessing as mp
+
+    world_size = 2
+    mp.spawn(
+        _distributed_vocab_worker,
+        args=(world_size, with_mask, with_entropy, chunk_size, _free_port()),
+        nprocs=world_size,
+        join=True,
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__]))

--- a/tests/test_ppo_logprob_entropy_gpu.py
+++ b/tests/test_ppo_logprob_entropy_gpu.py
@@ -1,0 +1,312 @@
+"""CUDA parity test for fused PPO log-probability and entropy calculation."""
+
+from __future__ import annotations
+
+import os
+import socket
+
+import pytest
+import torch
+
+from slime.utils.ppo_utils import calculate_log_probs_and_entropy
+
+
+NUM_GPUS = 2
+
+# Megatron's JIT fused CE can differ from the same Python-level expression by
+# one fp32 ulp in the unmasked path.
+FORWARD_ATOL = 1e-7
+FORWARD_RTOL = 0.0
+BACKWARD_ATOL = 1e-8
+BACKWARD_RTOL = 0.0
+
+PARITY_SCENARIOS = [
+    (-1, False, False, False),
+    (-1, False, True, False),
+    (-1, False, True, True),
+    (-1, True, False, False),
+    (-1, True, True, False),
+    (-1, True, True, True),
+    (2, False, False, False),
+    (2, False, True, False),
+    (2, False, True, True),
+    (2, True, False, False),
+    (2, True, True, False),
+    (2, True, True, True),
+]
+
+
+def _free_port() -> int:
+    sock = socket.socket()
+    sock.bind(("", 0))
+    port = sock.getsockname()[1]
+    sock.close()
+    return port
+
+
+def _full_logits() -> torch.Tensor:
+    return torch.tensor(
+        [
+            [1.0, 2.0, 3.0, 4.0, 0.5, -1.0],
+            [4.0, 1.0, 0.5, 2.0, 3.0, 0.0],
+            [-1.0, 3.0, 2.0, 0.0, 1.0, 5.0],
+            [0.2, -0.4, 1.7, -2.0, 3.3, 0.0],
+        ],
+        dtype=torch.float32,
+    )
+
+
+def _keep_mask() -> torch.Tensor:
+    return torch.tensor(
+        [
+            [False, True, False, True, False, False],  # target 5 is absent.
+            [False, True, False, False, True, False],  # target 0 is absent.
+            [True, False, True, False, False, True],  # target 3 is absent.
+            [False, True, False, True, False, False],  # target 2 is absent.
+        ],
+        dtype=torch.bool,
+    )
+
+
+def _weighted_loss(
+    log_probs: torch.Tensor,
+    entropy: torch.Tensor | None,
+    *,
+    logprob_weights: torch.Tensor,
+    entropy_weights: torch.Tensor | None,
+) -> torch.Tensor:
+    loss = (log_probs.squeeze(-1) * logprob_weights).sum()
+    if entropy is not None and entropy_weights is not None:
+        loss = loss + (entropy * entropy_weights).sum()
+    return loss
+
+
+def _legacy_compute_log_probs(
+    logits: torch.Tensor,
+    tokens: torch.Tensor,
+    process_group,
+    keep_mask: torch.Tensor | None = None,
+) -> torch.Tensor:
+    from megatron.core.fusions.fused_cross_entropy import fused_vocab_parallel_cross_entropy
+
+    if keep_mask is not None:
+        keep_mask = keep_mask.clone()
+        vocab_local = keep_mask.size(-1)
+        vocab_start = process_group.rank() * vocab_local
+        local_tokens = tokens - vocab_start
+        on_shard = (local_tokens >= 0) & (local_tokens < vocab_local)
+        rows = torch.nonzero(on_shard, as_tuple=False).squeeze(-1)
+        if rows.numel() > 0:
+            keep_mask[rows, local_tokens[rows]] = True
+        logits = logits.masked_fill(~keep_mask, float("-inf"))
+
+    return -fused_vocab_parallel_cross_entropy(logits.unsqueeze(1), tokens.unsqueeze(1), process_group)
+
+
+class _LegacyVocabParallelEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, vocab_parallel_logits: torch.Tensor, process_group) -> torch.Tensor:
+        logits_max = vocab_parallel_logits.max(dim=-1, keepdim=True).values
+        torch.distributed.all_reduce(logits_max, op=torch.distributed.ReduceOp.MAX, group=process_group)
+        normalized_vocab_parallel_logits = vocab_parallel_logits - logits_max
+        normalized_exp_logits = normalized_vocab_parallel_logits.exp_()
+        normalized_sum_exp_logits = normalized_exp_logits.sum(dim=-1, keepdim=True)
+        torch.distributed.all_reduce(normalized_sum_exp_logits, group=process_group)
+        softmax_logits = normalized_exp_logits.div_(normalized_sum_exp_logits)
+        sum_softmax_times_logits = (softmax_logits * vocab_parallel_logits).sum(dim=-1, keepdim=True)
+        torch.distributed.all_reduce(sum_softmax_times_logits, group=process_group)
+        entropy = logits_max + normalized_sum_exp_logits.log() - sum_softmax_times_logits
+        ctx.save_for_backward(vocab_parallel_logits, softmax_logits, sum_softmax_times_logits)
+        return entropy.squeeze(dim=-1)
+
+    @staticmethod
+    def backward(ctx, grad_output: torch.Tensor) -> tuple[torch.Tensor, None]:
+        vocab_parallel_logits, softmax_logits, sum_softmax_times_logits = ctx.saved_tensors
+        grad_input = softmax_logits * (sum_softmax_times_logits - vocab_parallel_logits)
+        grad_input = grad_input * grad_output.unsqueeze(dim=-1)
+        return grad_input, None
+
+
+def _legacy_compute_entropy_from_logits(logits: torch.Tensor, process_group) -> torch.Tensor:
+    return _LegacyVocabParallelEntropy.apply(logits, process_group)
+
+
+def _assert_legacy_parity(
+    *,
+    process_group,
+    device: torch.device,
+    logits: torch.Tensor,
+    tokens: torch.Tensor,
+    keep_mask: torch.Tensor | None,
+    chunk_size: int,
+    with_entropy: bool,
+    entropy_has_grad: bool,
+) -> None:
+    log_probs, entropy = calculate_log_probs_and_entropy(
+        logits,
+        tokens,
+        tp_group=process_group,
+        with_entropy=with_entropy,
+        chunk_size=chunk_size,
+        log_prob_keep_mask=keep_mask,
+    )
+
+    legacy_logits = logits.detach().clone().requires_grad_()
+    legacy_log_probs = _legacy_compute_log_probs(legacy_logits.clone(), tokens, process_group, keep_mask=keep_mask)
+
+    torch.testing.assert_close(log_probs, legacy_log_probs, rtol=FORWARD_RTOL, atol=FORWARD_ATOL)
+    if with_entropy:
+        legacy_entropy = _legacy_compute_entropy_from_logits(legacy_logits.clone(), process_group)
+        torch.testing.assert_close(entropy, legacy_entropy, rtol=FORWARD_RTOL, atol=FORWARD_ATOL)
+    else:
+        legacy_entropy = None
+        assert entropy is None
+
+    logprob_weights = torch.tensor([0.25, -0.5, 1.5, -0.75], dtype=torch.float32, device=device)
+    entropy_weights = torch.tensor([0.55, -0.2, 1.8, 0.4], dtype=torch.float32, device=device)
+    if not entropy_has_grad:
+        entropy_weights = None
+    loss = _weighted_loss(
+        log_probs,
+        entropy,
+        logprob_weights=logprob_weights,
+        entropy_weights=entropy_weights,
+    )
+    legacy_loss = _weighted_loss(
+        legacy_log_probs,
+        legacy_entropy,
+        logprob_weights=logprob_weights,
+        entropy_weights=entropy_weights,
+    )
+    loss.backward()
+    legacy_loss.backward()
+
+    torch.testing.assert_close(
+        logits.grad,
+        legacy_logits.grad,
+        rtol=BACKWARD_RTOL,
+        atol=BACKWARD_ATOL,
+    )
+
+
+@pytest.fixture(scope="module")
+def nccl_process_group():
+    import torch.distributed as dist
+
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required")
+    pytest.importorskip("megatron.core.fusions.fused_cross_entropy")
+    if not dist.is_nccl_available():
+        pytest.skip("NCCL is required")
+
+    created_process_group = False
+    if dist.is_initialized():
+        process_group = dist.group.WORLD
+        if dist.get_backend(process_group) != "nccl":
+            pytest.skip("legacy Megatron CUDA parity needs an NCCL process group")
+    else:
+        os.environ["MASTER_ADDR"] = "127.0.0.1"
+        os.environ["MASTER_PORT"] = str(_free_port())
+        dist.init_process_group(backend="nccl", rank=0, world_size=1)
+        created_process_group = True
+        process_group = dist.group.WORLD
+
+    yield process_group
+
+    if created_process_group:
+        dist.destroy_process_group()
+
+
+@pytest.mark.parametrize(
+    "with_entropy,entropy_has_grad",
+    [
+        pytest.param(False, False, id="without_entropy"),
+        pytest.param(True, False, id="entropy_forward_only"),
+        pytest.param(True, True, id="entropy_backward"),
+    ],
+)
+@pytest.mark.parametrize("with_mask", [False, True], ids=["unmasked", "masked"])
+@pytest.mark.parametrize("chunk_size", [-1, 2], ids=["no_chunks", "chunks"])
+def test_calculate_log_probs_and_entropy_matches_legacy_megatron_cuda(
+    nccl_process_group,
+    chunk_size: int,
+    with_mask: bool,
+    with_entropy: bool,
+    entropy_has_grad: bool,
+):
+    process_group = nccl_process_group
+    torch.cuda.set_device(0)
+    device = torch.device("cuda", torch.cuda.current_device())
+    logits = _full_logits().to(device=device).requires_grad_()
+    tokens = torch.tensor([5, 0, 3, 2], dtype=torch.long, device=device)
+    keep_mask = _keep_mask().to(device=device) if with_mask else None
+
+    _assert_legacy_parity(
+        process_group=process_group,
+        device=device,
+        logits=logits,
+        tokens=tokens,
+        keep_mask=keep_mask,
+        chunk_size=chunk_size,
+        with_entropy=with_entropy,
+        entropy_has_grad=entropy_has_grad,
+    )
+
+
+def _tp2_worker(rank: int, world_size: int, master_port: int) -> None:
+    import torch.distributed as dist
+
+    os.environ["MASTER_ADDR"] = "127.0.0.1"
+    os.environ["MASTER_PORT"] = str(master_port)
+    torch.cuda.set_device(rank)
+    dist.init_process_group(backend="nccl", rank=rank, world_size=world_size)
+    try:
+        process_group = dist.group.WORLD
+        device = torch.device("cuda", rank)
+        full_logits = _full_logits().to(device=device)
+        full_keep_mask = _keep_mask().to(device=device)
+        tokens = torch.tensor([5, 0, 3, 2], dtype=torch.long, device=device)
+
+        vocab_per_rank = full_logits.size(-1) // world_size
+        vocab_start = rank * vocab_per_rank
+        vocab_end = vocab_start + vocab_per_rank
+        for chunk_size, with_mask, with_entropy, entropy_has_grad in PARITY_SCENARIOS:
+            logits = full_logits[:, vocab_start:vocab_end].detach().clone().requires_grad_()
+            keep_mask = full_keep_mask[:, vocab_start:vocab_end] if with_mask else None
+            _assert_legacy_parity(
+                process_group=process_group,
+                device=device,
+                logits=logits,
+                tokens=tokens,
+                keep_mask=keep_mask,
+                chunk_size=chunk_size,
+                with_entropy=with_entropy,
+                entropy_has_grad=entropy_has_grad,
+            )
+    finally:
+        dist.destroy_process_group()
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_calculate_log_probs_and_entropy_matches_legacy_megatron_cuda_tp2():
+    pytest.importorskip("megatron.core.fusions.fused_cross_entropy")
+    if torch.cuda.device_count() < 2:
+        pytest.skip("TP=2 parity requires two CUDA devices")
+
+    import torch.distributed as dist
+    import torch.multiprocessing as mp
+
+    if not dist.is_nccl_available():
+        pytest.skip("NCCL is required")
+
+    world_size = 2
+    mp.spawn(
+        _tp2_worker,
+        args=(world_size, _free_port()),
+        nprocs=world_size,
+        join=True,
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__]))


### PR DESCRIPTION
Replace the separate logprob and entropy paths with a fused autograd helper and remove the unused production legacy helpers.

Add CPU torch/gloo coverage plus a 1-GPU legacy Megatron parity test, and register both tests in the PR workflow.