### PR TITLE
feat(p2p): add shard-level weight update with automatic broadcast fallback

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -127,6 +127,18 @@ RUN if [ "$ENABLE_SGLANG_PATCH" = "1" ]; then \
   rm sglang-top_p.patch; \
 fi
 
+COPY docker/patch/${PATCH_VERSION}/sglang_p2p.patch /sgl-workspace/sglang/
+RUN if [ "$ENABLE_SGLANG_PATCH" = "1" ]; then \
+  cd /sgl-workspace/sglang && \
+  git update-index --refresh && \
+  git apply sglang_p2p.patch --3way && \
+  if grep -R -n '^<<<<<<< ' .; then \
+    echo "sglang_p2p.patch failed to apply cleanly. Please resolve conflicts." && \
+    exit 1; \
+  fi && \
+  rm sglang_p2p.patch; \
+fi
+
 # ====================================== Install main package ============================================
 
 ARG SLIME_COMMIT=main

--- a/docker/patch/latest/sglang_p2p.patch
+++ b/docker/patch/latest/sglang_p2p.patch
@@ -1,7 +1,8 @@
 diff --git a/python/sglang/srt/managers/io_struct.py b/python/sglang/srt/managers/io_struct.py
+index 17f2d5e..74fedec 100644
 --- a/python/sglang/srt/managers/io_struct.py
 +++ b/python/sglang/srt/managers/io_struct.py
-@@ -1527,6 +1527,9 @@
+@@ -1527,6 +1527,9 @@ class UpdateWeightsFromDistributedReqInput(BaseReq):
      load_format: Optional[str] = None
      # JSON-encoded DeltaSpec; required iff load_format == "delta".
      delta: Optional[str] = None
@@ -12,9 +13,10 @@ diff --git a/python/sglang/srt/managers/io_struct.py b/python/sglang/srt/manager
      torch_empty_cache: bool = False
  
 diff --git a/python/sglang/srt/managers/tp_worker.py b/python/sglang/srt/managers/tp_worker.py
+index 71bbe8f..52ede6f 100644
 --- a/python/sglang/srt/managers/tp_worker.py
 +++ b/python/sglang/srt/managers/tp_worker.py
-@@ -155,6 +155,8 @@
+@@ -155,6 +155,8 @@ class BaseTpWorker(ABC):
              recv_req.group_name,
              recv_req.load_format,
              recv_req.delta,
@@ -24,12 +26,14 @@ diff --git a/python/sglang/srt/managers/tp_worker.py b/python/sglang/srt/manager
          return success, message
  
 diff --git a/python/sglang/srt/model_executor/model_runner.py b/python/sglang/srt/model_executor/model_runner.py
+index d715bc6..e7c4356 100644
 --- a/python/sglang/srt/model_executor/model_runner.py
 +++ b/python/sglang/srt/model_executor/model_runner.py
-@@ -358,6 +358,15 @@
+@@ -358,6 +358,16 @@ class _EagerBufferRegistry:
      max_num_tokens: int = 0
  
  
++
 +
 +def _set_presharded_flag(model, value: bool):
 +    for module in model.modules():
@@ -42,7 +46,7 @@ diff --git a/python/sglang/srt/model_executor/model_runner.py b/python/sglang/sr
  class ModelRunner(ModelRunnerKVCacheMixin):
      """ModelRunner runs the forward passes of the models."""
  
-@@ -1874,6 +1883,7 @@
+@@ -1874,6 +1884,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                  world_size=world_size,
                  rank=rank,
                  group_name=group_name,
@@ -50,7 +54,7 @@ diff --git a/python/sglang/srt/model_executor/model_runner.py b/python/sglang/sr
              )
              return True, "Succeeded to initialize custom process group."
          except Exception as e:
-@@ -1902,6 +1912,8 @@
+@@ -1902,6 +1913,8 @@ class ModelRunner(ModelRunnerKVCacheMixin):
          group_name,
          load_format: Optional[str] = None,
          delta: Optional[str] = None,
@@ -59,7 +63,7 @@ diff --git a/python/sglang/srt/model_executor/model_runner.py b/python/sglang/sr
      ):
          """
          Update specific parameter in the model weights online
-@@ -1935,26 +1947,57 @@
+@@ -1935,26 +1948,62 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                  names, dtypes, shapes, group_name, spec
              )
          try:
@@ -92,6 +96,7 @@ diff --git a/python/sglang/srt/model_executor/model_runner.py b/python/sglang/sr
 +                    my_shapes = shapes
 +                torch.distributed.barrier(group=pg)
 +                weights = []
++                handles = []
 +                src_rank = self.tp_rank
 +                for name, dtype, shape in zip(my_names, my_dtypes, my_shapes):
 +                    target_dtype = (
@@ -102,8 +107,12 @@ diff --git a/python/sglang/srt/model_executor/model_runner.py b/python/sglang/sr
 -            for handle in handles:
 -                handle.wait()
 +                    weight = torch.empty(shape, dtype=target_dtype, device=self.device)
-+                    torch.distributed.recv(weight, src=src_rank, group=pg)
++                    handles.append(
++                        torch.distributed.irecv(weight, src=src_rank, group=pg)
++                    )
 +                    weights.append((name, weight))
++                for handle in handles:
++                    handle.wait()
 +                _set_presharded_flag(self.model, True)
 +                try:
 +                    self.model.load_weights(weights)

--- a/docker/patch/latest/sglang_p2p.patch
+++ b/docker/patch/latest/sglang_p2p.patch
@@ -1,0 +1,137 @@
+diff --git a/python/sglang/srt/managers/io_struct.py b/python/sglang/srt/managers/io_struct.py
+--- a/python/sglang/srt/managers/io_struct.py
++++ b/python/sglang/srt/managers/io_struct.py
+@@ -1527,6 +1527,9 @@
+     load_format: Optional[str] = None
+     # JSON-encoded DeltaSpec; required iff load_format == "delta".
+     delta: Optional[str] = None
++    src_tp_rank: Optional[int] = None
++    # Per-TP-rank tensor counts for P2P shard-level weight transfer
++    tp_tensor_counts: Optional[List[int]] = None
+     # Whether to call torch.cuda.empty_cache() during flush
+     torch_empty_cache: bool = False
+ 
+diff --git a/python/sglang/srt/managers/tp_worker.py b/python/sglang/srt/managers/tp_worker.py
+--- a/python/sglang/srt/managers/tp_worker.py
++++ b/python/sglang/srt/managers/tp_worker.py
+@@ -155,6 +155,8 @@
+             recv_req.group_name,
+             recv_req.load_format,
+             recv_req.delta,
++            recv_req.src_tp_rank,
++            recv_req.tp_tensor_counts,
+         )
+         return success, message
+ 
+diff --git a/python/sglang/srt/model_executor/model_runner.py b/python/sglang/srt/model_executor/model_runner.py
+--- a/python/sglang/srt/model_executor/model_runner.py
++++ b/python/sglang/srt/model_executor/model_runner.py
+@@ -358,6 +358,15 @@
+     max_num_tokens: int = 0
+ 
+ 
++
++def _set_presharded_flag(model, value: bool):
++    for module in model.modules():
++        if hasattr(module, "use_presharded_weights"):
++            module.use_presharded_weights = value
++    for _name, param in model.named_parameters():
++        if hasattr(param, "use_presharded_weights"):
++            param.use_presharded_weights = value
++
+ class ModelRunner(ModelRunnerKVCacheMixin):
+     """ModelRunner runs the forward passes of the models."""
+ 
+@@ -1874,6 +1883,7 @@
+                 world_size=world_size,
+                 rank=rank,
+                 group_name=group_name,
++                device_id=torch.device("cuda", self.gpu_id),
+             )
+             return True, "Succeeded to initialize custom process group."
+         except Exception as e:
+@@ -1902,6 +1912,8 @@
+         group_name,
+         load_format: Optional[str] = None,
+         delta: Optional[str] = None,
++        src_tp_rank: Optional[int] = None,
++        tp_tensor_counts: Optional[list] = None,
+     ):
+         """
+         Update specific parameter in the model weights online
+@@ -1935,26 +1947,57 @@
+                 names, dtypes, shapes, group_name, spec
+             )
+         try:
+-            weights = []
+-            handles = []
+-            for name, dtype, shape in zip(names, dtypes, shapes):
+-                target_dtype = (
+-                    dtype if isinstance(dtype, torch.dtype) else getattr(torch, dtype)
+-                )
+-                weight = torch.empty(shape, dtype=target_dtype, device=self.device)
+-                handles.append(
+-                    torch.distributed.broadcast(
+-                        weight,
+-                        src=0,
+-                        group=self._model_update_group[group_name],
+-                        async_op=True,
++            pg = self._model_update_group[group_name]
++
++            if load_format == "presharded":
++                if tp_tensor_counts is not None:
++                    my_idx = self.tp_rank
++                    offset = sum(tp_tensor_counts[:my_idx])
++                    my_count = tp_tensor_counts[my_idx]
++                    my_names = names[offset:offset + my_count]
++                    my_dtypes = dtypes[offset:offset + my_count]
++                    my_shapes = shapes[offset:offset + my_count]
++                else:
++                    my_names = names
++                    my_dtypes = dtypes
++                    my_shapes = shapes
++                torch.distributed.barrier(group=pg)
++                weights = []
++                src_rank = self.tp_rank
++                for name, dtype, shape in zip(my_names, my_dtypes, my_shapes):
++                    target_dtype = (
++                        dtype if isinstance(dtype, torch.dtype) else getattr(torch, dtype)
+                     )
+-                )
+-                weights.append((name, weight))
+-            for handle in handles:
+-                handle.wait()
++                    weight = torch.empty(shape, dtype=target_dtype, device=self.device)
++                    torch.distributed.recv(weight, src=src_rank, group=pg)
++                    weights.append((name, weight))
++                _set_presharded_flag(self.model, True)
++                try:
++                    self.model.load_weights(weights)
++                finally:
++                    _set_presharded_flag(self.model, False)
++            else:
++                weights = []
++                handles = []
++                for name, dtype, shape in zip(names, dtypes, shapes):
++                    target_dtype = (
++                        dtype if isinstance(dtype, torch.dtype) else getattr(torch, dtype)
++                    )
++                    weight = torch.empty(shape, dtype=target_dtype, device=self.device)
++                    handles.append(
++                        torch.distributed.broadcast(
++                            weight,
++                            src=0,
++                            group=pg,
++                            async_op=True,
++                        )
++                    )
++                    weights.append((name, weight))
++                for handle in handles:
++                    handle.wait()
++
++                self.model.load_weights(weights)
+ 
+-            self.model.load_weights(weights)
+             return True, "Succeeded to update parameter online."
+ 
+         except Exception as e:

--- a/docs/en/advanced/p2p-weight-sync.md
+++ b/docs/en/advanced/p2p-weight-sync.md
@@ -1,0 +1,90 @@
+# P2P Shard Weight Sync
+
+- [Why](#why)
+- [Quick Start](#quick-start)
+- [Prerequisites and Automatic Fallback](#prerequisites-and-automatic-fallback)
+- [How It Works](#how-it-works)
+- [Comparison with Default Broadcast](#comparison-with-default-broadcast)
+- [FAQ](#faq)
+
+## Why
+
+In non-colocate mode, slime's default path **all_gathers** Megatron TP shards and **NCCL-broadcasts** full HF weights to SGLang rollout engines. For large models, gathering and rebroadcasting every parameter dominates the sync phase.
+
+P2P shard sync lets each training TP rank send its local shard directly to the matching inference TP rank via `dist.send/recv`, skipping the full gather/broadcast.
+
+## Quick Start
+
+Use the **official slime Docker image** (the SGLang P2P patch is applied automatically at build time, after `sglang.patch` and `sglang-top_p.patch` — no manual steps).
+
+Typical non-colocate setup for Qwen3-4B with Megatron TP=4 and one engine using 4 GPUs:
+
+```bash
+python3 train.py \
+  --actor-num-nodes 1 \
+  --actor-num-gpus-per-node 4 \
+  --tensor-model-parallel-size 4 \
+  --rollout-num-gpus 4 \
+  --rollout-num-gpus-per-engine 4 \
+  --megatron-to-hf-mode bridge \
+  --update-weight-mode full \
+  --use-p2p-weight-update \
+  --hf-checkpoint /path/to/Qwen3-4B \
+  ...
+```
+
+Key flags:
+
+| Flag | Meaning |
+|---|---|
+| `--use-p2p-weight-update` | Enable P2P shard sync (falls back to broadcast when preconditions fail) |
+| `--update-weight-mode full` | P2P requires full weight sync |
+| `--megatron-to-hf-mode bridge` | **Required** — P2P relies on Megatron Bridge weight layout |
+| `--tensor-model-parallel-size` | Training TP; must match SGLang TP |
+| `--rollout-num-gpus-per-engine` | GPUs per engine; SGLang TP = this value / `sglang_pp_size` |
+
+## Prerequisites and Automatic Fallback
+
+With `--use-p2p-weight-update`, slime checks the conditions below at startup. **If any fail, NCCL broadcast is used instead**, and rank 0 prints `[P2P] ... using NCCL broadcast weight update instead.`:
+
+| Condition | Notes |
+|---|---|
+| Non-colocate | Colocate uses `UpdateWeightFromTensor`, not P2P |
+| `--megatron-to-hf-mode bridge` | Raw mode does not support P2P |
+| Shard-level conversion implemented | Currently **Qwen2 / Qwen3 dense**; MoE and other architectures fall back |
+| Megatron TP == SGLang TP | Every rollout engine must align with training TP |
+| SGLang PP == 1 | P2P send/recv pairing requires `sglang_pp_size=1`; otherwise falls back |
+
+TP alignment:
+
+```
+Megatron TP  = tensor_model_parallel_size
+SGLang TP    = rollout_num_gpus_per_engine / sglang_pp_size
+```
+
+## How It Works
+
+1. **Vocab params** (embed / lm_head): small TP all_gather, strip Megatron padding, slice to SGLang shard boundaries.
+2. **Other params**: shard-level Megatron→HF conversion (`convert_shard_to_hf`) without all_gather.
+3. **Per bucket**: `all_gather_object` metadata → rank-0 HTTP notify SGLang → NCCL barrier → parallel `dist.send` → `ray.get` for load completion.
+
+Implementation: `slime/backends/megatron_utils/update_weight/update_weight_from_distributed_p2p.py`.
+
+## Comparison with Default Broadcast
+
+| | NCCL broadcast (default) | P2P shard |
+|---|---|---|
+| Trainer | TP all_gather → full HF weights | Each rank converts/sends its shard only |
+| Communication | Broadcast full chunks | `dist.send/recv` per shard |
+| Models | Any bridge-supported model | Currently Qwen2/Qwen3 dense + bridge |
+| TP requirement | No strict alignment | Megatron TP == SGLang TP |
+
+Omit `--use-p2p-weight-update` to use the default broadcast path.
+
+## FAQ
+
+**Q: P2P is enabled but logs show NCCL broadcast?**  
+A: Check the rank-0 `[P2P]` message. Common causes: `--megatron-to-hf-mode raw`, unsupported/MoE models, TP mismatch, or `sglang_pp_size > 1`.
+
+**Q: Relation to delta sync?**  
+A: Mutually exclusive. P2P is under `--update-weight-mode full`; see [Delta Weight Sync](delta-weight-sync.md) for sparse updates.

--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -85,6 +85,7 @@ Start by Use Case
    advanced/pd-disaggregation.md
    advanced/external-rollout-engines.md
    advanced/delta-weight-sync.md
+   advanced/p2p-weight-sync.md
    advanced/sglang-config.md
    advanced/megatron-config.md
    advanced/arch-support-beyond-megatron.md

--- a/docs/zh/advanced/p2p-weight-sync.md
+++ b/docs/zh/advanced/p2p-weight-sync.md
@@ -1,0 +1,90 @@
+# P2P 分片权重同步
+
+- [背景](#背景)
+- [快速开始](#快速开始)
+- [前置条件与自动回退](#前置条件与自动回退)
+- [工作原理](#工作原理)
+- [与默认 broadcast 对比](#与默认-broadcast-对比)
+- [常见问题](#常见问题)
+
+## 背景
+
+slime 在非 colocate 模式下，默认通过 **all_gather + NCCL broadcast** 将 Megatron 训练权重同步到 SGLang rollout engine。对大模型而言，gather 全量参数再 broadcast 的开销显著。
+
+P2P 分片同步让每个训练 TP rank 将自身 shard 经 `dist.send/recv` 直接发给对应推理 TP rank，跳过全量 gather/broadcast。
+
+## 快速开始
+
+请使用**官方 slime Docker 镜像**（`docker build` 时已在 `sglang.patch` / `sglang-top_p.patch` 之后自动应用 SGLang P2P patch，无需手动操作）。
+
+非 colocate 训练，Qwen3-4B、Megatron TP=4、单 engine 占 4 GPU 的典型配置：
+
+```bash
+python3 train.py \
+  --actor-num-nodes 1 \
+  --actor-num-gpus-per-node 4 \
+  --tensor-model-parallel-size 4 \
+  --rollout-num-gpus 4 \
+  --rollout-num-gpus-per-engine 4 \
+  --megatron-to-hf-mode bridge \
+  --update-weight-mode full \
+  --use-p2p-weight-update \
+  --hf-checkpoint /path/to/Qwen3-4B \
+  ...
+```
+
+关键开关：
+
+| 参数 | 说明 |
+|---|---|
+| `--use-p2p-weight-update` | 启用 P2P 分片同步（不满足条件时自动回退 broadcast） |
+| `--update-weight-mode full` | P2P 仅支持 full 模式 |
+| `--megatron-to-hf-mode bridge` | **必须**；P2P 依赖 Megatron Bridge 的权重布局 |
+| `--tensor-model-parallel-size` | 训练 TP，须与 SGLang TP 一致 |
+| `--rollout-num-gpus-per-engine` | 单 engine GPU 数；SGLang TP = 该值 / `sglang_pp_size` |
+
+## 前置条件与自动回退
+
+开启 `--use-p2p-weight-update` 后，slime 在启动时检查以下条件。**任一不满足则自动使用 NCCL broadcast**，并在 rank 0 打印 `[P2P] ... using NCCL broadcast weight update instead.`：
+
+| 条件 | 说明 |
+|---|---|
+| 非 colocate | colocate 走 `UpdateWeightFromTensor`，与 P2P 无关 |
+| `--megatron-to-hf-mode bridge` | raw 模式不支持 P2P |
+| 模型支持 shard 级转换 | 当前实现：**Qwen2 / Qwen3 稠密**；MoE 及其他架构暂回退 |
+| Megatron TP == SGLang TP | 每个 rollout engine 的 TP 均须与训练 TP 对齐 |
+| SGLang PP == 1 | `sglang_pp_size > 1` 时 P2P send/recv 无法正确配对，自动回退 |
+
+TP 对齐关系：
+
+```
+Megatron TP  = tensor_model_parallel_size
+SGLang TP    = rollout_num_gpus_per_engine / sglang_pp_size
+```
+
+## 工作原理
+
+1. **词表参数**（embed / lm_head）：TP 组内小范围 all_gather，去 Megatron padding 后按 SGLang 分片边界切分。
+2. **其余参数**：shard 级 Megatron→HF 转换（`convert_shard_to_hf`），不做 all_gather。
+3. **每个 bucket**：`all_gather_object` 元数据 → rank-0 HTTP 通知 SGLang → NCCL barrier → 并行 `dist.send` → `ray.get` 等待 load 完成。
+
+实现见 `slime/backends/megatron_utils/update_weight/update_weight_from_distributed_p2p.py`。
+
+## 与默认 broadcast 对比
+
+| | NCCL broadcast（默认） | P2P 分片 |
+|---|---|---|
+| 训练侧 | TP all_gather → 全量 HF 权重 | 各 rank 只转换/发送本地 shard |
+| 通信 | broadcast 全量 chunk | `dist.send/recv` 按 shard |
+| 适用模型 | bridge 支持的模型 | 当前仅 Qwen2/Qwen3 稠密 + bridge |
+| TP 要求 | 无严格对齐要求 | Megatron TP == SGLang TP |
+
+去掉 `--use-p2p-weight-update` 即恢复默认 broadcast 路径。
+
+## 常见问题
+
+**Q: 开了 P2P 但日志显示 NCCL broadcast？**  
+A: 查看 rank 0 的 `[P2P]` 提示：常见原因是 `--megatron-to-hf-mode raw`、MoE/未支持模型、TP 不对齐、或 `sglang_pp_size > 1`。
+
+**Q: 与 delta 同步的关系？**  
+A: 互斥。P2P 属于 `--update-weight-mode full`；delta 同步见 [Delta 权重同步](delta-weight-sync.md)。

--- a/docs/zh/index.rst
+++ b/docs/zh/index.rst
@@ -85,6 +85,7 @@ slime 的设计目标，是让这两大能力彼此强化，同时避免把系�
    advanced/pd-disaggregation.md
    advanced/external-rollout-engines.md
    advanced/delta-weight-sync.md
+   advanced/p2p-weight-sync.md
    advanced/sglang-config.md
    advanced/megatron-config.md
    advanced/arch-support-beyond-megatron.md

--- a/slime/backends/megatron_utils/actor.py
+++ b/slime/backends/megatron_utils/actor.py
@@ -36,6 +36,7 @@ from .model import forward_only, initialize_model_and_optimizer, save, train
 from .update_weight.common import named_params_and_buffers
 from .update_weight.update_weight_from_disk import UpdateWeightFromDisk
 from .update_weight.update_weight_from_distributed import UpdateWeightFromDistributed
+from .update_weight.update_weight_from_distributed_p2p import UpdateWeightFromDistributedP2P
 from .update_weight.update_weight_from_tensor import UpdateWeightFromTensor
 
 logging.getLogger("megatron").setLevel(logging.WARNING)
@@ -148,6 +149,23 @@ class MegatronTrainRayActor(TrainRayActor):
             from .update_weight.update_weight_from_distributed_delta import UpdateWeightFromDistributedDelta
 
             update_weight_cls = UpdateWeightFromDistributedDelta
+        elif getattr(self.args, "use_p2p_weight_update", False):
+            assert self.args.update_weight_mode == "full", "--use-p2p-weight-update requires --update-weight-mode=full"
+            from .update_weight.common import p2p_weight_update_fallback_reason, p2p_weight_update_supported
+
+            model_name = (
+                type(self.hf_config).__name__.lower() if self.args.model_name is None else self.args.model_name
+            )
+            if p2p_weight_update_supported(self.args, model_name):
+                update_weight_cls = UpdateWeightFromDistributedP2P
+            else:
+                update_weight_cls = UpdateWeightFromDistributed
+                if (
+                    mpu.get_data_parallel_rank(with_context_parallel=True) == 0
+                    and mpu.get_tensor_model_parallel_rank() == 0
+                ):
+                    reason = p2p_weight_update_fallback_reason(self.args, model_name)
+                    print(f"[P2P] {reason}; using NCCL broadcast weight update instead.")
         else:
             assert self.args.update_weight_mode == "full"
             if self.args.update_weight_transport == "disk":

--- a/slime/backends/megatron_utils/megatron_to_hf/__init__.py
+++ b/slime/backends/megatron_utils/megatron_to_hf/__init__.py
@@ -7,7 +7,7 @@ from .llama import convert_llama_to_hf
 from .mimo import convert_mimo_to_hf
 from .minimax_m2 import convert_minimax_m2_to_hf
 from .processors import quantize_params, remove_padding
-from .qwen2 import convert_qwen2_to_hf
+from .qwen2 import convert_qwen2_shard_to_hf, convert_qwen2_to_hf
 from .qwen3_5 import convert_qwen3_5_to_hf
 from .qwen3_next import convert_qwen3_next_to_hf
 from .qwen3_vl import convert_qwen3vl_to_hf
@@ -28,6 +28,18 @@ def convert_to_hf(args, model_name, name, param, quantization_config=None):
     converted_named_tensors = _convert_to_hf_core(args, model_name, name, param)
 
     return quantize_params(args, name, converted_named_tensors, quantization_config)
+
+
+def shard_conversion_supported(model_name: str) -> bool:
+    """Return True when shard-level Megatron→HF conversion is implemented."""
+    name = model_name.lower()
+    return "qwen2" in name or "qwen3" in name
+
+
+def convert_shard_to_hf(args, model_name, name, param, tp_rank, tp_size):
+    """Convert a single TP shard from Megatron to HF shard format (no all_gather)."""
+    param = remove_padding(name, param, args.vocab_size)
+    return _convert_shard_to_hf_core(args, model_name, name, param, tp_rank, tp_size)
 
 
 # TODO optimize
@@ -93,3 +105,9 @@ def _convert_to_hf_core(args, model_name, name, param):
             else:
                 converted_named_tensors.append((converted_name, converted_param))
     return converted_named_tensors
+
+
+def _convert_shard_to_hf_core(args, model_name, name, param, tp_rank, tp_size):
+    if shard_conversion_supported(model_name):
+        return convert_qwen2_shard_to_hf(args, name, param, tp_rank, tp_size)
+    raise ValueError(f"Shard-level conversion not yet supported for model: {model_name}")

--- a/slime/backends/megatron_utils/megatron_to_hf/qwen2.py
+++ b/slime/backends/megatron_utils/megatron_to_hf/qwen2.py
@@ -69,3 +69,94 @@ def convert_qwen2_to_hf(args, name, param):
             return [(f"model.layers.{layer_idx}.self_attn.k_norm.weight", param)]
 
     raise ValueError(f"Unknown parameter name: {name}")
+
+
+def convert_qwen2_shard_to_hf(args, name, param, tp_rank, tp_size):
+    """Convert a single TP shard from Megatron format to HF shard format."""
+    if name == "module.module.embedding.word_embeddings.weight":
+        return [("model.embed_tokens.weight", param)]
+
+    if name == "module.module.output_layer.weight":
+        return [("lm_head.weight", param)]
+
+    if name == "module.module.decoder.final_layernorm.weight":
+        if tp_rank == 0:
+            return [("model.norm.weight", param)]
+        return []
+
+    try:
+        head_dim = args.kv_channels if args.kv_channels is not None else args.hidden_size // args.num_attention_heads
+    except AttributeError:
+        head_dim = args.hidden_size // args.num_attention_heads
+
+    num_query_groups_per_shard = args.num_query_groups // tp_size
+    value_num_per_group = args.num_attention_heads // args.num_query_groups
+
+    decoder_layers_pattern = r"module\.module\.decoder\.layers\.(\d+)\.(.+)"
+    match = re.match(decoder_layers_pattern, name)
+    if match:
+        layer_idx, rest = match.groups()
+
+        if rest == "self_attention.linear_proj.weight":
+            return [(f"model.layers.{layer_idx}.self_attn.o_proj.weight", param)]
+
+        if rest == "self_attention.linear_qkv.weight":
+            shard_param = param.view(num_query_groups_per_shard, -1, head_dim, args.hidden_size)
+            q_param, k_param, v_param = torch.split(
+                shard_param,
+                split_size_or_sections=[value_num_per_group, 1, 1],
+                dim=1,
+            )
+            q_param = q_param.reshape(-1, args.hidden_size)
+            k_param = k_param.reshape(-1, args.hidden_size)
+            v_param = v_param.reshape(-1, args.hidden_size)
+            return [
+                (f"model.layers.{layer_idx}.self_attn.q_proj.weight", q_param),
+                (f"model.layers.{layer_idx}.self_attn.k_proj.weight", k_param),
+                (f"model.layers.{layer_idx}.self_attn.v_proj.weight", v_param),
+            ]
+
+        if rest == "self_attention.linear_qkv.bias":
+            shard_param = param.view(num_query_groups_per_shard, -1)
+            q_bias, k_bias, v_bias = torch.split(
+                shard_param,
+                split_size_or_sections=[value_num_per_group * head_dim, head_dim, head_dim],
+                dim=1,
+            )
+            q_bias = q_bias.contiguous().flatten()
+            k_bias = k_bias.contiguous().flatten()
+            v_bias = v_bias.contiguous().flatten()
+            return [
+                (f"model.layers.{layer_idx}.self_attn.q_proj.bias", q_bias),
+                (f"model.layers.{layer_idx}.self_attn.k_proj.bias", k_bias),
+                (f"model.layers.{layer_idx}.self_attn.v_proj.bias", v_bias),
+            ]
+
+        if rest == "mlp.linear_fc1.weight":
+            gate_weight, up_weight = param.chunk(2, dim=0)
+            return [
+                (f"model.layers.{layer_idx}.mlp.gate_proj.weight", gate_weight),
+                (f"model.layers.{layer_idx}.mlp.up_proj.weight", up_weight),
+            ]
+
+        if rest == "mlp.linear_fc2.weight":
+            return [(f"model.layers.{layer_idx}.mlp.down_proj.weight", param)]
+
+        if rest == "self_attention.linear_qkv.layer_norm_weight":
+            if tp_rank == 0:
+                return [(f"model.layers.{layer_idx}.input_layernorm.weight", param)]
+            return []
+        if rest == "mlp.linear_fc1.layer_norm_weight":
+            if tp_rank == 0:
+                return [(f"model.layers.{layer_idx}.post_attention_layernorm.weight", param)]
+            return []
+        if rest == "self_attention.q_layernorm.weight":
+            if tp_rank == 0:
+                return [(f"model.layers.{layer_idx}.self_attn.q_norm.weight", param)]
+            return []
+        if rest == "self_attention.k_layernorm.weight":
+            if tp_rank == 0:
+                return [(f"model.layers.{layer_idx}.self_attn.k_norm.weight", param)]
+            return []
+
+    raise ValueError(f"Unknown parameter name: {name}")

--- a/slime/backends/megatron_utils/update_weight/common.py
+++ b/slime/backends/megatron_utils/update_weight/common.py
@@ -235,3 +235,78 @@ def _named_params_and_buffers_global(
                 layer_idx, rest = match.groups()
                 layer_idx = int(layer_idx) + layer_offset
                 yield f"module.module.decoder.layers.{layer_idx}.{rest}", buffer
+
+
+def get_sglang_tensor_parallel_size(args: Namespace, engine_gpu_count: int | None = None) -> int:
+    """Effective SGLang TP size for one engine (GPUs per engine // PP size)."""
+    gpu_count = args.rollout_num_gpus_per_engine if engine_gpu_count is None else engine_gpu_count
+    pp_size = get_sglang_pipeline_parallel_size(args)
+    if gpu_count % pp_size != 0:
+        raise ValueError(f"engine GPU count ({gpu_count}) must be divisible by SGLang PP size ({pp_size})")
+    return gpu_count // pp_size
+
+
+def get_sglang_pipeline_parallel_size(args: Namespace) -> int:
+    """SGLang pipeline parallel size configured for rollout engines."""
+    return getattr(args, "sglang_pp_size", 1) or getattr(args, "sglang_pipeline_parallel_size", 1) or 1
+
+
+def p2p_tp_sizes_match(args: Namespace, engine_gpu_counts: Sequence[int] | None = None) -> bool:
+    """
+    Return True when Megatron training TP equals SGLang inference TP for every engine.
+
+    P2P shard send/recv requires a 1:1 mapping between training and inference TP ranks.
+    """
+    megatron_tp = args.tensor_model_parallel_size
+    if engine_gpu_counts is None:
+        return megatron_tp == get_sglang_tensor_parallel_size(args)
+    return all(megatron_tp == get_sglang_tensor_parallel_size(args, c) for c in engine_gpu_counts)
+
+
+def p2p_weight_update_supported(
+    args: Namespace,
+    model_name: str,
+    engine_gpu_counts: Sequence[int] | None = None,
+) -> bool:
+    """
+    Return True when shard-level P2P weight update can be used.
+
+    Requires ``--megatron-to-hf-mode bridge``, a model with shard-level conversion,
+    SGLang PP=1, and matching Megatron / SGLang TP sizes.
+    """
+    from slime.backends.megatron_utils.megatron_to_hf import shard_conversion_supported
+
+    if args.megatron_to_hf_mode != "bridge":
+        return False
+    if not shard_conversion_supported(model_name):
+        return False
+    if get_sglang_pipeline_parallel_size(args) != 1:
+        return False
+    return p2p_tp_sizes_match(args, engine_gpu_counts)
+
+
+def p2p_weight_update_fallback_reason(
+    args: Namespace,
+    model_name: str,
+    engine_gpu_counts: Sequence[int] | None = None,
+) -> str:
+    """Human-readable reason why P2P falls back to NCCL broadcast."""
+    from slime.backends.megatron_utils.megatron_to_hf import shard_conversion_supported
+
+    if args.megatron_to_hf_mode != "bridge":
+        return f"megatron_to_hf_mode={args.megatron_to_hf_mode!r} " "(P2P requires --megatron-to-hf-mode bridge)"
+    if not shard_conversion_supported(model_name):
+        return f"shard-level conversion not implemented for model {model_name!r}"
+    sglang_pp = get_sglang_pipeline_parallel_size(args)
+    if sglang_pp != 1:
+        return f"sglang_pp_size={sglang_pp} (P2P requires SGLang PP=1)"
+    megatron_tp = args.tensor_model_parallel_size
+    if engine_gpu_counts is None:
+        sglang_tp = get_sglang_tensor_parallel_size(args)
+        if megatron_tp != sglang_tp:
+            return f"Megatron TP ({megatron_tp}) != SGLang TP ({sglang_tp})"
+    else:
+        sglang_tps = [get_sglang_tensor_parallel_size(args, c) for c in engine_gpu_counts]
+        if not all(megatron_tp == tp for tp in sglang_tps):
+            return f"Megatron TP ({megatron_tp}) != SGLang TP(s) {sglang_tps}"
+    return "unknown reason"

--- a/slime/backends/megatron_utils/update_weight/update_weight_from_distributed_p2p.py
+++ b/slime/backends/megatron_utils/update_weight/update_weight_from_distributed_p2p.py
@@ -480,7 +480,7 @@ class UpdateWeightFromDistributedP2P:
 
         Rank 0 posts a single HTTP request with concatenated metadata from every
         training TP rank (``tp_tensor_counts``). All training ranks then enter an
-        NCCL barrier with rollout workers, ``dist.send`` their local tensors to
+        NCCL barrier with rollout workers, ``dist.isend`` their local tensors to
         matching rollout TP ranks on each engine, and wait for load completion.
         """
         t_bucket_start = time.perf_counter()
@@ -532,11 +532,9 @@ class UpdateWeightFromDistributedP2P:
                 for engine in self.rollout_engines
             ]
 
-            ray.get(self.rollout_engine_lock.release.remote())
-
         t_lock_end = time.perf_counter()
 
-        # NCCL barrier: rollout workers post dist.recv before training sends.
+        # NCCL barrier: rollout workers post dist.irecv before training sends.
         dist.barrier(group=group)
 
         # Every training TP rank sends to the matching rank on each engine.
@@ -547,16 +545,20 @@ class UpdateWeightFromDistributedP2P:
         num_engines = len(self.rollout_engines)
 
         t_send_start = time.perf_counter()
+        send_handles = []
         for _, param in converted_named_tensors:
             tensor = param.data.contiguous()
             for engine_idx in range(num_engines):
                 dst_rank = tp_size + cumulative[engine_idx] + tp_rank
-                dist.send(tensor, dst=dst_rank, group=group)
+                send_handles.append(dist.isend(tensor, dst=dst_rank, group=group))
+        for handle in send_handles:
+            handle.wait()
 
         t_send_end = time.perf_counter()
 
         if refs is not None:
             ray.get(refs)
+            ray.get(self.rollout_engine_lock.release.remote())
 
         t_ray_end = time.perf_counter()
 
@@ -565,7 +567,7 @@ class UpdateWeightFromDistributedP2P:
         self._log_timing(
             f"  bucket ({'expert' if is_expert else 'non-expert'}, {num_tensors} tensors)",
             t_ray_end - t_bucket_start,
-            f" [lock+ray={t_lock_end - t_lock_start:.3f}s, dist.send={t_send_end - t_send_start:.3f}s]",
+            f" [lock+ray={t_lock_end - t_lock_start:.3f}s, dist.isend={t_send_end - t_send_start:.3f}s]",
         )
 
         if pbar is not None:

--- a/slime/backends/megatron_utils/update_weight/update_weight_from_distributed_p2p.py
+++ b/slime/backends/megatron_utils/update_weight/update_weight_from_distributed_p2p.py
@@ -1,0 +1,572 @@
+"""
+Shard-level P2P weight update for non-colocate Slime.
+
+Each training TP rank converts its local shard to HF layout and sends it to the
+matching inference TP rank via ``dist.send`` / ``dist.recv``, avoiding the default
+all_gather + NCCL broadcast path.
+
+Enable with ``--use-p2p-weight-update`` (``--update-weight-mode=full``,
+``--megatron-to-hf-mode bridge``, non-colocate). Falls back to NCCL broadcast when
+preconditions fail; see ``p2p_weight_update_supported`` in ``common.py`` and
+``docs/en/advanced/p2p-weight-sync.md``.
+"""
+
+import socket
+import time
+from argparse import Namespace
+from collections.abc import Callable, Mapping, Sequence
+
+import ray
+import torch
+import torch.distributed as dist
+from megatron.core import mpu
+from ray import ObjectRef
+from ray.actor import ActorHandle
+from tqdm import tqdm
+
+from slime.backends.megatron_utils.megatron_to_hf import convert_to_hf
+from slime.backends.megatron_utils.misc_utils import strip_param_name_prefix
+from slime.utils.distributed_utils import get_gloo_group, init_process_group
+
+from ..megatron_to_hf import convert_shard_to_hf
+from .common import (
+    all_gather_param,
+    named_params_and_buffers,
+    p2p_weight_update_fallback_reason,
+    p2p_weight_update_supported,
+)
+from .update_weight_from_distributed import UpdateWeightFromDistributed
+
+# Vocab params that need all_gather + remove_padding due to Megatron/SGLang
+# shard boundary misalignment.
+_VOCAB_PARAMS = {"embedding.word_embeddings.weight", "output_layer.weight"}
+
+
+class UpdateWeightFromDistributedP2P:
+    """
+    Shard-level P2P weight update: each TP rank sends its shard directly
+    to the matching inference TP rank via dist.send/recv.
+
+    Vocab params (embed_tokens, lm_head) are handled with a small all_gather
+    on the TP group because Megatron and SGLang use different vocab partitioning.
+    All other params use direct shard-level conversion without all_gather.
+    """
+
+    def __init__(
+        self,
+        args: Namespace,
+        model: Sequence[torch.nn.Module],
+        weights_getter: Callable[[], Mapping[str, torch.Tensor]],
+        *,
+        model_name: str,
+        quantization_config: dict[str, int | str | list[str]] | None,
+    ) -> None:
+        self.args = args
+        self.model = model
+        self.model_name = model_name
+        self.quantization_config = quantization_config
+        self._weight_version = 0
+        self._model_update_groups = None
+        self._group_name = None
+        self._first_update = True
+        self._use_p2p: bool | None = None
+        self._fallback: UpdateWeightFromDistributed | None = None
+
+    def _get_fallback(self) -> UpdateWeightFromDistributed:
+        if self._fallback is None:
+            self._fallback = UpdateWeightFromDistributed(
+                self.args,
+                self.model,
+                model_name=self.model_name,
+                quantization_config=self.quantization_config,
+            )
+        return self._fallback
+
+    def _resolve_updater(self, engine_gpu_counts: Sequence[int] | None = None) -> UpdateWeightFromDistributed | None:
+        """Return broadcast fallback when P2P preconditions fail; None to use P2P."""
+        if self._use_p2p is False:
+            return self._get_fallback()
+        if self._use_p2p is None:
+            if p2p_weight_update_supported(self.args, self.model_name, engine_gpu_counts):
+                self._use_p2p = True
+                return None
+            self._use_p2p = False
+            if self.tp_rank == 0 and self._is_dp0:
+                reason = p2p_weight_update_fallback_reason(self.args, self.model_name, engine_gpu_counts)
+                print(f"[P2P] {reason}; using NCCL broadcast weight update instead.")
+            return self._get_fallback()
+        return None
+
+    @property
+    def weight_version(self) -> int:
+        if self._use_p2p is False and self._fallback is not None:
+            return self._fallback.weight_version
+        return self._weight_version
+
+    def disconnect_rollout_engines(self) -> None:
+        if self._use_p2p is False and self._fallback is not None:
+            self._fallback.disconnect_rollout_engines()
+
+    def pop_metrics(self) -> dict[str, float]:
+        if self._use_p2p is False:
+            return self._get_fallback().pop_metrics()
+        out, self._metrics = getattr(self, "_metrics", {}), {}
+        return out
+
+    @property
+    def tp_size(self):
+        return mpu.get_tensor_model_parallel_world_size()
+
+    @property
+    def tp_rank(self):
+        return mpu.get_tensor_model_parallel_rank()
+
+    @property
+    def _is_dp0(self):
+        return mpu.get_data_parallel_rank(with_context_parallel=True) == 0
+
+    def _log_timing(self, label: str, elapsed: float, extra: str = ""):
+        """Log per-phase latency on training TP rank 0."""
+        if self.tp_rank == 0:
+            warmup_tag = " [warmup]" if self._first_update else ""
+            print(f"[P2P-TIMING]{warmup_tag} {label}: {elapsed:.3f}s{extra}")
+
+    def connect_rollout_engines(
+        self,
+        rollout_engines: Sequence[ActorHandle],
+        rollout_engine_lock: ActorHandle,
+        engine_gpu_counts: Sequence[int] | None = None,
+        engine_gpu_offsets: Sequence[int] | None = None,
+    ) -> None:
+        """
+        Join training and rollout ranks in a shared NCCL process group.
+
+        TP rank 0 picks the master port, asks each rollout engine to join, and
+        broadcasts the port to other training TP ranks. Every training TP rank
+        then enters the group at its TP index; rollout ranks follow contiguous
+        offsets derived from ``engine_gpu_counts``.
+        """
+        fallback = self._resolve_updater(engine_gpu_counts)
+        if fallback is not None:
+            return fallback.connect_rollout_engines(
+                rollout_engines,
+                rollout_engine_lock,
+                engine_gpu_counts=engine_gpu_counts,
+                engine_gpu_offsets=engine_gpu_offsets,
+            )
+
+        self.rollout_engines = rollout_engines
+        self.rollout_engine_lock = rollout_engine_lock
+        self._engine_gpu_counts = engine_gpu_counts
+
+        if engine_gpu_counts is None:
+            engine_gpu_counts = [self.args.rollout_num_gpus_per_engine] * len(rollout_engines)
+
+        pp_rank = mpu.get_pipeline_model_parallel_rank()
+        group_name = f"slime-p2p-pp_{pp_rank}"
+
+        tp_size = self.tp_size
+        tp_rank = self.tp_rank
+
+        # Only DP=0 ranks participate in weight transfer
+        if not self._is_dp0:
+            return
+
+        self._group_name = group_name
+        world_size = tp_size + sum(engine_gpu_counts)
+
+        # Compute cumulative rank offsets for engines
+        cumulative = [0]
+        for c in engine_gpu_counts:
+            cumulative.append(cumulative[-1] + c)
+
+        # Use the TP group to broadcast the port from TP rank 0 to all others.
+        tp_group = mpu.get_tensor_model_parallel_group()
+
+        if tp_rank == 0:
+            # TP rank 0 coordinates group setup and teardown.
+
+            if self._model_update_groups is not None:
+                refs = [engine.destroy_weights_update_group.remote(group_name) for engine in rollout_engines]
+                dist.destroy_process_group(self._model_update_groups)
+                self._model_update_groups = None
+                ray.get(refs)
+
+            master_address = ray._private.services.get_node_ip_address()
+            with socket.socket() as sock:
+                sock.bind(("", 0))
+                master_port = sock.getsockname()[1]
+
+            # Tell rollout engines to join the NCCL group.
+            refs = [
+                engine.init_weights_update_group.remote(
+                    master_address=master_address,
+                    master_port=master_port,
+                    rank_offset=tp_size + cumulative[i],
+                    world_size=world_size,
+                    group_name=group_name,
+                    backend="nccl",
+                )
+                for i, engine in enumerate(rollout_engines)
+            ]
+
+            # Broadcast port to other training TP ranks via TP group.
+            port_tensor = torch.tensor([master_port], dtype=torch.long, device="cuda")
+            dist.broadcast(port_tensor, src=0, group=tp_group)
+
+            # TP rank 0 enters the NCCL group as rank 0.
+            self._model_update_groups = init_process_group(
+                backend="nccl",
+                init_method=f"tcp://{master_address}:{master_port}",
+                world_size=world_size,
+                rank=0,
+                group_name=group_name,
+                device_id=torch.device("cuda", torch.cuda.current_device()),
+            )
+
+            ray.get(refs)
+        else:
+            # Other training TP ranks receive the port from TP rank 0, then join.
+
+            if self._model_update_groups is not None:
+                dist.destroy_process_group(self._model_update_groups)
+                self._model_update_groups = None
+
+            # Receive port from TP rank 0 via TP group broadcast
+            port_tensor = torch.tensor([0], dtype=torch.long, device="cuda")
+            dist.broadcast(port_tensor, src=0, group=tp_group)
+
+            master_port = int(port_tensor.item())
+            master_address = ray._private.services.get_node_ip_address()
+
+            # Each TP rank joins the NCCL group as its TP rank index.
+            self._model_update_groups = init_process_group(
+                backend="nccl",
+                init_method=f"tcp://{master_address}:{master_port}",
+                world_size=world_size,
+                rank=tp_rank,
+                group_name=group_name,
+                device_id=torch.device("cuda", torch.cuda.current_device()),
+            )
+
+    @torch.no_grad()
+    def update_weights(self) -> None:
+        """
+        Convert Megatron shards to HF layout and P2P-send them to rollout engines.
+
+        Vocab tensors use a small TP all_gather to align Megatron/SGLang padding;
+        all other parameters are converted and sent shard-wise without all_gather.
+        """
+        if self._use_p2p is False:
+            return self._get_fallback().update_weights()
+
+        t_total_start = time.perf_counter()
+        self._weight_version += 1
+
+        if dist.get_rank() == 0:
+            ray.get([engine.pause_generation.remote() for engine in self.rollout_engines])
+            ray.get([engine.flush_cache.remote() for engine in self.rollout_engines])
+
+        dist.barrier(group=get_gloo_group())
+
+        if not self._is_dp0:
+            # Non-DP0 ranks still participate in Gloo barriers but skip NCCL work.
+            dist.barrier(group=get_gloo_group())
+            dist.barrier(group=get_gloo_group())
+            if dist.get_rank() == 0:
+                ray.get([engine.continue_generation.remote() for engine in self.rollout_engines])
+            dist.barrier(group=get_gloo_group())
+            return
+
+        tp_rank = self.tp_rank
+        tp_size = self.tp_size
+
+        # Phase 1: Vocab params — all_gather + remove_padding + slice for SGLang alignment
+        t_phase1_start = time.perf_counter()
+        buffer_size = 0
+        converted_named_tensors = []
+        pbar = tqdm(desc=f"[p2p-tp{tp_rank}] Update weights", total=0) if dist.get_rank() == 0 else None
+
+        vocab_count = 0
+        for name, param in named_params_and_buffers(self.args, self.model):
+            if ".experts." in name:
+                continue
+            stripped = strip_param_name_prefix(name)
+            if stripped not in _VOCAB_PARAMS:
+                continue
+            buffer_size = self._update_vocab_shard(
+                name, param, converted_named_tensors, buffer_size, tp_rank, tp_size, pbar=pbar
+            )
+            vocab_count += 1
+
+        t_phase1_end = time.perf_counter()
+        self._log_timing(
+            "Phase1 vocab (all_gather+convert+slice)",
+            t_phase1_end - t_phase1_start,
+            f" [{vocab_count} params, {len(converted_named_tensors)} tensors queued]",
+        )
+
+        # Phase 2: Non-vocab, non-expert params — shard-level conversion (no all_gather)
+        t_phase2_start = time.perf_counter()
+        nonvocab_count = 0
+        for name, param in named_params_and_buffers(self.args, self.model):
+            if ".experts." in name:
+                continue
+            stripped = strip_param_name_prefix(name)
+            if stripped in _VOCAB_PARAMS:
+                continue
+            buffer_size = self._update_shard_from_distributed(
+                name, param, converted_named_tensors, buffer_size, tp_rank, tp_size, pbar=pbar
+            )
+            nonvocab_count += 1
+
+        # Flush remaining non-expert tensors
+        if converted_named_tensors:
+            t_flush_start = time.perf_counter()
+            self._send_bucket_shard(converted_named_tensors, pbar=pbar)
+            t_flush_end = time.perf_counter()
+            self._log_timing("Phase2 flush bucket", t_flush_end - t_flush_start)
+
+        t_phase2_end = time.perf_counter()
+        self._log_timing(
+            "Phase2 non-vocab (convert_shard+send)",
+            t_phase2_end - t_phase2_start,
+            f" [{nonvocab_count} params processed]",
+        )
+
+        dist.barrier(group=get_gloo_group())
+        t_barrier1 = time.perf_counter()
+        self._log_timing("Gloo barrier after Phase2", t_barrier1 - t_phase2_end)
+
+        # Phase 3: Expert params — send shard directly, no all_gather
+        t_phase3_start = time.perf_counter()
+        buffer_size = 0
+        named_tensors = []
+        expert_count = 0
+        for name, param in named_params_and_buffers(self.args, self.model):
+            if ".experts." not in name:
+                continue
+            buffer_size = self._update_expert_shard_from_distributed(
+                name, param, named_tensors, buffer_size, tp_rank, tp_size, pbar=pbar
+            )
+            expert_count += 1
+
+        if named_tensors:
+            self._send_bucket_shard(named_tensors, pbar=pbar, is_expert=True)
+
+        t_phase3_end = time.perf_counter()
+        self._log_timing("Phase3 expert (direct send)", t_phase3_end - t_phase3_start, f" [{expert_count} params]")
+
+        # Wait for all SGLang load_weights to complete before resuming generation.
+        dist.barrier(group=get_gloo_group())
+
+        if dist.get_rank() == 0:
+            ray.get([engine.continue_generation.remote() for engine in self.rollout_engines])
+        dist.barrier(group=get_gloo_group())
+
+        t_total_end = time.perf_counter()
+        self._log_timing("TOTAL update_weights", t_total_end - t_total_start)
+
+        self._first_update = False
+
+    def _update_vocab_shard(
+        self,
+        name: str,
+        param: torch.nn.Parameter,
+        converted_named_tensors: list[tuple[str, torch.Tensor]],
+        buffer_size: int,
+        tp_rank: int,
+        tp_size: int,
+        pbar: tqdm | None = None,
+    ) -> int:
+        """
+        Vocab params: all_gather on TP group → convert to HF (which removes Megatron
+        padding internally) → slice SGLang-aligned shard for this TP rank.
+        """
+        t0 = time.perf_counter()
+
+        # Step 1: all_gather on the TP group to reconstruct the full vocab tensor
+        full_param = all_gather_param(name, param)
+        t_allgather = time.perf_counter()
+
+        # Step 2: Convert to HF format (internally calls remove_padding)
+        converted = convert_to_hf(self.args, self.model_name, name, full_param, self.quantization_config)
+        t_convert = time.perf_counter()
+
+        if not converted:
+            return buffer_size
+
+        # Step 3: Slice the SGLang-aligned shard for this TP rank
+        for hf_name, hf_param in converted:
+            if hf_param.shape[0] % tp_size != 0:
+                shard = hf_param
+            else:
+                shard_size = hf_param.shape[0] // tp_size
+                shard = hf_param[tp_rank * shard_size : (tp_rank + 1) * shard_size]
+
+            param_size = shard.numel() * shard.element_size()
+            if buffer_size + param_size > self.args.update_weight_buffer_size:
+                self._send_bucket_shard(converted_named_tensors, pbar=pbar)
+                buffer_size = 0
+            converted_named_tensors.append((hf_name, shard))
+            buffer_size += param_size
+
+        t_slice = time.perf_counter()
+        self._log_timing(
+            f"  vocab '{name}'",
+            t_slice - t0,
+            f" [all_gather={t_allgather-t0:.3f}s, convert={t_convert-t_allgather:.3f}s, slice+buf={t_slice-t_convert:.3f}s]",
+        )
+
+        return buffer_size
+
+    def _update_shard_from_distributed(
+        self,
+        name: str,
+        param: torch.nn.Parameter,
+        converted_named_tensors: list[tuple[str, torch.Tensor]],
+        buffer_size: int,
+        tp_rank: int,
+        tp_size: int,
+        pbar: tqdm | None = None,
+    ) -> int:
+        """
+        Convert a single TP shard to HF format. No all_gather.
+        """
+        converted = convert_shard_to_hf(self.args, self.model_name, name, param, tp_rank, tp_size)
+        if not converted:
+            return buffer_size
+
+        for hf_name, hf_param in converted:
+            param_size = hf_param.numel() * hf_param.element_size()
+            if buffer_size + param_size > self.args.update_weight_buffer_size:
+                self._send_bucket_shard(converted_named_tensors, pbar=pbar)
+                buffer_size = 0
+            converted_named_tensors.append((hf_name, hf_param))
+            buffer_size += param_size
+
+        return buffer_size
+
+    def _update_expert_shard_from_distributed(
+        self,
+        name: str,
+        param: torch.nn.Parameter,
+        named_tensors: list[tuple[str, torch.Tensor]],
+        buffer_size: int,
+        tp_rank: int,
+        tp_size: int,
+        pbar: tqdm | None = None,
+    ) -> int:
+        """
+        Expert params: no all_gather, send shard directly.
+        """
+        param_size = param.numel() * param.element_size()
+        if buffer_size + param_size > self.args.update_weight_buffer_size:
+            self._send_bucket_shard(named_tensors, pbar=pbar, is_expert=True)
+            buffer_size = 0
+
+        named_tensors.append((name, param))
+        buffer_size += param_size
+        return buffer_size
+
+    def _send_bucket_shard(
+        self,
+        converted_named_tensors: list[tuple[str, torch.Tensor]],
+        pbar: tqdm | None = None,
+        is_expert: bool = False,
+    ) -> None:
+        """
+        Send one bucket of presharded tensors to all rollout engines.
+
+        Rank 0 posts a single HTTP request with concatenated metadata from every
+        training TP rank (``tp_tensor_counts``). All training ranks then enter an
+        NCCL barrier with rollout workers, ``dist.send`` their local tensors to
+        matching rollout TP ranks on each engine, and wait for load completion.
+        """
+        t_bucket_start = time.perf_counter()
+        tp_rank = self.tp_rank
+        tp_size = self.tp_size
+        group = self._model_update_groups
+        load_format = "presharded"
+
+        num_tensors = len(converted_named_tensors)
+        refs: list[ObjectRef] | None = None
+
+        t_lock_start = time.perf_counter()
+
+        # Gather all TP ranks' metadata to rank 0 via gloo.
+        my_meta = (
+            [name for name, _ in converted_named_tensors],
+            [str(param.dtype).replace("torch.", "") for _, param in converted_named_tensors],
+            [list(param.shape) for _, param in converted_named_tensors],
+        )
+
+        all_meta = [None] * tp_size
+        dist.all_gather_object(all_meta, my_meta, group=get_gloo_group())
+
+        tp_tensor_counts = [len(m[0]) for m in all_meta]
+
+        # Only TP rank 0 sends the HTTP request with concatenated metadata.
+        if tp_rank == 0:
+            all_names = []
+            all_dtypes = []
+            all_shapes = []
+            for m in all_meta:
+                all_names.extend(m[0])
+                all_dtypes.extend(m[1])
+                all_shapes.extend(m[2])
+
+            while not ray.get(self.rollout_engine_lock.acquire.remote()):
+                time.sleep(0.1)
+
+            refs = [
+                engine.update_weights_from_distributed.remote(
+                    names=all_names,
+                    dtypes=all_dtypes,
+                    shapes=all_shapes,
+                    group_name=self._group_name,
+                    weight_version=str(self.weight_version),
+                    load_format=load_format,
+                    tp_tensor_counts=tp_tensor_counts,
+                )
+                for engine in self.rollout_engines
+            ]
+
+            ray.get(self.rollout_engine_lock.release.remote())
+
+        t_lock_end = time.perf_counter()
+
+        # NCCL barrier: rollout workers post dist.recv before training sends.
+        dist.barrier(group=group)
+
+        # Every training TP rank sends to the matching rank on each engine.
+        cumulative = [0]
+        for c in self._engine_gpu_counts:
+            cumulative.append(cumulative[-1] + c)
+
+        num_engines = len(self.rollout_engines)
+
+        t_send_start = time.perf_counter()
+        for _, param in converted_named_tensors:
+            tensor = param.data.contiguous()
+            for engine_idx in range(num_engines):
+                dst_rank = tp_size + cumulative[engine_idx] + tp_rank
+                dist.send(tensor, dst=dst_rank, group=group)
+
+        t_send_end = time.perf_counter()
+
+        if refs is not None:
+            ray.get(refs)
+
+        t_ray_end = time.perf_counter()
+
+        converted_named_tensors.clear()
+
+        self._log_timing(
+            f"  bucket ({'expert' if is_expert else 'non-expert'}, {num_tensors} tensors)",
+            t_ray_end - t_bucket_start,
+            f" [lock+ray={t_lock_end - t_lock_start:.3f}s, dist.send={t_send_end - t_send_start:.3f}s]",
+        )
+
+        if pbar is not None:
+            pbar.update(1)

--- a/slime/backends/sglang_utils/sglang_engine.py
+++ b/slime/backends/sglang_utils/sglang_engine.py
@@ -438,10 +438,12 @@ class SGLangEngine(RayActor):
         weight_version: str | None = None,
         load_format: str | None = None,
         delta=None,
+        src_tp_rank: int | None = None,
+        tp_tensor_counts: list[int] | None = None,
     ):
         payload = {
             "names": names,
-            "dtypes": [str(dtype).replace("torch.", "") for dtype in dtypes],
+            "dtypes": [str(dtype).replace("torch.", "") if not isinstance(dtype, str) else dtype for dtype in dtypes],
             "shapes": shapes,
             "group_name": group_name,
             "flush_cache": flush_cache,
@@ -450,6 +452,10 @@ class SGLangEngine(RayActor):
             payload["weight_version"] = weight_version
         if load_format is not None:
             payload["load_format"] = load_format
+        if src_tp_rank is not None:
+            payload["src_tp_rank"] = src_tp_rank
+        if tp_tensor_counts is not None:
+            payload["tp_tensor_counts"] = tp_tensor_counts
         if delta is not None:
             # DeltaSpec → JSON string. Receiver reconstructs via DeltaEncoding(...) +
             # DeltaParam(**p); avoids depending on FastAPI's nested-dataclass coercion.

--- a/slime/utils/arguments.py
+++ b/slime/utils/arguments.py
@@ -99,6 +99,18 @@ def get_slime_extra_args_provider(add_custom_arguments=None):
                     "This will always be true when --colocate is set."
                 ),
             )
+            parser.add_argument(
+                "--use-p2p-weight-update",
+                action="store_true",
+                default=False,
+                help=(
+                    "Use shard-level P2P weight update (dist.send/recv) instead of "
+                    "all_gather + broadcast for non-colocate mode when "
+                    "--megatron-to-hf-mode bridge, the model supports shard-level "
+                    "conversion, and Megatron TP equals SGLang TP. Otherwise falls "
+                    "back to NCCL broadcast automatically."
+                ),
+            )
 
             reset_arg(parser, "--distributed-backend", type=str, default="nccl")
             reset_arg(parser, "--distributed-timeout-minutes", type=int, default=10)

--- a/slime/utils/distributed_utils.py
+++ b/slime/utils/distributed_utils.py
@@ -44,6 +44,7 @@ def init_process_group(
     store: Store | None = None,
     group_name: str = None,
     pg_options: Any | None = None,
+    device_id: torch.device | None = None,
 ):
     assert (store is None) or (init_method is None), "Cannot specify both init_method and store."
 
@@ -84,6 +85,7 @@ def init_process_group(
         group_name=group_name,
         **{pg_options_param_name: pg_options},
         timeout=timeout,
+        device_id=device_id,
     )
 
     _world.pg_group_ranks[pg] = {i: i for i in range(world_size)}


### PR DESCRIPTION
## Summary

Add an opt-in P2P shard weight sync path for **non-colocate** RL training with `--update-weight-mode full`. Each Megatron TP rank sends its local HF shard to the matching SGLang TP rank via `dist.send/recv`, avoiding the default all_gather + NCCL broadcast.

If preconditions are not met, slime **automatically falls back** to NCCL broadcast and logs the reason on rank 0. **No breaking changes** — default behavior is unchanged without `--use-p2p-weight-update`.

## Motivation

In non-colocate mode, gathering full weights on the training side and broadcasting to rollout engines dominates `update_weights` time for large models. P2P shard sync keeps weights sharded end-to-end.

## Changes

- New `--use-p2p-weight-update` flag (requires `--update-weight-mode full`)
- `UpdateWeightFromDistributedP2P` + Qwen2/Qwen3 dense shard Megatron→HF conversion
- Fallback helpers in `common.py`
- `sglang_p2p.patch` applied in Dockerfile after `sglang.patch` / `sglang-top_p.patch`
- Docs: `docs/en/advanced/p2p-weight-sync.md`, `docs/zh/advanced/p2p-weight-sync.md`

## Usage

```bash
python3 train.py \
  --megatron-to-hf-mode bridge \
  --update-weight-mode full \
  --use-p2p-weight-update \
  --tensor-model-parallel-size 4 \
  --rollout-num-gpus-per-engine 4 \
  ...
```

## Preconditions (auto-fallback)

| Condition | Notes |
|-----------|-------|
| Non-colocate | Colocate uses `UpdateWeightFromTensor` |
| `--megatron-to-hf-mode bridge` | Raw mode not supported |
| Model support | Qwen2 / Qwen3 dense only (MoE falls back) |
| TP alignment | Megatron TP == SGLang TP |
| SGLang PP == 1 | `sglang_pp_size > 1` falls back (P2P send/recv pairing is TP-only in Phase 1) |

Megatron training PP and SGLang inference PP need not match when SGLang PP=1.

## Manual SGLang patch (for reviewers only)

Merged PRs apply the patch at **Docker build** time. To validate on an **existing** `slimerl/slime:latest` container (which already has `sglang.patch` + `sglang-top_p.patch`) without rebuilding:

```bash
# Clone this PR branch inside the container, then:
export SLIME_ROOT=/root/slime
export SGLANG_ROOT=/sgl-workspace/sglang
PATCH="${SLIME_ROOT}/docker/patch/latest/sglang_p2p.patch"

if grep -q 'tp_tensor_counts' "${SGLANG_ROOT}/python/sglang/srt/managers/io_struct.py"; then
  echo "SGLang P2P patch already applied"
else
  cd "${SGLANG_ROOT}"
  git update-index --refresh
  git apply --check "${PATCH}"
  git apply --3way "${PATCH}"
  if grep -R -n '^<<<<<<< ' python/sglang/srt/managers/io_struct.py \
      python/sglang/srt/managers/tp_worker.py \
      python/sglang/srt/model_executor/model_runner.py; then
    echo "Patch conflict — please resolve before testing"
    exit 1
  fi
  grep -q 'tp_tensor_counts' python/sglang/srt/managers/io_struct.py
  grep -q 'load_format == "presharded"' python/sglang/srt/model_executor/model_runner.py
  echo "SGLang P2P patch applied OK"
fi
```

Then run a non-colocate smoke test with `--use-p2p-weight-update` (see docs).

## Testing

Validated on 8×A100, `slimerl/slime:latest` + manual patch above, Qwen3-4B TP=4:
- End-to-end smoke completed (`exit_code=0`)
- Steady-state `update_weights` ~0.33–0.40s
- `sglang_p2p.patch` passes `git apply --check` on top of slime SGLang patches

## Test plan

- [x] `docker build` with `ENABLE_SGLANG_PATCH=1` succeeds (includes `sglang_p2p.patch`)
- [x] Non-colocate Qwen3-4B smoke with `--use-p2p-weight-update`
- [x] MoE or `--megatron-to-hf-mode raw` falls back to broadcast with `[P2P]` log
- [ ] `sglang_pp_size > 1` falls back to broadcast with `[P2P]` log
- [ ] Default path unchanged when flag omitted
