### PR TITLE
fix: support fbox answers in math rewards

### DIFF
--- a/slime/rollout/rm_hub/deepscaler.py
+++ b/slime/rollout/rm_hub/deepscaler.py
@@ -23,7 +23,7 @@ def get_deepscaler_rule_based_reward(response, label):
     processed_ground_truths = []
     for truth in ground_truths:
         truth = str(truth)
-        if "\\boxed" in truth:
+        if "\\boxed" in truth or "\\fbox" in truth:
             processed_truth = extract_answer(truth)
             if processed_truth is not None:
                 processed_ground_truths.append(processed_truth)

--- a/slime/rollout/rm_hub/math_utils.py
+++ b/slime/rollout/rm_hub/math_utils.py
@@ -410,17 +410,18 @@ def last_boxed_only_string(string):
 
 
 def remove_boxed(s):
-    left = "\\boxed{"
     try:
-        assert s[: len(left)] == left
-        assert s[-1] == "}"
-        return s[len(left) : -1]
+        for left in ("\\boxed{", "\\fbox{"):
+            if s[: len(left)] == left:
+                assert s[-1] == "}"
+                return s[len(left) : -1]
+        return None
     except Exception:
         return None
 
 
 def extract_boxed_answer(solution: str) -> str:
-    """Extract the answer from inside a LaTeX \\boxed{} command"""
+    """Extract the answer from inside a LaTeX \\boxed{} or \\fbox{} command."""
     solution = last_boxed_only_string(solution)
     solution = remove_boxed(solution)
     return solution
@@ -476,7 +477,7 @@ def grade_answer_mathd(given_answer: str, ground_truth: str) -> bool:
 
 
 def extract_answer(passage: str) -> str:
-    if "\\boxed" in passage:
+    if "\\boxed" in passage or "\\fbox" in passage:
         return extract_boxed_answer(passage)
     return None
 
@@ -485,7 +486,7 @@ def grade_answer_verl(solution_str, ground_truth):
     if not ground_truth:
         return False
     ground_truth = str(ground_truth)
-    if "\\boxed" in ground_truth:
+    if "\\boxed" in ground_truth or "\\fbox" in ground_truth:
         ground_truth = extract_answer(ground_truth)
     given_answer = extract_answer(solution_str)
     if given_answer is None:

--- a/tests/test_rm_deepscaler.py
+++ b/tests/test_rm_deepscaler.py
@@ -36,6 +36,12 @@ def test_response_split_on_response_marker_grades_tail():
 
 
 @pytest.mark.unit
+def test_response_with_fbox_grades_tail():
+    response = r"Reasoning</think>Final: \fbox{42}"
+    assert get_deepscaler_rule_based_reward(response, "42") == 1
+
+
+@pytest.mark.unit
 def test_response_without_any_marker_returns_zero():
     """No ``</think>`` AND no ``###Response`` → fall through to 0
     immediately (deepscaler.py:9-10). This is the silent-failure pole —
@@ -78,6 +84,11 @@ def test_label_with_boxed_marker_is_extracted_too():
     """If the ground truth itself is wrapped in ``\\boxed{}``, it must be
     unwrapped before grading (deepscaler.py:26-29)."""
     assert get_deepscaler_rule_based_reward(r"</think>\boxed{42}", r"\boxed{42}") == 1
+
+
+@pytest.mark.unit
+def test_label_with_fbox_marker_is_extracted_too():
+    assert get_deepscaler_rule_based_reward(r"</think>\fbox{42}", r"\fbox{42}") == 1
 
 
 @pytest.mark.unit

--- a/tests/test_rm_math.py
+++ b/tests/test_rm_math.py
@@ -62,6 +62,11 @@ def test_last_boxed_falls_back_to_fbox():
 
 
 @pytest.mark.unit
+def test_extract_boxed_answer_handles_fbox_end_to_end():
+    assert extract_boxed_answer(r"answer: \fbox{7}") == "7"
+
+
+@pytest.mark.unit
 def test_last_boxed_returns_none_when_missing():
     assert last_boxed_only_string("plain text, no box") is None
 
@@ -112,9 +117,13 @@ def test_extract_boxed_answer_end_to_end():
 
 @pytest.mark.unit
 def test_extract_answer_returns_none_when_no_boxed_marker():
-    """``extract_answer`` only triggers when ``\\boxed`` is in the passage;
-    otherwise returns None (pinning the branch at math_utils.py:479)."""
+    """Return None when neither supported box marker is present."""
     assert extract_answer("just 42") is None
+
+
+@pytest.mark.unit
+def test_extract_answer_handles_fbox():
+    assert extract_answer(r"Solution: \fbox{42}") == "42"
 
 
 # ---------------------------------------------------------------------------
@@ -215,6 +224,11 @@ def test_grade_answer_verl_extracts_both_sides_from_boxed():
     function extracts then grades. Confirms the wiring at
     math_utils.py:488-492 not just the inner mathd/sympy logic."""
     assert grade_answer_verl(r"answer: \boxed{42}", r"\boxed{42}") is True
+
+
+@pytest.mark.unit
+def test_grade_answer_verl_extracts_fbox():
+    assert grade_answer_verl(r"answer: \fbox{42}", r"\fbox{42}") is True
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary
- support '\fbox{}' in boxed-answer extraction
- recognize '\fbox{}' preds and labels in math and DeepScalar rewards
- regression tests for extraction and grading
