### PR TITLE
fix(model_provider): add attention_backend and attention_softmax_in_fp32 to provider

### DIFF
--- a/slime/backends/megatron_utils/model_provider.py
+++ b/slime/backends/megatron_utils/model_provider.py
@@ -99,6 +99,10 @@ def _get_model_provider_func(
         provider.sequence_parallel = args.sequence_parallel
         provider.context_parallel_size = args.context_parallel_size
         provider.variable_seq_lengths = args.variable_seq_lengths
+        if getattr(args, "attention_backend", None) is not None:
+            provider.attention_backend = args.attention_backend
+        if hasattr(args, "attention_softmax_in_fp32"):
+            provider.attention_softmax_in_fp32 = args.attention_softmax_in_fp32
         if hasattr(args, "moe_token_dispatcher_type"):
             provider.moe_token_dispatcher_type = args.moe_token_dispatcher_type
         if getattr(args, "decoder_first_pipeline_num_layers", None) is not None:


### PR DESCRIPTION
**Forward `attention_backend` and `attention_softmax_in_fp32` to the bridge model provider**

When `--megatron-to-hf-mode bridge` is used, the model provider is built by `AutoBridge` and only a subset of args are manually copied onto it. This meant `attention_backend` and `attention_softmax_in_fp32` were silently dropped, so bridge mode ignored the user's choices and fell back to the bridge defaults — diverging from the default (non-bridge) path, where these are forwarded automatically via `core_transformer_config_from_args`. This change copies both values from args onto the provider alongside the existing parallelism overrides, and does so before `provider.finalize()` so finalize-time invariants (e.g. `apply_query_key_layer_scaling` forcing `attention_softmax_in_fp32=True`) still hold. The fix is scoped entirely to the bridge branch and does not affect any other code path.