### PR TITLE
Support Qwen3.5 MoE INT4-QAT

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -739,6 +739,10 @@ jobs:
             },
             {
               "num_gpus": 0,
+              "test_file": "test_sglang_patch.py"
+            },
+            {
+              "num_gpus": 0,
               "test_file": "test_qwen3_linear_attention_cu_seqlens.py"
             },
             {

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -735,6 +735,10 @@ jobs:
             },
             {
               "num_gpus": 0,
+              "test_file": "test_qwen35_int4_fused_expert_quantizer.py"
+            },
+            {
+              "num_gpus": 0,
               "test_file": "test_qwen3_linear_attention_cu_seqlens.py"
             },
             {

--- a/.github/workflows/pr-test.yml.j2
+++ b/.github/workflows/pr-test.yml.j2
@@ -109,6 +109,7 @@
         {'test_file': 'test_rollout_sample_hooks.py', 'num_gpus': 0},
         {'test_file': 'test_hf_to_megatron.py', 'num_gpus': 0},
         {'test_file': 'test_qwen3_5_vl_native.py', 'num_gpus': 0},
+        {'test_file': 'test_qwen35_int4_fused_expert_quantizer.py', 'num_gpus': 0},
         {'test_file': 'test_qwen3_linear_attention_cu_seqlens.py', 'num_gpus': 0},
         {'test_file': 'test_accelerator.py', 'num_gpus': 0},
         {'test_file': 'test_reloadable_process_group_world.py', 'num_gpus': 0},

--- a/.github/workflows/pr-test.yml.j2
+++ b/.github/workflows/pr-test.yml.j2
@@ -110,6 +110,7 @@
         {'test_file': 'test_hf_to_megatron.py', 'num_gpus': 0},
         {'test_file': 'test_qwen3_5_vl_native.py', 'num_gpus': 0},
         {'test_file': 'test_qwen35_int4_fused_expert_quantizer.py', 'num_gpus': 0},
+        {'test_file': 'test_sglang_patch.py', 'num_gpus': 0},
         {'test_file': 'test_qwen3_linear_attention_cu_seqlens.py', 'num_gpus': 0},
         {'test_file': 'test_accelerator.py', 'num_gpus': 0},
         {'test_file': 'test_reloadable_process_group_world.py', 'num_gpus': 0},

--- a/docker/patch/latest/sglang.patch
+++ b/docker/patch/latest/sglang.patch
@@ -351,7 +351,7 @@ index bd9d7eafa1c9721a01d98c397deebf17e95a06dc..c74f7666a9972ba7ee5b0c94c805189e
  
 +@app.post("/post_process_weights")
 +@auth_level(AuthLevel.ADMIN_OPTIONAL)
-+async def post_process_weights(req: PostProcessWeightsReqInput, request: Request):
++async def post_process_weights(req: Annotated[PostProcessWeightsReqInput, Body()], request: Request):
 +    """Optional post-processing for updated weights, e.g. quantization packing."""
 +    success, message = await _global_state.tokenizer_manager.post_process_weights(
 +        req, request

--- a/docker/patch/v0.5.15.post1/sglang.patch
+++ b/docker/patch/v0.5.15.post1/sglang.patch
@@ -351,7 +351,7 @@ index bd9d7eafa1c9721a01d98c397deebf17e95a06dc..c74f7666a9972ba7ee5b0c94c805189e
  
 +@app.post("/post_process_weights")
 +@auth_level(AuthLevel.ADMIN_OPTIONAL)
-+async def post_process_weights(req: PostProcessWeightsReqInput, request: Request):
++async def post_process_weights(req: Annotated[PostProcessWeightsReqInput, Body()], request: Request):
 +    """Optional post-processing for updated weights, e.g. quantization packing."""
 +    success, message = await _global_state.tokenizer_manager.post_process_weights(
 +        req, request

--- a/docs/en/advanced/low-precision.md
+++ b/docs/en/advanced/low-precision.md
@@ -124,6 +124,35 @@ RUNTIME_ENV_JSON="{
 - `128` for `moonlight-16B-A3B`, `qwen3-30B-A3B`, and `qwen3-235B-A22B-int4`;
 - `32` for `kimi-k2-Thinking-int4`.
 
+### Qwen3.5 MoE INT4-QAT
+
+Qwen3.5 MoE is supported on the routed-expert INT4-QAT path. The converter automatically handles Qwen3.5 fused expert weights and produces an INT4 checkpoint that can be used by SGLang rollout.
+
+Current scope:
+
+```text
+INT4: routed experts
+BF16: attention, linear_attn, conv1d, shared_expert, router gate, visual, mtp, embedding, norm, lm_head
+```
+
+Convert the Hugging Face checkpoint:
+
+```bash
+python tools/convert_hf_to_int4_direct.py \
+  --model-dir /path/to/Qwen3.5-35B-A3B \
+  --save-dir /path/to/Qwen3.5-35B-A3B-INT4 \
+  --group-size 128 \
+  --is-symmetric
+```
+
+Then launch:
+
+```bash
+bash scripts/low_precision/run-qwen3.5-35B-A3B-int4-qat-rl.sh
+```
+
+MTP training and visual INT4-QAT are not included in this path.
+
 3. Launch an example:
 
 ```bash
@@ -138,6 +167,9 @@ bash scripts/low_precision/run-qwen3-235B-A22B-int4.sh
 
 # Kimi-k2-Thinking INT4 training (32 nodes)
 bash scripts/low_precision/run-kimi-k2-Thinking-int4.sh
+
+# Qwen3.5-35B-A3B routed-expert INT4-QAT training
+bash scripts/low_precision/run-qwen3.5-35B-A3B-int4-qat-rl.sh
 ```
 
 For multi-node environments, start the Ray service according to your cluster configuration.

--- a/docs/en/advanced/low-precision.md
+++ b/docs/en/advanced/low-precision.md
@@ -124,6 +124,39 @@ RUNTIME_ENV_JSON="{
 - `128` for `moonlight-16B-A3B`, `qwen3-30B-A3B`, and `qwen3-235B-A22B-int4`;
 - `32` for `kimi-k2-Thinking-int4`.
 
+### Qwen3.5 MoE INT4-QAT
+
+Qwen3.5 MoE supports routed-expert INT4-QAT through slime's native HF-to-Megatron and Megatron-to-HF bridge. The converter first requires the exact Qwen3.5 MoE `model_type` and `architectures`, then detects the fused 3D expert tensors and writes the per-expert 2D compressed-tensors layout expected by SGLang. The same strict model identity and layout adapter are used for online actor weight updates.
+
+Current precision scope:
+
+```text
+INT4: routed experts
+BF16: attention, linear_attn, conv1d, shared_expert, router gate,
+      visual, mtp, embedding, norm, lm_head
+```
+
+Convert the rollout checkpoint:
+
+```bash
+python tools/convert_hf_to_int4_direct.py \
+  --model-dir /path/to/Qwen3.5-35B-A3B \
+  --save-dir /path/to/Qwen3.5-35B-A3B-INT4 \
+  --group-size 128 \
+  --is-symmetric
+```
+
+The training actor remains BF16. In this recipe, `--ref-load` is only the first-run initialization fallback when `SAVE_DIR` is not yet a valid Megatron checkpoint; the reference/KL-loss path is disabled. Point `HF_MODEL` at the original Hugging Face directory and `INT4_MODEL` at the converted checkpoint. The native bridge loads the BF16 checkpoint directly, so a separate `torch_dist` conversion is not required:
+
+```bash
+BASE_FOLDER=/path/to/workdir \
+HF_MODEL=/path/to/Qwen3.5-35B-A3B \
+INT4_MODEL=/path/to/Qwen3.5-35B-A3B-INT4 \
+bash scripts/low_precision/run-qwen3.5-35B-A3B-int4-qat-rl.sh
+```
+
+This path currently requires `--expert-tensor-parallel-size 1`. MTP training and visual INT4-QAT are not included.
+
 3. Launch an example:
 
 ```bash
@@ -138,6 +171,9 @@ bash scripts/low_precision/run-qwen3-235B-A22B-int4.sh
 
 # Kimi-k2-Thinking INT4 training (32 nodes)
 bash scripts/low_precision/run-kimi-k2-Thinking-int4.sh
+
+# Qwen3.5-35B-A3B routed-expert INT4-QAT training
+bash scripts/low_precision/run-qwen3.5-35B-A3B-int4-qat-rl.sh
 ```
 
 For multi-node environments, start the Ray service according to your cluster configuration.

--- a/docs/research/qwen35-int4-qat-native-bridge-port.md
+++ b/docs/research/qwen35-int4-qat-native-bridge-port.md
@@ -1,0 +1,131 @@
+# Qwen3.5 routed-expert INT4-QAT 适配记录
+
+## 目标与边界
+
+本适配只保证 Qwen3.5 MoE 的 routed experts 进入 INT4 fake-QAT 和 SGLang INT4 rollout：
+
+```text
+INT4：routed experts
+BF16：attention、linear_attn、vision、shared expert、router、MTP、
+      embedding、norm、lm_head
+```
+
+训练 actor 保持 BF16 Parameter，通过 Megatron grouped-expert 的 fake INT4 路径训练；SGLang 使用 compressed-tensors INT4 权重做 rollout。当前只支持 `expert-tensor-parallel-size=1`，不恢复已经删除的 NVIDIA Megatron-Bridge。
+
+## 最终数据路径
+
+```text
+初始化
+BF16 HF checkpoint ──native HF→Megatron──> Megatron actor
+        │
+        └──convert_hf_to_int4_direct.py
+             ├── config 精确匹配 Qwen3.5 MoE
+             ├── fused expert 3D→逐 expert 2D
+             └── symmetric group-wise INT4 pack
+                         │
+                         └──> SGLang rollout checkpoint
+
+每轮更新
+Megatron local 3D expert Parameter
+        │  保留 Parameter 的 TP 属性
+        │  名字携带当前 EP rank 的 global expert offset
+        ▼
+TP/EP collective
+        ▼
+qwen3_5.py：恢复 offset，拆成逐 expert gate/up/down 2D
+        ▼
+compressed-tensors online pack
+        ▼
+SGLang：restore 原始布局 → load → repack kernel 布局
+```
+
+## 必要机制
+
+### 严格模型 identity
+
+只有下面两个字段同时匹配才进入 Qwen3.5 专用转换：
+
+```text
+model_type   = qwen3_5_moe
+architecture = Qwen3_5MoeForConditionalGeneration
+```
+
+参数名字只识别 tensor layout，不再承担模型识别职责。
+
+### 共享 expert layout
+
+`slime/backends/qwen3_5_expert_layout.py` 是离线 converter 和在线 exporter 的共同实现，负责：
+
+- 识别 HF `gate_up_proj` / `down_proj` fused key；
+- 识别 Megatron `linear_fc1` / `linear_fc2` grouped-expert key；
+- 将 `[E, 2F, H]` 拆成逐 expert gate/up `[F, H]`；
+- 将 `[E, H, F]` 拆成逐 expert down `[H, F]`；
+- 编解码 EP rank 的第一个 global expert id。
+
+这层不能删除：若分别内联到离线和在线路径，两套命名及切分逻辑会重新出现并可能漂移。
+
+### EP global expert id
+
+Qwen3.5 grouped expert 的参数名没有本地 expert 编号。EP rank `r` 对应的起始编号为：
+
+```text
+first_expert_id = r * num_experts / ep_size
+```
+
+切分不能发生在 collective 之前，否则 tensor slice 会丢失 Megatron Parameter 上的 TP metadata。当前 `ParamInfo` interface 又没有 expert offset 字段，因此 offset 临时编码进内部名字，在 exporter 完成切分后移除；该后缀不会发给 SGLang。
+
+### 离线与在线一致性
+
+两条路径最终必须产生相同的名字与二维 shape：
+
+```text
+model.language_model.layers.L.mlp.experts.E.gate_proj.weight
+model.language_model.layers.L.mlp.experts.E.up_proj.weight
+model.language_model.layers.L.mlp.experts.E.down_proj.weight
+```
+
+量化后变为 `weight_packed`、`weight_scale` 和 `weight_shape`。初始 checkpoint 写入的 ignore rules 也用于每轮在线更新，从而保证只有 routed experts 被量化。
+
+## 主线迁移
+
+迁移没有直接恢复旧 mbridge 代码，而是落到主线已有 interface：
+
+- 原生 HF→Megatron loader 初始化 BF16 actor；
+- `named_params_and_buffers()` 负责 PP/EP 全局命名；
+- `qwen3_5.py` 负责 Megatron→HF；
+- `quantizer_compressed_tensors.py` 负责在线 INT4 pack；
+- slime 的 SGLang patch 提供在线权重 restore/repack。
+
+启动脚本中 `--hf-checkpoint` 指向 INT4 rollout checkpoint；`--ref-load` 指向原始 BF16 HF checkpoint，仅作为首次 actor 初始化回退；`--load` / `--save` 指向 Megatron 训练 checkpoint。
+
+## 2026-09-04 消融结果
+
+以“Qwen3.5-35B-A3B、EP=4、ETP=1 可以完成离线转换和在线同步”为不变量，删除以下设计：
+
+| 删除项 | 原因 | 结果 |
+|---|---|---|
+| 转换前扫描所有 safetensors key/shape | config 已经精确限定模型，转换时仍会检查 fused name 和 3D shape | 少一次完整 checkpoint 遍历 |
+| `_is_qwen35_fused_expert()` 等一次性包装函数 | 没有形成独立 interface，只转发一次调用 | 逻辑直接留在 converter |
+| 合并通用和 Qwen3.5 ignore rules | Qwen3.5 精度范围固定，不需要可变组合 | 输出 config 使用固定 Qwen3.5 rules |
+| 重复的 `conv1d`、`shared_experts` rule | 已分别被 `linear_attn`、`shared_expert` 覆盖 | 行为不变 |
+| EP offset 的负数保护 | offset 只由非负 EP rank 公式产生 | 删除不可达分支 |
+| 独立 style/test-fix 历史 | 属于提交组织噪音 | 重整时并入对应功能提交 |
+
+以下设计经删除测试后保留：
+
+- 共享 layout 模块：有离线、在线两个真实消费者；
+- `model_type + architectures` 精确 gate：避免其他同名 MoE tensor 进入专用路径；
+- EP offset：否则不同 EP rank 都从 expert 0 开始并互相覆盖；
+- ETP=1 限制：当前没有验证 fused expert 的 ETP 分片轴；
+- SGLang `post_process_weights`：compressed-tensors 在线更新必须 restore/load/repack。
+
+## 验证边界
+
+本地可完成 Python compile、shell syntax、patch syntax、静态调用链和 pre-commit。完整验收仍需在 H20 环境完成：
+
+1. 转换后的 checkpoint 只有 routed experts 含 INT4 packed tensors；
+2. 256 个 global expert id 完整且无 EP 覆盖；
+3. 第一次在线权重更新通过 `post_process_weights`；
+4. 至少完成两个 rollout→train→update iteration；
+5. reward、loss、gradient 无 NaN/Inf；
+6. checkpoint 可以恢复训练。

--- a/docs/zh/advanced/low-precision.md
+++ b/docs/zh/advanced/low-precision.md
@@ -124,6 +124,35 @@ RUNTIME_ENV_JSON="{
 - `128`：`moonlight-16B-A3B`、`qwen3-30B-A3B`、`qwen3-235B-A22B-int4`；
 - `32`：`kimi-k2-Thinking-int4`。
 
+### Qwen3.5 MoE INT4-QAT
+
+Qwen3.5 MoE 已支持 routed experts INT4-QAT 路径。转换器会自动处理 Qwen3.5 的 fused expert 权重，并生成可供 SGLang rollout 使用的 INT4 checkpoint。
+
+当前支持范围：
+
+```text
+INT4：routed experts
+BF16：attention、linear_attn、conv1d、shared_expert、router gate、visual、mtp、embedding、norm、lm_head
+```
+
+转换 Hugging Face checkpoint：
+
+```bash
+python tools/convert_hf_to_int4_direct.py \
+  --model-dir /path/to/Qwen3.5-35B-A3B \
+  --save-dir /path/to/Qwen3.5-35B-A3B-INT4 \
+  --group-size 128 \
+  --is-symmetric
+```
+
+然后启动：
+
+```bash
+bash scripts/low_precision/run-qwen3.5-35B-A3B-int4-qat-rl.sh
+```
+
+当前路径不包含 MTP training 和 visual INT4-QAT。
+
 3. 启动 example：
 
 ```bash
@@ -138,6 +167,9 @@ bash scripts/low_precision/run-qwen3-235B-A22B-int4.sh
 
 # Kimi-k2-Thinking INT4 training (32 nodes)
 bash scripts/low_precision/run-kimi-k2-Thinking-int4.sh
+
+# Qwen3.5-35B-A3B routed experts INT4-QAT training
+bash scripts/low_precision/run-qwen3.5-35B-A3B-int4-qat-rl.sh
 ```
 
 多机环境请根据集群配置启动 Ray 服务。

--- a/docs/zh/advanced/low-precision.md
+++ b/docs/zh/advanced/low-precision.md
@@ -124,6 +124,39 @@ RUNTIME_ENV_JSON="{
 - `128`：`moonlight-16B-A3B`、`qwen3-30B-A3B`、`qwen3-235B-A22B-int4`；
 - `32`：`kimi-k2-Thinking-int4`。
 
+### Qwen3.5 MoE INT4-QAT
+
+Qwen3.5 MoE 通过 slime 自己维护的原生 HF→Megatron / Megatron→HF bridge 支持 routed-expert INT4-QAT。转换器先精确检查 Qwen3.5 MoE 的 `model_type` 与 `architectures`，再识别 3D fused expert tensor，并写出 SGLang 所需的逐 expert 2D compressed-tensors 布局；在线 actor 权重更新复用同一模型 identity 与布局适配器。
+
+当前精度范围：
+
+```text
+INT4：routed experts
+BF16：attention、linear_attn、conv1d、shared_expert、router gate、
+      visual、mtp、embedding、norm、lm_head
+```
+
+先转换 rollout checkpoint：
+
+```bash
+python tools/convert_hf_to_int4_direct.py \
+  --model-dir /path/to/Qwen3.5-35B-A3B \
+  --save-dir /path/to/Qwen3.5-35B-A3B-INT4 \
+  --group-size 128 \
+  --is-symmetric
+```
+
+训练 actor 保持 BF16。本 recipe 中，`--ref-load` 只在 `SAVE_DIR` 尚不是有效 Megatron checkpoint 时作为首次初始化回退，不启用 reference/KL-loss 路径。令 `HF_MODEL` 指向原始 Hugging Face 目录，`INT4_MODEL` 指向转换后的 checkpoint；原生 bridge 可以直接加载 BF16 HF checkpoint，不再需要预先转换一份 `torch_dist`：
+
+```bash
+BASE_FOLDER=/path/to/workdir \
+HF_MODEL=/path/to/Qwen3.5-35B-A3B \
+INT4_MODEL=/path/to/Qwen3.5-35B-A3B-INT4 \
+bash scripts/low_precision/run-qwen3.5-35B-A3B-int4-qat-rl.sh
+```
+
+当前路径要求 `--expert-tensor-parallel-size 1`，且不包含 MTP training 和 visual INT4-QAT。
+
 3. 启动 example：
 
 ```bash
@@ -138,6 +171,9 @@ bash scripts/low_precision/run-qwen3-235B-A22B-int4.sh
 
 # Kimi-k2-Thinking INT4 training (32 nodes)
 bash scripts/low_precision/run-kimi-k2-Thinking-int4.sh
+
+# Qwen3.5-35B-A3B routed experts INT4-QAT training
+bash scripts/low_precision/run-qwen3.5-35B-A3B-int4-qat-rl.sh
 ```
 
 多机环境请根据集群配置启动 Ray 服务。

--- a/scripts/low_precision/run-qwen3.5-35B-A3B-int4-qat-rl.sh
+++ b/scripts/low_precision/run-qwen3.5-35B-A3B-int4-qat-rl.sh
@@ -1,0 +1,144 @@
+#!/bin/bash
+
+# for rerun the task (container has its own PID namespace -> only kills in-container procs)
+pkill -9 sglang
+sleep 3
+ray stop --force
+pkill -9 ray
+pkill -9 python
+sleep 3
+pkill -9 ray
+pkill -9 python
+
+set -ex
+
+export PYTHONUNBUFFERED=1
+
+NVLINK_COUNT=$(nvidia-smi topo -m 2>/dev/null | grep -o 'NV[0-9][0-9]*' | wc -l)
+if [ "$NVLINK_COUNT" -gt 0 ]; then
+    HAS_NVLINK=1
+else
+    HAS_NVLINK=0
+fi
+echo "HAS_NVLINK: $HAS_NVLINK (detected $NVLINK_COUNT NVLink references)"
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+source "${SCRIPT_DIR}/../models/qwen3.5-35B-A3B.sh"
+
+BASE_FOLDER=${BASE_FOLDER:-/mnt/slime-qwen35}
+
+CKPT_ARGS=(
+   --hf-checkpoint ${BASE_FOLDER}/Qwen3.5-35B-A3B-INT4/
+   --ref-load ${BASE_FOLDER}/Qwen3.5-35B-A3B_torch_dist/
+   --load ${BASE_FOLDER}/Qwen3.5-35B-A3B_slime/
+   --save ${BASE_FOLDER}/Qwen3.5-35B-A3B_slime/
+   --save-interval 2
+)
+
+ROLLOUT_ARGS=(
+   --prompt-data ${BASE_FOLDER}/dapo-math-17k/dapo-math-17k.jsonl
+   --input-key prompt
+   --label-key label
+   --apply-chat-template
+   --rollout-shuffle
+
+   --rm-type deepscaler
+
+   --num-rollout 2
+   --rollout-batch-size 4
+   --n-samples-per-prompt 2
+   --rollout-max-response-len 1024
+   --rollout-temperature 0.8
+
+   --global-batch-size 8
+   --balance-data
+)
+
+PERF_ARGS=(
+   --tensor-model-parallel-size 1
+   --sequence-parallel
+   --pipeline-model-parallel-size 1
+   --context-parallel-size 1
+   --expert-model-parallel-size 4
+   --expert-tensor-parallel-size 1
+
+   --recompute-granularity full
+   --recompute-method uniform
+   --recompute-num-layers 1
+
+   --use-dynamic-batch-size
+   --max-tokens-per-gpu 4096
+)
+
+GRPO_ARGS=(
+   --advantage-estimator grpo
+   --use-kl-loss
+   --kl-loss-coef 0.00
+   --kl-loss-type low_var_kl
+   --entropy-coef 0.00
+   --eps-clip 0.2
+   --eps-clip-high 0.28
+   --use-tis
+)
+
+OPTIMIZER_ARGS=(
+   --optimizer adam
+   --lr 1e-6
+   --lr-decay-style constant
+   --weight-decay 0.1
+   --adam-beta1 0.9
+   --adam-beta2 0.98
+
+   --optimizer-cpu-offload
+   --overlap-cpu-optimizer-d2h-h2d
+   --use-precision-aware-optimizer
+)
+
+WANDB_ARGS=(
+)
+
+SGLANG_ARGS=(
+   --rollout-num-gpus-per-engine 1
+   --sglang-mem-fraction-static 0.7
+   --qwen-gdn-backend fla
+   --sglang-cuda-graph-bs 1 2 4 8
+)
+
+MISC_ARGS=(
+   --attention-dropout 0.0
+   --hidden-dropout 0.0
+   --accumulate-allreduce-grads-in-fp32
+   --attention-softmax-in-fp32
+   --attention-backend flash
+)
+
+# launch the master node of ray in container
+export MASTER_ADDR=${MASTER_ADDR:-"127.0.0.1"}
+ray start --head --node-ip-address ${MASTER_ADDR} --num-gpus 4 --disable-usage-stats --dashboard-host=0.0.0.0 --dashboard-port=8265
+
+RUNTIME_ENV_JSON="{
+  \"env_vars\": {
+    \"PYTHONPATH\": \"/root/Megatron-LM/\",
+    \"CUDA_DEVICE_MAX_CONNECTIONS\": \"1\",
+    \"NVSHMEM_DISABLE_NCCL\": \"1\",
+    \"NCCL_NVLS_ENABLE\": \"0\",
+    \"OPEN_TRAINING_INT4_FAKE_QAT_FLAG\": \"1\",
+    \"OPEN_TRAINING_INT4_GROUP_SIZE\": \"128\"
+  }
+}"
+
+ray job submit --address="http://127.0.0.1:8265" \
+   --runtime-env-json="${RUNTIME_ENV_JSON}" \
+   -- python3 train.py \
+   --actor-num-nodes 1 \
+   --actor-num-gpus-per-node 4 \
+   --colocate \
+   ${MODEL_ARGS[@]} \
+   ${CKPT_ARGS[@]} \
+   ${ROLLOUT_ARGS[@]} \
+   ${OPTIMIZER_ARGS[@]} \
+   ${GRPO_ARGS[@]} \
+   ${WANDB_ARGS[@]} \
+   ${PERF_ARGS[@]} \
+   ${SGLANG_ARGS[@]} \
+   ${MISC_ARGS[@]}

--- a/scripts/low_precision/run-qwen3.5-35B-A3B-int4-qat-rl.sh
+++ b/scripts/low_precision/run-qwen3.5-35B-A3B-int4-qat-rl.sh
@@ -1,0 +1,152 @@
+#!/bin/bash
+
+# Qwen3.5-35B-A3B routed-expert INT4-QAT on 4 GPUs. The latest native slime
+# bridge loads the BF16 Hugging Face checkpoint directly; no torch_dist
+# pre-conversion or external Megatron-Bridge package is required.
+
+# For rerunning inside the slime container (which has its own PID namespace).
+pkill -9 sglang
+sleep 3
+ray stop --force
+pkill -9 ray
+pkill -9 python
+sleep 3
+pkill -9 ray
+pkill -9 python
+
+set -ex
+
+export PYTHONUNBUFFERED=1
+
+NVLINK_COUNT=$(nvidia-smi topo -m 2>/dev/null | grep -o 'NV[0-9][0-9]*' | wc -l)
+if [ "$NVLINK_COUNT" -gt 0 ]; then
+    HAS_NVLINK=1
+else
+    HAS_NVLINK=0
+fi
+echo "HAS_NVLINK: $HAS_NVLINK (detected $NVLINK_COUNT NVLink references)"
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+source "${SCRIPT_DIR}/../models/qwen3.5-35B-A3B.sh"
+
+BASE_FOLDER=${BASE_FOLDER:-/mnt/slime-qwen35}
+HF_MODEL=${HF_MODEL:-${BASE_FOLDER}/Qwen3.5-35B-A3B}
+INT4_MODEL=${INT4_MODEL:-${BASE_FOLDER}/Qwen3.5-35B-A3B-INT4}
+SAVE_DIR=${SAVE_DIR:-${BASE_FOLDER}/Qwen3.5-35B-A3B_slime}
+PROMPT_DATA=${PROMPT_DATA:-${BASE_FOLDER}/dapo-math-17k/dapo-math-17k.jsonl}
+
+CKPT_ARGS=(
+   # SGLang starts from this compressed-tensors checkpoint. Its config.json
+   # also drives INT4 quantization during every online actor weight update.
+   --hf-checkpoint "${INT4_MODEL}"
+
+   # The native HF -> Megatron loader initializes actor weights from BF16. If
+   # SAVE_DIR has no Megatron tracker yet, --load falls back to this HF
+   # directory; later runs resume from SAVE_DIR. KL loss is intentionally off,
+   # so --ref-load is only the initialization fallback here.
+   --ref-load "${HF_MODEL}"
+   --load "${SAVE_DIR}"
+   --save "${SAVE_DIR}"
+   --save-interval 2
+)
+
+ROLLOUT_ARGS=(
+   --prompt-data "${PROMPT_DATA}"
+   --input-key prompt
+   --label-key label
+   --apply-chat-template
+   --rollout-shuffle
+
+   --rm-type deepscaler
+
+   --num-rollout 2
+   --rollout-batch-size 4
+   --n-samples-per-prompt 2
+   --rollout-max-response-len 1024
+   --rollout-temperature 0.8
+
+   --global-batch-size 8
+   --balance-data
+)
+
+PERF_ARGS=(
+   --tensor-model-parallel-size 1
+   --sequence-parallel
+   --pipeline-model-parallel-size 1
+   --context-parallel-size 1
+   --expert-model-parallel-size 4
+   --expert-tensor-parallel-size 1
+
+   --recompute-granularity full
+   --recompute-method uniform
+   --recompute-num-layers 1
+
+   --use-dynamic-batch-size
+   --max-tokens-per-gpu 4096
+)
+
+GRPO_ARGS=(
+   --advantage-estimator grpo
+   --entropy-coef 0.00
+   --eps-clip 0.2
+   --eps-clip-high 0.28
+   --use-tis
+)
+
+OPTIMIZER_ARGS=(
+   --optimizer adam
+   --lr 1e-6
+   --lr-decay-style constant
+   --weight-decay 0.1
+   --adam-beta1 0.9
+   --adam-beta2 0.98
+
+   --optimizer-cpu-offload
+   --overlap-cpu-optimizer-d2h-h2d
+   --use-precision-aware-optimizer
+)
+
+SGLANG_ARGS=(
+   --rollout-num-gpus-per-engine 1
+   --sglang-mem-fraction-static 0.7
+   --qwen-gdn-backend fla
+   --sglang-cuda-graph-bs 1 2 4 8
+)
+
+MISC_ARGS=(
+   --attention-dropout 0.0
+   --hidden-dropout 0.0
+   --accumulate-allreduce-grads-in-fp32
+   --attention-softmax-in-fp32
+   --attention-backend flash
+)
+
+export MASTER_ADDR=${MASTER_ADDR:-"127.0.0.1"}
+ray start --head --node-ip-address "${MASTER_ADDR}" --num-gpus 4 --disable-usage-stats \
+   --dashboard-host=0.0.0.0 --dashboard-port=8265
+
+RUNTIME_ENV_JSON="{
+  \"env_vars\": {
+    \"PYTHONPATH\": \"/root/Megatron-LM/\",
+    \"CUDA_DEVICE_MAX_CONNECTIONS\": \"1\",
+    \"NVSHMEM_DISABLE_NCCL\": \"1\",
+    \"NCCL_NVLS_ENABLE\": \"${HAS_NVLINK}\",
+    \"OPEN_TRAINING_INT4_FAKE_QAT_FLAG\": \"1\",
+    \"OPEN_TRAINING_INT4_GROUP_SIZE\": \"128\"
+  }
+}"
+
+ray job submit --address="http://127.0.0.1:8265" \
+   --runtime-env-json="${RUNTIME_ENV_JSON}" \
+   -- python3 train.py \
+   --actor-num-nodes 1 \
+   --actor-num-gpus-per-node 4 \
+   --colocate \
+   "${MODEL_ARGS[@]}" \
+   "${CKPT_ARGS[@]}" \
+   "${ROLLOUT_ARGS[@]}" \
+   "${OPTIMIZER_ARGS[@]}" \
+   "${GRPO_ARGS[@]}" \
+   "${PERF_ARGS[@]}" \
+   "${SGLANG_ARGS[@]}" \
+   "${MISC_ARGS[@]}"

--- a/slime/backends/megatron_utils/arguments.py
+++ b/slime/backends/megatron_utils/arguments.py
@@ -5,6 +5,8 @@ from megatron.training.arguments import parse_args as _megatron_parse_args
 from megatron.training.arguments import validate_args as _megatron_validate_args
 from transformers import AutoConfig
 
+from slime.backends.qwen3_5_expert_layout import is_qwen3_5_moe_config
+
 try:
     from megatron.core.tokenizers.utils.build_tokenizer import vocab_size_with_padding as _vocab_size_with_padding
 except ImportError:
@@ -198,6 +200,10 @@ def megatron_parse_args(extra_args_provider, skip_hf_validate=False):
     if args.hf_checkpoint and not skip_hf_validate:
         hf_config = AutoConfig.from_pretrained(args.hf_checkpoint, trust_remote_code=True)
         _hf_validate_args(args, hf_config)
+
+    # Resolve the model identity once from config. Downstream bridge code uses
+    # this flag instead of inferring Qwen3.5 from generic parameter names.
+    args.is_qwen3_5_moe = is_qwen3_5_moe_config(hf_config)
 
     if not skip_hf_validate:
         _validate_allgather_cp_supported(args, hf_config)

--- a/slime/backends/megatron_utils/megatron_to_hf/processors/quantizer_compressed_tensors.py
+++ b/slime/backends/megatron_utils/megatron_to_hf/processors/quantizer_compressed_tensors.py
@@ -264,7 +264,8 @@ def pack_layer(weight, group_size, sym=True):
 
 
 def quantize_params_compressed_tensors(converted_named_params, quantization_config):
-    w_cfg = quantization_config["config_groups"]["group_0"]["weights"]
+    # key-agnostic: llmcompressor writes "config_group_0", slime writes "group_0"
+    w_cfg = next(iter(quantization_config["config_groups"].values()))["weights"]
     group_size = w_cfg["group_size"]
     is_symmetric = w_cfg["symmetric"]
     ignore_rules = quantization_config.get("ignore", [])
@@ -272,11 +273,19 @@ def quantize_params_compressed_tensors(converted_named_params, quantization_conf
     results = []
 
     for name, param in converted_named_params:
+        # compressed-tensors ignore rules target MODULE names (e.g. "...mlp.gate"),
+        # but `name` here is a parameter name ("...mlp.gate.weight"). Match against
+        # both so llmcompressor-style "$"-anchored module rules apply correctly.
+        module_name = re.sub(r"\.(weight|bias)$", "", name)
         is_ignored = any(
-            (r.startswith("re:") and re.match(r[3:], name)) or r == name or name.startswith(r) for r in ignore_rules
+            (r.startswith("re:") and (re.match(r[3:], name) or re.match(r[3:], module_name)))
+            or r == name
+            or r == module_name
+            or name.startswith(r)
+            for r in ignore_rules
         )
 
-        if is_ignored or not name.endswith(".weight") or param.dim() < 2:
+        if is_ignored or not name.endswith(".weight") or param.dim() != 2:
             results.append((name, param))
             continue
 

--- a/slime/backends/megatron_utils/megatron_to_hf/qwen3_5.py
+++ b/slime/backends/megatron_utils/megatron_to_hf/qwen3_5.py
@@ -31,6 +31,27 @@ def _convert_mtp_layer(args, name, param, layer_idx):
     return None
 
 
+def _split_gate_up(param):
+    return param.chunk(2, dim=0)
+
+
+def _expert_hf_prefix(layer_prefix, expert_id):
+    return f"{layer_prefix}.mlp.experts.{expert_id}"
+
+
+def _emit_expert_gate_up(layer_prefix, expert_id, param):
+    gate, up = _split_gate_up(param)
+    expert_prefix = _expert_hf_prefix(layer_prefix, expert_id)
+    return [
+        (f"{expert_prefix}.gate_proj.weight", gate),
+        (f"{expert_prefix}.up_proj.weight", up),
+    ]
+
+
+def _emit_expert_down(layer_prefix, expert_id, param):
+    return [(f"{_expert_hf_prefix(layer_prefix, expert_id)}.down_proj.weight", param)]
+
+
 def convert_qwen3_5_to_hf(args, name, param):
     """Convert Qwen3.5 model parameters from Megatron to HuggingFace format.
 
@@ -69,11 +90,30 @@ def convert_qwen3_5_to_hf(args, name, param):
         layer_idx, rest = match.groups()
         prefix = f"model.language_model.layers.{layer_idx}"
 
-        # experts (grouped gemm - fused format)
-        if rest == "mlp.experts.linear_fc1":
-            return [(f"{prefix}.mlp.experts.gate_up_proj", param)]
-        elif rest == "mlp.experts.linear_fc2":
-            return [(f"{prefix}.mlp.experts.down_proj", param)]
+        # experts (grouped gemm) -- Megatron stores all experts fused as a 3D
+        # tensor: linear_fc1.weight [num_experts, 2*ffn, hidden] (gate|up) and
+        # linear_fc2.weight [num_experts, hidden, ffn] (down). Split per-expert
+        # into individual 2D Linear weights, matching the llmcompressor
+        # compressed-tensors layout that sglang's wNa16 MoE loader expects.
+        #
+        # EP global expert id: common.py:_named_params_and_buffers_global encodes the
+        # source ep_rank's expert_offset into the name as a ".__ep_offset{N}" suffix
+        # (the source ep_rank is NOT otherwise carried into convert_to_hf, so it must
+        # ride on the name). Strip and parse it FIRST, then split with global ids
+        # (offset + local_i) so EP ranks map to disjoint, non-overlapping id ranges.
+        _ep_match = re.search(r"\.__ep_offset(\d+)$", rest)
+        _expert_offset = int(_ep_match.group(1)) if _ep_match else 0
+        _rest_clean = rest[: _ep_match.start()] if _ep_match else rest
+        if re.match(r"mlp\.experts(?:\.experts)*\.linear_fc1(?:\.weight)?$", _rest_clean) and param.dim() == 3:
+            out = []
+            for _i in range(param.shape[0]):
+                out.extend(_emit_expert_gate_up(prefix, _expert_offset + _i, param[_i]))
+            return out
+        if re.match(r"mlp\.experts(?:\.experts)*\.linear_fc2(?:\.weight)?$", _rest_clean) and param.dim() == 3:
+            out = []
+            for _i in range(param.shape[0]):
+                out.extend(_emit_expert_down(prefix, _expert_offset + _i, param[_i]))
+            return out
 
         # experts (ungrouped - individual expert format)
         expert_pattern = r"mlp.experts\.(.+)\.weight(\d+)"
@@ -81,13 +121,9 @@ def convert_qwen3_5_to_hf(args, name, param):
         if match:
             rest, expert_idx = match.groups()
             if rest == "linear_fc1":
-                gate_weight, up_weight = param.chunk(2, dim=0)
-                return [
-                    (f"{prefix}.mlp.experts.{expert_idx}.gate_proj.weight", gate_weight),
-                    (f"{prefix}.mlp.experts.{expert_idx}.up_proj.weight", up_weight),
-                ]
+                return _emit_expert_gate_up(prefix, expert_idx, param)
             elif rest == "linear_fc2":
-                return [(f"{prefix}.mlp.experts.{expert_idx}.down_proj.weight", param)]
+                return _emit_expert_down(prefix, expert_idx, param)
             else:
                 raise ValueError(f"Unknown expert parameter name: {name}")
 

--- a/slime/backends/megatron_utils/megatron_to_hf/qwen3_5.py
+++ b/slime/backends/megatron_utils/megatron_to_hf/qwen3_5.py
@@ -2,6 +2,12 @@ import re
 
 import torch
 
+from slime.backends.qwen3_5_expert_layout import (
+    decode_expert_parallel_offset,
+    iter_fused_expert_projections,
+    megatron_fused_expert_projection,
+)
+
 
 def _convert_mtp_layer(args, name, param, layer_idx):
     """Convert MTP layer parameters from Megatron to HuggingFace format."""
@@ -72,11 +78,24 @@ def convert_qwen3_5_to_hf(args, name, param):
         layer_idx, rest = match.groups()
         prefix = f"model.language_model.layers.{layer_idx}"
 
-        # experts (grouped gemm - fused format)
-        if rest == "mlp.experts.linear_fc1":
-            return [(f"{prefix}.mlp.experts.gate_up_proj", param)]
-        elif rest == "mlp.experts.linear_fc2":
-            return [(f"{prefix}.mlp.experts.down_proj", param)]
+        # Grouped-GEMM routed experts are local 3D tensors. The native bridge's
+        # ParamInfo seam carries only name/tensor metadata, so common.py encodes
+        # this EP rank's first global expert id in an internal name suffix. Split
+        # only after TP gather, then expose the per-expert 2D HF layout required
+        # by compressed-tensors/SGLang.
+        rest, expert_offset = decode_expert_parallel_offset(rest)
+        fused_projection = megatron_fused_expert_projection(rest)
+        if fused_projection is not None:
+            if param.dim() != 3:
+                raise ValueError(f"Qwen3.5 fused expert parameter must be 3D, got {tuple(param.shape)} for {name}")
+            return [
+                (f"{prefix}.mlp.experts.{expert_id}.{projection}.weight", weight)
+                for expert_id, projection, weight in iter_fused_expert_projections(
+                    param,
+                    fused_projection,
+                    first_expert_id=expert_offset,
+                )
+            ]
 
         # experts (ungrouped - individual expert format)
         expert_pattern = r"mlp.experts\.(.+)\.weight(\d+)"

--- a/slime/backends/megatron_utils/update_weight/common.py
+++ b/slime/backends/megatron_utils/update_weight/common.py
@@ -39,7 +39,12 @@ def all_gather_param(name: str, param: torch.nn.Parameter) -> torch.Tensor:
     ), "partition_stride != 1 is not supported"
     # TODO: here we did an extra copy during concat, maybe merge this with convert_to_hf is better?
     # TODO: check only GLU is used.
-    if "linear_fc1.weight" in name or "linear_fc1.bias" in name:
+    # GLU rechunk is only valid for 2D weights (Qwen3 per-expert / dense GLU). For Qwen3.5
+    # fused 3D experts [E, 2F, H] dim0 is the EXPERT axis, so chunk(2, dim=0) would split
+    # experts in half -> corruption. Under ETP=1 these are non-TP and we never reach here,
+    # but guard on dim==2 so this is correct regardless of the tensor_model_parallel flag;
+    # the gate/up split for fused experts is done per-expert later in convert_to_hf.
+    if ("linear_fc1.weight" in name or "linear_fc1.bias" in name) and param.dim() == 2:
         param_partitions = [p.chunk(2, dim=0) for p in param_partitions]
         param_partitions = [p[0] for p in param_partitions] + [p[1] for p in param_partitions]
     # this is bug in megatron's grouped moe.
@@ -101,7 +106,9 @@ def all_gather_params_async(
             assert partition_dim is not None, "partition_stride != 1 is not supported"
             # TODO: here we did an extra copy during concat, maybe merge this with convert_to_hf is better?
             # TODO: check only GLU is used.
-            if "linear_fc1.weight" in info.name or "linear_fc1.bias" in info.name:
+            # only 2D weights get the GLU rechunk; fused 3D experts [E,2F,H] are split
+            # per-expert later in convert_to_hf (see all_gather_param for rationale).
+            if ("linear_fc1.weight" in info.name or "linear_fc1.bias" in info.name) and param_partitions[0].dim() == 2:
                 param_partitions = [p.chunk(2, dim=0) for p in param_partitions]
                 param_partitions = [p[0] for p in param_partitions] + [p[1] for p in param_partitions]
             # this is bug in megatron's grouped moe.
@@ -215,6 +222,14 @@ def _named_params_and_buffers_global(
                 rest, param_type, expert_idx = match.groups()
                 expert_idx = int(expert_idx) + expert_offset
                 yield f"module.module.decoder.layers.{layer_idx}.mlp.experts.{rest}.{param_type}{expert_idx}", param
+            elif args.num_experts and re.match(r".*mlp\.experts(?:\.experts)*\.linear_fc[12]\.weight$", rest):
+                # Qwen3.5 fused 3D routed experts (linear_fc1.weight [E,2F,H] / linear_fc2.weight
+                # [E,H,F], no per-expert digit). Do NOT slice here: slicing drops the
+                # tensor_model_parallel / partition_dim attributes that all_gather_param asserts on.
+                # Instead encode the EP global-expert-id offset into the name; convert_to_hf splits
+                # into per-expert tensors with global ids AFTER the TP/EP gather. The "__ep_offset"
+                # suffix is non-numeric right after "weight", so it never collides with weight(\d+).
+                yield f"module.module.decoder.layers.{layer_idx}.{rest}.__ep_offset{expert_offset}", param
             else:
                 yield f"module.module.decoder.layers.{layer_idx}.{rest}", param
 

--- a/slime/backends/megatron_utils/update_weight/common.py
+++ b/slime/backends/megatron_utils/update_weight/common.py
@@ -8,6 +8,7 @@ import torch.distributed as dist
 from megatron.core import mpu
 from megatron.core.transformer.transformer_layer import get_transformer_layer_offset
 
+from slime.backends.qwen3_5_expert_layout import encode_expert_parallel_offset, megatron_fused_expert_projection
 from slime.utils.types import ParamInfo
 
 
@@ -183,6 +184,21 @@ def named_params_and_buffers(args: Namespace, model: Sequence[torch.nn.Module]) 
                 rest, param_type, expert_idx = match.groups()
                 expert_idx = int(expert_idx) + expert_offset
                 yield f"{prefix}decoder.layers.{layer_idx}.mlp.experts.{rest}.{param_type}{expert_idx}", param
+            elif (
+                getattr(args, "is_qwen3_5_moe", False)
+                and args.num_experts
+                and param.dim() == 3
+                and megatron_fused_expert_projection(rest) is not None
+            ):
+                if getattr(args, "expert_tensor_parallel_size", 1) != 1:
+                    raise ValueError("Qwen3.5 fused-expert INT4 sync currently requires expert tensor parallel size 1")
+                # Fused grouped experts have no per-expert digit in their MCore
+                # name. Keep the Parameter intact so its TP attributes survive
+                # gathering, and carry the EP rank's global offset through the
+                # name-only ParamInfo interface. The Qwen3.5 exporter consumes
+                # this suffix after collectives and then splits the 3D tensor.
+                rest = encode_expert_parallel_offset(rest, expert_offset)
+                yield f"{prefix}decoder.layers.{layer_idx}.{rest}", param
             else:
                 yield f"{prefix}decoder.layers.{layer_idx}.{rest}", param
 

--- a/slime/backends/qwen3_5_expert_layout.py
+++ b/slime/backends/qwen3_5_expert_layout.py
@@ -1,0 +1,94 @@
+"""Qwen3.5 fused routed-expert layout helpers.
+
+The native slime bridge sees the same logical routed experts in two physical
+layouts:
+
+* Hugging Face stores one 3D ``gate_up_proj`` / ``down_proj`` tensor per layer.
+* compressed-tensors and SGLang exchange one 2D weight per expert/projection.
+
+This module owns that layout boundary so offline checkpoint conversion and
+online Megatron-to-HF updates cannot silently drift apart.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterator, Mapping
+from typing import Any
+
+
+QWEN3_5_MOE_MODEL_TYPE = "qwen3_5_moe"
+QWEN3_5_MOE_ARCHITECTURE = "Qwen3_5MoeForConditionalGeneration"
+GATE_UP_PROJ = "gate_up_proj"
+DOWN_PROJ = "down_proj"
+
+_HF_FUSED_EXPERT_RE = re.compile(r"(?P<prefix>.*\.mlp\.experts)\.(?P<projection>gate_up_proj|down_proj)$")
+_MEGATRON_FUSED_EXPERT_RE = re.compile(r"mlp\.experts\.linear_fc(?P<projection>[12])$")
+_EP_OFFSET_RE = re.compile(r"\.__ep_offset(?P<offset>\d+)$")
+
+
+def is_qwen3_5_moe_config(config: Any) -> bool:
+    """Match the exact Qwen3.5 MoE identity used by the supported checkpoint."""
+    if config is None:
+        return False
+    if isinstance(config, Mapping):
+        model_type = config.get("model_type")
+        architectures = config.get("architectures") or []
+    else:
+        model_type = getattr(config, "model_type", None)
+        architectures = getattr(config, "architectures", None) or []
+    return model_type == QWEN3_5_MOE_MODEL_TYPE and QWEN3_5_MOE_ARCHITECTURE in architectures
+
+
+def match_hf_fused_expert(name: str) -> tuple[str, str] | None:
+    """Return ``(expert_prefix, projection)`` for a fused Qwen3.5 HF key."""
+    match = _HF_FUSED_EXPERT_RE.fullmatch(name)
+    if match is None:
+        return None
+    return match.group("prefix"), match.group("projection")
+
+
+def megatron_fused_expert_projection(name: str) -> str | None:
+    """Return the canonical projection for a fused Qwen3.5 MCore name."""
+    match = _MEGATRON_FUSED_EXPERT_RE.fullmatch(name)
+    if match is None:
+        return None
+    return GATE_UP_PROJ if match.group("projection") == "1" else DOWN_PROJ
+
+
+def encode_expert_parallel_offset(name: str, expert_offset: int) -> str:
+    """Carry an EP rank's first global expert id across the name-only bridge seam."""
+    return f"{name}.__ep_offset{expert_offset}"
+
+
+def decode_expert_parallel_offset(name: str) -> tuple[str, int]:
+    """Strip the internal EP offset suffix, defaulting to rank-zero offset."""
+    match = _EP_OFFSET_RE.search(name)
+    if match is None:
+        return name, 0
+    return name[: match.start()], int(match.group("offset"))
+
+
+def iter_fused_expert_projections(
+    weight: Any,
+    projection: str,
+    *,
+    first_expert_id: int = 0,
+) -> Iterator[tuple[int, str, Any]]:
+    """Split one 3D fused tensor into ``(global_id, projection, 2D weight)``."""
+    if weight.dim() != 3:
+        raise ValueError(f"fused expert weight must be 3D, got shape {tuple(weight.shape)}")
+    if projection not in {GATE_UP_PROJ, DOWN_PROJ}:
+        raise ValueError(f"unsupported fused expert projection: {projection}")
+    if projection == GATE_UP_PROJ and weight.shape[1] % 2 != 0:
+        raise ValueError(f"gate_up_proj output dimension must be even, got shape {tuple(weight.shape)}")
+
+    for local_expert_id in range(weight.shape[0]):
+        expert_id = first_expert_id + local_expert_id
+        expert_weight = weight[local_expert_id]
+        if projection == GATE_UP_PROJ:
+            gate, up = expert_weight.chunk(2, dim=0)
+            yield expert_id, "gate_proj", gate.contiguous()
+            yield expert_id, "up_proj", up.contiguous()
+        else:
+            yield expert_id, "down_proj", expert_weight.contiguous()

--- a/tests/test_qwen35_int4_fused_expert_quantizer.py
+++ b/tests/test_qwen35_int4_fused_expert_quantizer.py
@@ -1,0 +1,284 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+from tools import convert_hf_to_int4_direct as converter
+
+
+def _load_module(module_name, relative_path):
+    module_path = REPO_ROOT / relative_path
+    sys.modules.pop(module_name, None)
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+qwen3_5 = _load_module(
+    "test_qwen35_megatron_to_hf_qwen3_5",
+    "slime/backends/megatron_utils/megatron_to_hf/qwen3_5.py",
+)
+quantizer_compressed_tensors = _load_module(
+    "test_qwen35_quantizer_compressed_tensors",
+    "slime/backends/megatron_utils/megatron_to_hf/processors/quantizer_compressed_tensors.py",
+)
+
+
+NUM_EXPERTS = 256
+EP_SIZE = 4
+LOCAL_EXPERTS = NUM_EXPERTS // EP_SIZE
+FFN = 8
+HIDDEN = 4
+
+
+def _args():
+    return SimpleNamespace(
+        num_experts=NUM_EXPERTS,
+        kv_channels=None,
+        hidden_size=HIDDEN,
+        num_attention_heads=2,
+        num_query_groups=1,
+    )
+
+
+def _ep_offset(ep_rank):
+    return ep_rank * NUM_EXPERTS // EP_SIZE
+
+
+def _expert_ids(named_params, suffix):
+    ids = []
+    for name, _ in named_params:
+        marker = ".mlp.experts."
+        if suffix in name and marker in name:
+            ids.append(int(name.split(marker, 1)[1].split(".", 1)[0]))
+    return sorted(ids)
+
+
+@pytest.mark.unit
+def test_runtime_fused_experts_keep_ep_global_ids():
+    args = _args()
+    all_gate_ids = []
+    all_down_ids = []
+
+    for ep_rank in range(EP_SIZE):
+        offset = _ep_offset(ep_rank)
+        fc1_name = f"module.module.decoder.layers.0.mlp.experts.experts.linear_fc1.weight.__ep_offset{offset}"
+        fc2_name = f"module.module.decoder.layers.0.mlp.experts.experts.linear_fc2.weight.__ep_offset{offset}"
+
+        fc1_out = qwen3_5.convert_qwen3_5_to_hf(args, fc1_name, torch.zeros(LOCAL_EXPERTS, 2 * FFN, HIDDEN))
+        fc2_out = qwen3_5.convert_qwen3_5_to_hf(args, fc2_name, torch.zeros(LOCAL_EXPERTS, HIDDEN, FFN))
+
+        expected = list(range(offset, offset + LOCAL_EXPERTS))
+        assert _expert_ids(fc1_out, "gate_proj.weight") == expected
+        assert _expert_ids(fc2_out, "down_proj.weight") == expected
+        all_gate_ids.extend(expected)
+        all_down_ids.extend(expected)
+
+    assert sorted(all_gate_ids) == list(range(NUM_EXPERTS))
+    assert sorted(all_down_ids) == list(range(NUM_EXPERTS))
+
+
+@pytest.mark.unit
+def test_runtime_fused_expert_split_matches_offline_split():
+    args = _args()
+    fc1 = torch.arange(LOCAL_EXPERTS * 2 * FFN * HIDDEN, dtype=torch.float32).view(LOCAL_EXPERTS, 2 * FFN, HIDDEN)
+    fc2 = torch.arange(LOCAL_EXPERTS * HIDDEN * FFN, dtype=torch.float32).view(LOCAL_EXPERTS, HIDDEN, FFN)
+
+    out = dict(
+        qwen3_5.convert_qwen3_5_to_hf(
+            args,
+            "module.module.decoder.layers.0.mlp.experts.experts.linear_fc1.weight.__ep_offset0",
+            fc1,
+        )
+        + qwen3_5.convert_qwen3_5_to_hf(
+            args,
+            "module.module.decoder.layers.0.mlp.experts.experts.linear_fc2.weight.__ep_offset0",
+            fc2,
+        )
+    )
+
+    for expert_id in range(LOCAL_EXPERTS):
+        gate, up = fc1[expert_id].chunk(2, dim=0)
+        assert torch.equal(out[f"model.language_model.layers.0.mlp.experts.{expert_id}.gate_proj.weight"], gate)
+        assert torch.equal(out[f"model.language_model.layers.0.mlp.experts.{expert_id}.up_proj.weight"], up)
+        assert torch.equal(
+            out[f"model.language_model.layers.0.mlp.experts.{expert_id}.down_proj.weight"], fc2[expert_id]
+        )
+
+
+@pytest.mark.unit
+def test_offline_converter_default_ignore_rules_stay_backward_compatible():
+    assert converter.DEFAULT_IGNORE_RULES == [
+        "re:.*lm_head.*",
+        "re:.*norm.*",
+        "re:.*embed.*",
+        "re:.*self_attn.*",
+        "re:.*shared_experts.*",
+        "re:.*mlp\\.(gate|up|gate_up|down)_proj.*",
+        "re:.*mlp\\.gate\\.*",
+    ]
+    for qwen35_only_rule in ["re:.*linear_attn.*", "re:.*conv1d.*", "re:.*visual.*", "re:.*mtp.*"]:
+        assert qwen35_only_rule not in converter.DEFAULT_IGNORE_RULES
+
+
+@pytest.mark.unit
+def test_offline_converter_fused_mode_quantizes_only_split_routed_experts(monkeypatch):
+    def fake_pack_layer(weight, group_size, sym=True):
+        packed = torch.full((weight.shape[0], 1), fill_value=weight.shape[0], dtype=torch.int32)
+        scale = torch.ones(weight.shape[0], 1, dtype=weight.dtype)
+        return packed, scale, None
+
+    monkeypatch.setattr(converter, "pack_layer", fake_pack_layer)
+
+    weights = {
+        "model.language_model.layers.0.mlp.experts.gate_up_proj": torch.randn(2, 2 * FFN, HIDDEN),
+        "model.language_model.layers.0.mlp.experts.down_proj": torch.randn(2, HIDDEN, FFN),
+        "model.language_model.layers.0.linear_attn.out_proj.weight": torch.randn(HIDDEN, HIDDEN),
+        "model.language_model.layers.0.mlp.gate.weight": torch.randn(2, HIDDEN),
+        "model.language_model.layers.0.mlp.shared_expert.down_proj.weight": torch.randn(HIDDEN, FFN),
+        "model.visual.patch_embed.weight": torch.randn(HIDDEN, HIDDEN),
+        "mtp.layers.0.mlp.down_proj.weight": torch.randn(HIDDEN, FFN),
+    }
+
+    q_weights = converter.convert_weights(
+        weights,
+        group_size=128,
+        is_symmetric=True,
+        ignore_rules=converter.DEFAULT_IGNORE_RULES,
+        qwen35_fused_expert_only=True,
+    )
+
+    for expert_id in range(2):
+        assert f"model.language_model.layers.0.mlp.experts.{expert_id}.gate_proj.weight_packed" in q_weights
+        assert f"model.language_model.layers.0.mlp.experts.{expert_id}.up_proj.weight_packed" in q_weights
+        assert f"model.language_model.layers.0.mlp.experts.{expert_id}.down_proj.weight_packed" in q_weights
+
+    assert "model.language_model.layers.0.mlp.experts.gate_up_proj" not in q_weights
+    assert "model.language_model.layers.0.mlp.experts.down_proj" not in q_weights
+    assert "model.language_model.layers.0.linear_attn.out_proj.weight" in q_weights
+    assert "model.language_model.layers.0.linear_attn.out_proj.weight_packed" not in q_weights
+    assert "model.language_model.layers.0.mlp.gate.weight" in q_weights
+    assert "model.language_model.layers.0.mlp.gate.weight_packed" not in q_weights
+    assert "model.language_model.layers.0.mlp.shared_expert.down_proj.weight" in q_weights
+    assert "model.language_model.layers.0.mlp.shared_expert.down_proj.weight_packed" not in q_weights
+    assert "model.visual.patch_embed.weight" in q_weights
+    assert "model.visual.patch_embed.weight_packed" not in q_weights
+    assert "mtp.layers.0.mlp.down_proj.weight" in q_weights
+    assert "mtp.layers.0.mlp.down_proj.weight_packed" not in q_weights
+
+
+@pytest.mark.unit
+def test_qwen35_custom_ignore_rule_keeps_split_expert_bf16_offline_and_runtime(monkeypatch):
+    def fake_pack_layer(weight, group_size, sym=True):
+        return torch.ones(weight.shape[0], 1, dtype=torch.int32), torch.ones(weight.shape[0], 1), None
+
+    monkeypatch.setattr(converter, "pack_layer", fake_pack_layer)
+
+    gate_name = "model.language_model.layers.0.mlp.experts.0.gate_proj.weight"
+    up_name = "model.language_model.layers.0.mlp.experts.0.up_proj.weight"
+    ignore_rules = ["re:.*\\.mlp\\.experts\\.0\\.gate_proj.*"]
+
+    offline_weights = converter.convert_weights(
+        {
+            "model.language_model.layers.0.mlp.experts.gate_up_proj": torch.randn(1, 2 * FFN, HIDDEN),
+        },
+        group_size=128,
+        is_symmetric=True,
+        ignore_rules=ignore_rules,
+        qwen35_fused_expert_only=True,
+    )
+
+    assert gate_name in offline_weights
+    assert gate_name.replace(".weight", ".weight_packed") not in offline_weights
+    assert up_name.replace(".weight", ".weight_packed") in offline_weights
+
+    runtime_gate = torch.randn(FFN, HIDDEN)
+    runtime_weights = quantizer_compressed_tensors.quantize_params_compressed_tensors(
+        [(gate_name, runtime_gate)],
+        {
+            "config_groups": {
+                "group_0": {
+                    "weights": {
+                        "group_size": 128,
+                        "symmetric": True,
+                    }
+                }
+            },
+            "ignore": ignore_rules,
+        },
+    )
+
+    assert runtime_weights == [(gate_name, runtime_gate)]
+
+
+@pytest.mark.unit
+def test_offline_converter_non_fused_mode_keeps_existing_quantization_behavior(monkeypatch):
+    def fake_pack_layer(weight, group_size, sym=True):
+        return torch.ones(weight.shape[0], 1, dtype=torch.int32), torch.ones(weight.shape[0], 1), None
+
+    monkeypatch.setattr(converter, "pack_layer", fake_pack_layer)
+
+    q_weights = converter.convert_weights(
+        {
+            "model.layers.0.self_attn.q_proj.weight": torch.randn(HIDDEN, HIDDEN),
+            "model.layers.0.mlp.experts.0.down_proj.weight": torch.randn(HIDDEN, FFN),
+        },
+        group_size=128,
+        is_symmetric=True,
+        ignore_rules=converter.DEFAULT_IGNORE_RULES,
+        qwen35_fused_expert_only=False,
+    )
+
+    assert "model.layers.0.self_attn.q_proj.weight" in q_weights
+    assert "model.layers.0.self_attn.q_proj.weight_packed" not in q_weights
+    assert "model.layers.0.mlp.experts.0.down_proj.weight" not in q_weights
+    assert "model.layers.0.mlp.experts.0.down_proj.weight_packed" in q_weights
+
+
+@pytest.mark.unit
+def test_runtime_quantizer_skips_non_2d_tensors(monkeypatch):
+    def fail_pack_layer(weight, group_size, sym=True):
+        raise AssertionError("3D tensors must not be packed")
+
+    monkeypatch.setattr(quantizer_compressed_tensors, "pack_layer", fail_pack_layer)
+
+    result = quantizer_compressed_tensors.quantize_params_compressed_tensors(
+        [("model.language_model.layers.0.linear_attn.conv1d.weight", torch.randn(2, 3, 4))],
+        {
+            "config_groups": {
+                "group_0": {
+                    "weights": {
+                        "group_size": 128,
+                        "symmetric": True,
+                    }
+                }
+            },
+            "ignore": [],
+        },
+    )
+
+    assert result[0][0] == "model.language_model.layers.0.linear_attn.conv1d.weight"
+    assert result[0][1].shape == (2, 3, 4)
+
+
+@pytest.mark.unit
+def test_qwen35_effective_quantization_config_keeps_non_experts_bf16():
+    effective_ignore = converter.get_effective_ignore_rules(qwen35_fused_expert_only=True)
+
+    assert "re:.*linear_attn.*" in effective_ignore
+    assert "re:.*conv1d.*" in effective_ignore
+    assert "re:.*visual.*" in effective_ignore
+    assert "re:.*shared_expert.*" in effective_ignore
+    assert "re:.*mtp.*" in effective_ignore
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/tests/test_qwen35_int4_fused_expert_quantizer.py
+++ b/tests/test_qwen35_int4_fused_expert_quantizer.py
@@ -1,0 +1,320 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+
+def _load_module(module_name, relative_path):
+    module_path = REPO_ROOT / relative_path
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+from slime.backends import qwen3_5_expert_layout as layout
+
+
+qwen3_5 = _load_module(
+    "test_qwen35_megatron_to_hf_qwen3_5",
+    "slime/backends/megatron_utils/megatron_to_hf/qwen3_5.py",
+)
+converter = _load_module("test_qwen35_int4_converter", "tools/convert_hf_to_int4_direct.py")
+
+
+@pytest.fixture(autouse=True)
+def _use_cpu_for_converter_metadata(monkeypatch):
+    monkeypatch.setattr(converter.accelerator, "memory_allocated", lambda: 0)
+    monkeypatch.setattr(converter.accelerator, "device", lambda: torch.device("cpu"))
+
+
+def _install_megatron_stubs():
+    megatron = types.ModuleType("megatron")
+    megatron.__path__ = []
+    core = types.ModuleType("megatron.core")
+    core.__path__ = []
+    mpu = types.ModuleType("megatron.core.mpu")
+    mpu.get_expert_model_parallel_world_size = lambda: 1
+    mpu.get_expert_model_parallel_rank = lambda: 0
+    transformer = types.ModuleType("megatron.core.transformer")
+    transformer.__path__ = []
+    transformer_layer = types.ModuleType("megatron.core.transformer.transformer_layer")
+    transformer_layer.get_transformer_layer_offset = lambda config, *args: 0
+    core.mpu = mpu
+    megatron.core = core
+    sys.modules.update(
+        {
+            "megatron": megatron,
+            "megatron.core": core,
+            "megatron.core.mpu": mpu,
+            "megatron.core.transformer": transformer,
+            "megatron.core.transformer.transformer_layer": transformer_layer,
+        }
+    )
+
+
+NUM_EXPERTS = 256
+EP_SIZE = 4
+LOCAL_EXPERTS = NUM_EXPERTS // EP_SIZE
+FFN = 8
+HIDDEN = 4
+
+
+def _args(*, is_qwen3_5_moe=True):
+    return SimpleNamespace(
+        num_experts=NUM_EXPERTS,
+        kv_channels=None,
+        hidden_size=HIDDEN,
+        num_attention_heads=2,
+        num_query_groups=1,
+        is_qwen3_5_moe=is_qwen3_5_moe,
+    )
+
+
+def _ep_offset(ep_rank):
+    return ep_rank * NUM_EXPERTS // EP_SIZE
+
+
+def _expert_ids(named_params, suffix):
+    ids = []
+    for name, _ in named_params:
+        marker = ".mlp.experts."
+        if suffix in name and marker in name:
+            ids.append(int(name.split(marker, 1)[1].split(".", 1)[0]))
+    return sorted(ids)
+
+
+@pytest.mark.integration
+def test_native_bridge_global_name_carries_ep_offset(monkeypatch):
+    try:
+        has_megatron = importlib.util.find_spec("megatron.core") is not None
+    except ModuleNotFoundError:
+        has_megatron = False
+    if not has_megatron:
+        original_modules = {name: sys.modules.get(name) for name in list(sys.modules) if name.startswith("megatron")}
+        _install_megatron_stubs()
+    else:
+        original_modules = None
+
+    try:
+        update_weight_common = _load_module(
+            "test_qwen35_update_weight_common",
+            "slime/backends/megatron_utils/update_weight/common.py",
+        )
+    finally:
+        if original_modules is not None:
+            for name in [name for name in list(sys.modules) if name.startswith("megatron")]:
+                sys.modules.pop(name, None)
+            sys.modules.update(original_modules)
+
+    monkeypatch.setattr(update_weight_common.mpu, "get_expert_model_parallel_world_size", lambda: EP_SIZE)
+    monkeypatch.setattr(update_weight_common.mpu, "get_expert_model_parallel_rank", lambda: 2)
+    monkeypatch.setattr(update_weight_common, "get_transformer_layer_offset", lambda config, *args: 3)
+
+    param = torch.nn.Parameter(torch.zeros(LOCAL_EXPERTS, 2 * FFN, HIDDEN))
+
+    class Model:
+        config = SimpleNamespace()
+
+        def named_parameters(self):
+            return iter(
+                [
+                    (
+                        "module.module.language_model.decoder.layers.1.mlp.experts.linear_fc1",
+                        param,
+                    )
+                ]
+            )
+
+        def named_buffers(self):
+            return iter([])
+
+    [(name, emitted_param)] = list(update_weight_common.named_params_and_buffers(_args(), [Model()]))
+
+    assert name == ("module.module.language_model.decoder.layers.4.mlp.experts.linear_fc1.__ep_offset128")
+    assert emitted_param is param
+
+    [(other_name, other_param)] = list(
+        update_weight_common.named_params_and_buffers(_args(is_qwen3_5_moe=False), [Model()])
+    )
+    assert other_name == "module.module.language_model.decoder.layers.4.mlp.experts.linear_fc1"
+    assert other_param is param
+
+    unsupported_args = _args()
+    unsupported_args.expert_tensor_parallel_size = 2
+    with pytest.raises(ValueError, match="expert tensor parallel size 1"):
+        list(update_weight_common.named_params_and_buffers(unsupported_args, [Model()]))
+
+
+@pytest.mark.unit
+def test_runtime_fused_experts_keep_ep_global_ids():
+    args = _args()
+    all_gate_ids = []
+    all_down_ids = []
+
+    for ep_rank in range(EP_SIZE):
+        offset = _ep_offset(ep_rank)
+        fc1_name = f"module.module.language_model.decoder.layers.0.mlp.experts.linear_fc1.__ep_offset{offset}"
+        fc2_name = f"module.module.language_model.decoder.layers.0.mlp.experts.linear_fc2.__ep_offset{offset}"
+
+        fc1_out = qwen3_5.convert_qwen3_5_to_hf(args, fc1_name, torch.zeros(LOCAL_EXPERTS, 2 * FFN, HIDDEN))
+        fc2_out = qwen3_5.convert_qwen3_5_to_hf(args, fc2_name, torch.zeros(LOCAL_EXPERTS, HIDDEN, FFN))
+
+        expected = list(range(offset, offset + LOCAL_EXPERTS))
+        assert _expert_ids(fc1_out, "gate_proj.weight") == expected
+        assert _expert_ids(fc2_out, "down_proj.weight") == expected
+        all_gate_ids.extend(expected)
+        all_down_ids.extend(expected)
+
+    assert sorted(all_gate_ids) == list(range(NUM_EXPERTS))
+    assert sorted(all_down_ids) == list(range(NUM_EXPERTS))
+
+
+@pytest.mark.integration
+def test_runtime_fused_expert_split_matches_offline_split():
+    args = _args()
+    fc1 = torch.arange(LOCAL_EXPERTS * 2 * FFN * HIDDEN, dtype=torch.float32).view(LOCAL_EXPERTS, 2 * FFN, HIDDEN)
+    fc2 = torch.arange(LOCAL_EXPERTS * HIDDEN * FFN, dtype=torch.float32).view(LOCAL_EXPERTS, HIDDEN, FFN)
+
+    runtime = dict(
+        qwen3_5.convert_qwen3_5_to_hf(
+            args,
+            "module.module.language_model.decoder.layers.0.mlp.experts.linear_fc1.__ep_offset0",
+            fc1,
+        )
+        + qwen3_5.convert_qwen3_5_to_hf(
+            args,
+            "module.module.language_model.decoder.layers.0.mlp.experts.linear_fc2.__ep_offset0",
+            fc2,
+        )
+    )
+    prefix = "model.language_model.layers.0.mlp.experts"
+    offline = {
+        f"{prefix}.{expert_id}.{projection}.weight": weight
+        for fused_weight, fused_projection in (
+            (fc1, layout.GATE_UP_PROJ),
+            (fc2, layout.DOWN_PROJ),
+        )
+        for expert_id, projection, weight in layout.iter_fused_expert_projections(
+            fused_weight,
+            fused_projection,
+        )
+    }
+
+    assert runtime.keys() == offline.keys()
+    assert all(torch.equal(runtime[name], offline[name]) for name in runtime)
+
+
+@pytest.mark.unit
+def test_fused_gate_up_rejects_an_odd_projection_dimension():
+    with pytest.raises(ValueError, match="output dimension must be even"):
+        list(layout.iter_fused_expert_projections(torch.zeros(2, 7, HIDDEN), layout.GATE_UP_PROJ))
+
+
+@pytest.mark.unit
+def test_fused_expert_mode_is_scoped_to_qwen35_configs():
+    exact_config = {
+        "model_type": "qwen3_5_moe",
+        "architectures": ["Qwen3_5MoeForConditionalGeneration"],
+    }
+    assert layout.is_qwen3_5_moe_config(exact_config)
+    assert layout.is_qwen3_5_moe_config(SimpleNamespace(**exact_config))
+    assert not layout.is_qwen3_5_moe_config({"model_type": "qwen3_5_moe"})
+    assert not layout.is_qwen3_5_moe_config(
+        {
+            "model_type": "qwen3_5_moe",
+            "architectures": ["Qwen3_5MoeForCausalLM"],
+        }
+    )
+    assert not layout.is_qwen3_5_moe_config(
+        {
+            "model_type": "other_moe",
+            "architectures": ["Qwen3_5MoeForConditionalGeneration"],
+        }
+    )
+
+
+@pytest.mark.unit
+def test_offline_converter_fused_mode_quantizes_only_split_routed_experts(monkeypatch):
+    def fake_pack_layer(weight, group_size, sym=True):
+        packed = torch.full((weight.shape[0], 1), fill_value=weight.shape[0], dtype=torch.int32)
+        scale = torch.ones(weight.shape[0], 1, dtype=weight.dtype)
+        return packed, scale, None
+
+    monkeypatch.setattr(converter, "pack_layer", fake_pack_layer)
+
+    weights = {
+        "model.language_model.layers.0.mlp.experts.gate_up_proj": torch.randn(2, 2 * FFN, HIDDEN),
+        "model.language_model.layers.0.mlp.experts.down_proj": torch.randn(2, HIDDEN, FFN),
+        "model.language_model.layers.0.linear_attn.out_proj.weight": torch.randn(HIDDEN, HIDDEN),
+        "model.language_model.layers.0.mlp.gate.weight": torch.randn(2, HIDDEN),
+        "model.language_model.layers.0.mlp.shared_expert.down_proj.weight": torch.randn(HIDDEN, FFN),
+        "model.visual.patch_embed.weight": torch.randn(HIDDEN, HIDDEN),
+        "mtp.layers.0.mlp.down_proj.weight": torch.randn(HIDDEN, FFN),
+    }
+
+    q_weights = converter.convert_weights(
+        weights,
+        group_size=128,
+        is_symmetric=True,
+        ignore_rules=converter.QWEN35_IGNORE_RULES,
+        qwen35_moe=True,
+    )
+
+    for expert_id in range(2):
+        assert f"model.language_model.layers.0.mlp.experts.{expert_id}.gate_proj.weight_packed" in q_weights
+        assert f"model.language_model.layers.0.mlp.experts.{expert_id}.up_proj.weight_packed" in q_weights
+        assert f"model.language_model.layers.0.mlp.experts.{expert_id}.down_proj.weight_packed" in q_weights
+
+    assert "model.language_model.layers.0.mlp.experts.gate_up_proj" not in q_weights
+    assert "model.language_model.layers.0.mlp.experts.down_proj" not in q_weights
+    for name in weights.keys() - {
+        "model.language_model.layers.0.mlp.experts.gate_up_proj",
+        "model.language_model.layers.0.mlp.experts.down_proj",
+    }:
+        assert name in q_weights
+        assert name.replace(".weight", ".weight_packed") not in q_weights
+
+
+@pytest.mark.unit
+def test_non_qwen_fused_key_is_not_split(monkeypatch):
+    def fail_pack_layer(weight, group_size, sym=True):
+        raise AssertionError("a non-Qwen fused key must not enter Qwen3.5 split/pack")
+
+    monkeypatch.setattr(converter, "pack_layer", fail_pack_layer)
+
+    name = "model.layers.0.mlp.experts.gate_up_proj"
+    tensor = torch.randn(2, 2 * FFN, HIDDEN)
+    result = converter.convert_weights(
+        {name: tensor},
+        group_size=128,
+        is_symmetric=True,
+        ignore_rules=[],
+        qwen35_moe=False,
+    )
+
+    assert list(result) == [name]
+    assert result[name] is tensor
+
+
+@pytest.mark.unit
+def test_qwen35_effective_quantization_config_keeps_non_experts_bf16():
+    effective_ignore = converter.QWEN35_IGNORE_RULES
+
+    assert "re:.*linear_attn.*" in effective_ignore
+    assert "re:.*visual.*" in effective_ignore
+    assert "re:.*shared_expert.*" in effective_ignore
+    assert "re:.*mtp.*" in effective_ignore
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__]))

--- a/tests/test_sglang_patch.py
+++ b/tests/test_sglang_patch.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("patch_version", ["latest", "v0.5.15.post1"])
+def test_post_process_weights_endpoint_reads_json_body(patch_version):
+    patch = (REPO_ROOT / "docker" / "patch" / patch_version / "sglang.patch").read_text()
+
+    assert "+async def post_process_weights(" in patch
+    assert "req: Annotated[PostProcessWeightsReqInput, Body()]" in patch
+    assert "req: PostProcessWeightsReqInput, request: Request" not in patch

--- a/tools/convert_hf_to_int4_direct.py
+++ b/tools/convert_hf_to_int4_direct.py
@@ -27,6 +27,32 @@ except ImportError:
     fake_int4_quant_cuda = None
 
 
+DEFAULT_IGNORE_RULES = [
+    "re:.*lm_head.*",
+    "re:.*norm.*",
+    "re:.*embed.*",
+    "re:.*self_attn.*",
+    "re:.*shared_experts.*",
+    "re:.*mlp\\.(gate|up|gate_up|down)_proj.*",
+    "re:.*mlp\\.gate\\.*",
+]
+
+QWEN35_FUSED_EXPERT_IGNORE_RULES = [
+    "re:.*lm_head.*",
+    "re:.*norm.*",
+    "re:.*embed.*",
+    "re:.*self_attn.*",
+    "re:.*linear_attn.*",
+    "re:.*conv1d.*",
+    "re:.*visual.*",
+    "re:.*mlp\\.gate\\..*",
+    "re:.*mlp\\.(gate|up|gate_up|down)_proj.*",
+    "re:.*shared_experts.*",
+    "re:.*shared_expert.*",
+    "re:.*mtp.*",
+]
+
+
 def pack_to_int32(
     value,
     num_bits,
@@ -164,38 +190,117 @@ class ConversionResult:
                 self.param_count += len(v)
 
 
-def process_file(input_path, output_path, filename, group_size, is_symmetric, ignore_rules, result_collector):
+def _matches_ignore_rule(name, ignore_rules):
+    return any(
+        (r.startswith("re:") and re.match(r[3:], name)) or r == name or name.startswith(r) for r in ignore_rules
+    )
+
+
+def _is_qwen35_fused_expert(name, shape):
+    return re.match(r".*\.mlp\.experts\.(gate_up_proj|down_proj)$", name) is not None and len(shape) == 3
+
+
+def _iter_qwen35_fused_expert_weights(name, weight):
+    match = re.match(r"(.*\.mlp\.experts)\.(gate_up_proj|down_proj)$", name)
+    if match is None or weight.dim() != 3:
+        return
+
+    prefix, which = match.groups()
+    for expert_id in range(weight.shape[0]):
+        if which == "gate_up_proj":
+            gate, up = weight[expert_id].chunk(2, dim=0)
+            yield f"{prefix}.{expert_id}.gate_proj.weight", gate.contiguous()
+            yield f"{prefix}.{expert_id}.up_proj.weight", up.contiguous()
+        else:
+            yield f"{prefix}.{expert_id}.down_proj.weight", weight[expert_id].contiguous()
+
+
+def _shape_from_safe_open(reader, key):
+    if hasattr(reader, "get_slice"):
+        return tuple(reader.get_slice(key).get_shape())
+    return tuple(reader.get_tensor(key).shape)
+
+
+def checkpoint_has_qwen35_fused_experts(input_path, safetensors_files):
+    for filename in safetensors_files:
+        with safetensors.safe_open(os.path.join(input_path, filename), framework="pt", device="cpu") as f:
+            for key in f.keys():
+                if _is_qwen35_fused_expert(key, _shape_from_safe_open(f, key)):
+                    return True
+    return False
+
+
+def get_effective_ignore_rules(qwen35_fused_expert_only, ignore_rules=None):
+    if qwen35_fused_expert_only:
+        return list(dict.fromkeys([*(ignore_rules or DEFAULT_IGNORE_RULES), *QWEN35_FUSED_EXPERT_IGNORE_RULES]))
+    return list(ignore_rules or DEFAULT_IGNORE_RULES)
+
+
+def convert_weights(weights, group_size, is_symmetric, ignore_rules, qwen35_fused_expert_only):
+    q_weights = {}
+
+    def _pack_and_store(pname, w):
+        print(f"Packing {pname}, memory usage: {torch.cuda.memory_allocated()}")
+        qw, s, zp = pack_layer(w, group_size, is_symmetric)
+        q_weights[pname.replace(".weight", ".weight_packed")] = qw
+        q_weights[pname.replace(".weight", ".weight_scale")] = s
+        q_weights[pname.replace(".weight", ".weight_shape")] = torch.tensor(
+            w.shape, dtype=torch.int32, device=w.device
+        )
+        if zp is not None:
+            q_weights[pname.replace(".weight", ".weight_zero_point")] = zp
+
+    for name, weight in weights.items():
+        if qwen35_fused_expert_only:
+            split_weights = list(_iter_qwen35_fused_expert_weights(name, weight))
+            if split_weights:
+                for split_name, split_weight in split_weights:
+                    if _matches_ignore_rule(split_name, ignore_rules):
+                        print(f"Ignoring {split_name}, memory usage: {torch.cuda.memory_allocated()}")
+                        q_weights[split_name] = split_weight
+                    else:
+                        _pack_and_store(split_name, split_weight)
+            else:
+                print(f"Ignoring {name}, memory usage: {torch.cuda.memory_allocated()}")
+                q_weights[name] = weight
+            continue
+
+        is_ignored = _matches_ignore_rule(name, ignore_rules)
+        split_weights = list(_iter_qwen35_fused_expert_weights(name, weight))
+        if split_weights and not is_ignored:
+            for split_name, split_weight in split_weights:
+                _pack_and_store(split_name, split_weight)
+            continue
+
+        if is_ignored or not name.endswith(".weight") or weight.dim() != 2:
+            print(f"Ignoring {name}, memory usage: {torch.cuda.memory_allocated()}")
+            q_weights[name] = weight
+            continue
+
+        _pack_and_store(name, weight)
+
+    return q_weights
+
+
+def process_file(
+    input_path,
+    output_path,
+    filename,
+    group_size,
+    is_symmetric,
+    ignore_rules,
+    qwen35_fused_expert_only,
+    result_collector,
+):
 
     print(f"Processing {filename}, memory usage: {torch.cuda.memory_allocated()}")
     weights = {}
-    q_weights = {}
 
     with safetensors.safe_open(os.path.join(input_path, filename), framework="pt", device="cuda") as f:
         for k in f.keys():
             weights[k] = f.get_tensor(k)
 
-    for name, weight in weights.items():
-        is_ignored = any(
-            (r.startswith("re:") and re.match(r[3:], name)) or r == name or name.startswith(r) for r in ignore_rules
-        )
-
-        if is_ignored or not name.endswith(".weight") or weight.dim() < 2:
-            print(f"Ignoring {name}, memory usage: {torch.cuda.memory_allocated()}")
-            q_weights[name] = weight
-            continue
-
-        print(f"Packing {name}, memory usage: {torch.cuda.memory_allocated()}")
-        qw, s, zp = pack_layer(weight, group_size, is_symmetric)
-        qweight_name = name.replace(".weight", ".weight_packed")
-        scale_name = name.replace(".weight", ".weight_scale")
-        weight_shape = torch.tensor(weight.shape, dtype=torch.int32, device="cuda")
-        weight_shape_name = name.replace(".weight", ".weight_shape")
-        if zp is not None:
-            zp_name = name.replace(".weight", ".weight_zero_point")
-            q_weights[zp_name] = zp
-        q_weights[qweight_name] = qw
-        q_weights[scale_name] = s
-        q_weights[weight_shape_name] = weight_shape
+    q_weights = convert_weights(weights, group_size, is_symmetric, ignore_rules, qwen35_fused_expert_only)
 
     safetensors.torch.save_file(q_weights, os.path.join(output_path, filename), metadata={"format": "pt"})
 
@@ -210,6 +315,8 @@ def convert_int4(input_path, output_path, group_size, is_symmetric, ignore_rules
             shutil.copyfile(os.path.join(input_path, filename), os.path.join(output_path, filename))
 
     safetensors_files = [f for f in os.listdir(input_path) if f.endswith(".safetensors")]
+    qwen35_fused_expert_only = checkpoint_has_qwen35_fused_experts(input_path, safetensors_files)
+    effective_ignore_rules = get_effective_ignore_rules(qwen35_fused_expert_only, ignore_rules)
 
     result_collector = ConversionResult()
     # debug in single thread
@@ -227,7 +334,8 @@ def convert_int4(input_path, output_path, group_size, is_symmetric, ignore_rules
                 filename,
                 group_size,
                 is_symmetric,
-                ignore_rules,
+                effective_ignore_rules,
+                qwen35_fused_expert_only,
                 result_collector,
             )
             futures.append(future)
@@ -257,7 +365,7 @@ def convert_int4(input_path, output_path, group_size, is_symmetric, ignore_rules
     quantization_config = {
         "config_groups": quant_group,
         "format": "pack-quantized",
-        "ignore": ignore_rules,
+        "ignore": effective_ignore_rules,
         "kv_cache_scheme": None,
         "quant_method": "compressed-tensors",
         "quantization_status": "compressed",
@@ -287,15 +395,7 @@ def parse_args():
     parser.add_argument(
         "--ignore-rules",
         nargs="+",
-        default=[
-            "re:.*lm_head.*",
-            "re:.*norm.*",
-            "re:.*embed.*",
-            "re:.*self_attn.*",
-            "re:.*shared_experts.*",
-            "re:.*mlp\\.(gate|up|gate_up|down)_proj.*",
-            "re:.*mlp\\.gate\\.*",
-        ],
+        default=DEFAULT_IGNORE_RULES,
         help="Ignore Rules",
     )
     parser.add_argument("--max-workers", type=int, default=1, help="Number of worker threads for parallel processing")

--- a/tools/convert_hf_to_int4_direct.py
+++ b/tools/convert_hf_to_int4_direct.py
@@ -21,12 +21,43 @@ import safetensors.torch
 import torch
 from tqdm import tqdm
 
+from slime.backends.qwen3_5_expert_layout import (
+    is_qwen3_5_moe_config,
+    iter_fused_expert_projections,
+    match_hf_fused_expert,
+)
 from slime.utils import accelerator
 
 try:
     import fake_int4_quant_cuda
 except ImportError:
     fake_int4_quant_cuda = None
+
+
+DEFAULT_IGNORE_RULES = [
+    "re:.*lm_head.*",
+    "re:.*norm.*",
+    "re:.*embed.*",
+    "re:.*self_attn.*",
+    "re:.*shared_experts.*",
+    "re:.*mlp\\.(gate|up|gate_up|down)_proj.*",
+    "re:.*mlp\\.gate\\.*",
+]
+
+# Qwen3.5-35B-A3B only quantizes routed experts. These rules are persisted to
+# config.json and also control every later online weight update.
+QWEN35_IGNORE_RULES = [
+    "re:.*lm_head.*",
+    "re:.*norm.*",
+    "re:.*embed.*",
+    "re:.*self_attn.*",
+    "re:.*linear_attn.*",
+    "re:.*visual.*",
+    "re:.*mlp\\.gate\\..*",
+    "re:.*mlp\\.(gate|up|gate_up|down)_proj.*",
+    "re:.*shared_expert.*",
+    "re:.*mtp.*",
+]
 
 
 def pack_to_int32(
@@ -166,11 +197,62 @@ class ConversionResult:
                 self.param_count += len(v)
 
 
-def process_file(input_path, output_path, filename, group_size, is_symmetric, ignore_rules, result_collector):
+def convert_weights(weights, group_size, is_symmetric, ignore_rules, qwen35_moe):
+    q_weights = {}
+
+    def pack_and_store(name, weight):
+        print(f"Packing {name}, memory usage: {accelerator.memory_allocated()}")
+        qw, scale, zero_point = pack_layer(weight, group_size, is_symmetric)
+        if zero_point is not None:
+            q_weights[name.replace(".weight", ".weight_zero_point")] = zero_point
+        q_weights[name.replace(".weight", ".weight_packed")] = qw
+        q_weights[name.replace(".weight", ".weight_scale")] = scale
+        q_weights[name.replace(".weight", ".weight_shape")] = torch.tensor(
+            weight.shape,
+            dtype=torch.int32,
+            device=accelerator.device(),
+        )
+
+    for name, weight in weights.items():
+        if qwen35_moe:
+            match = match_hf_fused_expert(name)
+            if match is None:
+                print(f"Ignoring {name}, memory usage: {accelerator.memory_allocated()}")
+                q_weights[name] = weight
+                continue
+
+            prefix, projection = match
+            for expert_id, split_projection, split_weight in iter_fused_expert_projections(weight, projection):
+                pack_and_store(f"{prefix}.{expert_id}.{split_projection}.weight", split_weight)
+            continue
+
+        is_ignored = any(
+            (rule.startswith("re:") and re.match(rule[3:], name)) or rule == name or name.startswith(rule)
+            for rule in ignore_rules
+        )
+        if is_ignored or not name.endswith(".weight") or weight.dim() < 2:
+            print(f"Ignoring {name}, memory usage: {accelerator.memory_allocated()}")
+            q_weights[name] = weight
+            continue
+
+        pack_and_store(name, weight)
+
+    return q_weights
+
+
+def process_file(
+    input_path,
+    output_path,
+    filename,
+    group_size,
+    is_symmetric,
+    ignore_rules,
+    qwen35_moe,
+    result_collector,
+):
 
     print(f"Processing {filename}, memory usage: {accelerator.memory_allocated()}")
     weights = {}
-    q_weights = {}
 
     with safetensors.safe_open(
         os.path.join(input_path, filename), framework="pt", device=accelerator.device_name()
@@ -178,28 +260,7 @@ def process_file(input_path, output_path, filename, group_size, is_symmetric, ig
         for k in f.keys():
             weights[k] = f.get_tensor(k)
 
-    for name, weight in weights.items():
-        is_ignored = any(
-            (r.startswith("re:") and re.match(r[3:], name)) or r == name or name.startswith(r) for r in ignore_rules
-        )
-
-        if is_ignored or not name.endswith(".weight") or weight.dim() < 2:
-            print(f"Ignoring {name}, memory usage: {accelerator.memory_allocated()}")
-            q_weights[name] = weight
-            continue
-
-        print(f"Packing {name}, memory usage: {accelerator.memory_allocated()}")
-        qw, s, zp = pack_layer(weight, group_size, is_symmetric)
-        qweight_name = name.replace(".weight", ".weight_packed")
-        scale_name = name.replace(".weight", ".weight_scale")
-        weight_shape = torch.tensor(weight.shape, dtype=torch.int32, device=accelerator.device())
-        weight_shape_name = name.replace(".weight", ".weight_shape")
-        if zp is not None:
-            zp_name = name.replace(".weight", ".weight_zero_point")
-            q_weights[zp_name] = zp
-        q_weights[qweight_name] = qw
-        q_weights[scale_name] = s
-        q_weights[weight_shape_name] = weight_shape
+    q_weights = convert_weights(weights, group_size, is_symmetric, ignore_rules, qwen35_moe)
 
     safetensors.torch.save_file(q_weights, os.path.join(output_path, filename), metadata={"format": "pt"})
 
@@ -214,6 +275,13 @@ def convert_int4(input_path, output_path, group_size, is_symmetric, ignore_rules
             shutil.copyfile(os.path.join(input_path, filename), os.path.join(output_path, filename))
 
     safetensors_files = [f for f in os.listdir(input_path) if f.endswith(".safetensors")]
+    config_path = os.path.join(input_path, "config.json")
+    config = None
+    if os.path.isfile(config_path):
+        with open(config_path) as config_file:
+            config = json.load(config_file)
+    qwen35_moe = is_qwen3_5_moe_config(config)
+    effective_ignore_rules = QWEN35_IGNORE_RULES if qwen35_moe else ignore_rules
 
     result_collector = ConversionResult()
     # debug in single thread
@@ -231,7 +299,8 @@ def convert_int4(input_path, output_path, group_size, is_symmetric, ignore_rules
                 filename,
                 group_size,
                 is_symmetric,
-                ignore_rules,
+                effective_ignore_rules,
+                qwen35_moe,
                 result_collector,
             )
             futures.append(future)
@@ -261,17 +330,16 @@ def convert_int4(input_path, output_path, group_size, is_symmetric, ignore_rules
     quantization_config = {
         "config_groups": quant_group,
         "format": "pack-quantized",
-        "ignore": ignore_rules,
+        "ignore": effective_ignore_rules,
         "kv_cache_scheme": None,
         "quant_method": "compressed-tensors",
         "quantization_status": "compressed",
     }
 
-    config_path = os.path.join(input_path, "config.json")
-    if os.path.exists(config_path):
-        cfg = json.load(open(config_path))
-        cfg["quantization_config"] = quantization_config
-        json.dump(cfg, open(os.path.join(output_path, "config.json"), "w"), indent=2)
+    if config is not None:
+        config["quantization_config"] = quantization_config
+        with open(os.path.join(output_path, "config.json"), "w") as config_file:
+            json.dump(config, config_file, indent=2)
 
     index_dict = {"weight_map": result_collector.weight_map, "metadata": {"total_size": result_collector.param_count}}
     json.dump(index_dict, open(os.path.join(output_path, "model.safetensors.index.json"), "w"), indent=2)
@@ -291,15 +359,7 @@ def parse_args():
     parser.add_argument(
         "--ignore-rules",
         nargs="+",
-        default=[
-            "re:.*lm_head.*",
-            "re:.*norm.*",
-            "re:.*embed.*",
-            "re:.*self_attn.*",
-            "re:.*shared_experts.*",
-            "re:.*mlp\\.(gate|up|gate_up|down)_proj.*",
-            "re:.*mlp\\.gate\\.*",
-        ],
+        default=DEFAULT_IGNORE_RULES,
         help="Ignore Rules",
     )
     parser.add_argument("--max-workers", type=int, default=1, help="Number of worker threads for parallel processing")


### PR DESCRIPTION
## Summary

Support Qwen3.5 MoE INT4-QAT for routed experts.

This PR adds:

- Qwen3.5 fused 3D routed expert support in `convert_hf_to_int4_direct.py`
- fused expert split from `gate_up_proj` / `down_proj` into per-expert 2D `gate_proj` / `up_proj` / `down_proj`
- runtime Megatron-to-HF weight sync support for Qwen3.5 fused experts
- EP global expert id preservation during runtime weight sync
- Qwen3.5 INT4-QAT run script
- English and Chinese low-precision docs
- unit tests for offline conversion, runtime split, ignore rules, and non-fused compatibility

## Scope

Current support targets routed experts only.

```text
INT4:
- mlp.experts.{i}.gate_proj
- mlp.experts.{i}.up_proj
- mlp.experts.{i}.down_proj

BF16:
- self_attn
- linear_attn
- conv1d
- shared_expert
- mlp.gate
- visual
- mtp
- embed
- norm
- lm_head
```

MTP training and visual INT4-QAT are not included in this PR.

## Why

Qwen3.5 MoE routed experts can be stored as fused 3D tensors in Hugging Face checkpoints:

```text
mlp.experts.gate_up_proj
mlp.experts.down_proj
```

The INT4 compressed-tensors / SGLang MoE path expects per-expert 2D weights. This PR adds the missing split path so Qwen3.5 can use the same experts-only INT4-QAT flow.

## Test Plan

Unit and static checks:

- [x] `python3 -m compileall -q tools/convert_hf_to_int4_direct.py slime/backends/megatron_utils/megatron_to_hf/qwen3_5.py slime/backends/megatron_utils/megatron_to_hf/processors/quantizer_compressed_tensors.py slime/backends/megatron_utils/update_weight/common.py tests/test_qwen35_int4_fused_expert_quantizer.py`
- [x] `bash -n scripts/low_precision/run-qwen3.5-35B-A3B-int4-qat-rl.sh`
- [x] `git diff --check refs/remotes/thudm/main...HEAD`
- [x] `python -m pytest tests/test_qwen35_int4_fused_expert_quantizer.py -q`
  - Result: `7 passed`

Server validation:

- [x] Convert Qwen3.5-35B-A3B HF checkpoint to Megatron BF16 `torch_dist`
- [x] Convert Qwen3.5-35B-A3B HF checkpoint to experts-only INT4 checkpoint
- [x] Verify INT4 checkpoint only packs routed experts
- [x] Run Qwen3.5-35B-A3B INT4-QAT-RL smoke
- [x] Confirm checkpoint is saved under `Qwen3.5-35B-A3B_slime`

Validated on 4 x H20 141GB. The Qwen3.5-35B-A3B INT4-QAT-RL smoke test completed successfully and saved a checkpoint under `Qwen3.5-35B-A3B_slime`.

Smoke config: `num-rollout=2`, `rollout-batch-size=2`, `n-samples-per-prompt=2`, `rollout-max-response-len=512`.

Server reproduction:

```bash
export BASE_FOLDER=/mnt/slime-qwen35
export HF_MODEL=/mnt/public_data/Qwen/Qwen3.5-35B-A3B
export MASTER_ADDR=127.0.0.1

source scripts/models/qwen3.5-35B-A3B.sh

PYTHONPATH=/root/Megatron-LM python tools/convert_hf_to_torch_dist.py \
  "${MODEL_ARGS[@]}" \
  --hf-checkpoint "$HF_MODEL" \
  --save "$BASE_FOLDER/Qwen3.5-35B-A3B_torch_dist"

python tools/convert_hf_to_int4_direct.py \
  --model-dir "$HF_MODEL" \
  --save-dir "$BASE_FOLDER/Qwen3.5-35B-A3B-INT4" \
  --group-size 128 \
  --is-symmetric \
  --max-workers 1

bash scripts/low_precision/run-qwen3.5-35B-A3B-int4-qat-rl.sh
```

Follow-up work:
- Accuracy validation against BF16 rollout on math eval sets.
- Longer INT4-QAT-RL runs to check reward/loss/KL stability.
- Resume-from-checkpoint validation.
- Multi-node and non-colocate rollout/training validation.
- Scaling validation for Qwen3.5-122B-A10B and Qwen3.5-397B-A17B.
- Throughput and memory comparison between BF16 rollout and INT4 rollout.
- Future support for MTP INT4-QAT and visual INT4-QAT, if needed.