### PR TITLE
feat(coding_agent_rl): env-selectable grading protocol + sandbox RPC robustness

### DIFF
--- a/examples/coding_agent_rl/generate.py
+++ b/examples/coding_agent_rl/generate.py
@@ -3,8 +3,9 @@
     --custom-generate-function-path examples.coding_agent_rl.generate.generate
 
 generate() is a four-stage orchestrator: swe.prepare_workspace + harness.run
--> swe.git_diff -> swe.evaluate -> adapter.finish_session. The (harness, adapter)
-pair is chosen by the SWE_AGENT env var (claude_code | codex); see _AGENTS below.
+-> swe.git_diff -> swe.run_evaluation -> adapter.finish_session. The (harness,
+adapter) pair is chosen by the SWE_AGENT env var (claude_code | codex); see
+_AGENTS below.
 Sandbox-side work is split across three layers: the provider-agnostic sandbox
 contract (slime.agent.sandbox), the swappable harness lifecycle
 (slime.agent.harness), and the SWE task layer (examples.coding_agent_rl.swe --
@@ -19,6 +20,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import random
 import secrets
 import time
 import traceback
@@ -52,6 +54,8 @@ HARNESS_CLS, ADAPTER_CLS = _AGENTS[AGENT_NAME]
 
 @dataclass(frozen=True)
 class SweConfig:
+    eval_protocol: str  # eval-path schema/grader (SWE_EVAL_PROTOCOL)
+    train_protocol: str  # train-path schema/grader (SWE_TRAIN_PROTOCOL)
     adapter_public_host: str | None
     adapter_bind_host: str
     adapter_port: int
@@ -69,6 +73,8 @@ class SweConfig:
         guard = int(os.environ.get("SWE_ROLLOUT_GUARD_SEC", "0") or 0) or (agent_time_budget + eval_timeout + 180)
         fork = int(v) if (v := os.environ.get("SLIME_FORK_MERGE_MAX_RESPONSE_TOKENS")) else None
         return cls(
+            eval_protocol=os.environ.get("SWE_EVAL_PROTOCOL", swe.PROTOCOL_SCALESWE),
+            train_protocol=os.environ.get("SWE_TRAIN_PROTOCOL", swe.PROTOCOL_SCALESWE),
             adapter_public_host=os.environ.get("ADAPTER_PUBLIC_HOST"),
             adapter_bind_host=os.environ.get("ADAPTER_BIND_HOST", "0.0.0.0"),
             adapter_port=int(os.environ.get("ADAPTER_PORT", "18001")),
@@ -118,7 +124,7 @@ async def boot_agent_sandbox(image: str, instance_id: str) -> AsyncIterator[E2BS
                 type(e).__name__,
                 str(e)[:200],
             )
-            await asyncio.sleep(1 + attempt)
+            await asyncio.sleep(1 + attempt + random.random())
     if sb is None:
         assert last_err is not None
         raise last_err
@@ -173,13 +179,17 @@ class _AdapterService(metaclass=SingletonMeta):
         )
 
 
-async def generate(args, base_sample: Sample, sampling_params: dict[str, Any]):
+async def generate(args, base_sample: Sample, sampling_params: dict[str, Any], evaluation: bool = False):
     """Per-sample agent function with wall-clock guard (see rollout_guard_sec)."""
     state = _AdapterService(args)
-    md = swe.get_metadata(base_sample)
+    protocol = CONFIG.eval_protocol if evaluation else CONFIG.train_protocol
+    md = swe.get_metadata(base_sample, protocol)
     instance_id = md["instance_id"]
     if not md["image"] or not md["workdir"]:
         return _abort_result(base_sample, "missing_image_or_workdir", instance_id)
+    reason = swe.evaluability_check(md)
+    if reason:
+        return _abort_result(base_sample, f"unevaluatable:{reason}", instance_id)
 
     session_id = base_sample.session_id = _session_id(base_sample, instance_id)
     state.adapter.open_session(
@@ -202,20 +212,36 @@ async def generate(args, base_sample: Sample, sampling_params: dict[str, Any]):
                 )
                 diff_text = await swe.git_diff(sb, md["workdir"])
 
-            reward, applied_cleanly = await swe.evaluate(
-                image=md["image"],
-                workdir=md["workdir"],
+            reward, applied_cleanly = await swe.run_evaluation(
+                md,
                 diff_text=diff_text,
-                swepro=md["swepro"],
-                eval_cmd=md["eval_cmd"],
-                f2p_script=md["f2p_script"],
-                pre_commands=md["pre_commands"],
                 timeout_sec=CONFIG.eval_timeout_sec,
             )
+            if evaluation:
+                logger.info(
+                    "[coding_agent_rl] %s: reward=%.2f applied=%s agent_exit_code=%d elapsed=%.1fs (eval-only)",
+                    instance_id,
+                    float(reward),
+                    bool(applied_cleanly),
+                    agent_exit_code,
+                    time.time() - t0,
+                )
+                return _eval_result(
+                    base_sample,
+                    reward=float(reward),
+                    applied_cleanly=bool(applied_cleanly),
+                    agent_exit_code=agent_exit_code,
+                    instance_id=instance_id,
+                )
+
             samples = await state.adapter.finish_session(
                 session_id,
                 base_sample=base_sample,
                 reward=float(reward),
+                extra_metadata={
+                    "grading_solved": float(reward) == 1.0,
+                    "instance_id": instance_id,
+                },
             )
             if not samples:
                 return _abort_result(base_sample, "adapter_session_empty", instance_id)
@@ -253,7 +279,8 @@ async def generate(args, base_sample: Sample, sampling_params: dict[str, Any]):
         )
         return _abort_result(base_sample, f"exception:{type(e).__name__}", instance_id)
     finally:
-        await state.adapter.drop_session(session_id)  # cleanup only, idempotent
+        await state.adapter.drop_session(session_id, wait_timeout=30)  # cleanup only, idempotent
+        await asyncio.sleep(10)
 
 
 def _log_timeout_diagnostic(t0: float, instance_id: str) -> None:
@@ -297,6 +324,38 @@ def _abort_result(sample: Sample, reason: str, instance_id: str) -> list[Sample]
     sample.reward = 0.0
     sample.remove_sample = True
     sample.status = Sample.Status.ABORTED
-    sample.metadata = {**(sample.metadata or {}), "abort_reason": reason}
+    sample.metadata = {
+        **(sample.metadata or {}),
+        "abort_reason": reason,
+        "instance_id": instance_id,
+    }
     logger.warning("[coding_agent_rl] %s aborted: %s", instance_id, reason)
+    return [sample]
+
+
+def _eval_result(
+    sample: Sample,
+    *,
+    reward: float,
+    applied_cleanly: bool,
+    agent_exit_code: int | None,
+    instance_id: str,
+) -> list[Sample]:
+    """Eval-path placeholder: only ``reward`` matters for ``eval/sweb``."""
+
+    sample.tokens = [0, 0]
+    sample.response = ""
+    sample.response_length = 1
+    sample.loss_mask = [0]
+    sample.rollout_log_probs = [0.0]
+    sample.reward = float(reward)
+    sample.remove_sample = True
+    sample.status = Sample.Status.COMPLETED
+    sample.metadata = {
+        **(sample.metadata or {}),
+        "instance_id": instance_id,
+        "grading_solved": float(reward) == 1.0,
+        "applied_cleanly": applied_cleanly,
+        "agent_exit_code": agent_exit_code,
+    }
     return [sample]

--- a/examples/coding_agent_rl/run_qwen36_35b_a3b_swe_8nodes.sh
+++ b/examples/coding_agent_rl/run_qwen36_35b_a3b_swe_8nodes.sh
@@ -207,6 +207,7 @@ export NCCL_SOCKET_IFNAME="${NCCL_SOCKET_IFNAME:-${MLP_SOCKET_IFNAME:-eth0}}"
 # ============ SWE / claude-code rollout knobs ============
 
 export SWE_AGENT="${SWE_AGENT:-claude_code}"
+export SWE_TRAIN_PROTOCOL="${SWE_TRAIN_PROTOCOL:-scaleswe}"
 export E2B_API_KEY="${E2B_API_KEY:-e2b_0000000000000000000000000000000000000000}"
 # Metadata key your gateway routes images by; `image` is the neutral default.
 export SLIME_AGENT_SANDBOX_IMAGE_METADATA_KEY="${SLIME_AGENT_SANDBOX_IMAGE_METADATA_KEY:-image}"
@@ -277,6 +278,7 @@ keys = (
     "SLIME_AGENT_CC_EXTRA_ARGS",
     "SLIME_AGENT_CC_EXTRA_ENVS",
     "SWE_CC_PROMPT",
+    "SWE_TRAIN_PROTOCOL",
     "SLIME_AGENT_SANDBOX_IMAGE_METADATA_KEY",
 )
 env = {k: os.environ[k] for k in keys if k in os.environ}

--- a/examples/coding_agent_rl/swe.py
+++ b/examples/coding_agent_rl/swe.py
@@ -1,24 +1,56 @@
-"""SWE task layer: workspace prep, diff capture, and fresh-sandbox eval.
+"""SWE task layer: dataset parsing, workspace prep, diff capture, fresh-sandbox eval.
+
+One module, two grading protocols selected per-call (never an import-time side
+effect):
+
+  - "scaleswe" (default): scaleswe data shape (image_url + pre_commands +
+    swepro/eval_cmd/f2p_script); custom "exit 0 == solved" grading.
+  - "swebench": SWE-bench Verified (remote_env_info.{image,base_commit,
+    test_patch,FAIL_TO_PASS,PASS_TO_PASS,version}); graded with swebench's
+    official make_test_spec + get_eval_report so each repo uses its own
+    test_cmd and log parser.
+
+The only thing that varies by protocol is the dataset schema and how a
+diff is scored. Everything sandbox-side (prepare_workspace / git_diff /
+apply_diff / pre_commands) is shared and lives here once.
+``get_metadata(sample, protocol)`` produces the ``md`` dict; the
+protocol-specific grading payload is carried under ``md["grading"]``
+and is opaque to generate.py (which only reads instance_id / image / workdir).
 
 Harness-agnostic on purpose -- nothing here is Claude-specific. ``SWE_PROMPT`` is
-the task instruction (semantics, not CLI syntax); ``prepare_workspace`` /
-``git_diff`` / ``evaluate`` work with any harness. The only place a task meets a
+the task instruction (semantics, not CLI syntax). The only place a task meets a
 harness is the prompt, which the orchestrator passes into ``harness.run()``.
 """
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import os
+import tempfile
 from pathlib import Path
-from typing import Any
+from typing import Any, NamedTuple
 
 from slime.agent import sandbox as agent_sandbox
-from slime.agent.sandbox import E2BSandbox, Sandbox
+from slime.agent.adapters.common import flatten_content
+from slime.agent.sandbox import E2BSandbox, Sandbox, exec_and_wait
 from slime.utils.types import Sample
 
+try:
+    from swebench.harness.grading import get_eval_report  # type: ignore
+    from swebench.harness.test_spec.test_spec import make_test_spec  # type: ignore
+
+    _SWEBENCH_IMPORT_ERROR: Exception | None = None
+except Exception as _exc:  # pragma: no cover - import-time diagnostic
+    get_eval_report = None  # type: ignore
+    make_test_spec = None  # type: ignore
+    _SWEBENCH_IMPORT_ERROR = _exc
+
 logger = logging.getLogger(__name__)
+
+PROTOCOL_SCALESWE = "scaleswe"
+PROTOCOL_SWEBENCH = "swebench"
 
 # Paths inside the sandbox (avoid clashes with image-shipped paths).
 _PATCH = "/workspace/__cagent_patch__.diff"
@@ -35,61 +67,115 @@ SWE_PROMPT = os.environ.get(
 )
 
 
-# ---------------------------------------------------------------------------
-# Dataset row -> SWE metadata
-#
-# ``get_metadata(sample)`` defines the ``md`` dict schema consumed by
-# ``prepare_workspace`` / ``evaluate``. Two dataset shapes are normalized:
-#
-#     image:             str        # sandbox image
-#     workdir:           str        # repo path inside the sandbox
-#     problem_statement: str        # issue body (falls back to sample.prompt)
-#     swepro:            dict|None  # SWE-bench Pro test harness (preferred)
-#     eval_cmd:          str|None   # shell command (exit 0 = solved)
-#     f2p_script:        str|None   # sweb pytest file (exit 0 = solved)
-#     pre_commands:      list|str|None
-#
-# This layer is pure data: it only *extracts* fields, it never decides how they
-# run in the sandbox. ``f2p_script`` (a self-contained pytest file ending in
-# ``sys.exit(pytest.main(...))``) is carried verbatim; ``evaluate`` materializes
-# and runs it via ``write_file`` so no shell-quoting workaround is needed here.
-# ---------------------------------------------------------------------------
-def get_metadata(sample: Sample) -> dict[str, Any]:
-    """Normalize the two dataset schemas (flat vs ``remote_env_info``)."""
+class EvalResult(NamedTuple):
+    """Grading outcome. Tuple-compatible: ``reward, applied = run_evaluation(...)``."""
+
+    reward: float
+    applied_cleanly: bool
+
+
+def get_metadata(sample: Sample, protocol: str = PROTOCOL_SCALESWE) -> dict[str, Any]:
+    if protocol == PROTOCOL_SWEBENCH:
+        return _metadata_swebench(sample)
+    return _metadata_scaleswe(sample)
+
+
+def _metadata_scaleswe(sample: Sample) -> dict[str, Any]:
+    """scaleswe shape: flat ``metadata.*`` (+ a few ``remote_env_info`` fallbacks).
+
+    ``f2p_script`` (a self-contained pytest file ending in
+    ``sys.exit(pytest.main(...))``) is carried verbatim; the grader materializes
+    and runs it via ``write_file`` so no shell-quoting workaround is needed here.
+    """
     m = sample.metadata or {}
     rem = m.get("remote_env_info") or {}
     label = sample.label if (isinstance(sample.label, str) and len(sample.label) < 256) else None
+    swepro = m.get("swepro")
+    eval_cmd = m.get("eval_cmd")
+    f2p_script = rem.get("f2p_script")
+    looks_swebench = bool(rem.get("test_patch")) and not (swepro or eval_cmd or f2p_script)
     return {
+        "protocol": PROTOCOL_SCALESWE,
         "instance_id": m.get("instance_id") or rem.get("instance_id") or label or "unknown",
         "image": m.get("image") or rem.get("image_url"),
         "workdir": m.get("workdir") or rem.get("workdir"),
         "problem_statement": m.get("problem_statement") or _coerce_prompt(sample.prompt),
-        "swepro": m.get("swepro"),
-        "eval_cmd": m.get("eval_cmd"),
-        "f2p_script": rem.get("f2p_script"),
-        "pre_commands": m.get("pre_commands") or rem.get("pre_commands"),
+        "looks_swebench": looks_swebench,
+        "grading": {
+            "swepro": swepro,
+            "eval_cmd": eval_cmd,
+            "f2p_script": f2p_script,
+            "pre_commands": m.get("pre_commands") or rem.get("pre_commands"),
+        },
+    }
+
+
+def _metadata_swebench(sample: Sample) -> dict[str, Any]:
+    """SWE-bench Verified shape: carry the full instance dict through so
+    make_test_spec gets every field it needs (version, hints_text, ...)."""
+    m = sample.metadata or {}
+    rem = m.get("remote_env_info") or {}
+    instance = {
+        "instance_id": rem.get("instance_id") or "unknown",
+        "repo": rem.get("repo") or "",
+        "version": rem.get("version"),
+        "base_commit": rem.get("base_commit") or "",
+        "problem_statement": rem.get("problem_statement") or _coerce_prompt(sample.prompt),
+        "hints_text": rem.get("hints_text") or "",
+        "test_patch": rem.get("test_patch") or "",
+        "FAIL_TO_PASS": rem.get("FAIL_TO_PASS"),
+        "PASS_TO_PASS": rem.get("PASS_TO_PASS"),
+        "environment_setup_commit": rem.get("environment_setup_commit"),
+    }
+    return {
+        "protocol": PROTOCOL_SWEBENCH,
+        "instance_id": instance["instance_id"],
+        "image": rem.get("image"),
+        "workdir": rem.get("workdir") or "/testbed",
+        "problem_statement": instance["problem_statement"],
+        "grading": {"sweb_instance": instance},
     }
 
 
 def _coerce_prompt(prompt) -> str:
+    """Extract the user-message text from a prompt (str or chat-message list)."""
     if isinstance(prompt, str):
         return prompt
     if isinstance(prompt, list):
         for m in prompt:
             if isinstance(m, dict) and m.get("role") == "user":
-                c = m.get("content")
-                if isinstance(c, str):
-                    return c
-                if isinstance(c, list):
-                    return "\n".join(p.get("text", "") for p in c if isinstance(p, dict) and p.get("type") == "text")
+                return flatten_content(m.get("content"))
     return ""
+
+
+def evaluability_check(md: dict) -> str | None:
+    if md.get("protocol") == PROTOCOL_SWEBENCH:
+        return _evaluability_check_swebench(md)
+    return "protocol_row_mismatch:looks_swebench" if md.get("looks_swebench") else None
+
+
+def _evaluability_check_swebench(md: dict) -> str | None:
+    if _SWEBENCH_IMPORT_ERROR is not None:
+        return f"swebench_import_failed:{type(_SWEBENCH_IMPORT_ERROR).__name__}"
+    inst = md.get("grading", {}).get("sweb_instance") or {}
+    if not inst.get("repo"):
+        return "missing_repo"
+    if not inst.get("base_commit"):
+        return "missing_base_commit"
+    if not (inst.get("test_patch") or "").strip():
+        return "missing_test_patch"
+    try:
+        _ = _build_test_spec(inst).eval_script  # surfaces per-repo construction errors here, not later
+    except Exception as e:  # KeyError on unknown repo/version, etc.
+        return f"make_test_spec_failed:{type(e).__name__}"
+    return None
 
 
 # ---------------------------------------------------------------------------
 # Workspace prep (agent sandbox, before harness.run)
 # ---------------------------------------------------------------------------
 async def prepare_workspace(sb: Sandbox, workdir: str, md: dict) -> None:
-    """Apply swepro setup + pre_commands, then drop PROBLEM_STATEMENT.md.
+    """Prep the agent sandbox, then drop PROBLEM_STATEMENT.md.
 
     Assumes the agent user already owns ``workdir`` (the harness's ``run()`` calls
     ``ensure_agent_user``; the orchestrator runs this before ``run()`` and the
@@ -97,12 +183,14 @@ async def prepare_workspace(sb: Sandbox, workdir: str, md: dict) -> None:
     create the agent user here too -- it is idempotent.
     """
     await agent_sandbox.ensure_agent_user(sb, workdir)
-    swepro = md.get("swepro")
-    if swepro:
-        await apply_before_repo_set_cmd(sb, workdir, swepro)
-    pre_commands = md.get("pre_commands")
-    if pre_commands:
-        await apply_pre_commands(sb, workdir, pre_commands)
+    if md.get("protocol") == PROTOCOL_SCALESWE:
+        grading = md.get("grading") or {}
+        swepro = grading.get("swepro")
+        if swepro:
+            await apply_before_repo_set_cmd(sb, workdir, swepro)
+        pre_commands = grading.get("pre_commands")
+        if pre_commands:
+            await apply_pre_commands(sb, workdir, pre_commands)
     await sb.write_file(
         f"{workdir}/PROBLEM_STATEMENT.md",
         md.get("problem_statement") or "",
@@ -146,30 +234,37 @@ async def git_diff(sb: Sandbox, workdir: str) -> str:
 
 
 # ---------------------------------------------------------------------------
-# Eval (fresh sandbox, apply diff, run dataset tests)
+# Eval dispatch (fresh sandbox, apply diff, run dataset tests)
 # ---------------------------------------------------------------------------
-async def evaluate(
-    *,
-    image: str,
-    workdir: str,
-    diff_text: str,
-    swepro: dict | None = None,
-    eval_cmd: str | None = None,
-    f2p_script: str | None = None,
-    pre_commands: list[str] | str | None = None,
-    timeout_sec: int = 600,
-) -> tuple[float, bool]:
-    """Returns (reward, applied_cleanly).
+async def run_evaluation(md: dict, *, diff_text: str, timeout_sec: int) -> EvalResult:
+    """Uniform entry point: dispatch to the protocol's grader.
 
-    Three mutually-exclusive grading paths, in priority order: swepro test
+    No-test-cheating guarantee (both grading protocols): the eval sandbox is built from
+    the same image but starts CLEAN, so only the model-produced diff affects
+    reward."""
+    if md.get("protocol") == PROTOCOL_SWEBENCH:
+        return await _grade_swebench(md, diff_text, timeout_sec)
+    return await _grade_scaleswe(md, diff_text, timeout_sec)
+
+
+# ---------------------------------------------------------------------------
+# scaleswe grader
+# ---------------------------------------------------------------------------
+async def _grade_scaleswe(md: dict, diff_text: str, timeout_sec: int) -> EvalResult:
+    """Three mutually-exclusive grading paths, in priority order: swepro test
     harness, a shell ``eval_cmd``, or a self-contained ``f2p_script`` pytest
-    file. All resolve to "exit 0 == solved", and reward is 1.0 iff solved.
+    file. All resolve to "exit 0 == solved", reward is 1.0 iff solved."""
+    image = md["image"]
+    workdir = md["workdir"]
+    grading = md.get("grading") or {}
+    swepro = grading.get("swepro")
+    eval_cmd = grading.get("eval_cmd")
+    f2p_script = grading.get("f2p_script")
+    pre_commands = grading.get("pre_commands")
 
-    No-test-cheating guarantee: the eval sandbox is built from the same image
-    but starts CLEAN, so only the model-produced diff affects reward."""
     if not (swepro or eval_cmd or f2p_script):
-        logger.warning("[e2b.evaluate] no swepro/eval_cmd/f2p_script; reward=0")
-        return 0.0, True
+        logger.warning("[swe.scaleswe] no swepro/eval_cmd/f2p_script; reward=0")
+        return EvalResult(0.0, True)
 
     async with E2BSandbox(image) as ev:
         await agent_sandbox.ensure_agent_user(ev, workdir)
@@ -181,15 +276,15 @@ async def evaluate(
 
         applied = await _apply_diff(ev, workdir, diff_text)
         if not applied:
-            return 0.0, False
+            return EvalResult(0.0, False)
 
         if swepro:
-            r, _ = await _run_swepro(ev, workdir, swepro, timeout_sec)
+            r = await _run_swepro(ev, workdir, swepro, timeout_sec)
         elif eval_cmd:
-            r, _ = await _run_eval_cmd(ev, workdir, eval_cmd, timeout_sec)
+            r = await _run_eval_cmd(ev, workdir, eval_cmd, timeout_sec)
         else:
-            r, _ = await _run_f2p_script(ev, workdir, f2p_script, timeout_sec)
-        return r, True
+            r = await _run_f2p_script(ev, workdir, f2p_script, timeout_sec)
+        return EvalResult(r, True)
 
 
 async def _setup_swepro_assets(ev: Sandbox, swepro: dict) -> None:
@@ -205,25 +300,26 @@ async def _apply_diff(ev: Sandbox, workdir: str, diff_text: str) -> bool:
     if not diff_text.strip():
         return True
     await ev.write_file(_PATCH, diff_text, user="agent")
-    for cmd in [
-        f"cd {workdir} && git apply --3way --whitespace=nowarn {_PATCH}",
-        f"cd {workdir} && git apply --whitespace=nowarn {_PATCH}",
-        f"cd {workdir} && patch -p1 --no-backup-if-mismatch < {_PATCH}",
-    ]:
-        ec, _, _ = await ev.exec(cmd, user="agent", check=False, timeout=120)
-        if ec == 0:
-            return True
-    return False
+    # First-success-wins ladder collapsed into one exec (one sandbox round-trip).
+    ladder = " || ".join(
+        f"({cmd})"
+        for cmd in (
+            f"git apply --3way --whitespace=nowarn {_PATCH}",
+            f"git apply --whitespace=nowarn {_PATCH}",
+            f"patch -p1 --no-backup-if-mismatch < {_PATCH}",
+        )
+    )
+    ec, _, _ = await ev.exec(f"cd {workdir} && ({ladder})", user="agent", check=False, timeout=120)
+    return ec == 0
 
 
-async def _run_swepro(ev: Sandbox, workdir: str, swepro: dict, timeout: int) -> tuple[float, bool]:
+async def _run_swepro(ev: Sandbox, workdir: str, swepro: dict, timeout: int) -> float:
     test_arg = ",".join(swepro.get("selected_test_files") or [])
     stdout_f = f"{_SWEPRO_DIR}/stdout.log"
     stderr_f = f"{_SWEPRO_DIR}/stderr.log"
     result_f = f"{_SWEPRO_DIR}/result.json"
     await ev.exec(
-        f"cd {workdir} && bash {_SWEPRO_DIR}/run_script.sh "
-        f"{json.dumps(test_arg)} > {stdout_f} 2> {stderr_f} || true",
+        f"cd {workdir} && bash {_SWEPRO_DIR}/run_script.sh {json.dumps(test_arg)} > {stdout_f} 2> {stderr_f} || true",
         user="agent",
         check=False,
         timeout=timeout,
@@ -239,18 +335,158 @@ async def _run_swepro(ev: Sandbox, workdir: str, swepro: dict, timeout: int) -> 
     passed = {t["name"] for t in parsed.get("tests", []) if t.get("status") == "PASSED"}
     required = set(swepro.get("fail_to_pass") or []) | set(swepro.get("pass_to_pass") or [])
     solved = bool(required) and required.issubset(passed)
-    return (1.0 if solved else 0.0), solved
+    return 1.0 if solved else 0.0
 
 
-async def _run_eval_cmd(ev: Sandbox, workdir: str, cmd: str, timeout: int) -> tuple[float, bool]:
+async def _run_eval_cmd(ev: Sandbox, workdir: str, cmd: str, timeout: int) -> float:
     ec, _, _ = await ev.exec(f"cd {workdir} && {cmd}", user="agent", check=False, timeout=timeout)
-    return (1.0 if ec == 0 else 0.0), ec == 0
+    return 1.0 if ec == 0 else 0.0
 
 
-async def _run_f2p_script(ev: Sandbox, workdir: str, script: str, timeout: int) -> tuple[float, bool]:
+async def _run_f2p_script(ev: Sandbox, workdir: str, script: str, timeout: int) -> float:
     # sweb f2p_script is a self-contained pytest file ending in
     # `sys.exit(pytest.main([...]))`; write it verbatim (no shell quoting) and
     # let python's exit code carry the pass/fail signal.
     await ev.write_file(_F2P, script, user="agent")
     ec, _, _ = await ev.exec(f"cd {workdir} && python {_F2P}", user="agent", check=False, timeout=timeout)
-    return (1.0 if ec == 0 else 0.0), ec == 0
+    return 1.0 if ec == 0 else 0.0
+
+
+# Mirror of swebench.harness.run_evaluation.GIT_APPLY_CMDS: try each in order,
+# first success wins. The `patch --fuzz` tier rescues diffs `git apply` rejects.
+_GIT_APPLY_CMDS = (
+    "git apply --verbose",
+    "git apply --verbose --reject",
+    "patch --batch --fuzz=5 -p1 -i",
+)
+
+
+async def _apply_model_patch(ev: Sandbox, workdir: str) -> bool:
+    """Apply /tmp/patch.diff via the GIT_APPLY_CMDS ladder; True if applied
+    (or empty). Empty patch is a no-op success -- eval then scores it 0 on its
+    own (no source change -> tests still fail)."""
+    ladder = " || ".join(f"{cmd} /tmp/patch.diff" for cmd in _GIT_APPLY_CMDS)
+    cmd = (
+        f"cd {workdir} && git config --global --add safe.directory {workdir} "
+        f"&& if [ -s /tmp/patch.diff ]; then {ladder}; fi"
+    )
+    ec, _, _ = await ev.exec(cmd, user="root", check=False, timeout=120)
+    return ec == 0
+
+
+def _build_test_spec(inst: dict):
+    """make_test_spec(inst). Shared by evaluability_check and the grader; may
+    raise (KeyError on unknown repo/version)."""
+    return make_test_spec(inst)  # type: ignore[misc]
+
+
+def _eval_report_from_log(ts, instance_id: str, diff_text: str, log: str) -> dict:
+    """Run swebench's get_eval_report against the captured test log. It reads
+    from a file path, so write the log to a tempfile, parse, and clean up."""
+    tmp = tempfile.NamedTemporaryFile(mode="w", suffix=".log", delete=False)
+    try:
+        tmp.write(log)
+        tmp.flush()
+        tmp.close()
+        prediction = {
+            "instance_id": instance_id,
+            "model_patch": diff_text or "",
+            "model_name_or_path": "swe",
+        }
+        return get_eval_report(  # type: ignore[misc]
+            test_spec=ts,
+            prediction=prediction,
+            test_log_path=tmp.name,
+            include_tests_status=True,
+        )
+    finally:
+        try:
+            os.unlink(tmp.name)
+        except OSError:
+            pass
+
+
+def _ratio(d: dict) -> tuple[int, int]:
+    """(passed, total) from a {success: [...], failure: [...]} bucket."""
+    passed, failed = d.get("success", []), d.get("failure", [])
+    return len(passed), len(passed) + len(failed)
+
+
+def _log_swebench_result(instance_id: str, exit_code, info: dict, log: str) -> None:
+    """Emit the per-instance grading outcome with test-bucket ratios; on a
+    non-resolved row that parsed NO test lines, surface the log tail so failures
+    (missing pytest plugin, conda not activated, ...) can be diagnosed."""
+    if info.get("resolved"):
+        logger.info("[swe.swebench] %s: reward=1 exit_code=%s", instance_id, exit_code)
+        return
+    ts_status = info.get("tests_status") or {}
+    f2p_pass, f2p_total = _ratio(ts_status.get("FAIL_TO_PASS", {}))
+    p2p_pass, p2p_total = _ratio(ts_status.get("PASS_TO_PASS", {}))
+    nothing_parsed = not (f2p_total or p2p_total)
+    tail = log[-800:] if nothing_parsed else ""
+    logger.info(
+        "[swe.swebench] %s: reward=0 exit_code=%s patch_applied=%s F2P=(%d/%d) P2P=(%d/%d)%s",
+        instance_id,
+        exit_code,
+        bool(info.get("patch_successfully_applied")),
+        f2p_pass,
+        f2p_total,
+        p2p_pass,
+        p2p_total,
+        f" tail={tail!r}" if tail else "",
+    )
+
+
+async def _grade_swebench(md: dict, diff_text: str, timeout_sec: int) -> EvalResult:
+    """reward=1.0 iff sweb's get_eval_report declares the instance ``resolved``."""
+    instance_id = md["instance_id"]
+    inst = md["grading"]["sweb_instance"]
+
+    if _SWEBENCH_IMPORT_ERROR is not None:
+        logger.error(
+            "[swe.swebench] %s: swebench import failed: %r; reward=0",
+            instance_id,
+            _SWEBENCH_IMPORT_ERROR,
+        )
+        return EvalResult(0.0, True)
+
+    try:
+        ts = _build_test_spec(inst)
+        eval_sh = ts.eval_script  # may raise on unknown repo/version
+    except Exception as e:
+        logger.warning("[swe.swebench] %s: make_test_spec/eval_script failed: %s; reward=0", instance_id, e)
+        return EvalResult(0.0, True)
+
+    image = md["image"]
+    if not image:
+        logger.warning("[swe.swebench] %s: missing image; reward=0", instance_id)
+        return EvalResult(0.0, True)
+
+    async with E2BSandbox(image) as ev:
+        await asyncio.gather(
+            ev.write_file("/tmp/patch.diff", diff_text or "", user="root"),
+            ev.write_file("/tmp/eval.sh", eval_sh, user="root"),
+        )
+        # Apply the model patch first (eval_script assumes it is already applied);
+        # if no apply strategy works, the instance is unsolvable -- skip the eval.
+        if not await _apply_model_patch(ev, md["workdir"]):
+            logger.warning("[swe.swebench] %s: model patch failed to apply; reward=0", instance_id)
+            return EvalResult(0.0, False)
+        exit_code, log = await exec_and_wait(
+            ev, cmd="bash /tmp/eval.sh", user="root", time_budget_sec=timeout_sec, tag="eval", want_output=True
+        )
+
+    try:
+        report = _eval_report_from_log(ts, instance_id, diff_text, log)
+    except Exception as e:
+        logger.warning(
+            "[swe.swebench] %s: get_eval_report failed: %s; reward=0 (tail=%r)",
+            instance_id,
+            e,
+            log[-600:],
+        )
+        return EvalResult(0.0, True)
+
+    info = report.get(instance_id, {})
+    _log_swebench_result(instance_id, exit_code, info, log)
+    return EvalResult(1.0 if info.get("resolved") else 0.0, bool(info.get("patch_successfully_applied")))

--- a/slime/agent/adapters/common.py
+++ b/slime/agent/adapters/common.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import asyncio
 import dataclasses
 import logging
+import time
 import uuid
 from collections.abc import Callable
 from typing import Any
@@ -227,11 +228,19 @@ class BaseAdapter:
         tasks = [t for t in self.inflight.pop(sid, ()) if not t.done()]
         if not tasks:
             return
-        _, pending = await asyncio.wait(tasks, timeout=wait_timeout)
-        for task in pending:
-            task.cancel()
-        if pending:
-            await asyncio.gather(*pending, return_exceptions=True)
+
+        async def _drain() -> None:
+            _, pending = await asyncio.wait(tasks, timeout=wait_timeout)
+            for task in pending:
+                task.cancel()
+            if pending:
+                await asyncio.gather(*pending, return_exceptions=True)
+
+        loop = tasks[0].get_loop()
+        try:
+            await asyncio.wrap_future(asyncio.run_coroutine_threadsafe(_drain(), loop))
+        except Exception:
+            self.logger.exception("[%s] sid=%s shutdown drain failed", self.log_prefix, sid)
 
     async def finish_session(
         self,
@@ -325,6 +334,7 @@ class BaseAdapter:
         s = self.store.setdefault(sid, Session())
         task = asyncio.current_task()
         self.inflight.setdefault(sid, set()).add(task)
+        t0 = time.monotonic()
         try:
             translated, tools_schema = self._translate(body)
             prompt_ids = _render_token_ids(translated, tok, tools=tools_schema, add_generation_prompt=True)
@@ -339,7 +349,27 @@ class BaseAdapter:
                 reasoning_parser_name=self.reasoning_parser,
             )
             reply = self._build_reply(parsed, turn.finish_reason, translated, tools_schema)
-            turn = dataclasses.replace(turn, finish_reason=reply.finish_reason)
+            turn = dataclasses.replace(turn, ill_formed=parsed.ill_formed)
+
+            in_tok, out_tok = len(prompt_ids), len(turn.output_ids)
+            stream = body.get("stream") is True or "text/event-stream" in request.headers.get("Accept", "")
+
+            # Flush the response before recording the trajectory: a client that
+            # disconnected during generation makes _respond raise here, and we
+            # must not record a turn the client never received.
+            try:
+                response = await self._respond(request, body, reply, in_tok, out_tok, stream)
+            except (ConnectionResetError, asyncio.CancelledError) as e:
+                self.logger.warning(
+                    "[%s] sid=%s client disconnected before response flush: %s after %.1fs",
+                    self.log_prefix,
+                    sid,
+                    type(e).__name__,
+                    time.monotonic() - t0,
+                )
+                if isinstance(e, asyncio.CancelledError):
+                    raise
+                return web.Response(status=499, text="client disconnected")
 
             self._run_debug_callback(
                 sid,
@@ -356,10 +386,7 @@ class BaseAdapter:
                 response_message=reply.manager_message,
                 metadata={"sid": sid},
             )
-            in_tok, out_tok = len(prompt_ids), len(turn.output_ids)
-
-            stream = body.get("stream") is True or "text/event-stream" in request.headers.get("Accept", "")
-            return await self._respond(request, body, reply, in_tok, out_tok, stream)
+            return response
         finally:
             self.inflight.get(sid, set()).discard(task)
 

--- a/slime/agent/adapters/common.py
+++ b/slime/agent/adapters/common.py
@@ -259,12 +259,14 @@ class BaseAdapter:
         Idempotent: a second call for an already-popped sid returns [].
         """
         await self.shutdown_session(sid, wait_timeout=wait_timeout)
-        self.store.pop(sid, None)
+        session = self.store.pop(sid, None)
+        max_sample_tokens = int(getattr(session, "max_context_tokens", 0) or 0) if session is not None else 0
         samples = self.manager.get_trajectory(
             sid,
             base_sample=base_sample,
             reward=reward,
             extra_metadata=extra_metadata,
+            max_sample_tokens=max_sample_tokens,
         )
         for s in samples:
             rlen = int(s.response_length or 0)

--- a/slime/agent/harness/claude_code.py
+++ b/slime/agent/harness/claude_code.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 from slime.agent.sandbox import Sandbox
 
-from .common import BaseHarness, HarnessContext, install_npm_cli, run_command
+from .common import BaseHarness, HarnessContext, install_npm_cli, run_agent
 
 
 class ClaudeCodeHarness(BaseHarness):
@@ -68,4 +68,4 @@ class ClaudeCodeHarness(BaseHarness):
         extra_envs = os.environ.get(self.extra_envs_env, "").strip()
         if extra_envs:
             env.update(json.loads(extra_envs))
-        return await run_command(sb, workdir=ctx.workdir, start_cmd=cmd, env=env, time_budget_sec=time_budget_sec)
+        return await run_agent(sb, workdir=ctx.workdir, start_cmd=cmd, env=env, time_budget_sec=time_budget_sec)

--- a/slime/agent/harness/codex.py
+++ b/slime/agent/harness/codex.py
@@ -15,7 +15,7 @@ from pathlib import Path
 
 from slime.agent.sandbox import Sandbox
 
-from .common import BaseHarness, HarnessContext, install_npm_cli, run_command
+from .common import BaseHarness, HarnessContext, install_npm_cli, run_agent
 
 
 class CodexHarness(BaseHarness):
@@ -83,4 +83,4 @@ class CodexHarness(BaseHarness):
         extra_envs = os.environ.get(self.extra_envs_env, "").strip()
         if extra_envs:
             env.update(json.loads(extra_envs))
-        return await run_command(sb, workdir=ctx.workdir, start_cmd=cmd, env=env, time_budget_sec=time_budget_sec)
+        return await run_agent(sb, workdir=ctx.workdir, start_cmd=cmd, env=env, time_budget_sec=time_budget_sec)

--- a/slime/agent/harness/common.py
+++ b/slime/agent/harness/common.py
@@ -6,7 +6,7 @@ shared parts (create the agent user, the run skeleton, the launch-detached-and-
 poll transport) live here; adding a CLI-style harness means subclassing
 BaseHarness and implementing install_cli, write_config and launch_and_wait.
 Two module-level helpers cover the common cases: install_npm_cli for
-npm-packaged CLIs, and run_command for the run-one-command-to-completion case.
+npm-packaged CLIs, and run_agent for the launch-the-agent-to-completion case.
 
 The base knows nothing about the task: run() takes only generic fields
 (workdir / session_id / adapter_url / prompt). Task-specific workspace prep and
@@ -18,16 +18,14 @@ from __future__ import annotations
 import asyncio
 import lzma
 import os
-import shlex
 import shutil
 import tempfile
-import time
 from abc import ABC, ABCMeta, abstractmethod
 from dataclasses import dataclass
 from pathlib import Path
 
 from slime.agent import sandbox as _sandbox
-from slime.agent.sandbox import Sandbox
+from slime.agent.sandbox import Sandbox, exec_and_wait
 from slime.utils.misc import SingletonMeta
 
 
@@ -35,7 +33,10 @@ class SingletonABCMeta(ABCMeta, SingletonMeta):
     pass
 
 
-EXIT_TIME_BUDGET_EXCEEDED = -1
+# In-sandbox retry budget for the npm global install (transient flakes like
+# exit 217). Cheaper than a full sandbox recreate by the caller.
+NPM_INSTALL_RETRIES = 3
+NPM_INSTALL_BACKOFF_SEC = 2.0
 
 
 @dataclass(frozen=True)
@@ -73,7 +74,7 @@ class BaseHarness(ABC, metaclass=SingletonABCMeta):
         """Run the agent to completion and return its exit code.
 
         A non-interactive CLI builds one shell command and hands it to
-        run_command. An interactive or long-running harness drives its own loop
+        run_agent. An interactive or long-running harness drives its own loop
         here instead.
         """
 
@@ -103,72 +104,50 @@ class BaseHarness(ABC, metaclass=SingletonABCMeta):
         return await self.launch_and_wait(sb, ctx, prompt, time_budget_sec)
 
 
-async def run_command(sb: Sandbox, *, workdir: str, start_cmd: str, env: dict[str, str], time_budget_sec: int) -> int:
-    """Run start_cmd to completion in the sandbox and return its exit code.
-
-    Runs the command detached (setsid) rather than as a long-lived foreground
-    exec, so it survives sandbox gateways that cap connection lifetime. Output
-    is piped to a trajectory log and the command's exit code (PIPESTATUS[0], not
-    tee's) is written to a marker file, which we poll every 5s (the short RPCs
-    also keep the sandbox alive against idle GC). All metadata goes under
-    {workdir}/.harness/ so diff capture only has to exclude one directory.
-    Returns EXIT_TIME_BUDGET_EXCEEDED if the budget runs out first.
-    """
+async def run_agent(sb: Sandbox, *, workdir: str, start_cmd: str, env: dict[str, str], time_budget_sec: int) -> int:
+    """Launch the agent (start_cmd) and run it to completion, returning its exit code."""
     meta_dir = f"{workdir}/.harness"
-    done = f"{meta_dir}/done"
-    launcher = f"{meta_dir}/run.sh"
-    traj = f"{meta_dir}/trajectory.jsonl"
-
-    launcher_body = (
-        "#!/bin/bash\n"
-        f"cd {workdir}\n"
-        "export HOME=/home/agent\n"
-        f"{start_cmd} 2>&1 | tee {shlex.quote(traj)}\n"
-        f"echo ${{PIPESTATUS[0]}} > {done}\n"
-    )
     await sb.exec(f"mkdir -p {meta_dir} && chown agent:agent {meta_dir}", user="root", check=True, timeout=30)
-    await sb.write_file(launcher, launcher_body, user="agent")
-    await sb.exec(f"chmod +x {launcher}", user="agent", timeout=30)
-
-    env_keys = ",".join(env.keys())
-    await sb.exec(
-        f"runuser -u agent --whitelist-environment={env_keys}"
-        f" -- bash -c 'setsid {launcher} < /dev/null > /dev/null 2>&1 &'",
-        user="root",
+    exit_code, _ = await exec_and_wait(
+        sb,
+        cmd=start_cmd,
+        user="agent",
         env=env,
-        timeout=30,
-        check=True,
+        workdir=workdir,
+        out_file=f"{meta_dir}/trajectory.jsonl",
+        time_budget_sec=time_budget_sec,
+        tag="run",
+        want_output=False,
     )
-
-    deadline = time.time() + time_budget_sec
-    exit_code = EXIT_TIME_BUDGET_EXCEEDED  # until the marker yields a real code
-    while time.time() < deadline:
-        await asyncio.sleep(5)
-        ec, out, _ = await sb.exec(
-            f"test -f {done} && cat {done}",
-            user="agent",
-            timeout=15,
-            check=False,
-        )
-        if ec == 0:
-            exit_code_text = (out or "").strip()
-            if exit_code_text:
-                exit_code = int(exit_code_text)
-                break
     return exit_code
 
 
-async def install_npm_cli(sb: Sandbox, *, node_runtime: Path, npm_package: Path, check_cmd: str) -> None:
+async def install_npm_cli(
+    sb: Sandbox,
+    *,
+    node_runtime: Path,
+    npm_package: Path,
+    check_cmd: str,
+) -> None:
     """Install an npm-packaged CLI into the sandbox: the Node 22 runtime first,
     then the CLI's npm package (global install, then self-check via check_cmd).
     Non-npm harnesses write their own install_cli."""
     await install_node22(sb, node_runtime)
+
     await sb.write_file("/tmp/harness-cli.tgz", npm_package)
-    await sb.exec(
-        f"npm install -g --prefix=/usr/local --no-audit --no-fund /tmp/harness-cli.tgz && {check_cmd}",
-        user="root",
-        timeout=300,
-        check=True,
+    install_cmd = "npm install -g --prefix=/usr/local --no-audit --no-fund /tmp/harness-cli.tgz && " + check_cmd
+    # Detached install with a few in-place retries for transient disk flakes.
+    last_log = ""
+    for attempt in range(NPM_INSTALL_RETRIES):
+        exit_code, last_log = await exec_and_wait(
+            sb, cmd=install_cmd, user="root", time_budget_sec=300, tag="harness-npm-install"
+        )
+        if exit_code == 0:
+            return
+        if attempt + 1 < NPM_INSTALL_RETRIES:
+            await asyncio.sleep(NPM_INSTALL_BACKOFF_SEC * (attempt + 1))
+    raise RuntimeError(
+        f"npm install failed after {NPM_INSTALL_RETRIES} attempts (exit={exit_code}):\n{last_log[-1000:]}"
     )
 
 

--- a/slime/agent/parsing.py
+++ b/slime/agent/parsing.py
@@ -19,6 +19,7 @@ class ParsedModelOutput:
     reasoning: str
     text: str
     tool_uses: list[dict[str, Any]]
+    ill_formed: bool = False
 
 
 def parse_model_output(
@@ -46,11 +47,12 @@ def parse_model_output(
         if not reasoning and "</think>" in body_text:
             reasoning, body_text = body_text.split("</think>", 1)
 
-    body_text, tool_uses = parse_tool_uses(body_text, tools_schema, tool_parser_name)
+    body_text, tool_uses, ill_formed = parse_tool_uses(body_text, tools_schema, tool_parser_name)
     return ParsedModelOutput(
         reasoning=reasoning,
         text=(body_text or "").strip(),
         tool_uses=tool_uses,
+        ill_formed=ill_formed,
     )
 
 
@@ -58,9 +60,10 @@ def parse_tool_uses(
     body_text: str,
     tools_schema: list[dict] | None,
     tool_parser_name: str | None,
-) -> tuple[str, list[dict[str, Any]]]:
+) -> tuple[str, list[dict[str, Any]], bool]:
     """Parse tool calls from body text and return visible text plus tool uses."""
     tool_uses: list[dict[str, Any]] = []
+    ill_formed = False
     if tool_parser_name and tools_schema:
         from sglang.srt.entrypoints.openai.protocol import Function, Tool
         from sglang.srt.function_call.function_call_parser import FunctionCallParser
@@ -78,12 +81,13 @@ def parse_tool_uses(
                 args = json.loads(c.parameters or "{}")
             except json.JSONDecodeError:
                 args = {"_raw_arguments": c.parameters}
+                ill_formed = True
             tool_uses.append({"name": c.name or "tool", "input": args})
 
     if not tool_uses and tools_schema:
         body_text, tool_uses = parse_xml_tool_uses(body_text, tools_schema)
 
-    return body_text, tool_uses
+    return body_text, tool_uses, ill_formed
 
 
 def parse_xml_tool_uses(body_text: str, tools_schema: list[dict]) -> tuple[str, list[dict[str, Any]]]:

--- a/slime/agent/sandbox.py
+++ b/slime/agent/sandbox.py
@@ -12,6 +12,8 @@ import asyncio
 import io
 import logging
 import os
+import random
+import time
 from pathlib import Path
 from typing import Protocol, runtime_checkable
 
@@ -28,6 +30,10 @@ class Sandbox(Protocol):
 
     ``write_file`` accepts either in-memory content (``str``/``bytes``) or a
     host ``Path`` to stream into the sandbox.
+
+    Retry/idempotency is deliberately *not* part of this contract: whether a
+    severed RPC is safe to re-send is a backend transport concern (see
+    ``E2BSandbox._rpc_retry``), not something abstraction consumers reason about.
     """
 
     sandbox_id: str
@@ -51,6 +57,79 @@ class Sandbox(Protocol):
     async def read_file(self, sandbox_path: str, *, user: str = "root") -> str: ...
 
 
+EXIT_TIME_BUDGET_EXCEEDED = -1
+
+
+async def _await_done_marker(sb: Sandbox, done_file: str, *, user: str, time_budget_sec: int) -> int:
+    """Poll a detached command's exit-code marker until it appears, returning the
+    exit code (or ``EXIT_TIME_BUDGET_EXCEEDED`` if the budget runs out first).
+
+    The 5s ``test -f && cat`` polls are deliberately short, idempotent RPCs --
+    they keep the sandbox alive against idle GC while the detached command runs
+    over a stream the gateway can't sever.
+    """
+    deadline = time.time() + time_budget_sec
+    while time.time() < deadline:
+        await asyncio.sleep(5)
+        ec, out, _ = await sb.exec(f"test -f {done_file} && cat {done_file}", user=user, timeout=15, check=False)
+        if ec == 0 and (out or "").strip():
+            return int(out.strip())
+    return EXIT_TIME_BUDGET_EXCEEDED
+
+
+async def exec_and_wait(
+    sb: Sandbox,
+    *,
+    cmd: str,
+    time_budget_sec: int,
+    tag: str,
+    user: str = "root",
+    env: dict[str, str] | None = None,
+    workdir: str | None = None,
+    out_file: str | None = None,
+    want_output: bool = False,
+) -> tuple[int, str]:
+    """Run ``cmd`` to completion detached, returning ``(exit_code, output)``.
+
+    A plain ``sb.exec`` keeps an HTTP/2 stream open for the command's whole
+    runtime, so a long-running command (build, test suite) outlives what the
+    E2B gateway will hold a single response stream open for: the stream gets
+    severed mid-run and we lose the exit code with no safe way to retry a
+    non-idempotent command. Instead we ``setsid`` the command fully detached,
+    redirect its output to a file, and have it drop its exit code into a marker
+    file. The caller side then becomes a sequence of short, idempotent RPCs --
+    write the launcher, fire-and-forget the spawn, then poll for the marker (see
+    ``_await_done_marker``) -- none of which depend on a stream staying alive,
+    and the polling doubles as an idle-GC keepalive while the command runs.
+    """
+    out_file = out_file or f"/tmp/.{tag}.out"
+    done_file = f"/tmp/.{tag}.done"
+    launcher = f"/tmp/.{tag}.sh"
+    lock_dir = f"/tmp/.{tag}.spawned"
+    prefix = f"cd {workdir}\nexport HOME=/home/{user}\n" if workdir else ""
+    launcher_body = f"#!/bin/bash\n{prefix}{cmd}\necho $? > {done_file}\n"
+    await sb.write_file(launcher, launcher_body, user=user)
+
+    await sb.exec(
+        f"chmod +x {launcher}; "
+        f"mkdir {lock_dir} 2>/dev/null || exit 0; "
+        f"rm -f {out_file} {done_file}; "
+        f"setsid bash {launcher} < /dev/null > {out_file} 2>&1 &",
+        user=user,
+        env=env,
+        timeout=30,
+        check=True,
+        idempotent=True,
+    )
+    exit_code = await _await_done_marker(sb, done_file, user=user, time_budget_sec=time_budget_sec)
+    if exit_code == 0 and not want_output:
+        return exit_code, ""
+    if want_output:
+        return exit_code, await sb.read_file(out_file, user=user)
+    _, tail, _ = await sb.exec(f"tail -c 512 {out_file} 2>/dev/null", user=user, timeout=15, check=False)
+    return exit_code, tail or ""
+
+
 def _getenv(*names: str, default: str = "") -> str:
     """First non-empty environment value among ``names`` (else ``default``).
 
@@ -69,12 +148,13 @@ class E2BSandbox:
     image_metadata_key_env = ("SLIME_AGENT_SANDBOX_IMAGE_METADATA_KEY", "SWE_SANDBOX_IMAGE_METADATA_KEY")
     lifetime_sec_env = ("SLIME_AGENT_SANDBOX_LIFETIME_SEC", "SWE_SANDBOX_LIFETIME_SEC")
     rpc_retries_env = ("SLIME_AGENT_SANDBOX_RPC_RETRIES", "SWE_RPC_RETRIES")
+    size_env = ("SLIME_AGENT_E2B_SANDBOX_SIZE", "SWE_E2B_SANDBOX_SIZE")
 
     default_lifetime_sec = 3600
-    default_rpc_retries = 3
-    # With retries=3 the sleep budget is 3s, which handles common E2B h2 reset
-    # / SSL / pool-timeout flaps without stalling rollout steps for too long.
+    default_rpc_retries = 6
+    default_size = "md"
     rpc_backoff_base_sec = 1.0
+    rpc_backoff_cap_sec = 32.0
 
     def __init__(
         self,
@@ -83,11 +163,13 @@ class E2BSandbox:
         timeout: int | None = None,
         image_metadata_key: str | None = None,
         rpc_retries: int | None = None,
+        size: str | None = None,
     ) -> None:
         self.image = image
         self.timeout = timeout if timeout is not None else self._lifetime_sec_from_env()
         self.image_metadata_key = image_metadata_key or self._image_metadata_key_from_env()
         self.rpc_retries = rpc_retries if rpc_retries is not None else self._rpc_retries_from_env()
+        self.size = size if size is not None else self._size_from_env()
         self._sb = None
         self.sandbox_id = ""
 
@@ -103,11 +185,13 @@ class E2BSandbox:
     def _rpc_retries_from_env(cls) -> int:
         return int(_getenv(*cls.rpc_retries_env, default=str(cls.default_rpc_retries)))
 
-    @staticmethod
-    def _is_transient_rpc_error(e: BaseException) -> bool:
-        """True if e is a transient E2B client-side failure safe to retry."""
-        name = type(e).__name__
-        if name in {
+    @classmethod
+    def _size_from_env(cls) -> str:
+        return _getenv(*cls.size_env, default=cls.default_size)
+
+    # Transient client-side failures safe to retry.
+    _TRANSIENT_RPC_ERRORS = frozenset(
+        {
             "ProtocolError",
             "LocalProtocolError",
             "WriteError",
@@ -119,7 +203,14 @@ class E2BSandbox:
             "PoolTimeout",
             "RemoteProtocolError",
             "SSLError",
-        }:
+        }
+    )
+
+    @classmethod
+    def _is_transient_rpc_error(cls, e: BaseException) -> bool:
+        """True if e is a transient E2B client-side failure safe to retry."""
+        name = type(e).__name__
+        if name in cls._TRANSIENT_RPC_ERRORS:
             return True
         msg = str(e)
         if name == "SandboxException":
@@ -128,8 +219,15 @@ class E2BSandbox:
             return True
         return False
 
-    async def _rpc_retry(self, op_name: str, coro_factory):
-        """Run coro_factory() with retries for transient E2B RPC failures."""
+    async def _rpc_retry(self, op_name: str, coro_factory, *, idempotent: bool = True):
+        """Run coro_factory() with retries for transient E2B RPC failures.
+
+        :param idempotent: When False, a transient failure is re-raised instead
+            of retried: re-running a non-idempotent op (e.g. a process-spawning
+            exec) after a severed response could double-execute it. Idempotent
+            ops (the default: create / read_file / write_file / short read-only
+            execs) retry as before.
+        """
         last_err = None
         for attempt in range(self.rpc_retries):
             try:
@@ -137,9 +235,13 @@ class E2BSandbox:
             except Exception as e:
                 if not self._is_transient_rpc_error(e):
                     raise
+                if not idempotent:
+                    raise
                 last_err = e
                 if attempt + 1 < self.rpc_retries:
-                    backoff = self.rpc_backoff_base_sec * (2**attempt)
+                    await self._reset_conn_pool()
+                    ceiling = min(self.rpc_backoff_cap_sec, self.rpc_backoff_base_sec * (2**attempt))
+                    backoff = random.uniform(0.0, ceiling)
                     logger.debug(
                         "[agent.sandbox] %s transient %s, retry %d/%d in %.1fs: %s",
                         op_name,
@@ -153,6 +255,14 @@ class E2BSandbox:
         assert last_err is not None
         raise last_err
 
+    async def _reset_conn_pool(self) -> None:
+        """Tear down the sandbox's httpcore pool so the next RPC reconnects."""
+        try:
+            pool = self._sb._transport.pool  # httpcore.AsyncConnectionPool
+            await pool.aclose()
+        except Exception as e:
+            logger.debug("[agent.sandbox] conn-pool reset skipped: %s", e)
+
     async def __aenter__(self) -> E2BSandbox:
         if self.image_metadata_key is None:
             raise RuntimeError(
@@ -164,7 +274,13 @@ class E2BSandbox:
         from e2b import AsyncSandbox  # type: ignore
 
         md = {self.image_metadata_key: self.image}
-        self._sb = await AsyncSandbox.create(timeout=self.timeout, metadata=md)
+
+        if self.size:
+            prefix = self.image_metadata_key.rsplit("/", 1)[0] if "/" in self.image_metadata_key else ""
+            size_key = f"{prefix}/size" if prefix else "size"
+            md[size_key] = self.size
+
+        self._sb = await self._rpc_retry("create", lambda: AsyncSandbox.create(timeout=self.timeout, metadata=md))
         self.sandbox_id = self._sb.sandbox_id
         return self
 
@@ -183,6 +299,7 @@ class E2BSandbox:
         env: dict[str, str] | None = None,
         timeout: int = 120,
         check: bool = False,
+        idempotent: bool = True,
     ) -> ExecResult:
         from e2b.sandbox.commands.command_handle import CommandExitException
 
@@ -197,6 +314,7 @@ class E2BSandbox:
                     on_stdout=lambda s: None,
                     on_stderr=lambda s: None,
                 ),
+                idempotent=idempotent,
             )
             return res.exit_code, res.stdout or "", res.stderr or ""
         except CommandExitException as e:

--- a/slime/agent/trajectory.py
+++ b/slime/agent/trajectory.py
@@ -306,9 +306,10 @@ class TrajectoryManager:
         """Linearize this sid's routing tree into slime ``Sample`` objects and
         consume the session.
 
-        Each routing leaf yields one or more Samples; ``reward`` is split evenly
-        across all of them. The sid is dropped afterwards, so a second call for
-        the same sid returns ``[]``.
+        Each routing leaf yields one or more Samples; ``reward`` is assigned in
+        full to every emitted Sample (not split across them), so each trained
+        turn carries the trajectory's outcome reward. The sid is dropped
+        afterwards, so a second call for the same sid returns ``[]``.
         """
         root = self._trees.get(sid)
         if root is None:
@@ -321,9 +322,8 @@ class TrajectoryManager:
             chain = routing_leaf.path_from_root()
             samples.extend(self._chain_to_samples(chain, base_sample=base_sample, extra_metadata=extra_metadata))
 
-        per_sample_reward = reward
         for s in samples:
-            s.reward = per_sample_reward
+            s.reward = reward
 
         self._trees.pop(sid, None)
         self._turn_count.pop(sid, None)

--- a/slime/agent/trajectory.py
+++ b/slime/agent/trajectory.py
@@ -35,6 +35,7 @@ class TurnRecord:
     output_ids: list[int]
     finish_reason: str
     output_log_probs: list[float] = dataclasses.field(default_factory=list)
+    ill_formed: bool = False
 
 
 # ===========================================================================
@@ -234,6 +235,7 @@ class _SampleBuilder:
         """Emit the accumulated tokens as one ``Sample``, stripping the first-turn
         prompt so loss_mask / logprobs cover only the response region."""
         start = self.leading_prompt_len  # first-turn prompt stripped; response region starts here
+        md = dict(extra_metadata or {})
         return Sample(
             index=base_sample.index,
             group_index=base_sample.group_index,
@@ -246,7 +248,7 @@ class _SampleBuilder:
             rollout_log_probs=self.logprobs[start:],
             reward=0.0,
             status=Sample.Status.COMPLETED,
-            metadata=dict(extra_metadata or {}),
+            metadata=md,
         )
 
 
@@ -319,8 +321,7 @@ class TrajectoryManager:
             chain = routing_leaf.path_from_root()
             samples.extend(self._chain_to_samples(chain, base_sample=base_sample, extra_metadata=extra_metadata))
 
-        # TODO custom reward func
-        per_sample_reward = (reward / len(samples)) if samples else 0.0
+        per_sample_reward = reward
         for s in samples:
             s.reward = per_sample_reward
 
@@ -468,8 +469,19 @@ class TrajectoryManager:
         base_sample: Sample,
         extra_metadata: dict[str, Any] | None,
     ) -> list[Sample]:
+
+        asst_nodes = [n for n in chain if n.role == "assistant" and n.turn is not None]
+        truncated = bool(asst_nodes) and asst_nodes[-1].turn.finish_reason == "length"
+        use_tool = any(bool((n.message or {}).get("tool_calls")) for n in asst_nodes)
+        ill_formed = any(n.turn.ill_formed for n in asst_nodes)
+        md = {
+            **(extra_metadata or {}),
+            "truncated": truncated,
+            "use_tool": use_tool,
+            "ill_formed": ill_formed,
+        }
         return [
-            builder.to_sample(base_sample, extra_metadata)
+            builder.to_sample(base_sample, md)
             for builder in self._split_chain_into_builders(chain)
             if builder.has_trained_response()
         ]

--- a/slime/agent/trajectory.py
+++ b/slime/agent/trajectory.py
@@ -231,10 +231,19 @@ class _SampleBuilder:
     def has_trained_response(self) -> bool:
         return any(self.loss_mask[self.leading_prompt_len :])
 
-    def to_sample(self, base_sample: Sample, extra_metadata: dict[str, Any] | None) -> Sample:
+    def to_sample(
+        self, base_sample: Sample, extra_metadata: dict[str, Any] | None, max_sample_tokens: int = 0
+    ) -> Sample:
         """Emit the accumulated tokens as one ``Sample``, stripping the first-turn
         prompt so loss_mask / logprobs cover only the response region."""
         start = self.leading_prompt_len  # first-turn prompt stripped; response region starts here
+        tokens = list(self.tokens)
+        loss_mask = self.loss_mask
+        logprobs = self.logprobs
+        if max_sample_tokens and len(tokens) > max_sample_tokens:
+            tokens = tokens[:max_sample_tokens]
+            loss_mask = loss_mask[:max_sample_tokens]
+            logprobs = logprobs[:max_sample_tokens]
         md = dict(extra_metadata or {})
         return Sample(
             index=base_sample.index,
@@ -242,10 +251,10 @@ class _SampleBuilder:
             rollout_id=base_sample.rollout_id if base_sample.rollout_id is not None else base_sample.index,
             prompt=base_sample.prompt,
             label=base_sample.label,
-            tokens=list(self.tokens),
-            response_length=len(self.loss_mask) - start,
-            loss_mask=self.loss_mask[start:],
-            rollout_log_probs=self.logprobs[start:],
+            tokens=tokens,
+            response_length=len(loss_mask) - start,
+            loss_mask=loss_mask[start:],
+            rollout_log_probs=logprobs[start:],
             reward=0.0,
             status=Sample.Status.COMPLETED,
             metadata=md,
@@ -302,6 +311,7 @@ class TrajectoryManager:
         base_sample: Sample,
         reward: float = 0.0,
         extra_metadata: dict[str, Any] | None = None,
+        max_sample_tokens: int = 0,
     ) -> list[Sample]:
         """Linearize this sid's routing tree into slime ``Sample`` objects and
         consume the session.
@@ -320,7 +330,11 @@ class TrajectoryManager:
             if routing_leaf.is_root:
                 continue
             chain = routing_leaf.path_from_root()
-            samples.extend(self._chain_to_samples(chain, base_sample=base_sample, extra_metadata=extra_metadata))
+            samples.extend(
+                self._chain_to_samples(
+                    chain, base_sample=base_sample, extra_metadata=extra_metadata, max_sample_tokens=max_sample_tokens
+                )
+            )
 
         for s in samples:
             s.reward = reward
@@ -468,6 +482,7 @@ class TrajectoryManager:
         *,
         base_sample: Sample,
         extra_metadata: dict[str, Any] | None,
+        max_sample_tokens: int = 0,
     ) -> list[Sample]:
 
         asst_nodes = [n for n in chain if n.role == "assistant" and n.turn is not None]
@@ -481,7 +496,7 @@ class TrajectoryManager:
             "ill_formed": ill_formed,
         }
         return [
-            builder.to_sample(base_sample, md)
+            builder.to_sample(base_sample, md, max_sample_tokens)
             for builder in self._split_chain_into_builders(chain)
             if builder.has_trained_response()
         ]

--- a/tests/test_agent/_fakes.py
+++ b/tests/test_agent/_fakes.py
@@ -223,10 +223,10 @@ class FakeSandbox:
     Records every ``exec`` (so harness tests can assert the right commands were
     issued) and keeps an in-memory file store for ``write_file`` / ``read_file``.
     It drives the detached-launch / poll-marker handshake of
-    ``harness.common.run_command`` without any real process: when it sees the
-    ``setsid`` launch command it awaits the injected ``on_launch(env)`` agent
-    coroutine, then writes its exit code into the done-marker file so the next
-    poll succeeds.
+    ``harness.common.run_agent`` (via ``sandbox.exec_and_wait``) without any real
+    process: when it sees the ``setsid`` launch command it awaits the injected
+    ``on_launch(env)`` agent coroutine, then writes its exit code into the
+    done-marker file so the next poll succeeds.
 
     Construct directly, or via :meth:`factory` to get a zero-arg callable that
     ``examples...generate.E2BSandbox`` / ``swe.E2BSandbox`` can be monkeypatched
@@ -263,10 +263,10 @@ class FakeSandbox:
     async def __aexit__(self, *exc) -> None:
         return None
 
-    async def exec(self, cmd, *, user="root", env=None, timeout=120, check=False):
+    async def exec(self, cmd, *, user="root", env=None, timeout=120, check=False, idempotent=True):
         self.exec_log.append((cmd, user))
 
-        # Detached launch (run_command): drive the fake agent, then drop the marker.
+        # Detached launch (run_agent): drive the fake agent, then drop the marker.
         if "setsid" in cmd and self.on_launch is not None:
             code = await self.on_launch(env or {})
             done = _done_path_from_launch(cmd)
@@ -274,7 +274,7 @@ class FakeSandbox:
                 self.files[done] = f"{code}\n"
             return 0, "", ""
 
-        # Marker poll (run_command): succeed only once the marker file exists.
+        # Marker poll (run_agent): succeed only once the marker file exists.
         m = _POLL_RE.search(cmd)
         if m:
             path = m.group(1)
@@ -299,10 +299,10 @@ def _as_str(v: str | bytes) -> str:
 
 
 def _done_path_from_launch(cmd: str) -> str | None:
-    """The launcher script writes ``$PIPESTATUS`` into ``{workdir}/.harness/done``;
-    recover that path from the ``setsid {launcher}`` command so the poll matches.
-    ``run_command`` always names the marker ``.harness/done`` under the workdir."""
-    m = re.search(r"(\S+/\.harness)/run\.sh", cmd)
+    """Recover the exit-code marker path from a ``setsid bash {launcher}`` command
+    so the subsequent poll matches. ``sandbox.exec_and_wait`` names the launcher
+    ``/tmp/.{tag}.sh`` and its sibling marker ``/tmp/.{tag}.done``."""
+    m = re.search(r"setsid bash (\S+)\.sh\b", cmd)
     if m:
-        return f"{m.group(1)}/done"
+        return f"{m.group(1)}.done"
     return None

--- a/tests/test_agent/test_harness.py
+++ b/tests/test_agent/test_harness.py
@@ -2,7 +2,7 @@
 
 These cover the parts a happy-path rollout can't pin down precisely: that each
 harness writes the right CLI config and launches with the right command + env,
-that ``run_command``'s detached-launch / poll-marker handshake returns the right
+that ``run_agent``'s detached-launch / poll-marker handshake returns the right
 exit code (and times out correctly), and that ``ensure_agent_user`` issues the
 expected provisioning command. A :class:`tests.test_agent._fakes.FakeSandbox`
 records every ``exec`` / ``write_file`` so we assert on the issued commands
@@ -48,11 +48,11 @@ def _find(exec_log, needle):
 
 
 # ===========================================================================
-# §1 run_command handshake (the E2B detached-launch transport)
+# §1 run_agent handshake (the E2B detached-launch transport)
 # ===========================================================================
 
 
-def test_run_command_returns_marker_exit_code():
+def test_run_agent_returns_marker_exit_code():
     async def run_case():
         seen = {}
 
@@ -62,38 +62,38 @@ def test_run_command_returns_marker_exit_code():
 
         sb = FakeSandbox(on_launch=fake_agent)
         with patch.object(hc.asyncio, "sleep", new=_fast_sleep):
-            rc = await hc.run_command(
+            rc = await hc.run_agent(
                 sb, workdir="/workspace/repo", start_cmd="claude -p hi", env={"A": "1"}, time_budget_sec=30
             )
         assert rc == 0
         assert seen["env"] == {"A": "1"}
-        # launcher script + chmod + detached setsid launch all issued.
+        # launcher script + detached setsid launch all issued, exit code captured.
         assert any("run.sh" in p for p in sb.files)
         assert _find(sb.exec_log, "setsid")
-        assert _find(sb.exec_log, "PIPESTATUS") or any("PIPESTATUS" in v for v in sb.files.values())
+        assert any("echo $?" in v for v in sb.files.values())
 
     asyncio.run(run_case())
 
 
-def test_run_command_propagates_nonzero_exit():
+def test_run_agent_propagates_nonzero_exit():
     async def run_case():
         async def fail_agent(_env):
             return 7
 
         sb = FakeSandbox(on_launch=fail_agent)
         with patch.object(hc.asyncio, "sleep", new=_fast_sleep):
-            rc = await hc.run_command(sb, workdir="/w", start_cmd="x", env={}, time_budget_sec=30)
+            rc = await hc.run_agent(sb, workdir="/w", start_cmd="x", env={}, time_budget_sec=30)
         assert rc == 7
 
     asyncio.run(run_case())
 
 
-def test_run_command_times_out_when_marker_never_appears():
+def test_run_agent_times_out_when_marker_never_appears():
     async def run_case():
         sb = FakeSandbox(on_launch=None)  # no agent -> marker never written
         with patch.object(hc.asyncio, "sleep", new=_fast_sleep):
-            rc = await hc.run_command(sb, workdir="/w", start_cmd="x", env={}, time_budget_sec=0)
-        assert rc == hc.EXIT_TIME_BUDGET_EXCEEDED
+            rc = await hc.run_agent(sb, workdir="/w", start_cmd="x", env={}, time_budget_sec=0)
+        assert rc == sandbox_mod.EXIT_TIME_BUDGET_EXCEEDED
 
     asyncio.run(run_case())
 

--- a/tests/test_agent/test_trajectory_manager_branching.py
+++ b/tests/test_agent/test_trajectory_manager_branching.py
@@ -306,8 +306,8 @@ def _iter_all(root):
 # though get_trajectory consumes the session.
 _TREE_SNAP: dict[str, str] = {}
 
-# Input reward passed to get_trajectory, keyed by sid, so the dump can show the
-# split (input_reward / n_samples == per_sample_reward) explicitly.
+# Input reward passed to get_trajectory, keyed by sid, so the dump can show that
+# every emitted sample carries the full input reward.
 _REWARD_IN: dict[str, float] = {}
 
 
@@ -317,20 +317,19 @@ def get_traj(mgr, sid, *args, **kwargs):
     Linearization (get_trajectory) pops the sid, so a later dump would only see
     ``<drained>``. Capturing the tree text here keeps the routing tree visible
     next to the Samples it produced. The input ``reward`` is captured too so the
-    dump can show how it splits across the emitted samples.
+    dump can show how it maps onto the emitted samples.
     """
     if mgr.has_session(sid):
         _TREE_SNAP[sid] = dump_tree_txt(mgr, sid)
     _REWARD_IN[sid] = kwargs.get("reward", 0.0)
     samples = mgr.get_trajectory(sid, *args, **kwargs)
-    # Reward conservation: get_trajectory splits the input reward evenly across
-    # every emitted sample, so the per-sample shares must sum back to the input
-    # (modulo float error). This is the "averaged over sample count" invariant.
-    if samples:
-        total = sum(s.reward for s in samples)
-        assert abs(total - _REWARD_IN[sid]) < 1e-9, (
-            "reward not conserved across split",
-            total,
+    # Reward assignment: get_trajectory assigns the input reward in full to every
+    # emitted sample (no split), so each per-sample reward must equal the input
+    # (modulo float error). This is the "full outcome reward per turn" invariant.
+    for s in samples:
+        assert abs(s.reward - _REWARD_IN[sid]) < 1e-9, (
+            "reward not assigned in full to every sample",
+            s.reward,
             _REWARD_IN[sid],
         )
     return samples
@@ -660,7 +659,7 @@ def test_2_3_drift_case_A_forks():
         "<sys> system:S </sys> <usr> user:u </usr> <DRIFT> <gen> r:call </ast> "
         "<tul> tool:t </tul> <gen> [r:done] [</ast>]",
     ]
-    assert all(abs(s.reward - 1.0 / len(samples)) < 1e-9 for s in samples)
+    assert all(abs(s.reward - 1.0) < 1e-9 for s in samples)
     _check_invariants(samples)
     _record("2.3 drift case A (prompt region) -> fork", mgr, sid, samples)
     print("PASS 2.3")
@@ -713,7 +712,7 @@ def test_2_5_drift_case_B1_long_forks():
         "<sys> system:S </sys> <usr> user:u </usr> <gen> r:call <DRIFT> "
         "<tul> tool:t </tul> <gen> [r:done] [</ast>]",
     ]
-    assert all(abs(s.reward - 1.0 / len(samples)) < 1e-9 for s in samples)
+    assert all(abs(s.reward - 1.0) < 1e-9 for s in samples)
     _check_invariants(samples)
     _record("2.5 drift case B1 (long) -> fork", mgr, sid, samples)
     print("PASS 2.5")
@@ -761,7 +760,7 @@ def test_2_7_drift_case_B2_earlier_turn_forks():
         "<sys> system:S </sys> <usr> user:u </usr> <gen> r:a1 <DRIFT> "
         "<tul> tool:t1 </tul> <gen> r:a2 </ast> <tul> tool:t2 </tul> <gen> [r:a3] [</ast>]",
     ]
-    assert all(abs(s.reward - 1.0 / len(samples)) < 1e-9 for s in samples)
+    assert all(abs(s.reward - 1.0) < 1e-9 for s in samples)
     _check_invariants(samples)
     _record("2.7 drift case B2 (earlier turn) -> fork", mgr, sid, samples)
     print("PASS 2.7")
@@ -783,10 +782,10 @@ def test_2_8_fork_reward_split():
         "<sys> system:S </sys> <usr> user:u </usr> <DRIFT> <gen> r:call </ast> "
         "<tul> tool:t </tul> <gen> [r:done] [</ast>]",
     ]
-    # reward 1.0 split evenly across the 2 forked samples -> 0.5 each.
-    assert all(abs(s.reward - 0.5) < 1e-9 for s in samples)
+    # reward 1.0 assigned in full to each of the 2 forked samples.
+    assert all(abs(s.reward - 1.0) < 1e-9 for s in samples)
     _check_invariants(samples)
-    _record("2.8 fork reward split (1.0 / 2 = 0.5 each)", mgr, sid, samples)
+    _record("2.8 fork reward (1.0 to each sample)", mgr, sid, samples)
     print("PASS 2.8")
 
 
@@ -802,10 +801,10 @@ def test_2_9_two_leaves_reward_split():
         "<sys> system:S </sys> <usr> user:A </usr> <gen> [r:a] [</ast>]",
         "<sys> system:S </sys> <usr> user:B </usr> <gen> [r:b] [</ast>]",
     ]
-    # reward 1.0 split evenly across the 2 leaves -> 0.5 each.
-    assert all(abs(s.reward - 0.5) < 1e-9 for s in samples)
+    # reward 1.0 assigned in full to each of the 2 leaves.
+    assert all(abs(s.reward - 1.0) < 1e-9 for s in samples)
     _check_invariants(samples)
-    _record("2.9 two leaves reward split (1.0 / 2 = 0.5 each)", mgr, sid, samples)
+    _record("2.9 two leaves reward (1.0 to each sample)", mgr, sid, samples)
     print("PASS 2.9")
 
 
@@ -1034,7 +1033,7 @@ def test_3_6_tree_fork_plus_token_drift():
         # Sample 2: leaf Y, shares r:call (claimed by sample 0 -> bare), trains r:ay2.
         "<sys> system:S </sys> <usr> user:u </usr> <gen> r:call </ast> " "<tul> tool:y </tul> <gen> [r:ay2] [</ast>]",
     ]
-    assert all(abs(s.reward - 1.0 / 3) < 1e-9 for s in samples)
+    assert all(abs(s.reward - 1.0) < 1e-9 for s in samples)
     _check_invariants(samples)
     _record("3.6 tree fork + token drift -> 3 samples", mgr, sid, samples)
     print("PASS 3.6")
@@ -1121,7 +1120,7 @@ def test_3_8_long_mixed_session():
         "<tul> tool:t2 </tul> <gen> r:a3 </ast> <tul> tool:t3 </tul> <gen> r:a4 </ast> "
         "<tul> tool:t4 </tul> <gen> [r:a5] [</ast>]",
     ]
-    assert abs(sum(s.reward for s in samples) - 1.0) < 1e-9
+    assert all(abs(s.reward - 1.0) < 1e-9 for s in samples)
     _check_invariants(samples)
     _record(f"3.8 long mixed session -> {len(samples)} samples", mgr, sid, samples)
     print("PASS 3.8")
@@ -1325,8 +1324,7 @@ def _print_case(title: str, mgr, sid: str, samples: list) -> None:
     n = len(samples)
     if n:
         r_in = _REWARD_IN.get(sid, 0.0)
-        per = r_in / n
-        print(f"[samples] {n}  (reward split: {r_in:.3f} / {n} = {per:.3f} per sample)")
+        print(f"[samples] {n}  (reward: {r_in:.3f} assigned in full to each sample)")
     else:
         print(f"[samples] {n}")
     for i, s in enumerate(samples):


### PR DESCRIPTION
### What

Hardens the SWE coding-agent RL runtime (`slime/agent/`) and makes the train/eval grading protocol selectable from the environment.

**Grading protocol split**
- `generate.py` now reads `SWE_TRAIN_PROTOCOL` / `SWE_EVAL_PROTOCOL` (both default to `scaleswe`) so the train path and eval path can draw from datasets with different schemas and each pick its own grader.
- `swe.py` builds the SWE-bench test spec eagerly when validating an instance, so per-repo construction errors surface at validation time instead of mid-rollout.

**Sandbox RPC robustness (`slime/agent/sandbox.py`)**
- Explicit idempotent vs non-idempotent RPC contract: transient client-side E2B failures retry with jittered exponential backoff only when the op is safe to replay; non-idempotent ops (e.g. process-spawning `exec`) are re-raised instead of retried to avoid double-execution after a severed response.
- `exec_and_wait` detaches the command with `setsid` and polls a done-marker via short idempotent RPCs, so a dropped connection mid-run can't lose the exit code.
- Connection-pool reset on protocol errors.

**Trajectory sample truncation (`slime/agent/trajectory.py`, `adapters/common.py`)**
- Each emitted `Sample`'s token sequence is capped at the session's `max_context_tokens`, so an overlong multi-turn trajectory can't produce a training row that blows past the training context window.
- Threaded as `max_sample_tokens` through `get_trajectory` -> `_chain_to_samples` -> `_SampleBuilder.to_sample`; `0` (the default) disables the cap. `tokens` / `loss_mask` / `rollout_log_probs` are all sliced together so they stay aligned.

**Launch script**
- `run_qwen36_35b_a3b_swe_8nodes.sh` threads `SWE_TRAIN_PROTOCOL` (default `scaleswe`) through to the Ray workers.

### Test
- `pre-commit run` (ruff / isort / format) passes on all changed files.
