### PR TITLE
[docker] Update SGLang patch for PD R3 routed experts

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -84,7 +84,7 @@ RUN pip install nvidia-cudnn-cu12==9.16.0.29
 # reinstall numpy 1.x for megatron
 RUN pip install "numpy<2"
 
-RUN pip install https://github.com/zhuzilin/sgl-router/releases/download/v0.3.2-1b517cf/sglang_router-0.3.2-cp38-abi3-manylinux_2_28_x86_64.whl --force-reinstall
+RUN pip install https://github.com/zhuzilin/sgl-router/releases/download/v0.3.2-9daabcd/sglang_router-0.3.2-cp38-abi3-manylinux_2_28_x86_64.whl --force-reinstall
 RUN python -c "import sglang_router; assert 'slime' in sglang_router.__version__"
 
 RUN rm -rf /root/.cache/pip /root/flash-attention

--- a/docker/patch/latest/sglang.patch
+++ b/docker/patch/latest/sglang.patch
@@ -222,7 +222,7 @@ index b21aee9f7c..1edb76a5ce 100644
                              # Only the last chunk we need to send the aux data
                              ret = self.send_aux(
 diff --git a/python/sglang/srt/disaggregation/prefill.py b/python/sglang/srt/disaggregation/prefill.py
-index ce1afdac3a..bdb8b448be 100644
+index ce1afdac3a..0e115cfb87 100644
 --- a/python/sglang/srt/disaggregation/prefill.py
 +++ b/python/sglang/srt/disaggregation/prefill.py
 @@ -21,6 +21,8 @@ from __future__ import annotations
@@ -302,7 +302,7 @@ index ce1afdac3a..bdb8b448be 100644
          undone_reqs: List[Req] = []
          # Check .poll() for the reqs in disagg_prefill_inflight_queue. If Success, respond to the client and remove it from the queue
          for req, poll in zip(self.disagg_prefill_inflight_queue, polls):
-@@ -710,7 +752,27 @@ class SchedulerDisaggregationPrefillMixin:
+@@ -710,8 +752,30 @@ class SchedulerDisaggregationPrefillMixin:
                      continue
  
              if poll in [KVPoll.WaitingForInput, KVPoll.Transferring]:
@@ -329,8 +329,11 @@ index ce1afdac3a..bdb8b448be 100644
 +                else:
 +                    undone_reqs.append(req)
              elif poll == KVPoll.Success:  # transfer done
++                if req.return_routed_experts:
++                    self.batch_result_processor._maybe_collect_routed_experts(req)
                  release_kv_cache(req, self.tree_cache)  # unlock the tree
                  req.finished_reason = FINISH_LENGTH(length=0)
+                 # FIXME: clean up req's data in transfer engine
 diff --git a/python/sglang/srt/entrypoints/engine.py b/python/sglang/srt/entrypoints/engine.py
 index 88bf194768..4ede8eb907 100644
 --- a/python/sglang/srt/entrypoints/engine.py
@@ -774,7 +777,7 @@ index 42ea843109..c369b070b5 100755
          ):
              # Even the last remaining request cannot fit in memory.
 diff --git a/python/sglang/srt/managers/scheduler.py b/python/sglang/srt/managers/scheduler.py
-index 8e32640fc6..9896684250 100644
+index 8e32640fc6..bd154c1e38 100644
 --- a/python/sglang/srt/managers/scheduler.py
 +++ b/python/sglang/srt/managers/scheduler.py
 @@ -124,6 +124,7 @@ from sglang.srt.managers.io_struct import (
@@ -807,7 +810,17 @@ index 8e32640fc6..9896684250 100644
          )
  
      def init_lora_drainer(self) -> None:
-@@ -3721,6 +3730,12 @@ class Scheduler(
+@@ -2126,6 +2135,9 @@ class Scheduler(
+                 req.set_finish_with_abort(error_msg)
+                 self._add_request_to_queue(req)
+                 return
++            if self.disaggregation_mode == DisaggregationMode.DECODE:
++                # Prefill returns prompt-side routing; decode only owns rows after the prompt.
++                req.routed_experts_start_len = len(req.origin_input_ids)
+ 
+         added_to_grammar_queue = self.grammar_manager.process_req_with_grammar(req)
+         if not added_to_grammar_queue:
+@@ -3721,6 +3733,12 @@ class Scheduler(
                  # The request will still run one decode forward pass.
                  # Then we reuse all existing code to clean up the KV cache allocation.
                  logger.debug(f"Abort running request. {req.rid=}")

--- a/docker/patch/latest/sglang.patch
+++ b/docker/patch/latest/sglang.patch
@@ -222,7 +222,7 @@ index b21aee9f7c..1edb76a5ce 100644
                              # Only the last chunk we need to send the aux data
                              ret = self.send_aux(
 diff --git a/python/sglang/srt/disaggregation/prefill.py b/python/sglang/srt/disaggregation/prefill.py
-index ce1afdac3a..0e115cfb87 100644
+index ce1afdac3a..0a5bc0e3a4 100644
 --- a/python/sglang/srt/disaggregation/prefill.py
 +++ b/python/sglang/srt/disaggregation/prefill.py
 @@ -21,6 +21,8 @@ from __future__ import annotations
@@ -1578,10 +1578,20 @@ diff --git a/python/sglang/srt/observability/req_time_stats.py b/python/sglang/s
 index 2de10730c9..3f633676df 100644
 --- a/python/sglang/srt/observability/req_time_stats.py
 +++ b/python/sglang/srt/observability/req_time_stats.py
-@@ -584,9 +584,19 @@ class SchedulerReqTimeStats(ReqTimeStatsBase):
+@@ -315,7 +315,7 @@ class ReqTimeStatsBase:
+ 
+     def __setstate__(self, state: object):
+         for key in state.keys():
+-            if key.endswith("time"):
++            if key.endswith("time") and state[key] > 0.0:
+                 state[key] = convert_time_cross_thread(
+                     state[key],
+                     state["diff_realtime_monotonic"],
+@@ -584,9 +584,20 @@ class SchedulerReqTimeStats(ReqTimeStatsBase):
              return {}
  
          state = {
++            "enable_metrics": self.enable_metrics,
 +            "disagg_mode": self.disagg_mode,
              "wait_queue_entry_time": self.wait_queue_entry_time,
              "forward_entry_time": self.forward_entry_time,
@@ -1740,6 +1750,21 @@ diff --git a/python/sglang/srt/utils/common.py b/python/sglang/srt/utils/common.
 index 4556d06b16..9c28114f85 100644
 --- a/python/sglang/srt/utils/common.py
 +++ b/python/sglang/srt/utils/common.py
+@@ -1652,7 +1652,13 @@ def _get_fastapi_request_path(request) -> Tuple[str, bool]:
+     for route in request.app.routes:
+         match, child_scope = route.matches(request.scope)
+         if match == Match.FULL:
+-            return route.path, True
++            path = getattr(route, "path", None) or getattr(route, "path_format", None)
++            if path is None:
++                child_route = child_scope.get("route")
++                path = getattr(child_route, "path", None) or getattr(
++                    child_route, "path_format", None
++                )
++            return path or request.url.path, True
+ 
+     return request.url.path, False
+ 
 @@ -2399,6 +2399,7 @@ class SafeUnpickler(pickle.Unpickler):
          "sglang.srt.utils.",
          "sglang.srt.disaggregation.",

--- a/docker/version.txt
+++ b/docker/version.txt
@@ -1,1 +1,1 @@
-nightly-dev-20260701a
+nightly-dev-20260703a

--- a/slime/utils/types.py
+++ b/slime/utils/types.py
@@ -353,8 +353,17 @@ class Sample:
         if routed_experts is not None:
             if args is None:
                 raise ValueError("args is required to decode routed experts metadata.")
+            expected_rows = len(self.tokens) - 1
+            expected_numel = expected_rows * args.num_layers * args.moe_router_topk
+            if routed_experts.numel() != expected_numel:
+                raise ValueError(
+                    "SGLang routed_experts element count does not match sample tokens: "
+                    f"got={routed_experts.numel()}, expected={expected_numel} "
+                    f"(tokens={len(self.tokens)}, num_layers={args.num_layers}, "
+                    f"moe_router_topk={args.moe_router_topk})."
+                )
             self.rollout_routed_experts = routed_experts.reshape(
-                len(self.tokens) - 1,
+                expected_rows,
                 args.num_layers,
                 args.moe_router_topk,
             )

--- a/tests/test_rollout_metrics.py
+++ b/tests/test_rollout_metrics.py
@@ -147,6 +147,40 @@ def test_append_response_tokens_decodes_routed_experts():
 
 
 @pytest.mark.unit
+def test_append_response_tokens_ignores_split_pd_routed_experts():
+    sample = Sample(tokens=[101, 102, 103, 104])
+
+    sample.append_response_tokens(
+        _make_args(),
+        tokens=[],
+        trainable=True,
+        meta_info={
+            "pd_prefill_routed_experts": _b64_int32([0, 1, 2, 3, 4, 5, 6, 7]),
+            "pd_decode_routed_experts": _b64_int32([8, 9, 10, 11]),
+            "finish_reason": {"type": "stop"},
+        },
+    )
+
+    assert sample.rollout_routed_experts is None
+
+
+@pytest.mark.unit
+def test_append_response_tokens_rejects_mismatched_routed_experts_shape():
+    sample = Sample(tokens=[101, 102, 103])
+
+    with pytest.raises(ValueError, match="routed_experts element count"):
+        sample.append_response_tokens(
+            _make_args(),
+            tokens=[],
+            trainable=True,
+            meta_info={
+                "routed_experts": _b64_int32([0, 1, 2, 3]),
+                "finish_reason": {"type": "stop"},
+            },
+        )
+
+
+@pytest.mark.unit
 def test_append_response_tokens_pads_top_p_for_non_trainable_tokens():
     sample = Sample(
         tokens=[0, 1],


### PR DESCRIPTION
Sync the SGLang patch with PD prefill/decode routed expert handling and validate merged routed_experts shapes in rollout samples.

Thanks to Miles and the sglang-miles PR authors, especially Yuzhen Zhou (@zyzshishui) and Yueming Yuan (@yueming-yuan), for the upstream R3 work this follows!