### PR TITLE
fix: add rotary_percent to Megatron TransformerConfig patch so MiniMax-M2 hf->torch_dist conversion works

### DIFF
--- a/docker/patch/latest/megatron.patch
+++ b/docker/patch/latest/megatron.patch
@@ -862,10 +862,13 @@ diff --git a/megatron/core/transformer/transformer_config.py b/megatron/core/tra
 index dce438520..de51edaf3 100644
 --- a/megatron/core/transformer/transformer_config.py
 +++ b/megatron/core/transformer/transformer_config.py
-@@ -229,6 +229,9 @@ class TransformerConfig(ModelParallelConfig):
+@@ -229,6 +229,12 @@ class TransformerConfig(ModelParallelConfig):
      attention_output_gate: bool = False
      """Whether to apply output gate to the attention layers."""
 
++    rotary_percent: Optional[float] = None
++    """Percent of rotary dimension to use for rotary position embeddings."""
++
 +    post_self_attn_layernorm: bool = False
 +    post_mlp_layernorm: bool = False
 +

--- a/docker/patch/v0.5.0rc0-cu126/megatron.patch
+++ b/docker/patch/v0.5.0rc0-cu126/megatron.patch
@@ -329,10 +329,13 @@ diff --git a/megatron/core/transformer/transformer_config.py b/megatron/core/tra
 index 6f557e1f..b295fd35 100644
 --- a/megatron/core/transformer/transformer_config.py
 +++ b/megatron/core/transformer/transformer_config.py
-@@ -173,6 +173,9 @@ class TransformerConfig(ModelParallelConfig):
+@@ -173,6 +173,12 @@ class TransformerConfig(ModelParallelConfig):
      qk_layernorm: bool = False
      """Whether to apply `normalization` type of normalization to the query and key embeddings."""
  
++    rotary_percent: Optional[float] = None
++    """Percent of rotary dimension to use for rotary position embeddings."""
++
 +    post_self_attn_layernorm: bool = False
 +    post_mlp_layernorm: bool = False
 +

--- a/docker/patch/v0.5.12.post1/megatron.patch
+++ b/docker/patch/v0.5.12.post1/megatron.patch
@@ -862,10 +862,13 @@ diff --git a/megatron/core/transformer/transformer_config.py b/megatron/core/tra
 index dce438520..de51edaf3 100644
 --- a/megatron/core/transformer/transformer_config.py
 +++ b/megatron/core/transformer/transformer_config.py
-@@ -229,6 +229,9 @@ class TransformerConfig(ModelParallelConfig):
+@@ -229,6 +229,12 @@ class TransformerConfig(ModelParallelConfig):
      attention_output_gate: bool = False
      """Whether to apply output gate to the attention layers."""
 
++    rotary_percent: Optional[float] = None
++    """Percent of rotary dimension to use for rotary position embeddings."""
++
 +    post_self_attn_layernorm: bool = False
 +    post_mlp_layernorm: bool = False
 +

--- a/docker/patch/v0.5.5.post1/megatron.patch
+++ b/docker/patch/v0.5.5.post1/megatron.patch
@@ -723,10 +723,13 @@ diff --git a/megatron/core/transformer/transformer_config.py b/megatron/core/tra
 index d55bebe7e..1eecbbd38 100644
 --- a/megatron/core/transformer/transformer_config.py
 +++ b/megatron/core/transformer/transformer_config.py
-@@ -173,6 +173,10 @@ class TransformerConfig(ModelParallelConfig):
+@@ -173,6 +173,13 @@ class TransformerConfig(ModelParallelConfig):
      qk_layernorm: bool = False
      """Whether to apply `normalization` type of normalization to the query and key embeddings."""
  
++    rotary_percent: Optional[float] = None
++    """Percent of rotary dimension to use for rotary position embeddings."""
++
 +    post_self_attn_layernorm: bool = False
 +    post_mlp_layernorm: bool = False
 +    use_gated_attention: bool = False

--- a/docker/patch/v0.5.6/megatron.patch
+++ b/docker/patch/v0.5.6/megatron.patch
@@ -736,10 +736,13 @@ diff --git a/megatron/core/transformer/transformer_config.py b/megatron/core/tra
 index d55bebe7e..1eecbbd38 100644
 --- a/megatron/core/transformer/transformer_config.py
 +++ b/megatron/core/transformer/transformer_config.py
-@@ -173,6 +173,10 @@ class TransformerConfig(ModelParallelConfig):
+@@ -173,6 +173,13 @@ class TransformerConfig(ModelParallelConfig):
      qk_layernorm: bool = False
      """Whether to apply `normalization` type of normalization to the query and key embeddings."""
  
++    rotary_percent: Optional[float] = None
++    """Percent of rotary dimension to use for rotary position embeddings."""
++
 +    post_self_attn_layernorm: bool = False
 +    post_mlp_layernorm: bool = False
 +    use_gated_attention: bool = False

--- a/docker/patch/v0.5.7/megatron.patch
+++ b/docker/patch/v0.5.7/megatron.patch
@@ -650,10 +650,13 @@ diff --git a/megatron/core/transformer/transformer_config.py b/megatron/core/tra
 index e2705bd9f..a0aa109b5 100644
 --- a/megatron/core/transformer/transformer_config.py
 +++ b/megatron/core/transformer/transformer_config.py
-@@ -210,6 +210,9 @@ class TransformerConfig(ModelParallelConfig):
+@@ -210,6 +210,12 @@ class TransformerConfig(ModelParallelConfig):
      attention_output_gate: bool = False
      """Whether to apply output gate to the attention layers."""
  
++    rotary_percent: Optional[float] = None
++    """Percent of rotary dimension to use for rotary position embeddings."""
++
 +    post_self_attn_layernorm: bool = False
 +    post_mlp_layernorm: bool = False
 +

--- a/docker/patch/v0.5.9/megatron.patch
+++ b/docker/patch/v0.5.9/megatron.patch
@@ -673,10 +673,13 @@ diff --git a/megatron/core/transformer/transformer_config.py b/megatron/core/tra
 index e2705bd9f..a0aa109b5 100644
 --- a/megatron/core/transformer/transformer_config.py
 +++ b/megatron/core/transformer/transformer_config.py
-@@ -210,6 +210,9 @@ class TransformerConfig(ModelParallelConfig):
+@@ -210,6 +210,12 @@ class TransformerConfig(ModelParallelConfig):
      attention_output_gate: bool = False
      """Whether to apply output gate to the attention layers."""
  
++    rotary_percent: Optional[float] = None
++    """Percent of rotary dimension to use for rotary position embeddings."""
++
 +    post_self_attn_layernorm: bool = False
 +    post_mlp_layernorm: bool = False
 +


### PR DESCRIPTION
## Summary

Converting a MiniMax-M2 HF checkpoint to `torch_dist` format no longer crashes with `TransformerConfig got an unexpected keyword argument 'rotary_percent'`; the bundled Megatron config patch now declares the field.

## Why this matters

Issue #2129 reports the crash when running the hf -> torch_dist conversion for MiniMax-M2. The conversion passes `rotary_percent` to Megatron's `TransformerConfig`, but that field is not present in the pinned Megatron-LM. slime already carries missing `TransformerConfig` fields in its `docker/patch/*/megatron.patch` files, so the field belongs there:

```python
rotary_percent: Optional[float] = None
"""Percent of rotary dimension to use for rotary position embeddings."""
```

## Changes

- Add `rotary_percent: Optional[float] = None` to the `TransformerConfig` block in every versioned `megatron.patch` (`latest`, `v0.5.12.post1`, `v0.5.9`, `v0.5.7`, `v0.5.6`, `v0.5.5.post1`, `v0.5.0rc0-cu126`) so the patch stays consistent across the image tags.

The default `None` preserves existing behavior for models that do not set it.

## Testing

Each patch file is a unified diff applied during the Docker image build. Confirmed each modified hunk's header line counts stay consistent after the insertion so the patch still applies cleanly.

Fixes #2129
