### PR TITLE
fix(ray): dynamically resolve torch_memory_saver hook preload path for CUDA compatibility

### DIFF
--- a/slime/ray/actor_group.py
+++ b/slime/ray/actor_group.py
@@ -63,29 +63,31 @@ class RayTrainGroup:
             import torch_memory_saver
             import torch
             import ctypes
-            
+
             def check_lib(path: str) -> bool:
                 try:
                     ctypes.CDLL(path)
                     return True
                 except Exception:
                     return False
-            
+
             dynlib_path = None
             try:
-                dynlib_path = torch_memory_saver.utils.get_binary_path_from_package("torch_memory_saver_hook_mode_preload")
+                dynlib_path = torch_memory_saver.utils.get_binary_path_from_package(
+                    "torch_memory_saver_hook_mode_preload"
+                )
             except Exception:
                 pass
-            
+
             if not dynlib_path:
                 cuda_major = int(torch.version.cuda.split(".")[0]) if torch.version.cuda else 12
-                
+
                 paths_to_try = [
                     f"torch_memory_saver_hook_mode_preload_cu{cuda_major}.abi3.so",
                     "torch_memory_saver_hook_mode_preload.abi3.so",
-                    "torch_memory_saver_hook_mode_preload_cu12.abi3.so"
+                    "torch_memory_saver_hook_mode_preload_cu12.abi3.so",
                 ]
-                
+
                 for path in paths_to_try:
                     p = os.path.join(
                         os.path.dirname(os.path.dirname(torch_memory_saver.__file__)),
@@ -103,7 +105,7 @@ class RayTrainGroup:
                         if os.path.exists(p):
                             dynlib_path = p
                             break
-                            
+
             if not dynlib_path:
                 raise FileNotFoundError(
                     "Cannot find torch_memory_saver dynamic library. Please make sure torch_memory_saver is properly installed."

--- a/slime/ray/actor_group.py
+++ b/slime/ray/actor_group.py
@@ -61,18 +61,50 @@ class RayTrainGroup:
 
         if self.args.offload_train and self.args.train_backend == "megatron":
             import torch_memory_saver
-
-            for path in [
-                "torch_memory_saver_hook_mode_preload_cu12.abi3.so",
-                "torch_memory_saver_hook_mode_preload.abi3.so",
-            ]:
-                dynlib_path = os.path.join(
-                    os.path.dirname(os.path.dirname(torch_memory_saver.__file__)),
-                    path,
-                )
-                if os.path.exists(dynlib_path):
-                    break
-            else:
+            import torch
+            import ctypes
+            
+            def check_lib(path: str) -> bool:
+                try:
+                    ctypes.CDLL(path)
+                    return True
+                except Exception:
+                    return False
+            
+            dynlib_path = None
+            try:
+                dynlib_path = torch_memory_saver.utils.get_binary_path_from_package("torch_memory_saver_hook_mode_preload")
+            except Exception:
+                pass
+            
+            if not dynlib_path:
+                cuda_major = int(torch.version.cuda.split(".")[0]) if torch.version.cuda else 12
+                
+                paths_to_try = [
+                    f"torch_memory_saver_hook_mode_preload_cu{cuda_major}.abi3.so",
+                    "torch_memory_saver_hook_mode_preload.abi3.so",
+                    "torch_memory_saver_hook_mode_preload_cu12.abi3.so"
+                ]
+                
+                for path in paths_to_try:
+                    p = os.path.join(
+                        os.path.dirname(os.path.dirname(torch_memory_saver.__file__)),
+                        path,
+                    )
+                    if os.path.exists(p) and check_lib(p):
+                        dynlib_path = p
+                        break
+                else:
+                    for path in paths_to_try:
+                        p = os.path.join(
+                            os.path.dirname(os.path.dirname(torch_memory_saver.__file__)),
+                            path,
+                        )
+                        if os.path.exists(p):
+                            dynlib_path = p
+                            break
+                            
+            if not dynlib_path:
                 raise FileNotFoundError(
                     "Cannot find torch_memory_saver dynamic library. Please make sure torch_memory_saver is properly installed."
                 )


### PR DESCRIPTION
Fixes #2186.

Updates the `LD_PRELOAD` logic for `torch_memory_saver` to dynamically resolve the correct `.so` library. It uses `torch_memory_saver.utils.get_binary_path_from_package` first, and if that fails, builds the correct suffix using `torch.version.cuda` and verifies it's loadable with `ctypes.CDLL` before selecting it. This ensures it successfully finds and loads the correct version on systems with CUDA 13, avoiding the `libcudart.so.12` missing error.