### PR TITLE
fix(ppo): clamp log-ratios before exp()

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -599,6 +599,10 @@ jobs:
             },
             {
               "num_gpus": 0,
+              "test_file": "test_ppo_ratio_numerics.py"
+            },
+            {
+              "num_gpus": 0,
               "test_file": "test_ppo_logprob_entropy.py"
             },
             {

--- a/.github/workflows/pr-test.yml.j2
+++ b/.github/workflows/pr-test.yml.j2
@@ -74,6 +74,7 @@
         {'test_file': 'test_logprob_response_spans.py', 'num_gpus': 0},
         {'test_file': 'test_value_temperature.py', 'num_gpus': 0},
         {'test_file': 'test_cispo_loss.py', 'num_gpus': 0},
+        {'test_file': 'test_ppo_ratio_numerics.py', 'num_gpus': 0},
         {'test_file': 'test_ppo_logprob_entropy.py', 'num_gpus': 0},
         {'test_file': 'test_rm_f1.py', 'num_gpus': 0},
         {'test_file': 'test_rm_gpqa.py', 'num_gpus': 0},

--- a/slime/utils/ppo_utils.py
+++ b/slime/utils/ppo_utils.py
@@ -7,6 +7,12 @@ import torch
 import torch.distributed as dist
 import torch.nn.functional as F
 
+_LOG_RATIO_EXP_CLAMP = 20.0
+
+
+def _clamped_exp(log_ratio: torch.Tensor) -> torch.Tensor:
+    return log_ratio.float().clamp(min=-_LOG_RATIO_EXP_CLAMP, max=_LOG_RATIO_EXP_CLAMP).exp()
+
 
 @torch.compile(dynamic=True)
 def compute_approx_kl(
@@ -36,7 +42,10 @@ def compute_approx_kl(
         # http://joschu.net/blog/kl-approx.html
         # Besides non negative, it is also unbiased and have lower variance.
         log_ratio = -log_ratio
-        kl = log_ratio.exp() - 1 - log_ratio
+        if kl_loss_type == "low_var_kl":
+            kl = _clamped_exp(log_ratio) - 1 - log_ratio
+        else:
+            kl = log_ratio.exp() - 1 - log_ratio
     else:
         raise ValueError(f"Unknown kl_loss_type: {kl_loss_type}")
 
@@ -129,7 +138,7 @@ def compute_policy_loss(
     eps_clip_high: float,
     eps_clip_c: float | None = None,
 ):
-    ratio = (-ppo_kl).exp()
+    ratio = _clamped_exp(-ppo_kl)
     pg_losses1 = -ratio * advantages
     pg_losses2 = -ratio.clamp(1 - eps_clip, 1 + eps_clip_high) * advantages
     clip_pg_losses1 = torch.maximum(pg_losses1, pg_losses2)

--- a/tests/test_ppo_ratio_numerics.py
+++ b/tests/test_ppo_ratio_numerics.py
@@ -1,0 +1,55 @@
+import pytest
+import torch
+
+from slime.utils.ppo_utils import compute_approx_kl, compute_policy_loss
+
+NUM_GPUS = 0
+
+
+def test_policy_loss_keeps_finite_extreme_log_ratios_stable():
+    ppo_kl = torch.tensor([-1000.0, 1000.0], requires_grad=True)
+    pg_losses, clipfrac = compute_policy_loss(
+        ppo_kl,
+        torch.ones_like(ppo_kl),
+        eps_clip=0.2,
+        eps_clip_high=0.2,
+    )
+
+    assert torch.isfinite(pg_losses).all()
+    assert torch.isfinite(clipfrac).all()
+    pg_losses.sum().backward()
+    assert torch.isfinite(ppo_kl.grad).all()
+
+
+def test_policy_loss_matches_unclamped_formula_for_healthy_ppo_kl():
+    ppo_kl = torch.tensor([-0.1, 0.0, 0.1])
+    advantages = torch.tensor([1.0, -2.0, 0.5])
+    pg_losses, clipfrac = compute_policy_loss(ppo_kl, advantages, eps_clip=0.2, eps_clip_high=0.2)
+
+    ratio = (-ppo_kl).exp()
+    expected1 = -ratio * advantages
+    expected2 = -ratio.clamp(0.8, 1.2) * advantages
+    torch.testing.assert_close(pg_losses, torch.maximum(expected1, expected2), rtol=0, atol=0)
+    torch.testing.assert_close(clipfrac, torch.gt(expected2, expected1).float(), rtol=0, atol=0)
+
+
+def test_low_var_kl_keeps_finite_extreme_log_ratios_stable():
+    log_probs = torch.tensor([-1000.0, 1000.0], requires_grad=True)
+    kl = compute_approx_kl(log_probs, torch.zeros_like(log_probs), kl_loss_type="low_var_kl")
+
+    assert torch.isfinite(kl).all()
+    kl.sum().backward()
+    assert torch.isfinite(log_probs.grad).all()
+
+
+def test_nan_log_ratios_remain_visible():
+    value = torch.tensor([float("nan")])
+    pg_losses, _ = compute_policy_loss(value, torch.ones_like(value), eps_clip=0.2, eps_clip_high=0.2)
+    kl = compute_approx_kl(value, torch.zeros_like(value), kl_loss_type="low_var_kl")
+
+    assert torch.isnan(pg_losses).all()
+    assert torch.isnan(kl).all()
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__]))


### PR DESCRIPTION
PPO policy loss and the low-variance KL estimator exponentiate log-ratios before later loss reduction. Large finite inputs can overflow exp() and contaminate gradients, so clamp exponent inputs to +/-20 first. torch.clamp leaves NaN unchanged, allowing the existing non-finite training guard to surface corrupted log-probabilities; healthy log-ratios are unchanged.

Focused CPU tests cover extreme forward/backward stability, exact healthy-path behavior, and NaN visibility.