### PR TITLE
Fix partial rollout off-policy loss mask alignment

### DIFF
--- a/slime/rollout/sglang_rollout.py
+++ b/slime/rollout/sglang_rollout.py
@@ -229,7 +229,7 @@ async def generate_and_rm(
 ) -> Sample | list[Sample]:
     # mask previous off-policy generation for partial rollout
     if args.partial_rollout and args.mask_offpolicy_in_partial_rollout and sample.response_length > 0:
-        sample.loss_mask = [0] * sample.response_length
+        sample.mask_response_tokens(0)
 
     # For samples with existing response, check if they're complete
     if sample.status == Sample.Status.COMPLETED or sample.status == Sample.Status.TRUNCATED:

--- a/slime/utils/types.py
+++ b/slime/utils/types.py
@@ -250,6 +250,11 @@ class Sample:
     def effective_response_length(self):
         return sum(self.loss_mask) if self.loss_mask is not None else self.response_length
 
+    def mask_response_tokens(self, value: int = 0) -> None:
+        """Set the response-side loss mask while preserving length invariants."""
+        self.loss_mask = [int(value)] * self.response_length
+        self._validate_response_metadata_lengths()
+
     def append_response_tokens(
         self,
         args=None,

--- a/tests/test_partial_rollout_loss_mask.py
+++ b/tests/test_partial_rollout_loss_mask.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from argparse import Namespace
+
+import pytest
+
+from slime.utils.types import Sample
+
+NUM_GPUS = 0
+
+
+def _make_args() -> Namespace:
+    return Namespace(sglang_speculative_algorithm=False)
+
+
+def _resume_sample(
+    sample: Sample,
+    *,
+    partial_rollout: bool,
+    tokens: list[int],
+    log_probs: list[float],
+    mask_offpolicy_in_partial_rollout: bool = True,
+) -> Sample:
+    if partial_rollout and mask_offpolicy_in_partial_rollout and sample.response_length > 0:
+        sample.mask_response_tokens(0)
+
+    sample.append_response_tokens(
+        _make_args(),
+        tokens=tokens,
+        log_probs=log_probs,
+        trainable=True,
+        meta_info={"finish_reason": {"type": "stop"}},
+        text=" new",
+    )
+    sample.reward = 1.0
+    return sample
+
+
+@pytest.mark.unit
+def test_partial_resume_masks_old_tokens_and_appends_trainable_loss_mask():
+    sample = Sample(
+        tokens=[1, 2, 10, 11],
+        response="old",
+        response_length=2,
+        loss_mask=[1, 1],
+        rollout_log_probs=[-0.7, -0.8],
+        status=Sample.Status.ABORTED,
+    )
+
+    _resume_sample(
+        sample,
+        partial_rollout=True,
+        tokens=[30, 31, 32],
+        log_probs=[-0.3, -0.4, -0.5],
+    )
+
+    assert sample.response_length == 5
+    assert sample.loss_mask == [0, 0, 1, 1, 1]
+    assert len(sample.loss_mask) == sample.response_length
+    assert sample.rollout_log_probs == [-0.7, -0.8, -0.3, -0.4, -0.5]
+    assert sample.status is Sample.Status.COMPLETED
+
+
+@pytest.mark.unit
+def test_non_partial_resume_preserves_existing_loss_mask():
+    sample = Sample(
+        tokens=[1, 2, 10, 11],
+        response="old",
+        response_length=2,
+        loss_mask=[1, 0],
+        rollout_log_probs=[-0.7, -0.8],
+        status=Sample.Status.ABORTED,
+    )
+
+    _resume_sample(sample, partial_rollout=False, tokens=[30], log_probs=[-0.3])
+
+    assert sample.response_length == 3
+    assert sample.loss_mask == [1, 0, 1]
+    assert len(sample.loss_mask) == sample.response_length
+
+
+@pytest.mark.unit
+def test_fresh_full_rollout_still_gets_all_trainable_loss_mask():
+    sample = Sample(tokens=[1, 2], status=Sample.Status.PENDING)
+
+    _resume_sample(sample, partial_rollout=False, tokens=[30, 31], log_probs=[-0.3, -0.4])
+
+    assert sample.response_length == 2
+    assert sample.loss_mask == [1, 1]
+    assert len(sample.loss_mask) == sample.response_length


### PR DESCRIPTION
## Summary

- Add a small `Sample.mask_response_tokens()` helper that preserves response-side `loss_mask` length invariants.
- Use it when partial rollout masks previous off-policy response tokens.
- Add CPU regression coverage for partial resume appending new trainable tokens after masking old tokens.

## Motivation

When partial rollout is combined with off-policy masking, old generated tokens are masked to zero before resumed generation appends new response tokens. If `response_length` grows without `loss_mask` staying aligned, training conversion can fail with `len(sample.loss_mask) == sample.response_length`, as reported in #1440.

This is a small stability step for the partial rollout / off-policy trajectory work discussed in #1800.

## Behavior

- Old partial response tokens remain masked to `0`.
- Newly resumed response tokens append trainable `1`s through `append_response_tokens()`.
- `len(loss_mask) == response_length` is preserved.
- Non-partial rollout behavior is unchanged.
- No RL algorithm, KV cache, routing, or schema changes.

## Testing

- `CUDA_VISIBLE_DEVICES='' python -m pytest tests/test_partial_rollout_loss_mask.py tests/test_sample.py -m unit`
- `CUDA_VISIBLE_DEVICES='' pre-commit run --files slime/utils/types.py slime/rollout/sglang_rollout.py tests/test_partial_rollout_loss_mask.py`
- `git diff --check`

All passed.

`tests/test_rollout_metrics.py` could not be collected in this environment because the installed `sglang` package is missing `GPU_MEMORY_TYPE_CUDA_GRAPH` from `sglang.srt.constants`.

Refs #1440, #1800.