### PR TITLE
fix(rollout): make dynamic refills granular

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -631,6 +631,10 @@ jobs:
             },
             {
               "num_gpus": 0,
+              "test_file": "test_sglang_rollout_abort.py"
+            },
+            {
+              "num_gpus": 0,
               "test_file": "test_reloadable_process_group_world.py"
             },
             {

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -691,6 +691,10 @@ jobs:
             },
             {
               "num_gpus": 0,
+              "test_file": "test_sglang_rollout_abort.py"
+            },
+            {
+              "num_gpus": 0,
               "test_file": "test_rollout_sample_hooks.py"
             },
             {

--- a/.github/workflows/pr-test.yml.j2
+++ b/.github/workflows/pr-test.yml.j2
@@ -82,6 +82,7 @@
         {'test_file': 'test_rm_deepscaler.py', 'num_gpus': 0},
         {'test_file': 'test_sample.py', 'num_gpus': 0},
         {'test_file': 'test_rollout_validation.py', 'num_gpus': 0},
+        {'test_file': 'test_sglang_rollout_abort.py', 'num_gpus': 0},
         {'test_file': 'test_reloadable_process_group_world.py', 'num_gpus': 0},
         {'test_file': 'test_placement_group.py', 'num_gpus': 0},
         {'test_file': 'test_external_sglang_engines.py', 'num_gpus': 0},

--- a/.github/workflows/pr-test.yml.j2
+++ b/.github/workflows/pr-test.yml.j2
@@ -98,6 +98,7 @@
         {'test_file': 'test_read_file_slicing.py', 'num_gpus': 0},
         {'test_file': 'test_rollout_validation.py', 'num_gpus': 0},
         {'test_file': 'test_fully_async_rollout.py', 'num_gpus': 0},
+        {'test_file': 'test_sglang_rollout_abort.py', 'num_gpus': 0},
         {'test_file': 'test_rollout_sample_hooks.py', 'num_gpus': 0},
         {'test_file': 'test_hf_to_megatron.py', 'num_gpus': 0},
         {'test_file': 'test_qwen3_5_vl_native.py', 'num_gpus': 0},

--- a/docs/en/examples/glm4-9B.md
+++ b/docs/en/examples/glm4-9B.md
@@ -243,7 +243,7 @@ slime supports more complex sampling schemes, such as the dynamic sampling in [D
      slime.rollout.filter_hub.dynamic_sampling_filters.check_reward_nonzero_std \
 ```
 
-Here, `over_sampling_batch_size` needs to be greater than `rollout_batch_size`. For example:
+`over_sampling_batch_size` controls the number of prompt groups requested at a time and must be positive. For example:
 
 ```bash
    --rollout-batch-size 32 \

--- a/docs/en/examples/glm4-9B.md
+++ b/docs/en/examples/glm4-9B.md
@@ -243,7 +243,7 @@ slime supports more complex sampling schemes, such as the dynamic sampling in [D
      slime.rollout.filter_hub.dynamic_sampling_filters.check_reward_nonzero_std \
 ```
 
-Here, `over_sampling_batch_size` needs to be greater than `rollout_batch_size`. For example:
+Here, `over_sampling_batch_size` must be positive. For example:
 
 ```bash
    --rollout-batch-size 32 \

--- a/docs/en/examples/qwen3-4B.md
+++ b/docs/en/examples/qwen3-4B.md
@@ -214,7 +214,7 @@ slime supports more complex sampling schemes, such as the dynamic sampling in [D
      slime.rollout.filter_hub.dynamic_sampling_filters.check_reward_nonzero_std \
 ```
 
-Here, `over_sampling_batch_size` needs to be greater than `rollout_batch_size`. For example, you can configure it as:
+`over_sampling_batch_size` controls the number of prompt groups requested at a time and must be positive. For example:
 
 ```bash
    --rollout-batch-size 32 \

--- a/docs/en/examples/qwen3-4B.md
+++ b/docs/en/examples/qwen3-4B.md
@@ -214,7 +214,7 @@ slime supports more complex sampling schemes, such as the dynamic sampling in [D
      slime.rollout.filter_hub.dynamic_sampling_filters.check_reward_nonzero_std \
 ```
 
-Here, `over_sampling_batch_size` needs to be greater than `rollout_batch_size`. For example, you can configure it as:
+Here, `over_sampling_batch_size` must be positive. For example, you can configure it as:
 
 ```bash
    --rollout-batch-size 32 \

--- a/docs/en/get_started/quick_start.md
+++ b/docs/en/get_started/quick_start.md
@@ -345,7 +345,7 @@ slime supports more complex sampling strategies, such as dynamic sampling used i
      slime.rollout.filter_hub.dynamic_sampling_filters.check_reward_nonzero_std
 ```
 
-Here `over_sampling_batch_size` needs to be greater than `rollout_batch_size`, for example, configured as:
+`over_sampling_batch_size` controls the number of prompt groups requested at a time and must be positive. For example:
 
 ```bash
    --rollout-batch-size 32 \
@@ -367,7 +367,7 @@ def check_reward_nonzero_std(args, samples: list[Sample], **kwargs):
     )
 ```
 
-If the filtering function is very strict, causing a large number of prompt groups to be discarded, the system will monitor the number of pending tasks in `remaining_batch_size`. Once the number of pending tasks drops below the target number (32) due to too many being discarded, the system will automatically trigger a new round of oversampling, requesting `over_sampling_batch_size` (64) new prompts again to repeat the above process.
+`remaining_batch_size` tracks accepted and pending prompt groups. Rejected groups decrement it; when it falls below the target (32), the system requests batches of `over_sampling_batch_size` (64) until the accepted and pending total reaches the target again.
 
 ### Partial Rollout
 

--- a/docs/en/get_started/quick_start.md
+++ b/docs/en/get_started/quick_start.md
@@ -345,7 +345,7 @@ slime supports more complex sampling strategies, such as dynamic sampling used i
      slime.rollout.filter_hub.dynamic_sampling_filters.check_reward_nonzero_std
 ```
 
-Here `over_sampling_batch_size` needs to be greater than `rollout_batch_size`, for example, configured as:
+Here `over_sampling_batch_size` must be positive, for example, configured as:
 
 ```bash
    --rollout-batch-size 32 \

--- a/docs/zh/examples/glm4-9B.md
+++ b/docs/zh/examples/glm4-9B.md
@@ -243,7 +243,7 @@ slime 支持了更复杂的 sampling 方案，例如 [DAPO](https://dapo-sia.git
      slime.rollout.filter_hub.dynamic_sampling_filters.check_reward_nonzero_std \
 ```
 
-这里 `over_sampling_batch_size` 需要大于 ``rollout_batch_size`，例如配置为：
+`over_sampling_batch_size` 控制每次请求的 prompt 组数，且必须为正数。例如：
 
 ```bash
    --rollout-batch-size 32 \

--- a/docs/zh/examples/glm4-9B.md
+++ b/docs/zh/examples/glm4-9B.md
@@ -243,7 +243,7 @@ slime 支持了更复杂的 sampling 方案，例如 [DAPO](https://dapo-sia.git
      slime.rollout.filter_hub.dynamic_sampling_filters.check_reward_nonzero_std \
 ```
 
-这里 `over_sampling_batch_size` 需要大于 ``rollout_batch_size`，例如配置为：
+这里 `over_sampling_batch_size` 必须为正数，例如配置为：
 
 ```bash
    --rollout-batch-size 32 \

--- a/docs/zh/examples/qwen3-4B.md
+++ b/docs/zh/examples/qwen3-4B.md
@@ -214,7 +214,7 @@ slime 支持了更复杂的 sampling 方案，例如 [DAPO](https://dapo-sia.git
      slime.rollout.filter_hub.dynamic_sampling_filters.check_reward_nonzero_std \
 ```
 
-这里 `over_sampling_batch_size` 需要大于 ``rollout_batch_size`，例如配置为：
+`over_sampling_batch_size` 控制每次请求的 prompt 组数，且必须为正数。例如：
 
 ```bash
    --rollout-batch-size 32 \

--- a/docs/zh/examples/qwen3-4B.md
+++ b/docs/zh/examples/qwen3-4B.md
@@ -214,7 +214,7 @@ slime 支持了更复杂的 sampling 方案，例如 [DAPO](https://dapo-sia.git
      slime.rollout.filter_hub.dynamic_sampling_filters.check_reward_nonzero_std \
 ```
 
-这里 `over_sampling_batch_size` 需要大于 ``rollout_batch_size`，例如配置为：
+这里 `over_sampling_batch_size` 必须为正数，例如配置为：
 
 ```bash
    --rollout-batch-size 32 \

--- a/docs/zh/get_started/quick_start.md
+++ b/docs/zh/get_started/quick_start.md
@@ -347,7 +347,7 @@ slime 支持更复杂的采样策略，例如 [DAPO](https://dapo-sia.github.io/
      slime.rollout.filter_hub.dynamic_sampling_filters.check_reward_nonzero_std
 ```
 
-这里 `over_sampling_batch_size` 需要大于 `rollout_batch_size`，例如配置为：
+`over_sampling_batch_size` 控制每次请求的 prompt 组数，且必须为正数。例如：
 
 ```bash
    --rollout-batch-size 32 \
@@ -369,7 +369,7 @@ def check_reward_nonzero_std(args, samples: list[Sample], **kwargs):
     )
 ```
 
-如果过滤函数非常严格，导致大量 prompt 组被丢弃，系统会监控 ` remaining_batch_size` 中待处理的任务数量。一旦待处理的任务数因丢弃过多而降至目标数 (32) 以下，系统会自动触发新一轮的过采样，再次请求  `over_sampling_batch_size` (64) 个新的 prompt 重复上述流程。
+`remaining_batch_size` 记录已接收和待处理的 prompt 组数。每丢弃一组，该值就会减一；当它低于目标值 (32) 时，系统会按 `over_sampling_batch_size` (64) 为一批补充请求，直到已接收和待处理的总数重新达到目标值。
 
 ### Partial Rollout
 

--- a/docs/zh/get_started/quick_start.md
+++ b/docs/zh/get_started/quick_start.md
@@ -347,7 +347,7 @@ slime 支持更复杂的采样策略，例如 [DAPO](https://dapo-sia.github.io/
      slime.rollout.filter_hub.dynamic_sampling_filters.check_reward_nonzero_std
 ```
 
-这里 `over_sampling_batch_size` 需要大于 `rollout_batch_size`，例如配置为：
+这里 `over_sampling_batch_size` 必须为正数，例如配置为：
 
 ```bash
    --rollout-batch-size 32 \

--- a/slime/rollout/sglang_rollout.py
+++ b/slime/rollout/sglang_rollout.py
@@ -334,40 +334,51 @@ async def generate_and_rm_group(
 
 
 async def abort(args: Namespace, rollout_id: int) -> list[list[Sample]]:
-    aborted_samples = []
-
     state = GenerateState(args)
     assert not state.aborted
     state.aborted = True
 
-    if parse(sglang_router.__version__) <= parse("0.2.1"):
-        response = await get(f"http://{args.sglang_router_ip}:{args.sglang_router_port}/list_workers")
-        urls = response["urls"]
-    else:
-        response = await get(f"http://{args.sglang_router_ip}:{args.sglang_router_port}/workers")
-        urls = [worker["url"] for worker in response["workers"]]
+    done = set()
+    try:
+        if not args.partial_rollout:
+            for task in state.pendings:
+                task.cancel()
+            if state.pendings:
+                await asyncio.gather(*state.pendings, return_exceptions=True)
+            state.pendings.clear()
 
-    await abort_servers_until_idle(urls)
+        if parse(sglang_router.__version__) <= parse("0.2.1"):
+            response = await get(f"http://{args.sglang_router_ip}:{args.sglang_router_port}/list_workers")
+            urls = response["urls"]
+        else:
+            response = await get(f"http://{args.sglang_router_ip}:{args.sglang_router_port}/workers")
+            urls = [worker["url"] for worker in response["workers"]]
 
-    # make sure all the pending tasks are finished
-    count = 0
-    while state.pendings:
-        done, state.pendings = await asyncio.wait(state.pendings, return_when=asyncio.FIRST_COMPLETED)
+        await abort_servers_until_idle(urls)
 
         if not args.partial_rollout:
-            continue
+            return []
 
-        # for partial rollout, collect the partial samples into the data buffer
-        for task in done:
-            group = task.result()
-            for sample in group:
-                if sample.response and "start_rollout_id" not in sample.metadata:
-                    sample.metadata["start_rollout_id"] = rollout_id
-            aborted_samples.append(group)
-            count += len(group)
+        aborted_samples = []
+        count = 0
+        while state.pendings:
+            done, state.pendings = await asyncio.wait(state.pendings, return_when=asyncio.FIRST_COMPLETED)
 
-    if args.partial_rollout:
-        logger.info(f"Collected {count} partial samples into the data buffer")
+            for task in done:
+                group = task.result()
+                for sample in group:
+                    if sample.response and "start_rollout_id" not in sample.metadata:
+                        sample.metadata["start_rollout_id"] = rollout_id
+                aborted_samples.append(group)
+                count += len(group)
+    except BaseException:
+        for task in state.pendings:
+            task.cancel()
+        await asyncio.gather(*done, *state.pendings, return_exceptions=True)
+        state.pendings.clear()
+        raise
+
+    logger.info(f"Collected {count} partial samples into the data buffer")
 
     return aborted_samples
 

--- a/slime/rollout/sglang_rollout.py
+++ b/slime/rollout/sglang_rollout.py
@@ -337,38 +337,48 @@ async def generate_and_rm_group(
 
 
 async def abort(args: Namespace, rollout_id: int) -> list[list[Sample]]:
-    aborted_samples = []
-
     state = GenerateState(args)
     assert not state.aborted
     state.aborted = True
 
-    response = await get(f"http://{args.sglang_router_ip}:{args.sglang_router_port}/workers")
-    urls = [worker["url"] for worker in response["workers"]]
+    try:
+        # Custom generate can keep issuing requests during drain. Cancel
+        # non-partial work first so abort_servers_until_idle can reach idle.
+        if not args.partial_rollout:
+            for task in state.pendings:
+                task.cancel()
+            if state.pendings:
+                await asyncio.gather(*state.pendings, return_exceptions=True)
+            state.pendings.clear()
 
-    await abort_servers_until_idle(urls)
-
-    # make sure all the pending tasks are finished
-    count = 0
-    while state.pendings:
-        done, state.pendings = await asyncio.wait(state.pendings, return_when=asyncio.FIRST_COMPLETED)
+        response = await get(f"http://{args.sglang_router_ip}:{args.sglang_router_port}/workers")
+        urls = [worker["url"] for worker in response["workers"]]
+        await abort_servers_until_idle(urls)
 
         if not args.partial_rollout:
-            continue
+            return []
 
-        # for partial rollout, collect the partial samples into the data buffer
-        for task in done:
-            group = task.result()
-            for sample in group:
-                if sample.response and "start_rollout_id" not in sample.metadata:
-                    sample.metadata["start_rollout_id"] = rollout_id
-            aborted_samples.append(group)
-            count += len(group)
+        aborted_samples = []
+        count = 0
+        while state.pendings:
+            done, state.pendings = await asyncio.wait(state.pendings, return_when=asyncio.FIRST_COMPLETED)
+            for task in done:
+                group = task.result()
+                for sample in group:
+                    if sample.response and "start_rollout_id" not in sample.metadata:
+                        sample.metadata["start_rollout_id"] = rollout_id
+                aborted_samples.append(group)
+                count += len(group)
 
-    if args.partial_rollout:
         logger.info(f"Collected {count} partial samples into the data buffer")
-
-    return aborted_samples
+        return aborted_samples
+    except BaseException:
+        for task in state.pendings:
+            task.cancel()
+        if state.pendings:
+            await asyncio.gather(*state.pendings, return_exceptions=True)
+        state.pendings.clear()
+        raise
 
 
 async def generate_rollout_async(

--- a/slime/utils/arguments.py
+++ b/slime/utils/arguments.py
@@ -1930,10 +1930,9 @@ def slime_validate_args(args):
     if args.over_sampling_batch_size is None:
         args.over_sampling_batch_size = args.rollout_batch_size
 
-    assert args.over_sampling_batch_size >= args.rollout_batch_size, (
-        f"over_sampling_batch_size {args.over_sampling_batch_size} should be greater than or equal to "
-        f"rollout_batch_size {args.rollout_batch_size}"
-    )
+    assert (
+        args.over_sampling_batch_size > 0
+    ), f"over_sampling_batch_size {args.over_sampling_batch_size} should be greater than zero"
 
     if args.num_epoch is not None:
         if args.num_rollout is not None:

--- a/slime/utils/arguments.py
+++ b/slime/utils/arguments.py
@@ -1985,10 +1985,9 @@ def slime_validate_args(args):
     if args.over_sampling_batch_size is None:
         args.over_sampling_batch_size = args.rollout_batch_size
 
-    assert args.over_sampling_batch_size >= args.rollout_batch_size, (
-        f"over_sampling_batch_size {args.over_sampling_batch_size} should be greater than or equal to "
-        f"rollout_batch_size {args.rollout_batch_size}"
-    )
+    assert (
+        args.over_sampling_batch_size > 0
+    ), f"over_sampling_batch_size {args.over_sampling_batch_size} should be greater than zero"
 
     if args.num_epoch is not None:
         if args.num_rollout is not None:

--- a/tests/test_megatron_argument_validation.py
+++ b/tests/test_megatron_argument_validation.py
@@ -306,6 +306,24 @@ def test_slime_validate_args_preserves_zero_rollout_gpus_without_colocate(monkey
 
 
 @pytest.mark.unit
+def test_slime_validate_args_allows_granular_dynamic_sampling_refill(monkeypatch):
+    module = load_slime_arguments_module(monkeypatch)
+    args = make_slime_validate_args(rollout_batch_size=64, over_sampling_batch_size=1)
+
+    module.slime_validate_args(args)
+
+    assert args.over_sampling_batch_size == 1
+
+
+@pytest.mark.unit
+def test_slime_validate_args_rejects_empty_dynamic_sampling_refill(monkeypatch):
+    module = load_slime_arguments_module(monkeypatch)
+
+    with pytest.raises(AssertionError, match="greater than zero"):
+        module.slime_validate_args(make_slime_validate_args(over_sampling_batch_size=0))
+
+
+@pytest.mark.unit
 def test_update_weight_delta_requires_disk_transport(monkeypatch):
     module = load_slime_arguments_module(monkeypatch)
     args = make_slime_validate_args(

--- a/tests/test_megatron_argument_validation.py
+++ b/tests/test_megatron_argument_validation.py
@@ -311,6 +311,24 @@ def test_slime_validate_args_rejects_non_positive_rollout_temperature(monkeypatc
 
 
 @pytest.mark.unit
+def test_slime_validate_args_allows_granular_dynamic_sampling_refill(monkeypatch):
+    module = load_slime_arguments_module(monkeypatch)
+    args = make_slime_validate_args(rollout_batch_size=64, over_sampling_batch_size=1)
+
+    module.slime_validate_args(args)
+
+    assert args.over_sampling_batch_size == 1
+
+
+@pytest.mark.unit
+def test_slime_validate_args_rejects_empty_dynamic_sampling_refill(monkeypatch):
+    module = load_slime_arguments_module(monkeypatch)
+
+    with pytest.raises(AssertionError, match="greater than zero"):
+        module.slime_validate_args(make_slime_validate_args(over_sampling_batch_size=0))
+
+
+@pytest.mark.unit
 def test_slime_validate_args_preserves_zero_rollout_gpus_under_colocate(monkeypatch):
     module = load_slime_arguments_module(monkeypatch)
     args = make_slime_validate_args(colocate=True, rollout_num_gpus=0)

--- a/tests/test_sglang_rollout_abort.py
+++ b/tests/test_sglang_rollout_abort.py
@@ -1,0 +1,205 @@
+import asyncio
+import types
+
+import pytest
+
+try:
+    from plugin_contracts._shared import install_paths, install_stubs
+except ImportError:
+    from tests.plugin_contracts._shared import install_paths, install_stubs
+
+install_paths()
+install_stubs(with_sglang_router=True, with_transformers=True)
+
+from slime.rollout import sglang_rollout as rollout
+
+NUM_GPUS = 0
+
+
+@pytest.mark.unit
+def test_abort_cancels_pending_groups_before_server_drain(monkeypatch) -> None:
+    async def scenario() -> None:
+        events = []
+
+        async def pending_group() -> None:
+            try:
+                await asyncio.Future()
+            finally:
+                await asyncio.sleep(0)
+                events.append("pending-cleanup")
+
+        task = asyncio.create_task(pending_group())
+        await asyncio.sleep(0)
+        state = types.SimpleNamespace(aborted=False, pendings={task})
+        monkeypatch.setattr(rollout, "GenerateState", lambda _args: state)
+
+        async def get_router_workers(_url):
+            events.append("list-workers")
+            return {"urls": ["http://engine"], "workers": [{"url": "http://engine"}]}
+
+        async def drain_servers(urls):
+            assert urls == ["http://engine"]
+            assert task.cancelled()
+            events.append("server-drain")
+
+        monkeypatch.setattr(rollout, "get", get_router_workers)
+        monkeypatch.setattr(rollout, "abort_servers_until_idle", drain_servers)
+
+        args = types.SimpleNamespace(
+            partial_rollout=False,
+            sglang_router_ip="127.0.0.1",
+            sglang_router_port=30000,
+        )
+        assert await rollout.abort(args, rollout_id=0) == []
+
+        assert events == ["pending-cleanup", "list-workers", "server-drain"]
+        assert state.aborted is True
+        assert state.pendings == set()
+
+    asyncio.run(scenario())
+
+
+@pytest.mark.unit
+def test_abort_preserves_partial_groups_until_after_server_drain(monkeypatch) -> None:
+    async def scenario() -> None:
+        events = []
+        server_drained = asyncio.Event()
+        sample = types.SimpleNamespace(response="partial response", metadata={})
+
+        async def pending_group():
+            await server_drained.wait()
+            events.append("pending-finished")
+            return [sample]
+
+        task = asyncio.create_task(pending_group())
+        await asyncio.sleep(0)
+        state = types.SimpleNamespace(aborted=False, pendings={task})
+        monkeypatch.setattr(rollout, "GenerateState", lambda _args: state)
+
+        async def get_router_workers(_url):
+            return {"urls": ["http://engine"], "workers": [{"url": "http://engine"}]}
+
+        async def drain_servers(urls):
+            assert urls == ["http://engine"]
+            assert not task.cancelled()
+            events.append("server-drain")
+            server_drained.set()
+            await asyncio.sleep(0)
+
+        monkeypatch.setattr(rollout, "get", get_router_workers)
+        monkeypatch.setattr(rollout, "abort_servers_until_idle", drain_servers)
+
+        args = types.SimpleNamespace(
+            partial_rollout=True,
+            sglang_router_ip="127.0.0.1",
+            sglang_router_port=30000,
+        )
+        assert await rollout.abort(args, rollout_id=7) == [[sample]]
+
+        assert events == ["server-drain", "pending-finished"]
+        assert sample.metadata == {"start_rollout_id": 7}
+        assert state.pendings == set()
+
+    asyncio.run(scenario())
+
+
+@pytest.mark.unit
+def test_abort_cleans_up_partial_groups_when_cancelled_during_drain(monkeypatch) -> None:
+    async def scenario() -> None:
+        events = []
+        drain_started = asyncio.Event()
+
+        async def pending_group():
+            try:
+                await asyncio.Future()
+            finally:
+                events.append("pending-cleanup")
+
+        pending_task = asyncio.create_task(pending_group())
+        await asyncio.sleep(0)
+        state = types.SimpleNamespace(aborted=False, pendings={pending_task})
+        monkeypatch.setattr(rollout, "GenerateState", lambda _args: state)
+
+        async def get_router_workers(_url):
+            return {"urls": ["http://engine"], "workers": [{"url": "http://engine"}]}
+
+        async def drain_servers(urls):
+            assert urls == ["http://engine"]
+            events.append("server-drain-started")
+            drain_started.set()
+            await asyncio.Future()
+
+        monkeypatch.setattr(rollout, "get", get_router_workers)
+        monkeypatch.setattr(rollout, "abort_servers_until_idle", drain_servers)
+
+        args = types.SimpleNamespace(
+            partial_rollout=True,
+            sglang_router_ip="127.0.0.1",
+            sglang_router_port=30000,
+        )
+        abort_task = asyncio.create_task(rollout.abort(args, rollout_id=7))
+        await drain_started.wait()
+        abort_task.cancel()
+
+        with pytest.raises(asyncio.CancelledError):
+            await abort_task
+
+        assert events == ["server-drain-started", "pending-cleanup"]
+        assert pending_task.cancelled()
+        assert state.aborted is True
+        assert state.pendings == set()
+
+    asyncio.run(scenario())
+
+
+@pytest.mark.unit
+def test_abort_cleans_up_partial_groups_when_one_fails(monkeypatch) -> None:
+    async def scenario() -> None:
+        events = []
+        server_drained = asyncio.Event()
+
+        async def failed_group():
+            await server_drained.wait()
+            raise RuntimeError("generation failed")
+
+        async def pending_group():
+            try:
+                await asyncio.Future()
+            finally:
+                events.append("pending-cleanup")
+
+        failed_task = asyncio.create_task(failed_group())
+        pending_task = asyncio.create_task(pending_group())
+        await asyncio.sleep(0)
+        state = types.SimpleNamespace(aborted=False, pendings={failed_task, pending_task})
+        monkeypatch.setattr(rollout, "GenerateState", lambda _args: state)
+
+        async def get_router_workers(_url):
+            return {"urls": ["http://engine"], "workers": [{"url": "http://engine"}]}
+
+        async def drain_servers(urls):
+            assert urls == ["http://engine"]
+            events.append("server-drain")
+            server_drained.set()
+            await asyncio.sleep(0)
+
+        monkeypatch.setattr(rollout, "get", get_router_workers)
+        monkeypatch.setattr(rollout, "abort_servers_until_idle", drain_servers)
+
+        args = types.SimpleNamespace(
+            partial_rollout=True,
+            sglang_router_ip="127.0.0.1",
+            sglang_router_port=30000,
+        )
+        with pytest.raises(RuntimeError, match="generation failed"):
+            await rollout.abort(args, rollout_id=7)
+
+        assert events == ["server-drain", "pending-cleanup"]
+        assert pending_task.cancelled()
+        assert state.pendings == set()
+
+    asyncio.run(scenario())
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__]))

--- a/tests/test_sglang_rollout_abort.py
+++ b/tests/test_sglang_rollout_abort.py
@@ -1,0 +1,239 @@
+"""CPU tests for SGLang rollout abort: cancel before drain, keep partials."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import types
+
+# Lean CPU env has no ray / transformers / tqdm / PIL. Abort never dials those
+# stacks; stub them so `sglang_rollout.abort` can be imported and patched.
+if "ray" not in sys.modules:
+    _ray_stub = types.ModuleType("ray")
+    _ray_stub._private = types.SimpleNamespace(services=types.SimpleNamespace(get_node_ip_address=lambda: "127.0.0.1"))
+    sys.modules["ray"] = _ray_stub
+if "sglang_router" not in sys.modules:
+    _router_stub = types.ModuleType("sglang_router")
+    _router_stub.__version__ = "0.2.3"
+    sys.modules["sglang_router"] = _router_stub
+if "transformers" not in sys.modules:
+    _tf_stub = types.ModuleType("transformers")
+    for _name in ("AutoProcessor", "AutoTokenizer", "PreTrainedTokenizerBase", "ProcessorMixin"):
+        setattr(_tf_stub, _name, type(_name, (), {}))
+    sys.modules["transformers"] = _tf_stub
+if "tqdm" not in sys.modules:
+    _tqdm_stub = types.ModuleType("tqdm")
+    _tqdm_stub.tqdm = lambda *args, **kwargs: None
+    sys.modules["tqdm"] = _tqdm_stub
+if "PIL" not in sys.modules:
+    _pil_stub = types.ModuleType("PIL")
+    _pil_image_stub = types.ModuleType("PIL.Image")
+    _pil_stub.Image = _pil_image_stub
+    sys.modules["PIL"] = _pil_stub
+    sys.modules["PIL.Image"] = _pil_image_stub
+
+_rm_hub_stub = types.ModuleType("slime.rollout.rm_hub")
+
+
+async def _unused_rm(*_args, **_kwargs):
+    raise AssertionError("rm_hub should not run in abort tests")
+
+
+_rm_hub_stub.async_rm = _unused_rm
+_rm_hub_stub.batched_async_rm = _unused_rm
+sys.modules["slime.rollout.rm_hub"] = _rm_hub_stub
+
+import pytest
+
+from slime.rollout import sglang_rollout as rollout
+
+NUM_GPUS = 0
+
+
+@pytest.mark.unit
+def test_abort_cancels_pending_groups_before_server_drain(monkeypatch) -> None:
+    async def scenario() -> None:
+        events = []
+
+        async def pending_group() -> None:
+            try:
+                await asyncio.Future()
+            finally:
+                await asyncio.sleep(0)
+                events.append("pending-cleanup")
+
+        task = asyncio.create_task(pending_group())
+        await asyncio.sleep(0)
+        state = types.SimpleNamespace(aborted=False, pendings={task})
+        monkeypatch.setattr(rollout, "GenerateState", lambda _args: state)
+
+        async def get_router_workers(_url):
+            events.append("list-workers")
+            return {"workers": [{"url": "http://engine"}]}
+
+        async def drain_servers(urls):
+            assert urls == ["http://engine"]
+            assert task.cancelled()
+            events.append("server-drain")
+
+        monkeypatch.setattr(rollout, "get", get_router_workers)
+        monkeypatch.setattr(rollout, "abort_servers_until_idle", drain_servers)
+
+        args = types.SimpleNamespace(
+            partial_rollout=False,
+            sglang_router_ip="127.0.0.1",
+            sglang_router_port=30000,
+        )
+        assert await rollout.abort(args, rollout_id=0) == []
+
+        assert events == ["pending-cleanup", "list-workers", "server-drain"]
+        assert state.aborted is True
+        assert state.pendings == set()
+
+    asyncio.run(scenario())
+
+
+@pytest.mark.unit
+def test_abort_preserves_partial_groups_until_after_server_drain(monkeypatch) -> None:
+    async def scenario() -> None:
+        events = []
+        server_drained = asyncio.Event()
+        sample = types.SimpleNamespace(response="partial response", metadata={})
+
+        async def pending_group():
+            await server_drained.wait()
+            events.append("pending-finished")
+            return [sample]
+
+        task = asyncio.create_task(pending_group())
+        await asyncio.sleep(0)
+        state = types.SimpleNamespace(aborted=False, pendings={task})
+        monkeypatch.setattr(rollout, "GenerateState", lambda _args: state)
+
+        async def get_router_workers(_url):
+            return {"workers": [{"url": "http://engine"}]}
+
+        async def drain_servers(urls):
+            assert urls == ["http://engine"]
+            assert not task.cancelled()
+            events.append("server-drain")
+            server_drained.set()
+            await asyncio.sleep(0)
+
+        monkeypatch.setattr(rollout, "get", get_router_workers)
+        monkeypatch.setattr(rollout, "abort_servers_until_idle", drain_servers)
+
+        args = types.SimpleNamespace(
+            partial_rollout=True,
+            sglang_router_ip="127.0.0.1",
+            sglang_router_port=30000,
+        )
+        assert await rollout.abort(args, rollout_id=7) == [[sample]]
+
+        assert events == ["server-drain", "pending-finished"]
+        assert sample.metadata == {"start_rollout_id": 7}
+        assert state.pendings == set()
+
+    asyncio.run(scenario())
+
+
+@pytest.mark.unit
+def test_abort_cleans_up_partial_groups_when_cancelled_during_drain(monkeypatch) -> None:
+    async def scenario() -> None:
+        events = []
+        drain_started = asyncio.Event()
+
+        async def pending_group():
+            try:
+                await asyncio.Future()
+            finally:
+                events.append("pending-cleanup")
+
+        pending_task = asyncio.create_task(pending_group())
+        await asyncio.sleep(0)
+        state = types.SimpleNamespace(aborted=False, pendings={pending_task})
+        monkeypatch.setattr(rollout, "GenerateState", lambda _args: state)
+
+        async def get_router_workers(_url):
+            return {"workers": [{"url": "http://engine"}]}
+
+        async def drain_servers(urls):
+            assert urls == ["http://engine"]
+            events.append("server-drain-started")
+            drain_started.set()
+            await asyncio.Future()
+
+        monkeypatch.setattr(rollout, "get", get_router_workers)
+        monkeypatch.setattr(rollout, "abort_servers_until_idle", drain_servers)
+
+        args = types.SimpleNamespace(
+            partial_rollout=True,
+            sglang_router_ip="127.0.0.1",
+            sglang_router_port=30000,
+        )
+        abort_task = asyncio.create_task(rollout.abort(args, rollout_id=7))
+        await drain_started.wait()
+        abort_task.cancel()
+
+        with pytest.raises(asyncio.CancelledError):
+            await abort_task
+
+        assert events == ["server-drain-started", "pending-cleanup"]
+        assert pending_task.cancelled()
+        assert state.aborted is True
+        assert state.pendings == set()
+
+    asyncio.run(scenario())
+
+
+@pytest.mark.unit
+def test_abort_cleans_up_partial_groups_when_one_fails(monkeypatch) -> None:
+    async def scenario() -> None:
+        events = []
+        server_drained = asyncio.Event()
+
+        async def failed_group():
+            await server_drained.wait()
+            raise RuntimeError("generation failed")
+
+        async def pending_group():
+            try:
+                await asyncio.Future()
+            finally:
+                events.append("pending-cleanup")
+
+        failed_task = asyncio.create_task(failed_group())
+        pending_task = asyncio.create_task(pending_group())
+        await asyncio.sleep(0)
+        state = types.SimpleNamespace(aborted=False, pendings={failed_task, pending_task})
+        monkeypatch.setattr(rollout, "GenerateState", lambda _args: state)
+
+        async def get_router_workers(_url):
+            return {"workers": [{"url": "http://engine"}]}
+
+        async def drain_servers(urls):
+            assert urls == ["http://engine"]
+            events.append("server-drain")
+            server_drained.set()
+            await asyncio.sleep(0)
+
+        monkeypatch.setattr(rollout, "get", get_router_workers)
+        monkeypatch.setattr(rollout, "abort_servers_until_idle", drain_servers)
+
+        args = types.SimpleNamespace(
+            partial_rollout=True,
+            sglang_router_ip="127.0.0.1",
+            sglang_router_port=30000,
+        )
+        with pytest.raises(RuntimeError, match="generation failed"):
+            await rollout.abort(args, rollout_id=7)
+
+        assert events == ["server-drain", "pending-cleanup"]
+        assert pending_task.cancelled()
+        assert state.pendings == set()
+
+    asyncio.run(scenario())
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__]))


### PR DESCRIPTION
## Problem

Dynamic sampling currently requires `over_sampling_batch_size` to be at least `rollout_batch_size`, even though the rollout state machine supports any positive refill granularity. A single rejected prompt group can therefore launch a full replacement wave.

At rollout completion, non-partial generation tasks are also left running while SGLang is drained. Multi-turn custom generation can issue new requests during that drain, delaying or preventing it from reaching idle.

## Change

- accept any positive `over_sampling_batch_size`
- cancel and await non-partial generation tasks before draining SGLang
- preserve partial-rollout prefixes through server drain
- make the complete abort lifecycle exception-safe while re-raising the original failure
- correct the EN/ZH docs that said the flag must be greater than `rollout_batch_size`
- add CPU regressions for validation, cancellation ordering, partial preservation, and failure cleanup

The existing scheduler remains unchanged: rejected groups decrement accepted-plus-pending coverage, and the configured refill granularity restores it.

## Validation

- `pytest --noconftest tests/test_sglang_rollout_abort.py tests/test_megatron_argument_validation.py` — 27 passed
- `python .github/workflows/generate_github_workflows.py`
- `pre-commit run --files` on the touched paths
- `git diff --check`

No live GPU or distributed rollout was run; the affected lifecycle boundaries are covered with CPU and mocked regressions.