### PR TITLE
fix(rm): deepscaler silently zeroes all rewards for non-thinking models

### DIFF
--- a/slime/rollout/rm_hub/deepscaler.py
+++ b/slime/rollout/rm_hub/deepscaler.py
@@ -7,7 +7,10 @@ def get_deepscaler_rule_based_reward(response, label):
     elif "###Response" in response:
         model_solution = response.split("###Response")[1]
     else:
-        return 0
+        # Non-thinking models emit neither marker; grade the whole response
+        # instead of silently returning 0 (which zeroes every reward and
+        # kills the GRPO signal without any visible error).
+        model_solution = response
 
     model_answer = extract_answer(model_solution)
     if model_answer is None:


### PR DESCRIPTION
## Motivation

`get_deepscaler_rule_based_reward` returns `0` whenever the response contains neither `</think>` nor `###Response`. For any **non-thinking model** (or a thinking model whose chat template strips the tags), every sample scores 0:

- all GRPO groups become zero-std → advantages vanish → training runs with **no signal**;
- there is no error or warning anywhere;
- the symptom is deceptive: generation looks healthy (sane response lengths, ~0% truncation, correct answers plainly visible in the sampled text) while reward stays flat at 0.

We hit this running DeepSeek-V3.2 GRPO (non-thinking chat template) on dapo-math-17k: several steps of flat-zero reward with otherwise perfect-looking rollouts.

## Change

One-line fallback: when neither marker is present, grade the whole response instead of returning 0. Extraction/verification below this point (`extract_answer` + `grade_answer_mathd`/`grade_answer_sympy`) already handles raw text fine.

## Verification

Same DeepSeek-V3.2 setup, only this change: reward went from `0.0` (all steps) to `0.676` at step 0 with a normal GRPO signal thereafter. Thinking-model path (`</think>` present) is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)