### PR TITLE
Fix ref weights being broadcast on the first async update after resume

### DIFF
--- a/slime/backends/megatron_utils/actor.py
+++ b/slime/backends/megatron_utils/actor.py
@@ -183,9 +183,10 @@ class MegatronTrainRayActor(TrainRayActor):
         # empty cache after initialization
         clear_memory()
 
-        if self.args.offload_train:
-            # recover to actor in the end.
+        if self._active_model_tag != "actor":
             self._switch_model("actor")
+
+        if self.args.offload_train:
             self.sleep()
 
         self.rollout_engines = None


### PR DESCRIPTION
## What does this PR do?

This PR fixes an incorrect first rollout weight update after resuming async non-colocate training with a reference model enabled.

The first `update_weights()` call can broadcast reference model weights to the SGLang rollout engines instead of the resumed actor weights. In the affected runs, this caused a sharp reward drop and spikes in KL divergence and `grad_norm` immediately after resume. The metrics recovered after approximately 2–3 training steps.

This is a small bug fix in the Megatron actor initialization path. It does not introduce a new feature or refactor existing abstractions.

## Reproduction

The issue can be reproduced under the following conditions:

- Async non-colocate training
- A reference model enabled through KL loss, such as `--use-kl-loss` or a nonzero `--kl-coef`
- Resume from a checkpoint where the trained actor weights differ from the reference model weights

Reproduction sequence:

1. Start async training with a reference model and save an actor checkpoint after training has progressed.
2. Resume training from that actor checkpoint while using the original reference checkpoint.
3. Observe the first rollout after initialization.
4. The first rollout uses reference weights instead of the resumed actor weights, causing reward to drop and KL divergence and `grad_norm` to spike.
5. The metrics recover after the actor training path restores the actor weights and later weight updates broadcast the correct model.

This is generally not visible during a fresh run because the actor load path can fall back to the reference checkpoint, making the initial actor and reference weights identical.

## Observed behavior

The following W&B metrics show the abnormal spike immediately after checkpoint resume. `train/kl_loss` and `train/grad_norm` spike at the same training step and recover shortly afterward.

These figures demonstrate the observed first-step regression. They support the reproduction but do not independently establish the root cause.

### KL loss

<img width="3476" height="1826" alt="W B Chart 2026_7_20 22_58_18" src="https://github.com/user-attachments/assets/6a9a26d0-82d5-4503-ad9e-7ed3c61df5b7" />

### Gradient norm

<img width="3476" height="1826" alt="W B Chart 2026_7_20 22_58_29" src="https://github.com/user-attachments/assets/d51567e8-b62f-4fa2-a7c0-f9b48f53e5b6" />

## Root cause

Actor initialization first backs up the actor weights:

```python
self._active_model_tag = "actor"
self.weights_backuper.backup("actor")
```

When a reference model is enabled, `load_other_checkpoint("ref", ...)` loads the reference weights into `self.model`. At the end of `load_other_checkpoint()`, it also updates the active model tag:

```python
self.weights_backuper.backup(model_tag)
self._active_model_tag = model_tag
```

Previously, initialization restored the actor only inside the `offload_train` branch:

```python
if self.args.offload_train:
    self._switch_model("actor")
    self.sleep()
```

In async non-colocate mode, `offload_train` is disabled, so initialization can return with the reference weights still loaded. `train_async.py` then immediately calls:

```python
actor_model.update_weights()
```

The async distributed updater broadcasts weights from the currently loaded `self.model`, which is still the reference model at this point.

## Fix

Restore the actor whenever initialization leaves a non-actor model active, and keep only `sleep()` conditional on `offload_train`:

```python
if self._active_model_tag != "actor":
    self._switch_model("actor")

if self.args.offload_train:
    self.sleep()
```

This makes the post-initialization model state consistent and ensures that the first rollout weight update uses the resumed actor weights.

## Verification and limitations

The issue and root cause were reproduced in the reference-model resume scenario described above. The diagnosis was verified using an alternative defensive workaround that called `_switch_model("actor")` at the beginning of `update_weights()`. With this workaround, reference weights were no longer broadcast during the first update, and the first-step regression disappeared.

The exact initialization-side patch in this PR has not yet been exercised in a complete end-to-end training run. The change is placed at initialization because that is where the inconsistent active-model state originates.

Only the reference-model path has been reproduced and checked. Initialization can also load `teacher` or `old_actor` model tags, and the generic active-tag check will restore the actor after those paths as well. Those configurations have not been tested as part of this PR.

The reported issue does not affect colocate/offloaded training because the existing `offload_train` path already restores the actor.