### PR TITLE
fix(utils): align Qwen tokenization for parallel tool calls

### DIFF
--- a/slime/utils/mask_utils.py
+++ b/slime/utils/mask_utils.py
@@ -58,13 +58,21 @@ class MultiTurnLossMaskGenerator:
         all_loss_masks = []
         all_token_ids = []
 
-        for i, message in enumerate(messages):
+        i = 0
+        while i < len(messages):
+            message = messages[i]
+            end = i + 1
+            if message["role"] == "tool":
+                while end < len(messages) and messages[end]["role"] == "tool":
+                    end += 1
+            current_messages = messages[i:end]
+
             if i == 0:
                 message_ids = self.tokenizer.apply_chat_template(
-                    [message], tokenize=True, tools=tools, return_dict=False
+                    current_messages, tokenize=True, tools=tools, return_dict=False
                 )
             else:
-                message_ids = self.tokenizer.apply_chat_template([message], tokenize=True, return_dict=False)
+                message_ids = self.tokenizer.apply_chat_template(current_messages, tokenize=True, return_dict=False)
 
             if message["role"] != "system" and i > 0:
                 message_ids = message_ids[self.system_message_length :]
@@ -79,6 +87,7 @@ class MultiTurnLossMaskGenerator:
 
             all_loss_masks.extend(loss_mask)
             all_token_ids.extend(message_ids)
+            i = end
 
         return all_token_ids, all_loss_masks
 


### PR DESCRIPTION
The fix groups consecutive tool messages before passing them to `apply_chat_template`, preserving the formatting defined by the native Qwen2 chat template.


The original issue was caused by calling `apply_chat_template` separately for every message in `gen_multi_turn_loss_mask_qwen`, without preserving the context between consecutive `tool` messages.

For a parallel tool-calling sequence:

```text
assistant(tool_calls=[A, B])
tool(result=A)
tool(result=B)
```

The Qwen2 chat template is designed to group consecutive tool responses into a single user block:

```text
<|im_start|>user
<tool_response>
result=A
</tool_response>
<tool_response>
result=B
</tool_response><|im_end|>
```

However, the original implementation rendered each tool message independently. Since each message appeared to be both the first and last tool message, it produced:

```text
<|im_start|>user
<tool_response>
result=A
</tool_response><|im_end|>
<|im_start|>user
<tool_response>
result=B
</tool_response><|im_end|>
```

This caused:

- `token_ids` to differ from the native Qwen chat-template output;
- redundant `<|im_start|>user` and `<|im_end|>` tokens to be inserted;
- the training input format to differ from the model’s actual inference format;
- token positions and loss-mask alignment to potentially become incorrect.

The issue only affects parallel tool calling with consecutive `role="tool"` responses. A single assistant message containing multiple `tool_calls`, or sequential `assistant → tool → assistant → tool` interactions, does not trigger this problem.
