### PR TITLE
fix: whiten advantages over the DP group that includes context parallel

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -587,6 +587,10 @@ jobs:
             },
             {
               "num_gpus": 0,
+              "test_file": "test_advantage_whiten_cp.py"
+            },
+            {
+              "num_gpus": 0,
               "test_file": "test_logprob_response_spans.py"
             },
             {

--- a/.github/workflows/pr-test.yml.j2
+++ b/.github/workflows/pr-test.yml.j2
@@ -71,6 +71,7 @@
         {'test_file': 'test_metric_report.py', 'num_gpus': 0},
         {'test_file': 'test_metric_report_dist.py', 'num_gpus': 0},
         {'test_file': 'test_loss_cp_invariance.py', 'num_gpus': 0},
+        {'test_file': 'test_advantage_whiten_cp.py', 'num_gpus': 0},
         {'test_file': 'test_logprob_response_spans.py', 'num_gpus': 0},
         {'test_file': 'test_value_temperature.py', 'num_gpus': 0},
         {'test_file': 'test_cispo_loss.py', 'num_gpus': 0},

--- a/slime/backends/megatron_utils/loss.py
+++ b/slime/backends/megatron_utils/loss.py
@@ -666,7 +666,7 @@ def compute_advantages_and_returns(args: Namespace, rollout_data: RolloutBatch) 
     estimator. Supported methods: "grpo", "gspo", "cispo", "ppo",
     "reinforce_plus_plus", and "reinforce_plus_plus_baseline". When
     `args.normalize_advantages` is True, advantages are whitened across the
-    data-parallel group using masked statistics.
+    data-parallel-with-context-parallel group using masked statistics.
 
     Early returns if both `log_probs` and `values` are None (intermediate
     pipeline stages).
@@ -809,20 +809,30 @@ def compute_advantages_and_returns(args: Namespace, rollout_data: RolloutBatch) 
 
             all_masks = torch.cat(mask_chunks)
 
-        if all_masks.numel() > 0:
-            assert (
-                all_advs.size() == all_masks.size()
-            ), f"Shape mismatch before whitening: advantages {all_advs.size()}, masks {all_masks.size()}"
-            dp_group = mpu.get_data_parallel_group()
+        assert (
+            all_advs.size() == all_masks.size()
+        ), f"Shape mismatch before whitening: advantages {all_advs.size()}, masks {all_masks.size()}"
+        # `all_advs` / `all_masks` only cover the tokens this CP rank owns, so the
+        # statistics must be reduced over the DP group *with* context parallel.
+        # The CP-excluding group makes every CP rank whiten its own zigzag slice
+        # with its own mean/var, i.e. the two halves of one sequence get
+        # different affine transforms.
+        #
+        # This has to stay unconditional: a CP rank can legitimately own zero
+        # response tokens (prompt-heavy sequences put both of its chunks inside
+        # the prompt), and skipping the collective on just that rank would
+        # desync the all_reduce. `distributed_masked_whiten` handles an empty
+        # local tensor — it contributes 0 to the reduced sums.
+        dp_cp_group = mpu.get_data_parallel_group(with_context_parallel=True)
 
-            whitened_advs_flat = distributed_masked_whiten(
-                all_advs,
-                all_masks,
-                process_group=dp_group,
-                shift_mean=True,
-            )
-            chunk_lengths = [chunk.size(0) for chunk in advantages]
-            advantages = list(torch.split(whitened_advs_flat, chunk_lengths))
+        whitened_advs_flat = distributed_masked_whiten(
+            all_advs,
+            all_masks,
+            process_group=dp_cp_group,
+            shift_mean=True,
+        )
+        chunk_lengths = [chunk.size(0) for chunk in advantages]
+        advantages = list(torch.split(whitened_advs_flat, chunk_lengths))
 
     rollout_data["advantages"] = advantages
     rollout_data["returns"] = returns

--- a/tests/test_advantage_whiten_cp.py
+++ b/tests/test_advantage_whiten_cp.py
@@ -1,0 +1,188 @@
+"""Advantage-whitening CP-invariance check on CPU.
+
+``compute_advantages_and_returns`` whitens advantages with
+``distributed_masked_whiten``, which all-reduces ``(sum, sum_sq, mask_sum)``
+over the process group it is handed. Under context parallelism each rank only
+holds its zigzag slice of every sequence, so those statistics are only the
+*global* statistics if the group spans the CP dimension as well as DP.
+
+If the CP-excluding group is used instead, every CP rank normalizes with the
+mean/variance of its own slice: the two halves of one sequence come out with
+different affine transforms, and none of them matches the correct whitening.
+
+The contract pinned here: for a fixed set of samples, the whitened advantage of
+a given sample is the same number for every ``(dp_size, cp_size)`` factorization
+of the world — and in particular the same as the single-rank baseline.
+
+Two of the cases use a prompt-heavy sequence whose response tokens all land on
+one CP rank, so some ranks contribute an entirely empty local mask. Those ranks
+must still take part in the all-reduce; a rank-dependent "skip whitening when I
+hold nothing" shortcut desyncs the collective and hangs. The spawn join below
+is bounded so that regression surfaces as a failure rather than a stuck job.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+
+# Megatron stub must land in sys.modules before anything imports
+# slime.backends.megatron_utils. pytest's prepend importmode puts ``tests/`` on
+# sys.path, so the bare-name import works without an ``__init__.py``.
+import _cp_dist_helpers  # noqa: F401
+import pytest
+from _cp_dist_helpers import free_port, stub_megatron_in_worker
+
+
+NUM_GPUS = 0
+
+# (total_length, response_length) per sample, plus its rollout reward. Eight
+# samples so dp_size in {1, 2, 4} divides evenly. Sample 3 is deliberately
+# prompt-heavy: at cp_size >= 2 its response sits entirely inside one rank's
+# chunk, leaving the other ranks with an empty mask for it.
+SEQS = [(64, 48), (100, 90), (40, 12), (256, 16), (72, 30), (90, 84), (50, 20), (110, 96)]
+REWARDS = [1.5, -0.5, -1.0, 2.0, 0.25, -1.75, 0.75, -0.25]
+
+WHITEN_CASES = [(1, 1), (2, 1), (1, 2), (2, 2), (1, 4), (4, 1)]
+
+
+class _Args:
+    advantage_estimator = "grpo"
+    normalize_advantages = True
+    kl_coef = 0.0
+    use_kl_loss = False
+    use_rollout_logprobs = False
+    use_opd = False
+    custom_advantage_function_path = None
+    kl_loss_type = "low_var_kl"
+    gamma = 1.0
+    lambd = 1.0
+
+
+def _whiten_worker(rank, world_size, cp_size, dp_size, master_port, result_dir):
+    """One spawned rank: whiten its DP shard's CP slice, dump the results."""
+    import torch
+    import torch.distributed as _dist
+
+    cp_rank = rank % cp_size
+    dp_rank = rank // cp_size
+    stub_megatron_in_worker(cp_size, cp_rank)
+
+    os.environ["MASTER_ADDR"] = "127.0.0.1"
+    os.environ["MASTER_PORT"] = str(master_port)
+    _dist.init_process_group(backend="gloo", rank=rank, world_size=world_size)
+    try:
+        from megatron.core import mpu
+
+        # No TP/PP here, so DP-with-CP is the whole world. The DP-only group is
+        # the set of ranks sharing this rank's cp_rank -- exactly the group that
+        # Megatron's ``get_data_parallel_group(with_context_parallel=False)``
+        # returns. Every rank must build every subgroup, in the same order.
+        dp_cp_group = _dist.new_group(ranks=list(range(world_size)))
+        dp_only_groups = [
+            _dist.new_group(ranks=[r for r in range(world_size) if r % cp_size == c]) for c in range(cp_size)
+        ]
+
+        mpu.is_pipeline_last_stage = lambda: True
+        mpu.get_data_parallel_group = lambda with_context_parallel=False, **kw: (
+            dp_cp_group if with_context_parallel else dp_only_groups[cp_rank]
+        )
+
+        from slime.backends.megatron_utils.cp_utils import get_logits_and_tokens_offset_with_cp
+        from slime.backends.megatron_utils.loss import compute_advantages_and_returns
+
+        def cp_slice(x, total_len, response_len):
+            """Keep only the response positions this CP rank owns."""
+            if cp_size == 1:
+                return x
+            prompt_len = total_len - response_len
+            _, _, _, offsets = get_logits_and_tokens_offset_with_cp(total_len, response_len)
+            parts = []
+            for start, end in offsets:
+                lo, hi = max(0, start - prompt_len), max(0, end - prompt_len)
+                if hi > lo:
+                    parts.append(x[lo:hi])
+            return torch.cat(parts) if parts else x[:0]
+
+        # Round-robin DP shard, mirroring how samples spread over DP ranks.
+        my_samples = [i for i in range(len(SEQS)) if i % dp_size == dp_rank]
+
+        rollout_data = {
+            "log_probs": [cp_slice(torch.zeros(SEQS[i][1]), *SEQS[i]) for i in my_samples],
+            "loss_masks": [torch.ones(SEQS[i][1]) for i in my_samples],
+            "rewards": [REWARDS[i] for i in my_samples],
+            "response_lengths": [SEQS[i][1] for i in my_samples],
+            "total_lengths": [SEQS[i][0] for i in my_samples],
+        }
+
+        compute_advantages_and_returns(_Args(), rollout_data)
+
+        # grpo gives every token of a sample the same advantage, and whitening is
+        # affine, so one value per sample fully describes the result. Ranks that
+        # own no tokens of a sample simply report nothing for it.
+        out = {
+            str(i): round(adv[0].item(), 6)
+            for i, adv in zip(my_samples, rollout_data["advantages"], strict=True)
+            if adv.numel() > 0
+        }
+        with open(os.path.join(result_dir, f"rank{rank}.json"), "w") as f:
+            json.dump(out, f)
+    finally:
+        _dist.destroy_process_group()
+
+
+def _run_case(dp_size, cp_size, tmp_path):
+    """Spawn the world, then merge every rank's per-sample whitened values."""
+    import torch.multiprocessing as mp
+
+    world_size = dp_size * cp_size
+    result_dir = tmp_path / f"dp{dp_size}_cp{cp_size}"
+    result_dir.mkdir(parents=True, exist_ok=True)
+
+    ctx = mp.spawn(
+        _whiten_worker,
+        args=(world_size, cp_size, dp_size, free_port(), str(result_dir)),
+        nprocs=world_size,
+        join=False,
+    )
+    deadline = time.time() + 180
+    while not ctx.join(timeout=5):
+        if time.time() > deadline:
+            for p in ctx.processes:
+                if p.is_alive():
+                    p.terminate()
+            pytest.fail(
+                f"dp={dp_size} cp={cp_size} workers did not finish in 180s; "
+                "a rank-dependent branch around the whitening all_reduce desyncs the collective"
+            )
+
+    merged: dict[str, float] = {}
+    for rank in range(world_size):
+        with open(result_dir / f"rank{rank}.json") as f:
+            for sample_idx, value in json.load(f).items():
+                if sample_idx in merged:
+                    # Every rank holding part of a sample must agree on it --
+                    # this is the assertion that fails on the CP-excluding group.
+                    assert merged[sample_idx] == pytest.approx(value, abs=1e-5), (
+                        f"dp={dp_size} cp={cp_size}: CP ranks disagree on sample {sample_idx}: "
+                        f"{merged[sample_idx]} vs {value}"
+                    )
+                merged[sample_idx] = value
+    return merged
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("dp_size,cp_size", WHITEN_CASES)
+def test_whitened_advantages_are_cp_invariant(dp_size, cp_size, tmp_path):
+    baseline = _run_case(1, 1, tmp_path)
+    assert len(baseline) == len(SEQS), "baseline should cover every sample"
+
+    got = _run_case(dp_size, cp_size, tmp_path)
+
+    assert sorted(got) == sorted(baseline)
+    for sample_idx, expected in baseline.items():
+        assert got[sample_idx] == pytest.approx(expected, abs=1e-5), (
+            f"dp={dp_size} cp={cp_size}: sample {sample_idx} whitened to {got[sample_idx]}, "
+            f"single-rank baseline is {expected}"
+        )


### PR DESCRIPTION
### What

`--normalize-advantages` is computed with the wrong process group under context parallelism, so advantages are whitened with per-CP-rank statistics instead of global ones.

### Root cause

`compute_advantages_and_returns` builds `all_advs` / `all_masks` from **this CP rank's** zigzag slice of every sequence (the `cp_size != 1` branch right above constructs the per-rank mask chunks explicitly), and then reduces over the CP-*excluding* group:

```python
dp_group = mpu.get_data_parallel_group()   # with_context_parallel defaults to False
whitened_advs_flat = distributed_masked_whiten(all_advs, all_masks, process_group=dp_group, ...)
```

`distributed_masked_whiten` all-reduces `(sum, sum_sq, mask_sum)` over that group, so the mean/variance only cover ranks that share the same `cp_rank`. Two consequences:

- each CP rank applies a **different affine transform to a different part of the same sequence**;
- no rank's statistics are the global ones, so even a single-CP-rank view is wrong.

Every other data-parallel group lookup in the repo is explicit about the flag — `data.py:186,188`, `model.py:693`, `loss.py:1295` use `with_context_parallel=True`, `actor.py:106,242` use `False`. This call site was the only implicit one.

### Impact

Hits any run combining context parallelism with `--normalize-advantages`. Note `slime_validate_args` *requires* `--normalize-advantages` for `reinforce_plus_plus` and `reinforce_plus_plus_baseline`, and CI already runs `--context-parallel-size 2` together with `--normalize-advantages` in `test_qwen3_4B_ppo.py` (and the disaggregate / critic-only variants) — nothing there checks the whitened values, which is why it went unnoticed.

Driving the real `compute_advantages_and_returns` at `cp_size=2, dp_size=1` with three sequences `(total, resp) = (64,48) (100,90) (40,12)` and group-centered rewards `+1.5 / -0.5 / -1.0`:

```
cp_rank 0:  65 local tokens  mean=-0.076923
cp_rank 1:  85 local tokens  mean=+0.235294
GLOBAL   : 150 tokens        mean=+0.100000

 seq    raw |  CURRENT cp0  CURRENT cp1 |  FIXED cp0  FIXED cp1
   0   +1.5 |    +1.707037    +1.273883 |  +1.439168  +1.439168
   1   -0.5 |    -0.457986    -0.740629 |  -0.616786  -0.616786
   2   -1.0 |    -0.999241    -1.244257 |  -1.130775  -1.130775
```

The two halves of sequence 0 disagree by ~34%, and both are off the correct value.

### Why the `numel() > 0` guard has to go too

A CP rank can legitimately own **zero** response tokens: for a prompt-heavy sequence both of its chunks land inside the prompt.

```
cp=2 prompt=8000 resp=1000 -> response tokens per CP rank: [1000, 0]
cp=4 prompt=3000 resp= 500 -> response tokens per CP rank: [433, 67, 0, 0]
```

Today `if all_masks.numel() > 0:` makes participation in the all-reduce data-dependent. That is already latently unsafe (two DP ranks at the same `cp_rank` can disagree under dynamic batching), and it becomes an unconditional hang the moment the group spans CP. So the call is now unconditional — `distributed_masked_whiten` handles an empty local tensor, contributing 0 to all three reduced sums, and still raises if the mask is globally empty.

### Test

`tests/test_advantage_whiten_cp.py` (new, registered in the `cpu-unittest` job) spawns `dp_size * cp_size` gloo workers, runs the real `compute_advantages_and_returns`, and asserts the whitened advantage of each sample is the same for every `(dp, cp)` factorization of the world and equal to the single-rank baseline. It covers `(1,1) (2,1) (1,2) (2,2) (1,4) (4,1)` and includes a prompt-heavy sequence so some ranks contribute an empty local mask.

On `main` it fails:

```
AssertionError: dp=1 cp=2: CP ranks disagree on sample 0: 1.504895 vs 1.762075
```

The spawn join is bounded at 180s so that a future rank-dependent branch around the collective surfaces as a test failure rather than a stuck CI job.
