### PR TITLE
fix: clear exec_and_wait's spawn lock between logical invocations

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -747,6 +747,10 @@ jobs:
             },
             {
               "num_gpus": 0,
+              "test_file": "test_agent/test_sandbox_exec_and_wait.py"
+            },
+            {
+              "num_gpus": 0,
               "test_file": "test_agent/test_agent_rollout_cpu.py"
             }
           ]

--- a/.github/workflows/pr-test.yml.j2
+++ b/.github/workflows/pr-test.yml.j2
@@ -102,6 +102,7 @@
         {'test_file': 'test_agent/test_trajectory_manager_branching.py', 'num_gpus': 0},
         {'test_file': 'test_agent/test_adapters.py', 'num_gpus': 0},
         {'test_file': 'test_agent/test_harness.py', 'num_gpus': 0},
+        {'test_file': 'test_agent/test_sandbox_exec_and_wait.py', 'num_gpus': 0},
         {'test_file': 'test_agent/test_agent_rollout_cpu.py', 'num_gpus': 0},
       ],
     },

--- a/slime/agent/sandbox.py
+++ b/slime/agent/sandbox.py
@@ -31,9 +31,10 @@ class Sandbox(Protocol):
     ``write_file`` accepts either in-memory content (``str``/``bytes``) or a
     host ``Path`` to stream into the sandbox.
 
-    Retry/idempotency is deliberately *not* part of this contract: whether a
-    severed RPC is safe to re-send is a backend transport concern (see
-    ``E2BSandbox._rpc_retry``), not something abstraction consumers reason about.
+    ``idempotent`` is a hint for the backend's transport-retry policy: callers
+    mark whether re-sending the command after a severed response is safe to
+    replay (see ``E2BSandbox._rpc_retry``). Backends without retries may
+    ignore it.
     """
 
     sandbox_id: str
@@ -50,6 +51,7 @@ class Sandbox(Protocol):
         env: dict[str, str] | None = None,
         timeout: int = 120,
         check: bool = False,
+        idempotent: bool = True,
     ) -> ExecResult: ...
 
     async def write_file(self, sandbox_path: str, content: FileContent, *, user: str = "root") -> None: ...
@@ -110,10 +112,23 @@ async def exec_and_wait(
     launcher_body = f"#!/bin/bash\n{prefix}{cmd}\necho $? > {done_file}\n"
     await sb.write_file(launcher, launcher_body, user=user)
 
+    # Clear the previous invocation's state in its own idempotent RPC, *before*
+    # the guarded spawn. The mkdir guard below exists only to dedupe transport
+    # retries of this one spawn (a severed response replayed by _rpc_retry); it
+    # must not survive into the next logical invocation of the same tag (e.g.
+    # install_npm_cli's retry loop), which would skip the spawn entirely and
+    # read the previous run's stale exit-code marker. Callers must not overlap
+    # two exec_and_wait calls with the same tag.
+    await sb.exec(
+        f"rm -rf {lock_dir}; rm -f {out_file} {done_file}",
+        user=user,
+        timeout=30,
+        check=True,
+        idempotent=True,
+    )
     await sb.exec(
         f"chmod +x {launcher}; "
         f"mkdir {lock_dir} 2>/dev/null || exit 0; "
-        f"rm -f {out_file} {done_file}; "
         f"setsid bash {launcher} < /dev/null > {out_file} 2>&1 &",
         user=user,
         env=env,

--- a/tests/test_agent/test_sandbox_exec_and_wait.py
+++ b/tests/test_agent/test_sandbox_exec_and_wait.py
@@ -1,0 +1,161 @@
+"""CPU tests for ``slime.agent.sandbox.exec_and_wait``'s spawn-lock contract.
+
+The detached spawn is guarded by ``mkdir {lock_dir} || exit 0`` so that a
+transport-level retry of the *same* spawn RPC (a severed response replayed by
+``E2BSandbox._rpc_retry``) cannot double-execute the command. That guard must
+not leak into the next *logical* invocation of the same tag: the lock dir used
+to survive forever, so a second ``exec_and_wait`` with the same tag skipped the
+spawn at the guard (before the stale-marker cleanup, which sat behind it) and
+``_await_done_marker`` immediately read the previous run's exit-code marker.
+
+Concrete victim: ``harness.common.install_npm_cli`` retries a failed npm
+install three times with ``tag="harness-npm-install"`` — attempts 2 and 3 ran
+nothing and returned attempt 1's exit code and log verbatim.
+
+The fake sandbox here interprets the actual command strings ``exec_and_wait``
+issues (mkdir guard short-circuit, rm cleanup, setsid launch, marker polls), so
+these tests hold for any command layout that keeps the semantics right and fail
+for one that reuses stale state.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+import shlex
+from types import SimpleNamespace
+
+import pytest
+
+import slime.agent.sandbox as sandbox_mod
+from slime.agent.sandbox import exec_and_wait
+
+
+_POLL_RE = re.compile(r"test -f (\S+) && cat \1")
+_SPAWN_RE = re.compile(r"mkdir (\S+) 2>/dev/null \|\| exit 0; (.*)$")
+_LAUNCH_RE = re.compile(r"setsid bash (\S+) ")
+_TAIL_RE = re.compile(r"tail -c \d+ (\S+)")
+
+
+class ShellFakeSandbox:
+    """Interprets exec_and_wait's shell commands against an in-memory FS.
+
+    ``run_script`` is called once per *actual* launch with the launcher path;
+    it returns ``(exit_code, output)`` which land in the done/out marker files
+    exactly like the real detached command would write them.
+    """
+
+    sandbox_id = "shell-fake"
+
+    def __init__(self, run_script):
+        self.run_script = run_script
+        self.files: dict[str, str] = {}
+        self.dirs: set[str] = set()
+        self.launches = 0
+        self.exec_log: list[str] = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return None
+
+    async def write_file(self, path, content, *, user="root"):
+        self.files[path] = content
+
+    async def read_file(self, path, *, user="root"):
+        return self.files.get(path, "")
+
+    async def exec(self, cmd, *, user="root", env=None, timeout=120, check=False, idempotent=True):
+        self.exec_log.append(cmd)
+
+        poll = _POLL_RE.search(cmd)
+        if poll:
+            path = poll.group(1)
+            if path in self.files:
+                return 0, self.files[path], ""
+            return 1, "", ""
+
+        tail = _TAIL_RE.search(cmd)
+        if tail:
+            return 0, self.files.get(tail.group(1), "")[-512:], ""
+
+        spawn = _SPAWN_RE.search(cmd)
+        if spawn:
+            lock_dir, rest = spawn.groups()
+            if lock_dir in self.dirs:
+                return 0, "", ""  # guard hit: nothing after it runs
+            self.dirs.add(lock_dir)
+            self._run_shell_fragment(rest)
+            return 0, "", ""
+
+        # Plain cleanup command(s): rm -rf / rm -f sequences.
+        self._run_shell_fragment(cmd)
+        return 0, "", ""
+
+    def _run_shell_fragment(self, fragment):
+        for part in fragment.split(";"):
+            part = part.strip().rstrip("&").strip()
+            if part.startswith(("rm -rf", "rm -f")):
+                for token in shlex.split(part)[2:]:
+                    self.files.pop(token, None)
+                    self.dirs.discard(token)
+            launch = _LAUNCH_RE.search(part + " ")
+            if launch:
+                launcher = launch.group(1)
+                assert launcher in self.files, "launcher must be written before the spawn"
+                self.launches += 1
+                exit_code, output = self.run_script(self.launches)
+                out_file = re.search(r"> (\S+) 2>&1", part).group(1)
+                done_file = launcher.replace(".sh", ".done")
+                self.files[out_file] = output
+                self.files[done_file] = f"{exit_code}\n"
+
+
+@pytest.fixture
+def fast_marker_polls(monkeypatch):
+    """_await_done_marker sleeps 5s between polls; make that instant."""
+
+    async def _instant(_seconds):
+        return None
+
+    monkeypatch.setattr(sandbox_mod, "asyncio", SimpleNamespace(sleep=_instant))
+
+
+@pytest.mark.unit
+def test_same_tag_reinvocation_actually_reruns(fast_marker_polls):
+    """A retry loop (e.g. install_npm_cli) must re-run the command, not be fed
+    the previous attempt's stale exit code and log."""
+    outcomes = {1: (1, "attempt-1 failed"), 2: (0, "attempt-2 ok")}
+    sb = ShellFakeSandbox(run_script=lambda n: outcomes[n])
+
+    async def _two_attempts():
+        first = await exec_and_wait(sb, cmd="npm install", time_budget_sec=60, tag="npm", want_output=True)
+        second = await exec_and_wait(sb, cmd="npm install", time_budget_sec=60, tag="npm", want_output=True)
+        return first, second
+
+    (first_code, first_out), (second_code, second_out) = asyncio.run(_two_attempts())
+
+    assert (first_code, first_out) == (1, "attempt-1 failed")
+    assert sb.launches == 2, "second invocation must actually spawn the command"
+    assert (second_code, second_out) == (0, "attempt-2 ok")
+
+
+@pytest.mark.unit
+def test_transport_retry_of_the_spawn_stays_deduped(fast_marker_polls):
+    """Replaying the spawn RPC itself (what the mkdir guard is *for*) must not
+    double-execute the command."""
+    sb = ShellFakeSandbox(run_script=lambda n: (0, "ok"))
+
+    asyncio.run(exec_and_wait(sb, cmd="true", time_budget_sec=60, tag="job"))
+
+    spawn_cmds = [c for c in sb.exec_log if "setsid" in c]
+    assert len(spawn_cmds) == 1
+    # Replay the identical spawn RPC, as _rpc_retry would after a severed
+    # response: the guard must swallow it.
+    asyncio.run(sb.exec(spawn_cmds[0]))
+    assert sb.launches == 1
+
+    # The per-invocation cleanup must NOT ride inside the guarded spawn —
+    # behind the guard it never runs on a replayed tag.
+    assert not any("rm -" in c and "setsid" in c for c in sb.exec_log)


### PR DESCRIPTION
### What

`exec_and_wait`'s retry protection makes retries impossible: a second invocation with the same `tag` executes nothing and silently returns the first invocation's exit code and log.

### Root cause

The detached spawn is guarded so that a transport-level replay of the spawn RPC can't double-execute:

```python
f"chmod +x {launcher}; "
f"mkdir {lock_dir} 2>/dev/null || exit 0; "   # dedupe guard
f"rm -f {out_file} {done_file}; "             # stale-marker cleanup — BEHIND the guard
f"setsid bash {launcher} < /dev/null > {out_file} 2>&1 &",
```

Two problems compose:

1. `lock_dir` is never removed, so the guard fires for every later *logical* invocation of the same tag, not just for transport replays of the same spawn.
2. The stale-marker cleanup sits behind the guard, so when the guard fires, the previous run's `.done` file is still there — `_await_done_marker` returns immediately with the **previous run's exit code**, and the `.out` tail is the previous run's log.

### Concrete victim

`harness.common.install_npm_cli` retries a failed npm install three times by design (`NPM_INSTALL_RETRIES = 3`, "Detached install with a few in-place retries for transient disk flakes"), all with `tag="harness-npm-install"`. Attempts 2 and 3 execute nothing and replay attempt 1's result — the backoff sleeps are the only thing that actually runs. `RuntimeError("npm install failed after 3 attempts")` really means "after 1 attempt", and a transient flake that would have succeeded on retry becomes a hard failure.

### Fix

Clear the per-invocation state in its **own idempotent RPC before** the guarded spawn:

```python
await sb.exec(f"rm -rf {lock_dir}; rm -f {out_file} {done_file}", ..., idempotent=True)
await sb.exec(f"chmod +x {launcher}; mkdir {lock_dir} 2>/dev/null || exit 0; setsid ...", ...)
```

The guard's actual purpose is preserved: a severed-response replay of the spawn RPC still hits `mkdir` and exits without double-executing. It just no longer outlives the invocation. (Callers must not overlap two same-tag calls — that was already true, and is now documented at the call site.)

Also fixes the adjacent Protocol mismatch: `Sandbox.exec` didn't declare `idempotent`, yet both `exec_and_wait` RPCs pass it — a third-party sandbox implementing the documented signature would raise `TypeError`. (`tests/test_agent/_fakes.py` already carried the parameter.)

### Test

New `tests/test_agent/test_sandbox_exec_and_wait.py`, wired into the `agent-test` CI job. The fake sandbox interprets the actual shell strings `exec_and_wait` issues (mkdir-guard short-circuit, rm cleanup, setsid launch, marker polls), so the tests pin semantics rather than the exact command layout:

- a same-tag reinvocation must really re-run — fails on `main` with `assert 1 == 2` (second invocation never spawned) and returns attempt 1's stale `(1, "attempt-1 failed")`;
- a replayed spawn RPC must stay deduped (the guard's real job), and the cleanup must not ride inside the guarded command.

The full `tests/test_agent/` suite passes (64 passed, 1 pre-existing skip).
