### PR TITLE
fix: restore negative dataset slice bounds (path@[-100:])

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -627,6 +627,10 @@ jobs:
             },
             {
               "num_gpus": 0,
+              "test_file": "test_read_file_slicing.py"
+            },
+            {
+              "num_gpus": 0,
               "test_file": "test_rollout_validation.py"
             },
             {

--- a/.github/workflows/pr-test.yml.j2
+++ b/.github/workflows/pr-test.yml.j2
@@ -81,6 +81,7 @@
         {'test_file': 'test_rm_math_dapo.py', 'num_gpus': 0},
         {'test_file': 'test_rm_deepscaler.py', 'num_gpus': 0},
         {'test_file': 'test_sample.py', 'num_gpus': 0},
+        {'test_file': 'test_read_file_slicing.py', 'num_gpus': 0},
         {'test_file': 'test_rollout_validation.py', 'num_gpus': 0},
         {'test_file': 'test_reloadable_process_group_world.py', 'num_gpus': 0},
         {'test_file': 'test_placement_group.py', 'num_gpus': 0},

--- a/slime/utils/data.py
+++ b/slime/utils/data.py
@@ -63,7 +63,14 @@ def read_file(path):
     if row_slice is not None:
 
         logger.info("read_file path=%s applying slice row_slice=%s", path, row_slice)
-        reader = itertools.islice(reader, row_slice.start, row_slice.stop, row_slice.step)
+        if (row_slice.start or 0) < 0 or (row_slice.stop or 0) < 0:
+            # islice forbids negative indices, but the @[...] syntax accepts
+            # them (e.g. "@[-100:]" = the last 100 rows). Resolving a negative
+            # bound needs the total row count, so materialize for this case and
+            # keep the streaming islice for plain non-negative slices.
+            reader = iter(list(reader)[row_slice])
+        else:
+            reader = itertools.islice(reader, row_slice.start, row_slice.stop, row_slice.step)
 
     yield from reader
 

--- a/tests/test_read_file_slicing.py
+++ b/tests/test_read_file_slicing.py
@@ -1,0 +1,82 @@
+"""CPU unit tests for the ``path@[start:end]`` dataset-slicing syntax.
+
+``_parse_generalized_path``'s regex explicitly accepts a sign on both bounds
+(``-?\\d*``), and the feature shipped with full negative-index support
+(``df.iloc[row_slice]``). The streaming rewrite swapped that for
+``itertools.islice``, which raises ``ValueError`` on any negative index — so
+``@[-100:]`` ("the last 100 rows") went from working to crashing while the
+parser still advertised it.
+
+Pinned here: non-negative slices keep streaming through ``islice``; slices
+with a negative bound resolve against the real row count; parsing itself.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from slime.utils.data import _parse_generalized_path, read_file
+
+
+NUM_GPUS = 0
+
+ROWS = [{"id": i} for i in range(10)]
+
+
+@pytest.fixture
+def jsonl_path(tmp_path):
+    path = tmp_path / "data.jsonl"
+    path.write_text("".join(json.dumps(row) + "\n" for row in ROWS))
+    return str(path)
+
+
+def _ids(generalized_path):
+    return [row["id"] for row in read_file(generalized_path)]
+
+
+@pytest.mark.unit
+def test_parse_generalized_path():
+    assert _parse_generalized_path("/a/b.jsonl") == ("/a/b.jsonl", None)
+    assert _parse_generalized_path("/a/b.jsonl@[3:7]") == ("/a/b.jsonl", slice(3, 7))
+    assert _parse_generalized_path("/a/b.jsonl@[-100:]") == ("/a/b.jsonl", slice(-100, None))
+    assert _parse_generalized_path("/a/b.jsonl@[:-2]") == ("/a/b.jsonl", slice(None, -2))
+
+
+@pytest.mark.unit
+def test_no_slice_reads_everything(jsonl_path):
+    assert _ids(jsonl_path) == list(range(10))
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "suffix,expected",
+    [
+        ("@[0:3]", [0, 1, 2]),
+        ("@[3:]", [3, 4, 5, 6, 7, 8, 9]),
+        ("@[:4]", [0, 1, 2, 3]),
+    ],
+)
+def test_non_negative_slices(jsonl_path, suffix, expected):
+    assert _ids(jsonl_path + suffix) == expected
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "suffix,expected",
+    [
+        ("@[-3:]", [7, 8, 9]),
+        ("@[:-2]", [0, 1, 2, 3, 4, 5, 6, 7]),
+        ("@[1:-1]", [1, 2, 3, 4, 5, 6, 7, 8]),
+        ("@[-5:-2]", [5, 6, 7]),
+    ],
+)
+def test_negative_slices(jsonl_path, suffix, expected):
+    assert _ids(jsonl_path + suffix) == expected
+
+
+@pytest.mark.unit
+def test_negative_slice_larger_than_file(jsonl_path):
+    # "@[-100:]" on a 10-row file is simply the whole file, like list slicing.
+    assert _ids(jsonl_path + "@[-100:]") == list(range(10))


### PR DESCRIPTION
### What

`--prompt-data data.jsonl@[-100:]` — take the last 100 rows — crashes with `ValueError`, even though the slice parser explicitly accepts negative bounds.

### Root cause

The `@[start:end]` syntax shipped in #526 with pandas semantics:

```python
df = df.iloc[row_slice]   # negative bounds fully supported
```

The streaming rewrite in #696 replaced this with `itertools.islice`:

```python
reader = itertools.islice(reader, row_slice.start, row_slice.stop, row_slice.step)
```

`islice` forbids negative indices, so any negative bound now raises:

```
@[0:3]   -> ['row0', 'row1', 'row2']
@[-3:]   -> ValueError: Indices for islice() must be None or an integer: 0 <= x <= sys.maxsize.
@[:-2]   -> ValueError: Indices for islice() must be None or an integer: 0 <= x <= sys.maxsize.
```

Meanwhile `_parse_generalized_path` still advertises the feature — its regex is `(?P<start>-?\d*):(?P<end>-?\d*)` with an explicit sign on both bounds.

### Fix

Resolving a negative bound requires the total row count, so that case materializes the reader and applies a plain list slice; non-negative slices keep the streaming `islice` path from #696 untouched:

```python
if (row_slice.start or 0) < 0 or (row_slice.stop or 0) < 0:
    reader = iter(list(reader)[row_slice])
else:
    reader = itertools.islice(reader, ...)
```

Materializing is exactly what the pre-#696 pandas implementation did for every file, so this is not a memory regression for the affected case — and the common non-negative case stays streaming.

### Test

New `tests/test_read_file_slicing.py` in the `cpu-unittest` job: parsing, streaming non-negative slices, negative start / stop / mixed bounds, and a negative bound larger than the file (`@[-100:]` on 10 rows = whole file, matching list semantics). The five negative-bound cases fail on `main` with the `ValueError` above.
