### PR TITLE
fix: cast gpu_id to int in sort_key to prevent lexicographic ordering

### DIFF
--- a/slime/ray/placement_group.py
+++ b/slime/ray/placement_group.py
@@ -36,7 +36,7 @@ def sort_key(x):
             # representation that allows for sorting.
             node_ip_parts = [ord(c) for c in node_identifier]
 
-    return (node_ip_parts, gpu_id)
+    return (node_ip_parts, int(gpu_id))
 
 
 def _create_placement_group(num_gpus):


### PR DESCRIPTION
[https://github.com/THUDM/slime/issues/2245](https://github.com/THUDM/slime/issues/2245)
