### PR TITLE
fix: forward dual-clip PPO epsilon

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -599,6 +599,10 @@ jobs:
             },
             {
               "num_gpus": 0,
+              "test_file": "test_policy_loss.py"
+            },
+            {
+              "num_gpus": 0,
               "test_file": "test_ppo_logprob_entropy.py"
             },
             {

--- a/.github/workflows/pr-test.yml.j2
+++ b/.github/workflows/pr-test.yml.j2
@@ -74,6 +74,7 @@
         {'test_file': 'test_logprob_response_spans.py', 'num_gpus': 0},
         {'test_file': 'test_value_temperature.py', 'num_gpus': 0},
         {'test_file': 'test_cispo_loss.py', 'num_gpus': 0},
+        {'test_file': 'test_policy_loss.py', 'num_gpus': 0},
         {'test_file': 'test_ppo_logprob_entropy.py', 'num_gpus': 0},
         {'test_file': 'test_rm_f1.py', 'num_gpus': 0},
         {'test_file': 'test_rm_gpqa.py', 'num_gpus': 0},

--- a/slime/backends/megatron_utils/loss.py
+++ b/slime/backends/megatron_utils/loss.py
@@ -978,7 +978,13 @@ def policy_loss_function(
     if args.advantage_estimator == "cispo":
         pg_loss, pg_clipfrac = compute_cispo_loss(ppo_kl, log_probs, advantages, args.eps_clip, args.eps_clip_high)
     else:
-        pg_loss, pg_clipfrac = compute_policy_loss(ppo_kl, advantages, args.eps_clip, args.eps_clip_high)
+        pg_loss, pg_clipfrac = compute_policy_loss(
+            ppo_kl,
+            advantages,
+            args.eps_clip,
+            args.eps_clip_high,
+            eps_clip_c=args.eps_clip_c,
+        )
 
     if args.use_opsm:
         pg_loss = pg_loss * opsm_mask

--- a/tests/test_policy_loss.py
+++ b/tests/test_policy_loss.py
@@ -1,0 +1,54 @@
+"""CPU tests for PPO policy-loss clipping and its training-path wiring."""
+
+import ast
+from pathlib import Path
+
+import pytest
+import torch
+
+from slime.utils.ppo_utils import compute_policy_loss
+
+NUM_GPUS = 0
+
+
+def test_compute_policy_loss_applies_dual_clip_to_negative_advantages():
+    ratios = torch.tensor([2.0, 2.0, 0.5])
+    ppo_kl = -ratios.log()
+    advantages = torch.tensor([2.0, -2.0, 2.0])
+
+    losses, _ = compute_policy_loss(
+        ppo_kl,
+        advantages,
+        eps_clip=0.2,
+        eps_clip_high=0.2,
+        eps_clip_c=1.5,
+    )
+
+    torch.testing.assert_close(losses, torch.tensor([-2.4, 3.0, -1.0]))
+
+
+def test_policy_loss_function_forwards_eps_clip_c():
+    loss_path = Path(__file__).parents[1] / "slime" / "backends" / "megatron_utils" / "loss.py"
+    module = ast.parse(loss_path.read_text())
+    policy_loss_function = next(
+        node for node in module.body if isinstance(node, ast.FunctionDef) and node.name == "policy_loss_function"
+    )
+    compute_policy_loss_calls = [
+        node
+        for node in ast.walk(policy_loss_function)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "compute_policy_loss"
+    ]
+
+    assert len(compute_policy_loss_calls) == 1
+    eps_clip_c_keyword = next(
+        (keyword for keyword in compute_policy_loss_calls[0].keywords if keyword.arg == "eps_clip_c"),
+        None,
+    )
+    assert eps_clip_c_keyword is not None
+    assert ast.dump(eps_clip_c_keyword.value) == ast.dump(
+        ast.Attribute(value=ast.Name(id="args", ctx=ast.Load()), attr="eps_clip_c", ctx=ast.Load())
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__]))


### PR DESCRIPTION
Fix Dual-clip PPO support by forwarding args.eps_clip_c from policy_loss_function to compute_policy_loss. Forward eps_clip_c=args.eps_clip_c in the PPO policy-loss path.