### PR TITLE
Add lightweight rollout hooks and sampling controls

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -563,6 +563,14 @@ jobs:
             },
             {
               "num_gpus": 0,
+              "test_file": "test_deep_ep_tms_patch.py"
+            },
+            {
+              "num_gpus": 0,
+              "test_file": "test_stateless_adam.py"
+            },
+            {
+              "num_gpus": 0,
               "test_file": "utils/test_megatron_server_arguments.py"
             },
             {
@@ -628,6 +636,10 @@ jobs:
             {
               "num_gpus": 0,
               "test_file": "test_rollout_validation.py"
+            },
+            {
+              "num_gpus": 0,
+              "test_file": "test_rollout_sample_hooks.py"
             },
             {
               "num_gpus": 0,

--- a/.github/workflows/pr-test.yml.j2
+++ b/.github/workflows/pr-test.yml.j2
@@ -65,6 +65,8 @@
       'cpu': True,
       'tests': [
         {'test_file': 'test_megatron_argument_validation.py', 'num_gpus': 0},
+        {'test_file': 'test_deep_ep_tms_patch.py', 'num_gpus': 0},
+        {'test_file': 'test_stateless_adam.py', 'num_gpus': 0},
         {'test_file': 'utils/test_megatron_server_arguments.py', 'num_gpus': 0},
         {'test_file': 'test_dp_schedule.py', 'num_gpus': 0},
         {'test_file': 'test_cp_utils.py', 'num_gpus': 0},
@@ -82,6 +84,7 @@
         {'test_file': 'test_rm_deepscaler.py', 'num_gpus': 0},
         {'test_file': 'test_sample.py', 'num_gpus': 0},
         {'test_file': 'test_rollout_validation.py', 'num_gpus': 0},
+        {'test_file': 'test_rollout_sample_hooks.py', 'num_gpus': 0},
         {'test_file': 'test_reloadable_process_group_world.py', 'num_gpus': 0},
         {'test_file': 'test_placement_group.py', 'num_gpus': 0},
         {'test_file': 'test_external_sglang_engines.py', 'num_gpus': 0},

--- a/slime/backends/megatron_utils/__init__.py
+++ b/slime/backends/megatron_utils/__init__.py
@@ -9,12 +9,21 @@ try:
     old_init = deep_ep.Buffer.__init__
 
     def new_init(self, *args, **kwargs):
-        if torch_memory_saver._impl is not None:
-            torch_memory_saver._impl._binary_wrapper.cdll.tms_set_interesting_region(False)
-        old_init(self, *args, **kwargs)
-        torch.cuda.synchronize()
-        if torch_memory_saver._impl is not None:
-            torch_memory_saver._impl._binary_wrapper.cdll.tms_set_interesting_region(True)
+        tms_impl = torch_memory_saver._impl
+        if tms_impl is None:
+            return old_init(self, *args, **kwargs)
+
+        cdll = tms_impl._binary_wrapper.cdll
+        original_interesting_region = cdll.tms_get_interesting_region()
+        cdll.tms_set_interesting_region(False)
+        try:
+            old_init(self, *args, **kwargs)
+            # DeepEP owns persistent buffers and may initialize them on its
+            # internal streams. Make their lifetime independent of the TMS
+            # disabled region before restoring allocation tracking.
+            torch.cuda.synchronize()
+        finally:
+            cdll.tms_set_interesting_region(original_interesting_region)
 
     deep_ep.Buffer.__init__ = new_init
 except ImportError:

--- a/slime/backends/sglang_utils/arguments.py
+++ b/slime/backends/sglang_utils/arguments.py
@@ -29,6 +29,9 @@ def add_sglang_router_arguments(parser):
         help="Timeout for requests to the SGLang router in seconds",
     )
     RouterArgs.add_cli_args(parser, use_router_prefix=True, exclude_host_port=True)
+    # Keep driver logs quiet by default while allowing --router-log-level to
+    # expose router dispatch and retry details when needed.
+    parser.set_defaults(router_log_level="warn")
     return parser
 
 

--- a/slime/ray/rollout.py
+++ b/slime/ray/rollout.py
@@ -18,6 +18,7 @@ from slime.backends.sglang_utils.external import start_external_rollout_servers
 from slime.backends.sglang_utils.sglang_config import ModelConfig, ServerGroupConfig, SglangConfig
 from slime.backends.sglang_utils.sglang_engine import SGLangEngine
 from slime.rollout.base_types import call_rollout_fn
+from slime.rollout.sample_hooks import set_current_rollout_id
 from slime.utils import logging_utils
 from slime.utils.data import get_source
 from slime.utils.dp_schedule import build_dp_schedule
@@ -552,6 +553,7 @@ class RolloutManager:
     def generate(self, rollout_id):
         start_time = time.time()
         self.rollout_id = rollout_id
+        set_current_rollout_id(rollout_id)
         self.health_monitoring_resume()
         if self.args.ci_test and self.args.use_fault_tolerance and rollout_id >= 2:
             self._try_ci_fault_injection()
@@ -568,6 +570,7 @@ class RolloutManager:
         if self.args.debug_train_only:
             # if debug train only, we don't generate evaluation data
             return
+        set_current_rollout_id(rollout_id)
         self.health_monitoring_resume()
 
         result = call_rollout_fn(self.eval_generate_rollout, self.args, rollout_id, self.data_source, evaluation=True)
@@ -1042,7 +1045,6 @@ def _start_router(args, *, has_pd_disaggregation: bool = False, force_new: bool 
     router_args.host = router_ip
     router_args.port = router_port
     router_args.prometheus_port = find_available_port(random.randint(4000, 5000))
-    router_args.log_level = "warn"
     router_args.request_timeout_secs = args.sglang_router_request_timeout_secs
 
     if has_pd_disaggregation:

--- a/slime/rollout/filter_hub/base_types.py
+++ b/slime/rollout/filter_hub/base_types.py
@@ -6,6 +6,22 @@ from dataclasses import dataclass
 class DynamicFilterOutput:
     keep: bool
     reason: str | None = None
+    # Keep a rejected group when dropping it would leave too few candidates to
+    # fill the rollout batch. This avoids launching another oversampling round.
+    keep_when_insufficient: bool = False
+
+
+def should_drop_dynamic_filter_output(
+    output: DynamicFilterOutput,
+    *,
+    remaining_batch_size: int,
+    target_data_size: int,
+) -> bool:
+    if output.keep:
+        return False
+    if output.keep_when_insufficient and remaining_batch_size <= target_data_size:
+        return False
+    return True
 
 
 def call_dynamic_filter(fn, *args, **kwargs):

--- a/slime/rollout/filter_hub/dynamic_sampling_filters.py
+++ b/slime/rollout/filter_hub/dynamic_sampling_filters.py
@@ -3,7 +3,7 @@ import torch
 from slime.rollout.filter_hub.base_types import DynamicFilterOutput
 from slime.utils.types import Sample
 
-__all__ = ["check_reward_nonzero_std"]
+__all__ = ["check_reward_nonzero_std", "check_reward_nonzero_std_with_fallback"]
 
 
 def check_reward_nonzero_std(args, samples: list[Sample], **kwargs):
@@ -13,3 +13,11 @@ def check_reward_nonzero_std(args, samples: list[Sample], **kwargs):
         keep=keep,
         reason=None if keep else f"zero_std_{round(rewards[0], 1)}",
     )
+
+
+def check_reward_nonzero_std_with_fallback(args, samples: list[Sample], **kwargs):
+    """Prefer non-zero-std groups without triggering another sampling round."""
+
+    output = check_reward_nonzero_std(args, samples, **kwargs)
+    output.keep_when_insufficient = True
+    return output

--- a/slime/rollout/sample_hooks.py
+++ b/slime/rollout/sample_hooks.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import inspect
+from typing import Any
+
+from slime.utils.misc import load_function
+from slime.utils.types import Sample
+
+_current_rollout_id: int | None = None
+
+
+def set_current_rollout_id(rollout_id: int | None) -> None:
+    global _current_rollout_id
+    _current_rollout_id = rollout_id
+
+
+def _accepted_kwargs(function, kwargs: dict[str, Any]) -> dict[str, Any]:
+    signature = inspect.signature(function)
+    if any(parameter.kind == inspect.Parameter.VAR_KEYWORD for parameter in signature.parameters.values()):
+        return kwargs
+    return {key: value for key, value in kwargs.items() if key in signature.parameters}
+
+
+async def _apply_to_sample(args, sample: Sample, paths: list[str], **kwargs) -> Sample:
+    for path in paths:
+        hook = load_function(path)
+        result = hook(args, sample, **_accepted_kwargs(hook, kwargs))
+        if inspect.isawaitable(result):
+            result = await result
+        if result is not None:
+            if not isinstance(result, Sample):
+                raise TypeError(
+                    f"Rollout sample hook {path!r} returned {type(result).__name__}, expected Sample or None."
+                )
+            sample = result
+    return sample
+
+
+async def apply_rollout_sample_hooks(args, value, **kwargs):
+    """Apply configured hooks to every Sample leaf while preserving list shape."""
+
+    paths = getattr(args, "rollout_sample_hook_path", None) or []
+    if not paths:
+        return value
+    kwargs.setdefault("rollout_id", _current_rollout_id)
+    if isinstance(value, Sample):
+        return await _apply_to_sample(args, value, paths, **kwargs)
+    if isinstance(value, list):
+        return [await apply_rollout_sample_hooks(args, item, **kwargs) for item in value]
+    raise TypeError(f"Rollout sample hooks expected Sample or list, got {type(value).__name__}.")

--- a/slime/rollout/sglang_rollout.py
+++ b/slime/rollout/sglang_rollout.py
@@ -16,7 +16,8 @@ from tqdm import tqdm
 
 from slime.backends.sglang_utils.server_control import abort_servers_until_idle
 from slime.rollout.base_types import RolloutFnEvalOutput, RolloutFnTrainOutput
-from slime.rollout.filter_hub.base_types import MetricGatherer, call_dynamic_filter
+from slime.rollout.filter_hub.base_types import MetricGatherer, call_dynamic_filter, should_drop_dynamic_filter_output
+from slime.rollout.sample_hooks import apply_rollout_sample_hooks
 from slime.utils.async_utils import run
 from slime.utils.data import Dataset
 from slime.utils.eval_config import EvalDatasetConfig
@@ -260,6 +261,8 @@ async def generate_and_rm(
             else:
                 sample = await generate(args, sample, sampling_params)
 
+    sample = await apply_rollout_sample_hooks(args, sample, evaluation=evaluation)
+
     # for the rm that need the whole group, we will not do the rm here
     if args.group_rm:
         return sample
@@ -427,7 +430,11 @@ async def generate_rollout_async(
             all_data.append(group)
 
             dynamic_filter_output = call_dynamic_filter(dynamic_filter, args, group)
-            if not dynamic_filter_output.keep:
+            if should_drop_dynamic_filter_output(
+                dynamic_filter_output,
+                remaining_batch_size=state.remaining_batch_size,
+                target_data_size=target_data_size,
+            ):
                 metric_gatherer.on_dynamic_filter_drop(reason=dynamic_filter_output.reason)
                 state.remaining_batch_size -= 1
                 continue

--- a/slime/utils/arguments.py
+++ b/slime/utils/arguments.py
@@ -428,7 +428,7 @@ def get_slime_extra_args_provider(add_custom_arguments=None):
                 help=(
                     "This defines the granularity of the sampling batch in the rollout function. "
                     "When the number of available samples falls below the target, a sampling "
-                    "operation of size over_sampling_batch_size will be triggered."
+                    "operation of size over_sampling_batch_size will be triggered. "
                     "Regardless of whether partial rollout is used or filters are applied, "
                     "the sampling granularity is always determined by this value. "
                     "If this value is None, rollout_batch_size will be used as the default over_sampling_batch_size."
@@ -440,9 +440,11 @@ def get_slime_extra_args_provider(add_custom_arguments=None):
                 default=None,
                 help=(
                     "This is the filter function for dynamic sampling. "
-                    "It should be able to judge whether the result of a prompt should be selected or not."
-                    "We will do dynamic filter for sampling as in DAPO. e.g. not all correct or all wrong samples."
-                    "You could use `slime.rollout.filter_hub.dynamic_sampling_filters.check_reward_nonzero_std` as an example."
+                    "It should be able to judge whether the result of a prompt should be selected or not. "
+                    "We will do dynamic filter for sampling as in DAPO. e.g. not all correct or all wrong samples. "
+                    "You could use `slime.rollout.filter_hub.dynamic_sampling_filters.check_reward_nonzero_std` as an example. "
+                    "To avoid another sampling round when the oversampled candidates cannot fill rollout_batch_size, "
+                    "use `slime.rollout.filter_hub.dynamic_sampling_filters.check_reward_nonzero_std_with_fallback`."
                 ),
             )
 
@@ -473,6 +475,16 @@ def get_slime_extra_args_provider(add_custom_arguments=None):
                 help=(
                     "Only substitue the `def generate(args, sample, sampling_params)` function within the example rollout function. "
                     "This should be useful if you need to implement some special rollout logic, e.g. multi-turn, function calling."
+                ),
+            )
+            parser.add_argument(
+                "--rollout-sample-hook-path",
+                action="append",
+                default=[],
+                help=(
+                    "Import path to a hook applied to each generated rollout Sample before reward computation. "
+                    "May be repeated. Hooks may be sync or async and have signature "
+                    "hook(args, sample, *, rollout_id=None, evaluation=False) -> Sample | None."
                 ),
             )
             parser.add_argument(

--- a/slime/utils/misc.py
+++ b/slime/utils/misc.py
@@ -2,6 +2,7 @@ import importlib
 import subprocess
 from collections import defaultdict
 from collections.abc import Callable, Iterable
+from functools import cache
 from typing import Any
 
 import torch
@@ -34,6 +35,7 @@ def decode_int32_meta_array(meta_info: dict[str, Any], keys: str | Iterable[str]
     return torch.as_tensor(value, dtype=torch.int32).reshape(-1)
 
 
+@cache
 def load_function(path):
     """
     Load a function from a module.

--- a/tests/plugin_contracts/test_plugin_path_loading_contracts.py
+++ b/tests/plugin_contracts/test_plugin_path_loading_contracts.py
@@ -34,7 +34,11 @@ NUM_GPUS = 0
 
 from slime.rollout.base_types import RolloutFnEvalOutput, call_rollout_fn
 from slime.rollout.data_source import RolloutDataSourceWithBuffer
-from slime.rollout.filter_hub.base_types import DynamicFilterOutput, call_dynamic_filter
+from slime.rollout.filter_hub.base_types import (
+    DynamicFilterOutput,
+    call_dynamic_filter,
+    should_drop_dynamic_filter_output,
+)
 from slime.rollout.rm_hub import async_rm, batched_async_rm
 from slime.rollout.sglang_rollout import generate_rollout as default_generate_rollout
 from slime.utils.misc import load_function
@@ -196,6 +200,25 @@ def check_dynamic_filter_path(path: str) -> None:
     assert tuple(inspect.signature(fn).parameters)[:2] == ("args", "samples")
     output = call_dynamic_filter(fn, make_args(), [make_sample(0, reward=1.0), make_sample(1, reward=2.0)])
     assert isinstance(output, DynamicFilterOutput)
+
+
+def test_dynamic_filter_can_fall_back_to_zero_std_groups_at_target_capacity():
+    fn = load_function("slime.rollout.filter_hub.dynamic_sampling_filters.check_reward_nonzero_std_with_fallback")
+    output = call_dynamic_filter(fn, make_args(), [make_sample(0, reward=1.0), make_sample(1, reward=1.0)])
+
+    assert not bool(output.keep)
+    assert output.keep_when_insufficient is True
+    assert should_drop_dynamic_filter_output(output, remaining_batch_size=3, target_data_size=2) is True
+    assert should_drop_dynamic_filter_output(output, remaining_batch_size=2, target_data_size=2) is False
+
+
+def test_strict_dynamic_filter_still_drops_at_target_capacity():
+    fn = load_function("slime.rollout.filter_hub.dynamic_sampling_filters.check_reward_nonzero_std")
+    output = call_dynamic_filter(fn, make_args(), [make_sample(0, reward=0.0), make_sample(1, reward=0.0)])
+
+    assert not bool(output.keep)
+    assert output.keep_when_insufficient is False
+    assert should_drop_dynamic_filter_output(output, remaining_batch_size=2, target_data_size=2) is True
 
 
 def check_buffer_filter_default() -> None:

--- a/tests/test_deep_ep_tms_patch.py
+++ b/tests/test_deep_ep_tms_patch.py
@@ -1,0 +1,105 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+import torch
+
+NUM_GPUS = 0
+
+
+def _load_megatron_utils_init(monkeypatch, buffer_cls, tms_impl, module_name):
+    deep_ep = types.ModuleType("deep_ep")
+    deep_ep.Buffer = buffer_cls
+    monkeypatch.setitem(sys.modules, "deep_ep", deep_ep)
+
+    torch_memory_saver_module = types.ModuleType("torch_memory_saver")
+    torch_memory_saver_module.torch_memory_saver = types.SimpleNamespace(_impl=tms_impl)
+    monkeypatch.setitem(sys.modules, "torch_memory_saver", torch_memory_saver_module)
+    monkeypatch.setitem(sys.modules, "megatron", types.ModuleType("megatron"))
+
+    package_path = Path(__file__).parents[1] / "slime" / "backends" / "megatron_utils"
+    spec = importlib.util.spec_from_file_location(
+        module_name,
+        package_path / "__init__.py",
+        submodule_search_locations=[str(package_path)],
+    )
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, module_name, module)
+    monkeypatch.setitem(sys.modules, f"{module_name}.megatron_patch", types.ModuleType("megatron_patch"))
+    spec.loader.exec_module(module)
+
+
+@pytest.mark.unit
+def test_deep_ep_init_restores_original_tms_region(monkeypatch):
+    events = []
+
+    class FakeCdll:
+        def __init__(self):
+            self.interesting_region = False
+
+        def tms_get_interesting_region(self):
+            events.append(("get", self.interesting_region))
+            return self.interesting_region
+
+        def tms_set_interesting_region(self, enabled):
+            self.interesting_region = enabled
+            events.append(("set", enabled))
+
+    cdll = FakeCdll()
+
+    class FakeBuffer:
+        def __init__(self):
+            events.append(("init", cdll.interesting_region))
+
+    tms_impl = types.SimpleNamespace(_binary_wrapper=types.SimpleNamespace(cdll=cdll))
+    monkeypatch.setattr(torch.cuda, "synchronize", lambda: events.append(("sync", cdll.interesting_region)))
+
+    _load_megatron_utils_init(monkeypatch, FakeBuffer, tms_impl, "_test_megatron_utils_tms_restore")
+    FakeBuffer()
+
+    assert events == [
+        ("get", False),
+        ("set", False),
+        ("init", False),
+        ("sync", False),
+        ("set", False),
+    ]
+    assert cdll.interesting_region is False
+
+
+@pytest.mark.unit
+def test_deep_ep_init_restores_tms_region_after_failure(monkeypatch):
+    events = []
+
+    class FakeCdll:
+        interesting_region = True
+
+        def tms_get_interesting_region(self):
+            return self.interesting_region
+
+        def tms_set_interesting_region(self, enabled):
+            self.interesting_region = enabled
+            events.append(("set", enabled))
+
+    cdll = FakeCdll()
+
+    class FailingBuffer:
+        def __init__(self):
+            events.append(("init", cdll.interesting_region))
+            raise RuntimeError("buffer init failed")
+
+    tms_impl = types.SimpleNamespace(_binary_wrapper=types.SimpleNamespace(cdll=cdll))
+    monkeypatch.setattr(torch.cuda, "synchronize", lambda: events.append(("sync", cdll.interesting_region)))
+
+    _load_megatron_utils_init(monkeypatch, FailingBuffer, tms_impl, "_test_megatron_utils_tms_failure")
+    with pytest.raises(RuntimeError, match="buffer init failed"):
+        FailingBuffer()
+
+    assert events == [("set", False), ("init", False), ("set", True)]
+    assert cdll.interesting_region is True
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__]))

--- a/tests/test_rollout_sample_hooks.py
+++ b/tests/test_rollout_sample_hooks.py
@@ -1,0 +1,59 @@
+import asyncio
+import types
+
+import pytest
+
+from slime.rollout.sample_hooks import apply_rollout_sample_hooks, set_current_rollout_id
+from slime.utils.types import Sample
+
+NUM_GPUS = 0
+
+
+def sync_hook(args, sample, *, rollout_id=None):
+    sample.metadata["sync_hook"] = (args.marker, rollout_id)
+
+
+async def async_hook(args, sample, *, evaluation=False):
+    sample.metadata["async_hook"] = evaluation
+    return sample
+
+
+def invalid_hook(args, sample):
+    return {"sample": sample}
+
+
+@pytest.mark.unit
+def test_rollout_sample_hooks_preserve_nested_shape_and_filter_kwargs():
+    args = types.SimpleNamespace(
+        marker="seen",
+        rollout_sample_hook_path=[f"{__name__}.sync_hook", f"{__name__}.async_hook"],
+    )
+    samples = [[Sample(index=0, metadata={})], [Sample(index=1, metadata={})]]
+    set_current_rollout_id(7)
+
+    result = asyncio.run(apply_rollout_sample_hooks(args, samples, evaluation=True, ignored="value"))
+
+    assert result is not samples
+    assert [[sample.index for sample in group] for group in result] == [[0], [1]]
+    for group in result:
+        assert group[0].metadata == {"sync_hook": ("seen", 7), "async_hook": True}
+
+
+@pytest.mark.unit
+def test_rollout_sample_hook_rejects_invalid_return_type():
+    args = types.SimpleNamespace(rollout_sample_hook_path=[f"{__name__}.invalid_hook"])
+
+    with pytest.raises(TypeError, match="expected Sample or None"):
+        asyncio.run(apply_rollout_sample_hooks(args, Sample(index=0)))
+
+
+@pytest.mark.unit
+def test_rollout_sample_hooks_are_noop_when_unconfigured():
+    args = types.SimpleNamespace(rollout_sample_hook_path=[])
+    sample = Sample(index=0)
+
+    assert asyncio.run(apply_rollout_sample_hooks(args, sample)) is sample
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__]))

--- a/tests/test_stateless_adam.py
+++ b/tests/test_stateless_adam.py
@@ -1,0 +1,62 @@
+import pytest
+import torch
+
+from slime.backends.megatron_utils.stateless_adam import StatelessAdam
+
+NUM_GPUS = 0
+
+
+def _run_with_reinitialized_adam(param, grads, *, adam_w_mode):
+    param = param.clone().detach()
+    optimizer_cls = torch.optim.AdamW if adam_w_mode else torch.optim.Adam
+    for grad in grads:
+        param = param.detach().requires_grad_(True)
+        optimizer = optimizer_cls(
+            [param],
+            lr=0.03,
+            betas=(0.9, 0.98),
+            eps=1e-6,
+            weight_decay=0.1,
+        )
+        param.grad = grad.clone()
+        optimizer.step()
+        param = param.detach()
+    return param
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("adam_w_mode", [True, False])
+def test_stateless_adam_matches_reinitialized_adam_each_step(adam_w_mode):
+    torch.manual_seed(0)
+    initial_param = torch.randn(8, dtype=torch.float64)
+    grads = [torch.randn_like(initial_param) for _ in range(4)]
+    param = initial_param.clone()
+    optimizer = StatelessAdam(
+        [param],
+        lr=0.03,
+        betas=(0.9, 0.98),
+        eps=1e-6,
+        weight_decay=0.1,
+        adam_w_mode=adam_w_mode,
+    )
+
+    for grad in grads:
+        param.grad = grad.clone()
+        optimizer.step()
+        optimizer.zero_grad()
+
+    expected = _run_with_reinitialized_adam(initial_param, grads, adam_w_mode=adam_w_mode)
+    torch.testing.assert_close(param, expected)
+
+
+@pytest.mark.unit
+def test_stateless_adam_does_not_persist_moment_tensors():
+    param = torch.tensor([1.0, -2.0])
+    optimizer = StatelessAdam([param])
+
+    assert optimizer.state == {}
+    assert optimizer.state_dict()["state"] == {}
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__]))


### PR DESCRIPTION
Preserve DeepEP TMS state, make router logging configurable, add generic per-sample rollout hooks, and support a one-round dynamic sampling fallback. Add focused coverage for these changes and stateless Adam behavior.