### PR TITLE
docs: correct reverse KL definition in OPD guide

### DIFF
--- a/docs/en/advanced/on-policy-distillation.md
+++ b/docs/en/advanced/on-policy-distillation.md
@@ -17,8 +17,8 @@ On-policy distillation (OPD) trains a student on response tokens sampled from th
 Let $\pi_\theta$ denote the student, $\pi_T$ the teacher, and $h_t$ the history before token $a_t$ on a student-generated trajectory. Following [Thinking Machines Lab's definition](https://thinkingmachines.ai/blog/on-policy-distillation/), the per-token reverse KL is
 
 $$
-D_{\mathrm{KL}}\!\left(\pi_\theta(\cdot \mid h_t)\,\|\,\pi_T(\cdot \mid h_t)\right)
-= \mathbb{E}_{a_t \sim \pi_\theta(\cdot \mid h_t)}\!\left[
+D_{\mathrm{KL}}\left(\pi_\theta(\cdot \mid h_t) \| \pi_T(\cdot \mid h_t)\right)
+= \mathbb{E}_{a_t \sim \pi_\theta(\cdot \mid h_t)}\left[
 \log \pi_\theta(a_t \mid h_t) - \log \pi_T(a_t \mid h_t)
 \right].
 $$

--- a/docs/en/advanced/on-policy-distillation.md
+++ b/docs/en/advanced/on-policy-distillation.md
@@ -1,6 +1,6 @@
 # On-Policy Distillation
 
-On-policy distillation (OPD) enables a student model to learn from a larger teacher model by training on its own rollouts while matching the teacher's token-level log-probabilities. OPD is orthogonal to advantage estimators — it works as an additive KL penalty on top of any estimator (GRPO, PPO, REINFORCE++, etc.).
+On-policy distillation (OPD) trains a student on response tokens sampled from the student's current policy. At every visited prefix, a fixed teacher scores the same next token, providing a dense token-level learning signal along the student's own trajectories. In slime, this signal is a sampled reverse-KL penalty applied to the advantage, so it can be combined with an advantage estimator such as GRPO, PPO, or REINFORCE++. With zero task reward, the same mechanism performs pure distillation.
 
 ## Key Arguments
 
@@ -14,15 +14,31 @@ On-policy distillation (OPD) enables a student model to learn from a larger teac
 
 ## How It Works
 
-OPD modifies the advantage computation by subtracting a KL penalty term that encourages the student to match the teacher's output distribution:
+Let $\pi_\theta$ denote the student, $\pi_T$ the teacher, and $h_t$ the history before token $a_t$ on a student-generated trajectory. Following [Thinking Machines Lab's definition](https://thinkingmachines.ai/blog/on-policy-distillation/), the per-token reverse KL is
 
 $$
-\hat{A}_t = A_t - \lambda_{\text{opd}} \cdot D_{\text{KL}}(P_{\text{teacher}} \| P_{\text{student}})_t
+D_{\mathrm{KL}}\!\left(\pi_\theta(\cdot \mid h_t)\,\|\,\pi_T(\cdot \mid h_t)\right)
+= \mathbb{E}_{a_t \sim \pi_\theta(\cdot \mid h_t)}\!\left[
+\log \pi_\theta(a_t \mid h_t) - \log \pi_T(a_t \mid h_t)
+\right].
 $$
 
-Where $A_t$ is the original advantage from the base estimator (e.g., GRPO), $\lambda_{\text{opd}}$ is `--opd-kl-coef`, and $D_{\text{KL}}$ is the token-level reverse KL divergence.
+The order is important: the student is the first argument of the KL, and the expectation is also over the student distribution. The teacher does not generate the training trajectory; it evaluates the token that the student actually sampled.
 
-This means OPD can be combined with any advantage estimator, including GRPO, PPO, REINFORCE++, and GSPO.
+slime does not enumerate the full vocabulary to compute this expectation. For each sampled token, it uses the Monte Carlo contribution
+
+$$
+\hat d_t = \log \pi_\theta(a_t \mid h_t) - \log \pi_T(a_t \mid h_t),
+\qquad a_t \sim \pi_\theta(\cdot \mid h_t),
+$$
+
+and modifies the base advantage as
+
+$$
+\hat A_t = A_t - \lambda_{\mathrm{opd}}\hat d_t.
+$$
+
+Here, $A_t$ is the advantage from the configured estimator (or zero for pure distillation), and $\lambda_{\mathrm{opd}}$ is `--opd-kl-coef`. An individual $\hat d_t$ may be negative even though the KL is non-negative in expectation. The policy loss uses $\hat A_t$, which makes the OPD term orthogonal to the choice of GRPO, PPO, REINFORCE++, GSPO, or another supported advantage estimator.
 
 ## Two Teacher Modes
 
@@ -30,13 +46,13 @@ This means OPD can be combined with any advantage estimator, including GRPO, PPO
 
 The teacher runs on an external SGLang server. Teacher log-probs are obtained during the rollout phase.
 
-**When to use**: The teacher has a different architecture from the student, or the teacher is too large to load alongside the training model.
+**When to use**: The teacher has a different architecture from the student, or the teacher is too large to load alongside the training model. Because the teacher scores the student's exact token IDs, the teacher and student must still use compatible tokenization and vocabularies.
 
 **How it works**:
 1. An external SGLang server runs the teacher model.
-2. During rollout, the custom reward function (`slime.rollout.on_policy_distillation.reward_func`) sends each sample to the teacher server to obtain token-level log-probs.
+2. During rollout, the custom reward function (`slime.rollout.on_policy_distillation.reward_func`) sends the student's sampled token IDs to the teacher server and obtains the teacher log-probability of those same tokens.
 3. The custom post-processing function (`slime.rollout.on_policy_distillation.post_process_rewards`) trims the teacher log-probs to the response span and stores them in `sample.teacher_log_probs`.
-4. During training, the KL penalty is computed from the stored teacher log-probs and applied to advantages.
+4. During training, slime subtracts the sampled log-probability difference, scaled by `--opd-kl-coef`, from the base advantage.
 
 **Configuration**:
 ```bash

--- a/docs/zh/advanced/on-policy-distillation.md
+++ b/docs/zh/advanced/on-policy-distillation.md
@@ -1,6 +1,6 @@
 # 在策略蒸馏 (On-Policy Distillation)
 
-在策略蒸馏 (OPD) 让学生模型在自己的 rollout 数据上训练，同时匹配教师模型的 token 级 log-probability，从而实现从大模型到小模型的知识传递。OPD 与 advantage estimator 正交——它作为 KL 惩罚项叠加在任意 estimator（GRPO、PPO、REINFORCE++ 等）之上。
+在策略蒸馏 (OPD) 使用学生当前策略采样的 response token 来训练学生。对于学生轨迹中访问到的每个前缀，固定的教师模型为同一个 next token 评分，从而沿学生自己的轨迹提供稠密的 token 级学习信号。在 slime 中，这一信号以逆 KL 的采样估计惩罚 advantage，因此可以与 GRPO、PPO、REINFORCE++ 等 advantage estimator 组合；当任务奖励为零时，同一机制就是纯蒸馏。
 
 ## 关键参数
 
@@ -14,15 +14,31 @@
 
 ## 原理
 
-OPD 通过减去一个 KL 惩罚项来修改 advantage 计算，鼓励学生匹配教师的输出分布：
+记 $\pi_\theta$ 为学生策略，$\pi_T$ 为教师策略，$h_t$ 为学生生成轨迹中采样 token $a_t$ 之前的历史。按照 [Thinking Machines Lab 给出的定义](https://thinkingmachines.ai/blog/on-policy-distillation/)，token 级逆 KL 为
 
 $$
-\hat{A}_t = A_t - \lambda_{\text{opd}} \cdot D_{\text{KL}}(P_{\text{teacher}} \| P_{\text{student}})_t
+D_{\mathrm{KL}}\!\left(\pi_\theta(\cdot \mid h_t)\,\|\,\pi_T(\cdot \mid h_t)\right)
+= \mathbb{E}_{a_t \sim \pi_\theta(\cdot \mid h_t)}\!\left[
+\log \pi_\theta(a_t \mid h_t) - \log \pi_T(a_t \mid h_t)
+\right].
 $$
 
-其中 $A_t$ 是基础 estimator（如 GRPO）的原始 advantage，$\lambda_{\text{opd}}$ 是 `--opd-kl-coef`，$D_{\text{KL}}$ 是 token 级的逆 KL 散度。
+这里的顺序很重要：KL 的第一个参数是学生分布，期望同样对学生分布取值。教师不生成训练轨迹，而是评估学生实际采样的 token。
 
-因此 OPD 可以与任何 advantage estimator 组合使用，包括 GRPO、PPO、REINFORCE++ 和 GSPO。
+slime 不会遍历完整词表来精确计算这个期望。对于每个采样 token，它使用如下 Monte Carlo 贡献：
+
+$$
+\hat d_t = \log \pi_\theta(a_t \mid h_t) - \log \pi_T(a_t \mid h_t),
+\qquad a_t \sim \pi_\theta(\cdot \mid h_t),
+$$
+
+然后修改基础 advantage：
+
+$$
+\hat A_t = A_t - \lambda_{\mathrm{opd}}\hat d_t.
+$$
+
+其中 $A_t$ 来自所配置的 estimator（纯蒸馏时为零），$\lambda_{\mathrm{opd}}$ 是 `--opd-kl-coef`。尽管 KL 的期望非负，单个样本的 $\hat d_t$ 仍可能为负。策略损失使用修改后的 $\hat A_t$，因此 OPD 项与 GRPO、PPO、REINFORCE++、GSPO 等 advantage estimator 的选择相互独立。
 
 ## 两种教师模式
 
@@ -30,13 +46,13 @@ $$
 
 教师模型运行在外部 SGLang 服务器上，教师的 log-probs 在 rollout 阶段获取。
 
-**适用场景**：教师与学生架构不同，或教师模型太大无法与训练模型同时加载。
+**适用场景**：教师与学生架构不同，或教师模型太大无法与训练模型同时加载。由于教师需要为学生的原始 token ID 评分，两者仍须使用兼容的 tokenizer 和词表。
 
 **工作流程**：
 1. 外部 SGLang 服务器运行教师模型。
-2. 在 rollout 阶段，自定义 reward 函数（`slime.rollout.on_policy_distillation.reward_func`）将每个样本发送到教师服务器以获取 token 级 log-probs。
+2. 在 rollout 阶段，自定义 reward 函数（`slime.rollout.on_policy_distillation.reward_func`）将学生采样的 token ID 发送给教师服务器，并获取教师对这些相同 token 的 log-probability。
 3. 自定义后处理函数（`slime.rollout.on_policy_distillation.post_process_rewards`）将教师 log-probs 裁剪到 response 范围并存储到 `sample.teacher_log_probs` 中。
-4. 在训练阶段，从存储的教师 log-probs 计算 KL 惩罚并应用到 advantages 上。
+4. 在训练阶段，slime 从基础 advantage 中减去按 `--opd-kl-coef` 缩放后的采样 log-probability 差值。
 
 **配置**：
 ```bash

--- a/docs/zh/advanced/on-policy-distillation.md
+++ b/docs/zh/advanced/on-policy-distillation.md
@@ -17,8 +17,8 @@
 记 $\pi_\theta$ 为学生策略，$\pi_T$ 为教师策略，$h_t$ 为学生生成轨迹中采样 token $a_t$ 之前的历史。按照 [Thinking Machines Lab 给出的定义](https://thinkingmachines.ai/blog/on-policy-distillation/)，token 级逆 KL 为
 
 $$
-D_{\mathrm{KL}}\!\left(\pi_\theta(\cdot \mid h_t)\,\|\,\pi_T(\cdot \mid h_t)\right)
-= \mathbb{E}_{a_t \sim \pi_\theta(\cdot \mid h_t)}\!\left[
+D_{\mathrm{KL}}\left(\pi_\theta(\cdot \mid h_t) \| \pi_T(\cdot \mid h_t)\right)
+= \mathbb{E}_{a_t \sim \pi_\theta(\cdot \mid h_t)}\left[
 \log \pi_\theta(a_t \mid h_t) - \log \pi_T(a_t \mid h_t)
 \right].
 $$


### PR DESCRIPTION
## Summary

- correct the reverse-KL direction to `D_KL(student || teacher)` and make the student-sampled expectation explicit, following the Thinking Machines Lab definition
- distinguish the full token-distribution KL from slime’s per-sampled-token Monte Carlo contribution and show how it modifies the base advantage
- clarify pure-distillation behavior and the tokenizer/vocabulary compatibility requirement for an external SGLang teacher
- keep the English and Chinese guides aligned

## Validation

- `bash docs/build.sh en` (succeeded; only pre-existing warnings elsewhere in the docs)
- `bash docs/build.sh zh` (succeeded; only pre-existing warnings elsewhere in the docs)
- `uvx pre-commit run --files docs/en/advanced/on-policy-distillation.md docs/zh/advanced/on-policy-distillation.md`