### PR TITLE
[docker] support cuda 13

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,8 +5,14 @@ FROM slimerl/sglang:${SGLANG_IMAGE_TAG} AS sglang
 
 ARG PATCH_VERSION=latest
 ARG MEGATRON_COMMIT=1dcf0dafa884ad52ffb243625717a3471643e087
+ARG DEEPGEMM_COMMIT=b38a77cd193cf38f670caae192310521d24343be
+ARG DEEPEP_COMMIT=6845ffd9d59126ec0030c13e0e155935a61e5b5a
+ARG DEEPEP_CUDA_ARCH_LIST=
+ARG FLASH_QLA_COMMIT=821fd9d37ede18fdc2a4e707fefe3770bfc32e58
+ARG TRANSFORMER_ENGINE_COMMIT=c9877beb87ad7e711e1869dd0b5062167ede447a
+ARG TRANSFORMER_ENGINE_CUDA_ARCHS=100a;103a
+ARG TMS_COMMIT=8d30c59ca12a68d9deccbc9c6599076a1218cbc5
 
-ARG ENABLE_CUDA_13=0
 ARG TMS_CUDA_MAJOR=
 
 # ======================================== Setup =============================================
@@ -20,30 +26,36 @@ RUN apt install -y nvtop rsync dnsutils prometheus
 
 # ====================================== Python dependencies ============================================
 
-# The SGLang base image may include FA4.  The validated TE 2.16 CP stack uses
-# FA2 + FA3, so remove FA4 explicitly to avoid backend selection conflicts.
-RUN pip uninstall -y flash-attn-4 flash_attn_4 || true
-
-# The compilation is slow, thus should be put at top
-RUN MAX_JOBS=64 pip -v install flash-attn==2.8.3 --no-build-isolation
-
-# The compilation is slow, thus should be put at top.  This FA3 commit uses the
-# window_size_left/window_size_right API required by TransformerEngine 2.16 CP.
-RUN git clone https://github.com/Dao-AILab/flash-attention.git && \
-    cd flash-attention/ && git checkout 002cce0a1068f8c07dfccb5a1d232b9a3276947c && git submodule update --init && \
-    cd hopper/ && \
-    FLASH_ATTENTION_FORCE_BUILD=TRUE MAX_JOBS=96 pip -v install . --no-build-isolation && \
-    cd /root/ && rm -rf flash-attention/
+# CUDA 12 training uses FA2/FA3.  On CUDA 13, keep the FA4 package supplied by
+# SGLang instead of replacing its Blackwell inference kernels with FA2.
+RUN if [ "$(python -c 'import torch; print(torch.version.cuda.split(".")[0])')" = "12" ]; then \
+      pip uninstall -y flash-attn-4 flash_attn_4 || true; \
+      MAX_JOBS=64 pip -v install flash-attn==2.8.3 --no-build-isolation; \
+      git clone https://github.com/Dao-AILab/flash-attention.git && \
+      cd flash-attention/ && git checkout 002cce0a1068f8c07dfccb5a1d232b9a3276947c && git submodule update --init && \
+      cd hopper/ && \
+      FLASH_ATTENTION_FORCE_BUILD=TRUE MAX_JOBS=96 pip -v install . --no-build-isolation && \
+      cd /root/ && rm -rf flash-attention/; \
+    fi
 
 RUN pip install flash-linear-attention==0.4.2
-# FlashQLA: optional GDN backend for Qwen3.5/Qwen3-Next (--qwen-gdn-backend flashqla; requires SM90+)
-RUN pip install git+https://github.com/QwenLM/FlashQLA.git --no-build-isolation
-RUN pip install tilelang -f https://tile-ai.github.io/whl/nightly/cu128/
+# FlashQLA currently requires TileLang 0.1.9, while SGLang 0.5.15.post1 on
+# CUDA 13 requires 0.1.11.  Keep the existing CUDA 12 installation and use
+# the default FLA backend on CUDA 13 instead of downgrading SGLang's runtime.
+RUN if [ "$(python -c 'import torch; print(torch.version.cuda.split(".")[0])')" = "12" ]; then \
+      pip install \
+        git+https://github.com/QwenLM/FlashQLA.git@${FLASH_QLA_COMMIT} \
+        --no-build-isolation; \
+      pip install tilelang -f https://tile-ai.github.io/whl/nightly/cu128/; \
+    fi
 
-# TE does not have wheel on cuda 13 yet, thus need to install from source
-RUN if [ "${ENABLE_CUDA_13}" = "1" ]; then \
-      pip install nvidia-mathdx==26.6.0 && \
-      pip -v install --no-build-isolation git+https://github.com/NVIDIA/TransformerEngine.git@release_v2.16; \
+# The cu13 TE wheel is built against a newer cuBLAS than SGLang's CUDA 13.0
+# toolkit.  Build TE against the base image's libraries on CUDA 13; retain the
+# validated wheel path for CUDA 12.
+RUN if [ "$(python -c 'import torch; print(torch.version.cuda.split(".")[0])')" = "13" ]; then \
+      NVTE_CUDA_ARCHS="${TRANSFORMER_ENGINE_CUDA_ARCHS}" MAX_JOBS=64 \
+        pip -v install --no-build-isolation \
+        git+https://github.com/NVIDIA/TransformerEngine.git@${TRANSFORMER_ENGINE_COMMIT}; \
     else \
       pip -v install --no-build-isolation "transformer_engine[pytorch]==2.16.1"; \
     fi
@@ -57,25 +69,40 @@ RUN git clone https://github.com/NVIDIA/Megatron-LM.git --recursive && \
     cd Megatron-LM && git checkout ${MEGATRON_COMMIT} && \
     pip install -e .
 
+# zhuzilin fork builds, grouped together right after Megatron-LM:
+# torch_memory_saver, plus the GLM-5 train/rollout alignment kernels
+# (DeepGEMM batch-invariant selection and the DeepEP low-latency fork).
 RUN TMS_CUDA_MAJOR="${TMS_CUDA_MAJOR:-$(python -c 'import torch; print(torch.version.cuda.split(".")[0])')}" && \
     export TMS_CUDA_MAJOR && \
-    pip install git+https://github.com/zhuzilin/torch_memory_saver.git --no-cache-dir --force-reinstall
-RUN pip install nvidia-modelopt[torch]>=0.37.0 --no-build-isolation
+    pip install git+https://github.com/zhuzilin/torch_memory_saver.git@${TMS_COMMIT} --no-cache-dir --force-reinstall
 
-# This patch from masahi will be included in later Triton releases
-RUN if [ "$ENABLE_CUDA_13" = "1" ]; then \
-    (cd /root && git clone -b feat/v350_plus_8045 https://github.com/fzyzcjy/triton.git && cd triton && pip install -r python/requirements.txt && pip install --verbose -e .); \
-  fi
+# DeepGEMM's batch-invariant kernel selection; build the SGLang-compatible wheel.
+RUN git clone https://github.com/zhuzilin/DeepGEMM.git --recursive && \
+    cd DeepGEMM && git checkout ${DEEPGEMM_COMMIT} && \
+    git submodule update --init --recursive && \
+    bash build_sgl_deep_gemm.sh && \
+    pip install --force-reinstall --no-deps dist/sgl_deep_gemm-*.whl && \
+    cd /root/ && rm -rf DeepGEMM
+
+# DeepEP low-latency alignment fork.  CUDA 13 relocated the CCCL/libcu++ headers
+# (<cuda/std/*>) under include/cccl, which nvshmem_tensor.h includes, so add that
+# directory to the compile search path (nvcc + host compiler) when it exists.
+RUN git clone https://github.com/zhuzilin/DeepEP.git /root/DeepEP && \
+    cd /root/DeepEP && git checkout ${DEEPEP_COMMIT} && \
+    CUDA_ARCHS="${DEEPEP_CUDA_ARCH_LIST:-9.0}" && \
+    if [ -d /usr/local/cuda/include/cccl ]; then \
+      export CPATH="/usr/local/cuda/include/cccl${CPATH:+:$CPATH}"; \
+      export NVCC_PREPEND_FLAGS="-I/usr/local/cuda/include/cccl ${NVCC_PREPEND_FLAGS:-}"; \
+    fi && \
+    TORCH_CUDA_ARCH_LIST="${CUDA_ARCHS}" MAX_JOBS=64 python setup.py bdist_wheel && \
+    pip install --force-reinstall --no-deps dist/deep_ep-*.whl && \
+    cd /root/ && rm -rf DeepEP
+
+RUN pip install "nvidia-modelopt[torch]>=0.37.0" --no-build-isolation
 
 COPY requirements.txt /tmp/requirements.txt
 RUN pip install --ignore-installed PyJWT && \
     pip install -r /tmp/requirements.txt
-
-# Temporarily install another sgl-kernel version for GB300 without rebuilding the whole image
-RUN if [ "$ENABLE_CUDA_13" = "1" ]; then \
-    SGL_KERNEL_VERSION=0.3.17.post2 && \
-    python3 -m pip install https://github.com/sgl-project/whl/releases/download/v${SGL_KERNEL_VERSION}/sgl_kernel-${SGL_KERNEL_VERSION}+cu130-cp310-abi3-manylinux2014_$(uname -m).whl --force-reinstall --no-deps; \
-  fi
 
 # Megatron currently requires NumPy 1.x, while SciPy 1.18+ requires NumPy 2.x.
 # Pin both packages together so downgrading NumPy does not leave an incompatible SciPy.

--- a/docker/README.md
+++ b/docker/README.md
@@ -17,11 +17,44 @@ history versions:
 - sglang v0.5.5.post1 (303cc957e62384044dfa8e52d7d8af8abe12f0ac), megatron v0.14.0 (23e00ed0963c35382dfe8a5a94fb3cda4d21e133)
 - sglang v0.5.0rc0-cu126 (8ecf6b9d2480c3f600826c7d8fef6a16ed603c3f), megatron 48406695c4efcf1026a7ed70bb390793918dd97b
 
-The command to build:
+The commands to build and publish:
 
 ```bash
-just release
+just release-primary   # CUDA 12 (cu129 base): publishes `latest`, `latest-cu129`, `<version>-cu129`
+just release-cu13      # CUDA 13 (cu130 base, Blackwell): publishes `latest-cu130`, `<version>-cu130`
 ```
+
+`slimerl/slime:latest` tracks the CUDA 12 build. The tag suffixes (`-cu129` /
+`-cu130`) match the SGLang base image. `docker/Dockerfile` branches on the base
+image's CUDA version; it defaults to the cu130 SGLang base, and the cu129 base
+is selected via build args (see `docker/justfile`).
+
+To build a single image directly without publishing:
+
+```bash
+# CUDA 13 (Blackwell)
+docker build -f docker/Dockerfile . \
+  --build-arg DEEPEP_CUDA_ARCH_LIST='10.0 10.3' \
+  -t slimerl/slime:cu130
+
+# CUDA 12
+docker build -f docker/Dockerfile . \
+  --build-arg SGLANG_IMAGE_REPOSITORY=slimerl/sglang \
+  --build-arg SGLANG_IMAGE_TAG=v0.5.15.post1-cu129 \
+  -t slimerl/slime:cu129
+```
+
+The following components are pinned and rebuilt in the image:
+
+- Megatron-LM `1dcf0dafa884ad52ffb243625717a3471643e087`, plus
+  `docker/patch/<version>/megatron.patch`.
+- DeepGEMM `b38a77cd193cf38f670caae192310521d24343be` from the
+  `zhuzilin/DeepGEMM` batch-invariant branch, rebuilt as an SGLang-compatible wheel.
+- DeepEP `6845ffd9d59126ec0030c13e0e155935a61e5b5a` from the
+  `zhuzilin/DeepEP` `align_fp8_quantization` branch (GLM-5 low-latency alignment).
+
+For a non-default GPU architecture list, pass
+`--build-arg DEEPEP_CUDA_ARCH_LIST='<torch arch list>'`.
 
 Before each update, we will test the following models with 64xH100:
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -32,16 +32,16 @@ is selected via build args (see `docker/justfile`).
 To build a single image directly without publishing:
 
 ```bash
+# CUDA 12
+docker build -f docker/Dockerfile . \
+  --build-arg SGLANG_IMAGE_TAG=v0.5.15.post1-cu129 \
+  -t slimerl/slime:latest-cu129
+
 # CUDA 13 (Blackwell)
 docker build -f docker/Dockerfile . \
   --build-arg DEEPEP_CUDA_ARCH_LIST='10.0 10.3' \
-  -t slimerl/slime:cu130
-
-# CUDA 12
-docker build -f docker/Dockerfile . \
-  --build-arg SGLANG_IMAGE_REPOSITORY=slimerl/sglang \
-  --build-arg SGLANG_IMAGE_TAG=v0.5.15.post1-cu129 \
-  -t slimerl/slime:cu129
+  --build-arg SGLANG_IMAGE_TAG=v0.5.15.post1-cu130 \
+  -t slimerl/slime:latest-cu130
 ```
 
 The following components are pinned and rebuilt in the image:
@@ -56,10 +56,3 @@ The following components are pinned and rebuilt in the image:
 For a non-default GPU architecture list, pass
 `--build-arg DEEPEP_CUDA_ARCH_LIST='<torch arch list>'`.
 
-Before each update, we will test the following models with 64xH100:
-
-- Qwen3-4B sync
-- Qwen3-4B async
-- Qwen3-30B-A3B sync
-- Qwen3-30B-A3B fp8 sync
-- GLM-4.5-355B-A32B sync

--- a/docker/justfile
+++ b/docker/justfile
@@ -2,11 +2,7 @@
 # unqualified `latest`, plus the rolling `latest-cu129` and the versioned
 # `<version>-cu129` tags. The tag suffix matches the SGLang base image.
 release-primary:
-    ARG_TAG_POSTFIX="-cu129" ARG_TAG_LATEST=1 ARG_BUILD_EXTRA_ARGS='--build-arg SGLANG_IMAGE_REPOSITORY=slimerl/sglang --build-arg SGLANG_IMAGE_TAG=v0.5.15.post1-cu129' just _release-raw
-
-# Should be executed on ARM machines
-release-cu129-arm64:
-    ARG_TAG_POSTFIX="-cu129-arm64" ARG_BUILD_EXTRA_ARGS='--build-arg SGLANG_IMAGE_REPOSITORY=slimerl/sglang --build-arg SGLANG_IMAGE_TAG=v0.5.5.post3-cu129-arm64 --build-arg ENABLE_SGLANG_PATCH=0' just _release-raw
+    ARG_TAG_POSTFIX="-cu129" ARG_TAG_LATEST=1 ARG_BUILD_EXTRA_ARGS='--build-arg SGLANG_IMAGE_TAG=v0.5.15.post1-cu129' just _release-raw
 
 # B200/B300 (Blackwell, x86) CUDA 13 build on the cu130 SGLang base. Publishes
 # `latest-cu130` and `<version>-cu130` (tag suffix matches the SGLang base
@@ -15,7 +11,7 @@ release-cu129-arm64:
 # spaces by PyTorch's TORCH_CUDA_ARCH_LIST parser and survives the unquoted
 # ARG_BUILD_EXTRA_ARGS expansion as one token.
 release-cu13:
-    ARG_TAG_POSTFIX="-cu130" ARG_BUILD_EXTRA_ARGS="--build-arg DEEPEP_CUDA_ARCH_LIST=10.0;10.3" just _release-raw
+    ARG_TAG_POSTFIX="-cu130" ARG_BUILD_EXTRA_ARGS="--build-arg DEEPEP_CUDA_ARCH_LIST=10.0;10.3 --build-arg SGLANG_IMAGE_TAG=v0.5.15.post1-cu130" just _release-raw
 
 _release-raw:
     #!/bin/bash

--- a/docker/justfile
+++ b/docker/justfile
@@ -1,13 +1,21 @@
+# Primary release stays on CUDA 12 (the cu129 SGLang base). Publishes the
+# unqualified `latest`, plus the rolling `latest-cu129` and the versioned
+# `<version>-cu129` tags. The tag suffix matches the SGLang base image.
 release-primary:
-    ARG_TAG_POSTFIX="" ARG_BUILD_EXTRA_ARGS="" just _release-raw
+    ARG_TAG_POSTFIX="-cu129" ARG_TAG_LATEST=1 ARG_BUILD_EXTRA_ARGS='--build-arg SGLANG_IMAGE_REPOSITORY=slimerl/sglang --build-arg SGLANG_IMAGE_TAG=v0.5.15.post1-cu129' just _release-raw
 
 # Should be executed on ARM machines
 release-cu129-arm64:
-    ARG_TAG_POSTFIX="-cu129-arm64" ARG_BUILD_EXTRA_ARGS='--build-arg SGLANG_IMAGE_TAG=v0.5.5.post3-cu129-arm64 --build-arg ENABLE_SGLANG_PATCH=0' just _release-raw
+    ARG_TAG_POSTFIX="-cu129-arm64" ARG_BUILD_EXTRA_ARGS='--build-arg SGLANG_IMAGE_REPOSITORY=slimerl/sglang --build-arg SGLANG_IMAGE_TAG=v0.5.5.post3-cu129-arm64 --build-arg ENABLE_SGLANG_PATCH=0' just _release-raw
 
-# Should be executed on ARM machines
-release-cu13-arm64:
-    ARG_TAG_POSTFIX="-cu13-arm64" ARG_BUILD_EXTRA_ARGS='--build-arg SGLANG_IMAGE_TAG=dev-arm64-cu13-20251122 --build-arg ENABLE_CUDA_13=1 --build-arg ENABLE_SGLANG_PATCH=0' just _release-raw
+# B200/B300 (Blackwell, x86) CUDA 13 build on the cu130 SGLang base. Publishes
+# `latest-cu130` and `<version>-cu130` (tag suffix matches the SGLang base
+# image). DeepEP must be compiled for the Blackwell arch list; the Dockerfile
+# default (9.0) targets Hopper only. The semicolon separator is normalized to
+# spaces by PyTorch's TORCH_CUDA_ARCH_LIST parser and survives the unquoted
+# ARG_BUILD_EXTRA_ARGS expansion as one token.
+release-cu13:
+    ARG_TAG_POSTFIX="-cu130" ARG_BUILD_EXTRA_ARGS="--build-arg DEEPEP_CUDA_ARCH_LIST=10.0;10.3" just _release-raw
 
 _release-raw:
     #!/bin/bash
@@ -20,7 +28,14 @@ _release-raw:
     docker build -f docker/Dockerfile . --build-arg HTTP_PROXY="$http_proxy" --build-arg HTTPS_PROXY="$https_proxy" --build-arg NO_PROXY="localhost,127.0.0.1" $ARG_BUILD_EXTRA_ARGS -t slimerl/slime:$IMAGE_TAG
     docker push slimerl/slime:$IMAGE_TAG
 
-    if [ -z "${ARG_TAG_POSTFIX}" ]; then
+    # Rolling per-variant latest tag (e.g. latest-cu129, latest-cu130).
+    if [ -n "${ARG_TAG_POSTFIX}" ]; then
+        docker tag slimerl/slime:$IMAGE_TAG slimerl/slime:latest${ARG_TAG_POSTFIX}
+        docker push slimerl/slime:latest${ARG_TAG_POSTFIX}
+    fi
+
+    # The primary build also owns the unqualified `latest`.
+    if [ "${ARG_TAG_LATEST:-}" = "1" ]; then
         docker tag slimerl/slime:$IMAGE_TAG slimerl/slime:latest
         docker push slimerl/slime:latest
     fi

--- a/docker/version.txt
+++ b/docker/version.txt
@@ -1,1 +1,1 @@
-nightly-dev-20260804a
+nightly-dev-20260807a


### PR DESCRIPTION
Add a CUDA-13 (Blackwell) build path on the cu130 SGLang base:

- Dockerfile: branch on the base CUDA version; on CUDA 13 build TransformerEngine from source, keep FA4, pin numpy/scipy, and build the zhuzilin forks (torch_memory_saver, DeepGEMM, DeepEP) grouped after Megatron-LM. Add the CCCL include path so DeepEP finds CUDA 13's relocated <cuda/std/*> headers.

- justfile: release-primary builds CUDA 12 and owns `latest`/`latest-cu129`; add release-cu13 (cu130, Blackwell DeepEP arch) publishing `latest-cu130`.