### PR TITLE
Fix: skip KL backward graph when coefficient is zero

### DIFF
--- a/slime/backends/megatron_utils/loss.py
+++ b/slime/backends/megatron_utils/loss.py
@@ -1053,18 +1053,28 @@ def policy_loss_function(
     if args.use_kl_loss:
         ref_log_probs = batch["ref_log_probs"]
         ref_log_probs = torch.cat(ref_log_probs, dim=0)
+        kl_loss_coef = float(args.kl_loss_coef)
+        with_kl_grad = kl_loss_coef != 0.0
+
+        # Keep reference KL metrics when the coefficient is zero, but detach
+        # their inputs so the metric-only path does not retain an actor
+        # backward graph or contaminate policy gradients with non-finite KL.
+        kl_log_probs = log_probs if with_kl_grad else log_probs.detach()
+        kl_old_log_probs = old_log_probs if with_kl_grad else old_log_probs.detach()
+        kl_ref_log_probs = ref_log_probs if with_kl_grad else ref_log_probs.detach()
         importance_ratio = None
         if args.use_unbiased_kl:
-            importance_ratio = torch.exp(log_probs - old_log_probs)
+            importance_ratio = torch.exp(kl_log_probs - kl_old_log_probs)
         kl = compute_approx_kl(
-            log_probs,
-            ref_log_probs,
+            kl_log_probs,
+            kl_ref_log_probs,
             kl_loss_type=args.kl_loss_type,
             importance_ratio=importance_ratio,
         )
         kl_loss = sum_of_sample_mean(kl)
 
-        loss = loss + args.kl_loss_coef * kl_loss
+        if with_kl_grad:
+            loss = loss + kl_loss_coef * kl_loss
 
     # make sure the gradient could backprop correctly.
     if log_probs.numel() == 0:


### PR DESCRIPTION
## Summary

When `--use-kl-loss` is enabled with `kl_loss_coef == 0`, slime still
constructs the reference KL autograd graph and adds the following term to the
actor loss:

```python
loss = loss + args.kl_loss_coef * kl_loss
```

This is not only unnecessary computation: it can turn an otherwise valid
policy loss and its gradients into NaN. Multiplying by a zero coefficient does
not make a non-finite KL value harmless, because `0 * NaN` is still `NaN`.

This PR keeps KL metric reporting for observability while preventing the
zero-weight KL path from participating in actor backward or contaminating the
training loss.

## Motivation

Users may want to keep reference KL metrics for observability without using
KL as a training objective.

The current implementation couples metric reporting with optimization. Even
when the coefficient is zero, it retains the KL computation graph and inserts
the zero-weight term into the total loss. If the KL calculation produces a
non-finite value under extreme log-probability differences, this can propagate
NaNs through actor backward and interrupt training despite KL regularization
being disabled.

It is therefore important to make zero mean *metric-only*, rather than
"compute the gradient and multiply it by zero."

## Changes

When `kl_loss_coef == 0`:

- Detach the current, old, and reference log-probabilities used by the KL
  metric path.
- Compute and report `kl_loss` as before.
- Do not add the zero-weight KL term to the actor loss.
- Apply the same behavior to the unbiased-KL importance-ratio path.

This prevents a non-finite metric-only KL value from poisoning the actor loss
or policy gradients.

When `kl_loss_coef != 0`, the existing differentiable behavior is preserved.

## Behavior

| Configuration | Result |
| --- | --- |
| `use_kl_loss=False` | Unchanged |
| `use_kl_loss=True`, `kl_loss_coef=0` | KL is metric-only |
| `use_kl_loss=True`, `kl_loss_coef!=0` | KL contributes to actor gradients |
| `use_unbiased_kl=True`, `kl_loss_coef=0` | Importance ratio is also computed without gradients |

Reference-model execution and `kl_loss` reporting remain enabled.

## Validation

A focused local regression test verified that:

- KL is still reported when the coefficient is zero.
- Tensors passed through the metric-only KL path do not require gradients.
- Policy backward remains functional.
- Policy gradients are not affected by the zero-weight KL term.

Additional checks passed:

```text
git diff --check
python -m py_compile slime/backends/megatron_utils/loss.py
```

## Example

```bash
--use-kl-loss
--kl-loss-coef 0.0
--kl-loss-type low_var_kl
```
