### PR TITLE
fix(rollout): restore partial continuation token budget

### DIFF
--- a/slime/rollout/sglang_rollout.py
+++ b/slime/rollout/sglang_rollout.py
@@ -163,6 +163,8 @@ async def generate(args: Namespace, sample: Sample, sampling_params: dict[str, A
 
     prompt_ids = _prepare_prompt_ids(sample, state.tokenizer, state.processor)
 
+    sampling_params["max_new_tokens"] -= sample.response_length
+
     assert (
         sampling_params["max_new_tokens"] >= 0
     ), f"max_new_tokens: {sampling_params['max_new_tokens']} should not be less than 0"

--- a/slime/rollout/sglang_streaming_rollout.py
+++ b/slime/rollout/sglang_streaming_rollout.py
@@ -59,6 +59,8 @@ async def generate_streaming(args: Namespace, sample: Sample, sampling_params: d
 
     prompt_ids = _prepare_prompt_ids(sample, state.tokenizer, state.processor)
 
+    sampling_params["max_new_tokens"] -= sample.response_length
+
     assert (
         sampling_params["max_new_tokens"] >= 0
     ), f"max_new_tokens: {sampling_params['max_new_tokens']} should not be less than 0"


### PR DESCRIPTION
Fixes #2260

## Problem

Partial rollout resumes an aborted sample with its accumulated `sample.tokens`. The SGLang rollout paths currently reuse the full configured `max_new_tokens`, even though `sample.response_length` tokens have already consumed part of that response budget. This regression was introduced in `1eed2493`, when prompt preparation was extracted into `_prepare_prompt_ids()` and the existing subtraction was dropped.

The continuation can consequently request more tokens than its configured total response budget and produce `len(prompt_ids) + max_new_tokens > rollout_max_context_len`. SGLang rejects such requests with HTTP 400, and the generic HTTP retry path repeatedly retries the deterministic error.

## Design

Restore the original response-budget behavior immediately after preparing the resumed prompt:

```python
sampling_params["max_new_tokens"] -= sample.response_length
```

`sample.response_length` is the current representation of the generated response-token count, so this is equivalent to the pre-`1eed2493` calculation without reintroducing the old prompt-length bookkeeping. The same one-line adjustment is applied to the regular and streaming entry points because they prepare and submit requests independently.

## Resulting behavior

Initial requests remain unchanged because `sample.response_length` is zero. A partial continuation requests only the unused portion of the configured response budget. If the budget is exhausted, the existing zero-budget path marks the sample truncated without sending a request; the existing assertion continues to expose invalid negative budgets.

## Scope

Included:

- Restore the response-budget subtraction in regular SGLang rollout.
- Restore the same subtraction in streaming SGLang rollout.

Not included:

- Changes to the HTTP retry policy for non-retryable 4xx responses.
- Additional context-length capping beyond the historical response-budget behavior.
- Oversampling, partial-buffer scheduling, placement, concurrency, or training configuration changes.

## Files

- `slime/rollout/sglang_rollout.py`: Adjusts the regular continuation budget.
- `slime/rollout/sglang_streaming_rollout.py`: Adjusts the streaming continuation budget.

## API and configuration

There are no public API, configuration, state-schema, storage, permission, deployment, or migration changes.

## Validation

Passed locally:

```text
python -m py_compile slime/rollout/sglang_rollout.py slime/rollout/sglang_streaming_rollout.py

uvx ruff check slime/rollout/sglang_rollout.py slime/rollout/sglang_streaming_rollout.py
All checks passed!

uvx black --check slime/rollout/sglang_rollout.py slime/rollout/sglang_streaming_rollout.py
2 files would be left unchanged.

git diff --check
```

A full GPU integration run against this branch has not yet been completed.

## Compatibility and rollback

The change restores the previous partial-rollout semantics and affects only samples with an existing response. Rollback consists of reverting this commit.
