### PR TITLE
fix: preserve consecutive tool responses in Qwen3 SFT tokenization

### DIFF
--- a/slime/utils/mask_utils.py
+++ b/slime/utils/mask_utils.py
@@ -91,10 +91,22 @@ class MultiTurnLossMaskGenerator:
         prefix_message = {"role": "user", "content": "FOR CALCULATING LOSS MASK ONLY"}
         prefix_token_ids = self.tokenizer.apply_chat_template([prefix_message], tokenize=True, return_dict=False)
 
-        for i, message in enumerate(messages):
+        i = 0
+        while i < len(messages):
+            message = messages[i]
+            if message["role"] == "tool":
+                # Qwen templates wrap consecutive tool responses in a single user turn.
+                group_end = i + 1
+                while group_end < len(messages) and messages[group_end]["role"] == "tool":
+                    group_end += 1
+                message_group = messages[i:group_end]
+            else:
+                group_end = i + 1
+                message_group = [message]
+
             if i == 0:
                 tailed_message_ids = self.tokenizer.apply_chat_template(
-                    [message, prefix_message],
+                    message_group + [prefix_message],
                     tokenize=True,
                     tools=tools,
                     return_dict=False,
@@ -102,7 +114,7 @@ class MultiTurnLossMaskGenerator:
                 message_ids = tailed_message_ids[: -len(prefix_token_ids)]
             else:
                 prefixed_message_ids = self.tokenizer.apply_chat_template(
-                    [prefix_message, message],
+                    [prefix_message] + message_group,
                     tokenize=True,
                     return_dict=False,
                 )
@@ -121,6 +133,7 @@ class MultiTurnLossMaskGenerator:
 
             all_loss_masks.extend(loss_mask)
             all_token_ids.extend(message_ids)
+            i = group_end
 
         return all_token_ids, all_loss_masks
 

--- a/tests/utils/test_loss_mask_type_qwen35.py
+++ b/tests/utils/test_loss_mask_type_qwen35.py
@@ -234,3 +234,30 @@ def test_qwen3_5_matches_expected_mask_for_tool_call_flow():
         "\n</think>\n\nTOOL_CALL\n\n<tool_call>\n<function=terminal>\n<parameter=command>\nls\n</parameter>\n</function>\n</tool_call><|im_end|>\n",
         "REASONING\n</think>\n\nFINAL<|im_end|>\n",
     ]
+
+
+def test_qwen3_matches_full_template_for_consecutive_tool_responses():
+    tokenizer = FakeQwen35Tokenizer()
+    messages = [
+        {"role": "system", "content": "SYSTEM"},
+        {"role": "user", "content": "USER"},
+        {
+            "role": "assistant",
+            "content": "CALL",
+            "tool_calls": [
+                {"function": {"name": "terminal", "arguments": {"command": "cat a.py"}}},
+                {"function": {"name": "terminal", "arguments": {"command": "cat b.py"}}},
+            ],
+        },
+        {"role": "tool", "content": "CONTENTS_A"},
+        {"role": "tool", "content": "CONTENTS_B"},
+    ]
+
+    expected_text, expected_loss_mask = tokenizer.render_with_expected_mask(messages)
+    expected_token_ids = tokenizer(expected_text, add_special_tokens=False)["input_ids"]
+    generator = MultiTurnLossMaskGenerator(tokenizer, tokenizer_type="qwen3")
+
+    token_ids, loss_mask = generator.get_loss_mask(messages)
+
+    assert token_ids == expected_token_ids
+    assert loss_mask == expected_loss_mask


### PR DESCRIPTION
## Summary

- render consecutive `tool` messages as one group in the Qwen3 SFT loss-mask generator
- preserve the existing per-message prefix/thinking behavior for all non-tool messages
- add a regression test that compares both token IDs and loss masks with the full chat-template rendering

## Problem

Qwen chat templates place consecutive tool responses from parallel tool calls in a single user turn. The Qwen3 loss-mask generator rendered each tool message independently, inserting an extra `<|im_end|><|im_start|>user` boundary between responses. Because the generated token IDs are assigned directly to `sample.tokens`, this changed the SFT input and made it inconsistent with normal full-history rendering at inference time.

Fixes #2263.

## Scope and compatibility

This change preserves the existing per-turn rendering and loss-mask generation design of `gen_multi_turn_loss_mask_qwen3()`. It does not switch the implementation to full-conversation rendering, nor does it change the existing handling of assistant messages, thinking content, or `step_loss_mask`.

The only exception is a consecutive sequence of `tool` messages. The Qwen chat template needs to see the complete sequence in one invocation in order to render multiple `<tool_response>` blocks within the same user turn. The updated implementation therefore collects each consecutive tool-response sequence and passes it to `apply_chat_template()` as one group. All other message types continue to be rendered individually as before.

The behavioral change is limited to the tokenization boundary of consecutive tool responses:

- a single tool response is unchanged
- non-consecutive tool responses are not grouped
- assistant loss-mask generation is unchanged
- tool-response tokens remain fully masked
- the `qwen` and `qwen3_5` paths are unaffected

Implementation-wise, the existing per-message `for` loop is replaced with a group-aware `while` loop. No new public interface, configuration, or state is introduced. Each message is still scanned once, so the overall time complexity remains O(n).

## Validation

- `pytest tests/utils/test_loss_mask_type_qwen35.py tests/utils/test_mask_utils.py -q` — 6 passed
- `ruff check slime/utils/mask_utils.py tests/utils/test_loss_mask_type_qwen35.py` — passed
- target Qwen3 tokenizer check on 200 real multi-turn tool trajectories:
  - before: 123/200 matched full `apply_chat_template()` token IDs
  - after: 200/200 matched, including all 77 trajectories with consecutive tool messages