### PR TITLE
Fix model convert when use latest megatron

### DIFF
--- a/slime/backends/megatron_utils/arguments.py
+++ b/slime/backends/megatron_utils/arguments.py
@@ -3,8 +3,12 @@ import logging
 
 from megatron.training.arguments import parse_args as _megatron_parse_args
 from megatron.training.arguments import validate_args as _megatron_validate_args
-from megatron.training.tokenizer.tokenizer import _vocab_size_with_padding
 from transformers import AutoConfig
+
+try:
+    from megatron.core.tokenizers.utils.build_tokenizer import vocab_size_with_padding as _vocab_size_with_padding
+except ImportError:
+    from megatron.training.tokenizer.tokenizer import _vocab_size_with_padding
 
 __all__ = ["validate_args", "megatron_parse_args", "set_default_megatron_args"]
 
@@ -147,6 +151,8 @@ def _hf_validate_args(args, hf_config):
 def _set_default_megatron_args(args):
     # always use zero optimizer
     args.use_distributed_optimizer = True
+    if not hasattr(args, "enable_gloo_process_groups"):
+        args.enable_gloo_process_groups = True
     # TODO: maybe change this after megatron has good fp8 support
     args.bf16 = not args.fp16
     # Checkpoint I/O defaults: these keep checkpoint contents unchanged while

--- a/slime_plugins/models/glm5/glm5.py
+++ b/slime_plugins/models/glm5/glm5.py
@@ -566,6 +566,7 @@ class DSAMLASelfAttention(DSAMultiLatentAttention):
         cp_comm_type: str | None = None,
         model_comm_pgs=None,
         pg_collection=None,
+        name: str | None = None,
     ):
         super().__init__(
             config=config,

--- a/slime_plugins/models/qwen3_5.py
+++ b/slime_plugins/models/qwen3_5.py
@@ -159,6 +159,7 @@ class Attention(HuggingfaceAttention):
         layer_number: int,
         cp_comm_type: str = "p2p",
         pg_collection=None,
+        name: str | None = None,
     ):
         super().__init__(
             args,

--- a/slime_plugins/models/qwen3_next.py
+++ b/slime_plugins/models/qwen3_next.py
@@ -181,6 +181,7 @@ class Attention(HuggingfaceAttention):
         layer_number: int,
         cp_comm_type: str = "p2p",
         pg_collection=None,
+        name: str | None = None,
     ):
         super().__init__(
             args,

--- a/tools/convert_hf_to_torch_dist.py
+++ b/tools/convert_hf_to_torch_dist.py
@@ -27,6 +27,7 @@ def add_convertion_args(parser):
         help="Path to a custom model provider function.",
     )
     parser.add_argument("--allgather-cp", action="store_true", default=False)
+    parser.add_argument("--use-gated-attention", action="store_true", default=False)
     try:
         parser.add_argument("--padded-vocab-size", type=int, default=None)
     except Exception:


### PR DESCRIPTION

- Add `--use-gated-attention` compatibility to the HF-to-`torch_dist` conversion tool while retaining `--attention-output-gate`.
- Default `enable_gloo_process_groups` to `True` when it is unavailable in the Megatron argument namespace.
- Support both old and new Megatron tokenizer utility import paths.
- Allow the custom Qwen3.5 and Qwen3-Next attention modules to accept Megatron’s optional `name` argument.

