### PR TITLE
Fix O(#segments) per-comm memory probe that slows weight sync & training under expandable_segments

### DIFF
--- a/slime/utils/reloadable_process_group.py
+++ b/slime/utils/reloadable_process_group.py
@@ -10,7 +10,7 @@ import torch.distributed as dist
 from torch.distributed.distributed_c10d import PrefixStore, _get_default_group, _get_default_store
 
 from slime.utils.distributed_utils import get_gloo_group, init_gloo_group, set_gloo_group
-from slime.utils.memory_utils import available_memory, clear_memory, print_memory
+from slime.utils.memory_utils import clear_memory, print_memory
 
 logger = logging.getLogger(__name__)
 
@@ -125,15 +125,47 @@ def _reload_default_process_group() -> None:
     )
 
 
+# Communication ops that skip the pre-call memory probe in _wrap_low_level_call.
+#
+# The probe (available_memory() -> cudaMemGetInfo + torch.cuda.memory_reserved())
+# runs before the collective. It is pure overhead on the hot path:
+#  - cudaMemGetInfo synchronizes the driver, which serializes async collectives
+#    (weight sync issues one dist.broadcast(async_op=True) per parameter);
+#  - the clear_memory() it guards only fires when free < 3GB, which never happens
+#    on real runs (weight sync / training have tens of GB free), so it is inert.
+#
+# Weight sync and training each issue one collective *per parameter / per
+# micro-batch*, so the skip set must cover BOTH the dist.* monkey-patch spellings
+# AND the low-level c10d method names dispatched by ReloadableProcessGroup._fwd
+# (e.g. _allgather_base for sequence-parallel TP all-gather, allreduce for grad
+# sync). See PR/issue: this made weight sync grow to >1500s and every training
+# micro-batch ~2x slower on a large MoE + expandable_segments.
 _COMM_MEMORY_CHECK_SKIP_OPS = {
-    "all_gather_into_tensor",
-    "allgather_into_tensor_coalesced",
+    # point-to-point / barrier
     "barrier",
-    "broadcast_object_list",
-    "reduce_scatter_tensor",
-    "all_to_all_single",
     "isend",
     "irecv",
+    # broadcast (dist.* and c10d spellings)
+    "broadcast",
+    "broadcast_object_list",
+    # all-gather family
+    "all_gather",
+    "allgather",
+    "_allgather_base",
+    "all_gather_into_tensor",
+    "allgather_coalesced",
+    "allgather_into_tensor_coalesced",
+    # all-reduce family
+    "all_reduce",
+    "allreduce",
+    "allreduce_coalesced",
+    # reduce / reduce-scatter
+    "reduce",
+    "reduce_scatter",
+    "reduce_scatter_tensor",
+    # all-to-all
+    "all_to_all",
+    "all_to_all_single",
 }
 
 
@@ -223,15 +255,15 @@ def monkey_patch_torch_dist():
     dist.get_group_rank = get_new_query_function(dist.get_group_rank)
     dist.get_process_group_ranks = get_new_query_function(dist.get_process_group_ranks)
 
-    dist.all_reduce = get_new_comm_function(dist.all_reduce)
-    dist.all_gather = get_new_comm_function(dist.all_gather)
+    dist.all_reduce = get_new_comm_function(dist.all_reduce, "all_reduce")
+    dist.all_gather = get_new_comm_function(dist.all_gather, "all_gather")
     dist.all_gather_into_tensor = get_new_comm_function(dist.all_gather_into_tensor, "all_gather_into_tensor")
     dist.all_gather_object = get_new_comm_function(dist.all_gather_object)
-    dist.all_to_all = get_new_comm_function(dist.all_to_all)
+    dist.all_to_all = get_new_comm_function(dist.all_to_all, "all_to_all")
     dist.all_to_all_single = get_new_comm_function(dist.all_to_all_single, "all_to_all_single")
-    dist.broadcast = get_new_comm_function(dist.broadcast)
+    dist.broadcast = get_new_comm_function(dist.broadcast, "broadcast")
     dist.broadcast_object_list = get_new_comm_function(dist.broadcast_object_list, "broadcast_object_list")
-    dist.reduce = get_new_comm_function(dist.reduce)
+    dist.reduce = get_new_comm_function(dist.reduce, "reduce")
     dist.reduce_scatter = get_new_comm_function(dist.reduce_scatter)
     dist.reduce_scatter_tensor = get_new_comm_function(dist.reduce_scatter_tensor, "reduce_scatter_tensor")
     dist.scatter = get_new_comm_function(dist.scatter)
@@ -475,8 +507,14 @@ def reload_process_groups():
 def _wrap_low_level_call(check_memory=True):
     try:
         if check_memory:
-            mem_info = available_memory()
-            if mem_info["free_GB"] < 3:
+            # Use torch.cuda.mem_get_info() directly rather than available_memory():
+            # the latter also calls torch.cuda.memory_reserved()/memory_allocated(),
+            # which build the full memory_stats() dict -- O(number of allocator
+            # segments). Under expandable_segments the segment count grows across
+            # steps, so this probe gets progressively more expensive. The free/clear
+            # decision only needs the driver-level free byte count.
+            free_bytes, _ = torch.cuda.mem_get_info()
+            if free_bytes < 3 * 1024**3:
                 clear_memory()
         yield
     except Exception as e:


### PR DESCRIPTION
Fixes #2268

## Problem

`slime/utils/reloadable_process_group.py::_wrap_low_level_call` runs a memory probe **before every wrapped collective**:

```python
def _wrap_low_level_call(check_memory=True):
    if check_memory:
        mem_info = available_memory()          # calls torch.cuda.memory_reserved()/allocated()
        if mem_info["free_GB"] < 3:
            clear_memory()
    yield
```

`available_memory()` calls `torch.cuda.memory_reserved()`/`memory_allocated()`, which build the full `memory_stats()` dict — **O(number of CUDA caching-allocator segments)**. Under `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True` the segment count grows across steps, so the probe gets progressively more expensive. It also calls `cudaMemGetInfo`, which **synchronizes the driver and serializes async collectives**.

This is on the hot path because weight sync issues one `dist.broadcast(param, async_op=True)` **per parameter** (`update_weights_from_distributed`) plus one `dist.all_gather` per expert bucket, and training issues per-micro-batch TP all-gather (`_allgather_base`) and grad all-reduce (`allreduce`). All of them hit the probe because:

1. they are registered with `get_new_comm_function(fn)` i.e. `op_name=None`, which forces `check_memory=True` (`True if op_name is None else _should_check_memory_for_comm(op_name)`); and
2. the low-level c10d method names (`_allgather_base`, `allreduce`, …) dispatched by `ReloadableProcessGroup._fwd` are not in `_COMM_MEMORY_CHECK_SKIP_OPS`.

Free memory during both phases is tens of GB, so the `clear_memory()` the probe guards **never fires** — the probe is pure overhead here.

## Impact (measured)

Qwen3.5-35B-A3B (MoE + gated-delta-net) async GRPO, 8×B300, `expandable_segments:True`:

| | before | after |
|---|---|---|
| `perf/update_weights_time` | 143 → 363 → 966 → **1596s** (grows every step) | flat **~7–20s** |
| training micro-batch (one ~700-token fwd/bwd, 3B active) | ~14s | ~1.5s |
| step time | ~57 min | ~9 min |

`py-spy` on the training actor showed it pinned in `mem_get_info` / `memory_reserved` via `_wrap_low_level_call`, first on `update_weights` broadcast and (after only fixing broadcast) on `_allgather_base`. The **geometric growth (143→1596s)** is the tell: a constant path cost can't grow like that; it's `memory_stats()` walking an ever-growing segment list under `expandable_segments`.

## Fix

1. `_wrap_low_level_call`: use `torch.cuda.mem_get_info()` directly instead of `available_memory()`, dropping the O(#segments) `memory_stats()` call. The free/clear decision only needs the driver-level free byte count.
2. Register the async collectives (`all_reduce`/`all_gather`/`broadcast`/`reduce`/`all_to_all`) with explicit `op_name`s, and list both the `dist.*` spellings and the c10d method names (`_allgather_base`, `allgather`, `allreduce`, …) in `_COMM_MEMORY_CHECK_SKIP_OPS`, so the hot weight-sync / training collectives skip the probe entirely. The check is retained for any op not listed.

Both changes are safe: none of these collectives allocate significant new memory (they operate on existing tensors), so none benefit from a pre-call `clear_memory()`, and the error-path memory dump in the `except` branch is unchanged.
