### PR TITLE
fix: preserve text-only rows in multimodal datasets

### DIFF
--- a/slime/utils/data.py
+++ b/slime/utils/data.py
@@ -160,6 +160,9 @@ def _build_messages(data: dict, prompt_key: str, as_conversation: bool, multimod
                 if multimodal_data is not None:
                     multimodals[mt.placeholder] = (mt, list(multimodal_data))
 
+        if not multimodals:
+            return prompt
+
         pattern = "(" + "|".join(re.escape(p) for p in multimodals.keys()) + ")"
 
         for message in prompt:

--- a/tests/test_filter_long_prompt.py
+++ b/tests/test_filter_long_prompt.py
@@ -18,9 +18,8 @@ import types
 
 import pytest
 
-from slime.utils.data import filter_long_prompt
+from slime.utils.data import _build_messages, filter_long_prompt
 from slime.utils.types import Sample
-
 
 NUM_GPUS = 0
 
@@ -110,3 +109,30 @@ def test_no_processor_path_still_preserves_order():
     kept = filter_long_prompt(samples, _Tokenizer(), None, max_length=100)
 
     assert [s.prompt for s in kept] == ["p0:5", "p2:5"]
+
+
+@pytest.mark.unit
+def test_text_only_row_keeps_string_content_with_multimodal_config():
+    data = {"prompt": "hello"}
+
+    prompt = _build_messages(data, "prompt", as_conversation=True, multimodal_keys={"image": "images"})
+
+    assert prompt == [{"role": "user", "content": "hello"}]
+
+
+@pytest.mark.unit
+def test_multimodal_placeholder_expansion_is_unchanged():
+    data = {"prompt": "look <image> here", "images": ["image.png"]}
+
+    prompt = _build_messages(data, "prompt", as_conversation=True, multimodal_keys={"image": "images"})
+
+    assert prompt == [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "look "},
+                {"type": "image", "image": "image.png"},
+                {"type": "text", "text": " here"},
+            ],
+        }
+    ]


### PR DESCRIPTION
## Problem

When `multimodal_keys` is configured for a mixed dataset, a text-only row can have no multimodal values. In that case `_build_messages` builds the regular expression `()` from an empty placeholder mapping.

Python treats that as an empty capturing group, so `re.split("()", "hello")` splits the text into individual characters. The row is then passed to the chat template and processor as many one-character text blocks instead of its original string content.

This is separate from #2237, which preserves sample order while filtering mixed text and multimodal rows.

## Change

Return the conversation unchanged when the current row contains no multimodal values. Rows with actual multimodal placeholders continue through the existing expansion path.

Add CPU regressions for both the text-only case and the existing image-placeholder behavior.

## Validation

- `.venv/bin/python -m pytest tests/test_filter_long_prompt.py -q` — 7 passed
- `ruff check slime/utils/data.py tests/test_filter_long_prompt.py` — passed
- `black --check slime/utils/data.py tests/test_filter_long_prompt.py` — passed
- `git diff --check` — passed
