### PR TITLE
feat: track policy versions in fully async rollout

### DIFF
--- a/slime/ray/rollout.py
+++ b/slime/ray/rollout.py
@@ -1,3 +1,4 @@
+import importlib
 import itertools
 import logging
 import time
@@ -77,6 +78,8 @@ class RolloutManager:
             runtime_env={"env_vars": add_default_ray_env_vars()},
         ).remote()
         self.rollout_id = -1
+        self.policy_version = 0
+        self.args.policy_version = self.policy_version
 
         self._health_monitors = []
         if not self.args.debug_train_only and self.args.use_fault_tolerance:
@@ -159,6 +162,37 @@ class RolloutManager:
     def get_num_rollout_per_epoch(self):
         assert self.args.rollout_global_dataset
         return len(self.data_source) // self.args.rollout_batch_size
+
+    def _call_generate_rollout_hook(self, hook_name: str, **kwargs):
+        """Call an optional lifecycle hook defined beside the rollout function."""
+
+        module = importlib.import_module(self.generate_rollout.__module__)
+        hook = getattr(module, hook_name, None)
+        if hook is None:
+            return None
+        return hook(**kwargs)
+
+    def before_weight_update(self) -> int:
+        """Notify the rollout implementation before actor weights are updated."""
+
+        self._call_generate_rollout_hook(
+            "before_weight_update",
+            policy_version=self.policy_version,
+        )
+        return self.policy_version
+
+    def after_weight_update(self, succeeded: bool) -> int:
+        """Publish a new policy version only after all weight updates succeed."""
+
+        if succeeded:
+            self.policy_version += 1
+            self.args.policy_version = self.policy_version
+        self._call_generate_rollout_hook(
+            "after_weight_update",
+            policy_version=self.policy_version,
+            succeeded=succeeded,
+        )
+        return self.policy_version
 
     def generate(self, rollout_id):
         start_time = time.time()

--- a/slime/rollout/fully_async_rollout.py
+++ b/slime/rollout/fully_async_rollout.py
@@ -14,13 +14,12 @@ Concurrency is sourced from ``args.sglang_server_concurrency`` and scaled by
 the number of sglang engines to match the per-sample semaphore cap in
 :mod:`slime.rollout.sglang_rollout`.
 
-The worker is intentionally oblivious to slime's higher-level pause /
-weight-update signalling (e.g. ``GenerateState.aborted``). Each in-flight
-generation short-circuits on those signals on its own and surfaces
-:data:`Sample.Status.ABORTED`; the only piece the worker owns is
-**redirecting ABORTED groups back to ``data_buffer``** instead of shipping
-them to training, so the next rollout (with refreshed weights) can pick
-them up.
+The worker snapshots the current training-side ``policy_version`` when each
+group is admitted and preserves that version on completion, even if a weight
+update finishes while generation is still running. It remains oblivious to
+pause / abort policy: each in-flight generation surfaces
+:data:`Sample.Status.ABORTED` on its own, and the worker redirects those groups
+back to ``data_buffer`` instead of shipping them to training.
 """
 
 from __future__ import annotations
@@ -31,6 +30,7 @@ import logging
 import queue
 import threading
 import time
+from dataclasses import dataclass
 
 from slime.rollout.sglang_rollout import GenerateState, generate_and_rm_group
 from slime.utils.async_utils import run
@@ -39,6 +39,7 @@ from slime.utils.types import Sample
 
 __all__ = [
     "AsyncRolloutWorker",
+    "CompletedSampleRecord",
     "generate_rollout_fully_async",
 ]
 
@@ -48,6 +49,16 @@ logger = logging.getLogger("slime.rollout.fully_async")
 # Global worker, shared across rollout calls so the queue stays warm.
 _global_worker: AsyncRolloutWorker | None = None
 _worker_lock = threading.Lock()
+_published_policy_version = 0
+
+
+@dataclass(frozen=True)
+class CompletedSampleRecord:
+    """A completed group and the immutable policy version captured at admission."""
+
+    gid: int
+    group: list[Sample]
+    policy_version: int
 
 
 def _get_global_worker(args, data_buffer) -> AsyncRolloutWorker:
@@ -56,7 +67,10 @@ def _get_global_worker(args, data_buffer) -> AsyncRolloutWorker:
         if _global_worker is None or not _global_worker.worker_thread.is_alive():
             logger.info("starting fully-async rollout worker")
             _global_worker = AsyncRolloutWorker(
-                args, data_buffer, concurrency=args.sglang_server_concurrency * get_rollout_num_engines(args)
+                args,
+                data_buffer,
+                concurrency=args.sglang_server_concurrency * get_rollout_num_engines(args),
+                policy_version=max(getattr(args, "policy_version", 0), _published_policy_version),
             )
             _global_worker.start()
         return _global_worker
@@ -73,11 +87,35 @@ def _stop_global_worker() -> None:
 atexit.register(_stop_global_worker)
 
 
+def before_weight_update(*, policy_version: int) -> None:
+    """Lifecycle hook called before training publishes a new actor policy."""
+
+    logger.debug("fully-async: preparing to update policy version %d", policy_version)
+
+
+def after_weight_update(*, policy_version: int, succeeded: bool) -> None:
+    """Publish ``policy_version`` after a successful actor weight update."""
+
+    if not succeeded:
+        logger.warning("fully-async: weight update failed; policy remains unpublished")
+        return
+
+    global _published_policy_version
+    with _worker_lock:
+        if policy_version < _published_policy_version:
+            raise ValueError(
+                f"policy version must be monotonic: current={_published_policy_version}, new={policy_version}"
+            )
+        _published_policy_version = policy_version
+        if _global_worker is not None:
+            _global_worker.publish_policy_version(policy_version)
+
+
 class AsyncRolloutWorker:
     """Background thread + asyncio loop that continuously consumes groups
     from ``data_buffer`` and runs :func:`generate_and_rm_group` on each."""
 
-    def __init__(self, args, data_buffer, concurrency: int = 10):
+    def __init__(self, args, data_buffer, concurrency: int = 10, policy_version: int = 0):
         self.args = args
         self.data_buffer = data_buffer
         self.concurrency = concurrency
@@ -87,10 +125,12 @@ class AsyncRolloutWorker:
         # and freeze every in-flight generation. Backpressure lives in _loop()
         # instead, which stops topping up while a full pool of completed groups
         # is already waiting to be consumed.
-        self.output_queue: queue.Queue[tuple[int, list[Sample]]] = queue.Queue()
+        self.output_queue: queue.Queue[CompletedSampleRecord] = queue.Queue()
         self.poll_interval = 1.0
         self.worker_thread: threading.Thread | None = None
         self.state = GenerateState(args)
+        self._policy_version = policy_version
+        self._policy_version_lock = threading.Lock()
 
     # -- public --------------------------------------------------------------
 
@@ -104,7 +144,7 @@ class AsyncRolloutWorker:
         if self.worker_thread and self.worker_thread.is_alive():
             self.worker_thread.join(timeout=5)
 
-    def get_completed_groups(self, limit: int | None = None) -> list[tuple[int, list[Sample]]]:
+    def get_completed_groups(self, limit: int | None = None) -> list[CompletedSampleRecord]:
         """Pop up to ``limit`` completed groups (all of them when ``None``).
 
         Callers that only need a fixed number of groups must pass ``limit`` —
@@ -112,7 +152,7 @@ class AsyncRolloutWorker:
         these groups are fully generated and reward-scored, with their prompts
         already consumed from ``data_buffer``.
         """
-        completed: list[tuple[int, list[Sample]]] = []
+        completed: list[CompletedSampleRecord] = []
         while limit is None or len(completed) < limit:
             try:
                 completed.append(self.output_queue.get_nowait())
@@ -122,6 +162,23 @@ class AsyncRolloutWorker:
 
     def queue_size(self) -> int:
         return self.output_queue.qsize()
+
+    @property
+    def policy_version(self) -> int:
+        """Return the latest successfully published policy version."""
+
+        with self._policy_version_lock:
+            return self._policy_version
+
+    def publish_policy_version(self, policy_version: int) -> None:
+        """Publish a monotonic policy version for future admissions."""
+
+        with self._policy_version_lock:
+            if policy_version < self._policy_version:
+                raise ValueError(
+                    f"policy version must be monotonic: current={self._policy_version}, new={policy_version}"
+                )
+            self._policy_version = policy_version
 
     # -- internals -----------------------------------------------------------
 
@@ -157,6 +214,9 @@ class AsyncRolloutWorker:
                     for group in groups:
                         gid = gid_counter
                         gid_counter += 1
+                        policy_version = self.policy_version
+                        for sample in group:
+                            sample.policy_version = policy_version
                         task = asyncio.create_task(
                             generate_and_rm_group(
                                 self.args,
@@ -165,7 +225,7 @@ class AsyncRolloutWorker:
                                 evaluation=False,
                             )
                         )
-                        task.add_done_callback(self._make_done_cb(gid))
+                        task.add_done_callback(self._make_done_cb(gid, policy_version))
                         active_tasks.add(task)
 
                 await asyncio.sleep(self.poll_interval)
@@ -183,7 +243,7 @@ class AsyncRolloutWorker:
             except Exception:  # noqa: BLE001
                 pass
 
-    def _make_done_cb(self, gid: int):
+    def _make_done_cb(self, gid: int, policy_version: int):
         def _cb(done_task: asyncio.Task) -> None:
             try:
                 result = done_task.result()
@@ -196,6 +256,11 @@ class AsyncRolloutWorker:
                     type(result).__name__,
                 )
                 return
+            # Custom generators may replace the admitted Sample objects. Stamp
+            # their outputs from the admission snapshot, never from mutable
+            # worker state observed at completion time.
+            for sample in result:
+                sample.policy_version = policy_version
             # Aborted group → requeue, don't ship to training.
             if any(getattr(s, "status", None) == Sample.Status.ABORTED for s in result):
                 try:
@@ -203,7 +268,7 @@ class AsyncRolloutWorker:
                 except Exception:  # noqa: BLE001
                     logger.exception("fully-async: failed to requeue aborted group")
                 return
-            self.output_queue.put((gid, result))
+            self.output_queue.put(CompletedSampleRecord(gid=gid, group=result, policy_version=policy_version))
 
         return _cb
 
@@ -229,8 +294,8 @@ async def _generate_rollout_async(args, rollout_id: int, data_buffer) -> list[li
         # Pull only what this rollout still needs; the surplus stays queued for
         # the next rollout (that is the "queue stays warm" contract).
         drained = 0
-        for gid, group in worker.get_completed_groups(limit=target - len(collected)):
-            collected[gid] = group
+        for record in worker.get_completed_groups(limit=target - len(collected)):
+            collected[record.gid] = record.group
             drained += 1
 
         if not drained:

--- a/slime/utils/types.py
+++ b/slime/utils/types.py
@@ -104,6 +104,10 @@ class Sample:
     # sibling, so loss aggregation averages within the rollout instead of
     # over-counting it.
     rollout_id: int | None = None
+    # Monotonic version of the actor policy used when this sample was admitted
+    # for generation. This is separate from ``weight_versions``, which contains
+    # backend-reported weight metadata collected while tokens are generated.
+    policy_version: int | None = None
     # prompt
     prompt: str | list[dict[str, str]] = ""
     tokens: list[int] = field(default_factory=list)

--- a/tests/test_fully_async_rollout.py
+++ b/tests/test_fully_async_rollout.py
@@ -45,7 +45,6 @@ import pytest
 import slime.rollout.fully_async_rollout as fa
 from slime.utils.types import Sample
 
-
 NUM_GPUS = 0
 
 
@@ -77,17 +76,22 @@ def _make_group(index: int) -> list[Sample]:
     return [sample]
 
 
-def _make_worker(monkeypatch, data_buffer=None, concurrency=4) -> fa.AsyncRolloutWorker:
+def _make_worker(monkeypatch, data_buffer=None, concurrency=4, policy_version=0) -> fa.AsyncRolloutWorker:
     monkeypatch.setattr(fa, "GenerateState", _FakeGenerateState)
     args = SimpleNamespace(rollout_global_dataset=True, rollout_batch_size=4)
-    return fa.AsyncRolloutWorker(args, data_buffer or _FakeDataBuffer([]), concurrency=concurrency)
+    return fa.AsyncRolloutWorker(
+        args,
+        data_buffer or _FakeDataBuffer([]),
+        concurrency=concurrency,
+        policy_version=policy_version,
+    )
 
 
 @pytest.mark.unit
 def test_rollout_takes_target_groups_and_leaves_surplus_queued(monkeypatch):
     worker = _make_worker(monkeypatch)
     for gid in range(10):
-        worker.output_queue.put((gid, _make_group(gid)))
+        worker.output_queue.put(fa.CompletedSampleRecord(gid, _make_group(gid), policy_version=0))
     monkeypatch.setattr(fa, "_get_global_worker", lambda args, data_buffer: worker)
 
     args = SimpleNamespace(rollout_global_dataset=True, rollout_batch_size=4)
@@ -98,17 +102,17 @@ def test_rollout_takes_target_groups_and_leaves_surplus_queued(monkeypatch):
     assert [group[0].index for group in out] == [0, 1, 2, 3]
     # The other six are still queued for the next rollout, not thrown away.
     assert worker.queue_size() == 6
-    assert [gid for gid, _ in worker.get_completed_groups()] == [4, 5, 6, 7, 8, 9]
+    assert [record.gid for record in worker.get_completed_groups()] == [4, 5, 6, 7, 8, 9]
 
 
 @pytest.mark.unit
 def test_get_completed_groups_limit(monkeypatch):
     worker = _make_worker(monkeypatch)
     for gid in range(5):
-        worker.output_queue.put((gid, _make_group(gid)))
+        worker.output_queue.put(fa.CompletedSampleRecord(gid, _make_group(gid), policy_version=0))
 
-    assert [gid for gid, _ in worker.get_completed_groups(limit=2)] == [0, 1]
-    assert [gid for gid, _ in worker.get_completed_groups()] == [2, 3, 4]
+    assert [record.gid for record in worker.get_completed_groups(limit=2)] == [0, 1]
+    assert [record.gid for record in worker.get_completed_groups()] == [2, 3, 4]
     assert worker.get_completed_groups(limit=3) == []
 
 
@@ -128,7 +132,7 @@ def test_done_callback_never_blocks_event_loop_thread(monkeypatch):
 
     def _push_all():
         for gid in range(1001):
-            worker._make_done_cb(gid)(_DoneTask(gid))
+            worker._make_done_cb(gid, worker.policy_version)(_DoneTask(gid))
 
     pusher = threading.Thread(target=_push_all, daemon=True)
     pusher.start()
@@ -169,6 +173,55 @@ def test_loop_backpressure_stops_topping_up_when_queue_is_full(monkeypatch):
     # In-flight tasks may still land after the gate check, so allow one pool
     # beyond the gate — but nothing near the unthrottled fuel size.
     assert 0 < max_seen <= 2 * concurrency, f"queue grew to {max_seen} with concurrency={concurrency}"
+
+
+@pytest.mark.unit
+def test_out_of_order_completion_keeps_each_admission_policy_version(monkeypatch):
+    worker = _make_worker(monkeypatch, policy_version=3)
+
+    class _DoneTask:
+        def __init__(self, index):
+            self.index = index
+
+        def result(self):
+            return _make_group(self.index)
+
+    old_admission_version = worker.policy_version
+    worker.publish_policy_version(4)
+    new_admission_version = worker.policy_version
+
+    # The newer-policy request finishes first. Neither record may consult the
+    # worker's mutable current version when its callback eventually runs.
+    worker._make_done_cb(gid=12, policy_version=new_admission_version)(_DoneTask(8))
+    worker._make_done_cb(gid=11, policy_version=old_admission_version)(_DoneTask(7))
+
+    records = worker.get_completed_groups(limit=2)
+    assert [(record.gid, record.policy_version) for record in records] == [(12, 4), (11, 3)]
+    assert [record.group[0].policy_version for record in records] == [4, 3]
+    assert worker.policy_version == 4
+
+
+@pytest.mark.unit
+def test_failed_weight_update_does_not_publish_policy_version(monkeypatch):
+    worker = _make_worker(monkeypatch, policy_version=5)
+    monkeypatch.setattr(fa, "_global_worker", worker)
+    monkeypatch.setattr(fa, "_published_policy_version", 5)
+
+    fa.after_weight_update(policy_version=5, succeeded=False)
+    assert fa._published_policy_version == 5
+    assert worker.policy_version == 5
+
+    fa.after_weight_update(policy_version=6, succeeded=True)
+    assert fa._published_policy_version == 6
+    assert worker.policy_version == 6
+
+
+@pytest.mark.unit
+def test_policy_version_rejects_regression(monkeypatch):
+    worker = _make_worker(monkeypatch, policy_version=2)
+
+    with pytest.raises(ValueError, match="policy version must be monotonic"):
+        worker.publish_policy_version(1)
 
 
 if __name__ == "__main__":

--- a/tests/test_sample.py
+++ b/tests/test_sample.py
@@ -23,7 +23,6 @@ import pytest
 
 from slime.utils.types import Sample
 
-
 NUM_GPUS = 0
 
 
@@ -40,6 +39,7 @@ def _make_sample(**overrides) -> Sample:
         group_index=0,
         index=42,
         rollout_id=7,
+        policy_version=3,
         prompt="hello",
         tokens=[1, 2, 3],
         multimodal_inputs={"images": ["fake_url"]},
@@ -123,6 +123,7 @@ def test_round_trip_preserves_every_field():
         "group_index",
         "index",
         "rollout_id",
+        "policy_version",
         "prompt",
         "tokens",
         "multimodal_inputs",

--- a/tests/test_train_async_policy_version.py
+++ b/tests/test_train_async_policy_version.py
@@ -1,0 +1,106 @@
+"""CPU tests for async-training policy-version publication."""
+
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+# Keep this lifecycle test independent of GPU/server packages imported by the
+# real training bootstrap. Restore the real module entries after importing the
+# helper so these stubs cannot leak into other test modules.
+_stubs = {
+    "slime.ray.placement_group": {
+        "create_placement_groups": None,
+        "create_rollout_manager": None,
+        "create_training_models": None,
+    },
+    "slime.utils.arguments": {"parse_args": None},
+    "slime.observability.logging_utils": {
+        "configure_logger": None,
+        "finish_tracking": None,
+        "init_tracking": None,
+    },
+}
+_original_modules = {name: sys.modules.get(name) for name in _stubs}
+try:
+    for name, attributes in _stubs.items():
+        module = types.ModuleType(name)
+        for attribute, value in attributes.items():
+            setattr(module, attribute, value)
+        sys.modules[name] = module
+
+    import train_async
+finally:
+    for name, original_module in _original_modules.items():
+        if original_module is None:
+            sys.modules.pop(name, None)
+        else:
+            sys.modules[name] = original_module
+
+NUM_GPUS = 0
+
+
+class _RemoteMethod:
+    def __init__(self, fn):
+        self._fn = fn
+
+    def remote(self, *args, **kwargs):
+        return self._fn(*args, **kwargs)
+
+
+class _FakeRolloutManager:
+    def __init__(self):
+        self.policy_version = 0
+        self.events = []
+        self.before_weight_update = _RemoteMethod(self._before_weight_update)
+        self.after_weight_update = _RemoteMethod(self._after_weight_update)
+
+    def _before_weight_update(self):
+        self.events.append(("before", self.policy_version))
+        return self.policy_version
+
+    def _after_weight_update(self, *, succeeded):
+        if succeeded:
+            self.policy_version += 1
+        self.events.append(("after", self.policy_version, succeeded))
+        return self.policy_version
+
+
+class _FakeActorModel:
+    def __init__(self, *, fail=False):
+        self.fail = fail
+        self.update_calls = 0
+
+    def update_weights(self):
+        self.update_calls += 1
+        if self.fail:
+            raise RuntimeError("weight update failed")
+
+
+@pytest.mark.unit
+def test_policy_version_advances_after_successful_weight_update(monkeypatch):
+    monkeypatch.setattr(train_async.ray, "get", lambda value: value)
+    actor_model = _FakeActorModel()
+    rollout_manager = _FakeRolloutManager()
+
+    train_async._update_actor_weights(actor_model, rollout_manager)
+
+    assert actor_model.update_calls == 1
+    assert rollout_manager.policy_version == 1
+    assert rollout_manager.events == [("before", 0), ("after", 1, True)]
+
+
+@pytest.mark.unit
+def test_failed_weight_update_keeps_policy_version(monkeypatch):
+    monkeypatch.setattr(train_async.ray, "get", lambda value: value)
+    actor_model = _FakeActorModel(fail=True)
+    rollout_manager = _FakeRolloutManager()
+
+    with pytest.raises(RuntimeError, match="weight update failed"):
+        train_async._update_actor_weights(actor_model, rollout_manager)
+
+    assert actor_model.update_calls == 1
+    assert rollout_manager.policy_version == 0
+    assert rollout_manager.events == [("before", 0), ("after", 0, False)]

--- a/train_async.py
+++ b/train_async.py
@@ -6,6 +6,18 @@ from slime.utils.arguments import parse_args
 from slime.utils.misc import should_run_periodic_action
 
 
+def _update_actor_weights(actor_model, rollout_manager) -> None:
+    """Publish actor weights and advance the rollout policy version only on success."""
+
+    ray.get(rollout_manager.before_weight_update.remote())
+    succeeded = False
+    try:
+        actor_model.update_weights()
+        succeeded = True
+    finally:
+        ray.get(rollout_manager.after_weight_update.remote(succeeded=succeeded))
+
+
 # The framework supports other asynchronous approaches such as fully async (which is shown in examples/full_async).
 def train(args):
     assert not args.colocate, "Colocation is not supported for async training."
@@ -23,7 +35,7 @@ def train(args):
     actor_model, critic_model = create_training_models(args, pgs, rollout_manager)
 
     # Always push actor weights to rollout once weights are loaded.
-    actor_model.update_weights()
+    _update_actor_weights(actor_model, rollout_manager)
 
     if args.check_weight_update_equal:
         ray.get(rollout_manager.check_weights.remote(action="compare"))
@@ -67,7 +79,7 @@ def train(args):
             # sync generate before update weights to prevent update weight in the middle of generation
             rollout_data_curr_ref = ray.get(x) if (x := rollout_data_next_future) is not None else None
             rollout_data_next_future = None
-            actor_model.update_weights()
+            _update_actor_weights(actor_model, rollout_manager)
 
         if should_run_periodic_action(rollout_id, args.eval_interval, num_rollout_per_epoch):
             ray.get(rollout_manager.eval.remote(rollout_id))


### PR DESCRIPTION
## Summary

This is the first, dependency-free slice of #1800. It establishes policy-version lifecycle semantics for fully async rollout without adding staleness control, eviction, or partial-resume policy yet.

- wrap both initial and periodic actor-to-rollout weight updates with optional `before_weight_update` / `after_weight_update` hooks
- advance the rollout policy version only after a successful weight publication; failed updates keep the previous version
- let `RolloutManager` forward lifecycle hooks to the configured rollout module while preserving compatibility with rollout functions that do not define them
- snapshot the current policy version when a fully async group is admitted, then preserve it in an immutable `CompletedSampleRecord` even if completions arrive out of order
- expose the admission version on `Sample.policy_version`

## Semantics

`policy_version` starts at zero in `RolloutManager`. A successful initial or periodic weight update increments it once. The async worker captures that published value at admission, so a weight update completing while generation is in flight cannot relabel an older trajectory. The existing behavior of recycling aborted groups remains unchanged.

## Validation

- `python -m pytest tests/test_fully_async_rollout.py tests/test_sample.py tests/test_train_async_policy_version.py` — 21 passed
- `pre-commit run --from-ref 41014d1f29e201137fdffce737bb8bac65bc5219 --to-ref HEAD` — all hooks passed

The tests cover successful and failed weight updates, monotonic version publication, out-of-order completion across an update boundary, immutable completion records, queue backpressure, and `Sample` serialization.

## Follow-ups

To keep review scope small, configurable staleness/requeue policy, partial rollout resume, and fixed-cardinality observability metrics will be submitted as follow-up PRs after this lifecycle foundation is reviewed.

Part of #1800.
