### PR TITLE
Fix Qwen3 loss masks for parallel tool results

### DIFF
--- a/slime/utils/mask_utils.py
+++ b/slime/utils/mask_utils.py
@@ -33,9 +33,7 @@ class MultiTurnLossMaskGenerator:
             {"role": "user", "content": test_string},
         ]
         raw_token_ids = self.tokenizer(test_string, add_special_tokens=False)["input_ids"]
-        chat_template_token = self.tokenizer.apply_chat_template(
-            test_messages, add_special_tokens=False, tokenize=False
-        )
+        chat_template_token = self.tokenizer.apply_chat_template(test_messages, add_special_tokens=False, tokenize=False)
         chat_template_token_ids = self.tokenizer(chat_template_token, add_special_tokens=False)["input_ids"]
         idx_1, idx_2 = self.find_all_sublist_indices(chat_template_token_ids, raw_token_ids)
         end_interval = len(chat_template_token_ids) - len(raw_token_ids) - idx_2
@@ -52,17 +50,13 @@ class MultiTurnLossMaskGenerator:
         system_message_length = idx_1 - ((idx_2 - idx_1) - end_interval - len(raw_token_ids))
         return system_message_length, gen_token_length
 
-    def gen_multi_turn_loss_mask_qwen(
-        self, messages: list[dict], tools: list[dict] = None
-    ) -> tuple[list[int], list[int]]:
+    def gen_multi_turn_loss_mask_qwen(self, messages: list[dict], tools: list[dict] = None) -> tuple[list[int], list[int]]:
         all_loss_masks = []
         all_token_ids = []
 
         for i, message in enumerate(messages):
             if i == 0:
-                message_ids = self.tokenizer.apply_chat_template(
-                    [message], tokenize=True, tools=tools, return_dict=False
-                )
+                message_ids = self.tokenizer.apply_chat_template([message], tokenize=True, tools=tools, return_dict=False)
             else:
                 message_ids = self.tokenizer.apply_chat_template([message], tokenize=True, return_dict=False)
 
@@ -82,9 +76,14 @@ class MultiTurnLossMaskGenerator:
 
         return all_token_ids, all_loss_masks
 
-    def gen_multi_turn_loss_mask_qwen3(
-        self, messages: list[dict], tools: list[dict] = None
-    ) -> tuple[list[int], list[int]]:
+    def gen_multi_turn_loss_mask_qwen3(self, messages: list[dict], tools: list[dict] = None) -> tuple[list[int], list[int]]:
+        # Qwen templates render consecutive Tool Results as one grouped user
+        # turn. Re-rendering each message in isolation changes the token stream
+        # (and can duplicate group delimiters), so structured tool histories
+        # must use the exact full-conversation rendering path.
+        if any(message.get("role") == "tool" or message.get("tool_calls") for message in messages):
+            return self._gen_multi_turn_loss_mask_full_text(messages, tools, tokenizer_label="Qwen3")
+
         all_loss_masks = []
         all_token_ids = []
 
@@ -124,8 +123,12 @@ class MultiTurnLossMaskGenerator:
 
         return all_token_ids, all_loss_masks
 
-    def gen_multi_turn_loss_mask_qwen3_5(
-        self, messages: list[dict], tools: list[dict] = None
+    def _gen_multi_turn_loss_mask_full_text(
+        self,
+        messages: list[dict],
+        tools: list[dict] = None,
+        *,
+        tokenizer_label: str,
     ) -> tuple[list[int], list[int]]:
         rendered_text = self.tokenizer.apply_chat_template(messages, tokenize=False, tools=tools, return_dict=False)
         tokenized = self.tokenizer(rendered_text, add_special_tokens=False, return_offsets_mapping=True)
@@ -133,18 +136,11 @@ class MultiTurnLossMaskGenerator:
         offset_mapping = tokenized.get("offset_mapping")
 
         if offset_mapping is None:
-            raise ValueError(
-                "Qwen3.5 loss mask generation requires a fast tokenizer " "with `return_offsets_mapping` support."
-            )
+            raise ValueError(f"{tokenizer_label} loss mask generation requires a fast tokenizer with `return_offsets_mapping` support.")
 
-        expected_token_ids = self.tokenizer.apply_chat_template(
-            messages, tokenize=True, tools=tools, return_dict=False
-        )
+        expected_token_ids = self.tokenizer.apply_chat_template(messages, tokenize=True, tools=tools, return_dict=False)
         if token_ids != expected_token_ids:
-            raise ValueError(
-                "Qwen3.5 rendered text tokenization does not match "
-                "`apply_chat_template(..., tokenize=True)` output."
-            )
+            raise ValueError(f"{tokenizer_label} rendered text tokenization does not match `apply_chat_template(..., tokenize=True)` output.")
 
         assistant_header = "<|im_start|>assistant\n"
         think_prefix = "<think>\n"
@@ -159,7 +155,7 @@ class MultiTurnLossMaskGenerator:
 
             header_pos = rendered_text.find(assistant_header, cursor)
             if header_pos < 0:
-                raise ValueError("Failed to locate assistant message in rendered Qwen3.5 chat template output.")
+                raise ValueError(f"Failed to locate assistant message in rendered {tokenizer_label} chat template output.")
 
             content_start = header_pos + len(assistant_header)
             end_pos = rendered_text.find(end_marker, content_start)
@@ -195,12 +191,11 @@ class MultiTurnLossMaskGenerator:
 
         return token_ids, loss_mask
 
-    def gen_multi_turn_loss_mask_distill_qwen(
-        self, messages: list[dict], tools: list[dict] = None
-    ) -> tuple[list[int], list[int]]:
-        prompt = self.tokenizer.apply_chat_template(
-            messages[:1], tokenize=False, add_generation_prompt=True, tools=tools
-        )
+    def gen_multi_turn_loss_mask_qwen3_5(self, messages: list[dict], tools: list[dict] = None) -> tuple[list[int], list[int]]:
+        return self._gen_multi_turn_loss_mask_full_text(messages, tools, tokenizer_label="Qwen3.5")
+
+    def gen_multi_turn_loss_mask_distill_qwen(self, messages: list[dict], tools: list[dict] = None) -> tuple[list[int], list[int]]:
+        prompt = self.tokenizer.apply_chat_template(messages[:1], tokenize=False, add_generation_prompt=True, tools=tools)
         response = messages[-1]["content"]
         prompt_tokens = self.tokenizer(prompt, add_special_tokens=False)["input_ids"]
         response_tokens = self.tokenizer(response, add_special_tokens=False)["input_ids"]
@@ -228,9 +223,7 @@ class MultiTurnLossMaskGenerator:
         else:
             raise ValueError(f"Unsupported tokenizer type: {self.tokenizer_type}")
 
-    def get_loss_mask_with_multimodal_alignment(
-        self, messages: list[dict], input_ids: list[int], tools: list[dict] = None
-    ) -> tuple[list[int], list[int]]:
+    def get_loss_mask_with_multimodal_alignment(self, messages: list[dict], input_ids: list[int], tools: list[dict] = None) -> tuple[list[int], list[int]]:
         text = []
         for msg in messages:
             if isinstance(msg.get("content"), list):
@@ -247,10 +240,7 @@ class MultiTurnLossMaskGenerator:
         _, loss_mask_text = self.get_loss_mask(text, tools=tools)
 
         diff = len(input_ids) - len(loss_mask_text)
-        assert diff >= 0, (
-            f"input_ids (length={len(input_ids)}) is shorter than text loss_mask (length={len(loss_mask_text)}) "
-            f"Please check if processor and tokenizer tokenization are consistent."
-        )
+        assert diff >= 0, f"input_ids (length={len(input_ids)}) is shorter than text loss_mask (length={len(loss_mask_text)}) Please check if processor and tokenizer tokenization are consistent."
         loss_mask = [0] * diff + loss_mask_text
 
         return input_ids, loss_mask

--- a/tests/utils/test_loss_mask_type_qwen35.py
+++ b/tests/utils/test_loss_mask_type_qwen35.py
@@ -234,3 +234,31 @@ def test_qwen3_5_matches_expected_mask_for_tool_call_flow():
         "\n</think>\n\nTOOL_CALL\n\n<tool_call>\n<function=terminal>\n<parameter=command>\nls\n</parameter>\n</function>\n</tool_call><|im_end|>\n",
         "REASONING\n</think>\n\nFINAL<|im_end|>\n",
     ]
+
+
+def test_qwen3_exact_path_groups_parallel_tool_results():
+    tokenizer = FakeQwen35Tokenizer()
+    messages = [
+        {"role": "system", "content": "SYSTEM"},
+        {"role": "user", "content": "USER"},
+        {
+            "role": "assistant",
+            "content": "TOOL_CALLS",
+            "tool_calls": [
+                {"function": {"name": "terminal", "arguments": {"command": "ls"}}},
+                {"function": {"name": "read_file", "arguments": {"path": "README.md"}}},
+            ],
+        },
+        {"role": "tool", "content": "README.md"},
+        {"role": "tool", "content": "hello"},
+        {"role": "assistant", "content": "FINAL"},
+    ]
+
+    expected_text, expected_mask = tokenizer.render_with_expected_mask(messages)
+    expected_token_ids = tokenizer(expected_text, add_special_tokens=False)["input_ids"]
+    generator = MultiTurnLossMaskGenerator(tokenizer, tokenizer_type="qwen3")
+
+    token_ids, loss_mask = generator.get_loss_mask(messages)
+
+    assert token_ids == expected_token_ids
+    assert loss_mask == expected_mask


### PR DESCRIPTION
## Summary

Qwen3 chat templates group consecutive tool results into one rendered turn. The existing `qwen3` loss-mask path renders each message independently, which changes the token stream for parallel tool-call histories.

This change:

- uses the existing full-conversation, offset-based mask path whenever a Qwen3 conversation contains structured `tool_calls` or `tool` messages;
- preserves the current per-message Qwen3 behavior for conversations without structured tool history;
- shares the exact renderer with the Qwen3.5 path;
- adds a regression covering two parallel calls followed by consecutive tool results.

## Real tokenizer reproduction

Model: `Qwen3-30B-A3B-Instruct-2507`  
Base: `acac66163804b141b66272bcf2ae3b55f8edc643`

Full-template tokens vs. loss-mask-path tokens:

| Conversation | Base | This PR |
| --- | ---: | ---: |
| Natural turn | 27 = 27 | 27 = 27 |
| One tool call/result | 203 = 203 | 203 = 203 |
| Two parallel calls/results | **232 != 236** | **232 = 232** |

For all three rows on this branch, the token ID sequences are exactly equal and the mask length equals the token sequence length.

## Validation

- All four tests in `tests/utils/test_loss_mask_type_qwen35.py` passed under the project tokenizer runtime.
- The real Qwen3 tokenizer probe above passed, including exact ID equality for the parallel-tool row.
- `ruff check`, Python compilation, and `git diff --check` passed.