### PR TITLE
fix(agent): restore a re-rendered assistant echo before rendering the prompt

### DIFF
--- a/slime/agent/adapters/common.py
+++ b/slime/agent/adapters/common.py
@@ -339,6 +339,9 @@ class BaseAdapter:
         t0 = time.monotonic()
         try:
             translated, tools_schema = self._translate(body)
+            # A harness may echo a prior assistant turn re-rendered rather than
+            # byte-identical; render from what we generated so the turn stays CLEAN.
+            translated = self.manager.restore_generated_messages(sid, translated, tools_schema)
             prompt_ids = _render_token_ids(translated, tok, tools=tools_schema, add_generation_prompt=True)
 
             turn = await call_sglang_generate(prompt_ids, s, body, adapter=self, session_id=sid)

--- a/slime/agent/trajectory.py
+++ b/slime/agent/trajectory.py
@@ -108,6 +108,125 @@ class MessageNode:
             yield from c.leaves()
 
 
+def _tool_defaults(tools_schema: list[dict] | None) -> dict[str, dict[str, Any]]:
+    """``{tool name: {argument: default}}`` from a chat-template tool schema.
+
+    Only properties that actually declare a ``default`` are collected; a tool with
+    none contributes an empty mapping, and an absent schema yields ``{}``.
+    """
+    out: dict[str, dict[str, Any]] = {}
+    for entry in tools_schema or []:
+        fn = (entry or {}).get("function") or {}
+        name = fn.get("name")
+        if not name:
+            continue
+        props = ((fn.get("parameters") or {}).get("properties")) or {}
+        if not isinstance(props, dict):
+            continue
+        defaults = {k: v["default"] for k, v in props.items() if isinstance(v, dict) and "default" in v}
+        if defaults:
+            out[name] = defaults
+    return out
+
+
+def _strip_trailing_ws(args: Any) -> Any:
+    """Right-strip every line of every string argument, recursively.
+
+    A client may right-strip a multi-line code payload on replay. How much it
+    removed is unknowable, so instead of trying to put it back, both sides are
+    compared with all trailing whitespace gone.
+    """
+    if isinstance(args, dict):
+        return {k: _strip_trailing_ws(v) for k, v in sorted(args.items())}
+    if isinstance(args, list):
+        return [_strip_trailing_ws(v) for v in args]
+    if isinstance(args, str):
+        return "\n".join(line.rstrip() for line in args.split("\n"))
+    return args
+
+
+def _drop_schema_defaults(args: Any, defaults: dict[str, Any]) -> Any:
+    """Drop top-level arguments whose value equals the tool's declared default.
+
+    Omitting an argument and passing its declared default are the same call, so a
+    client that fills one in on replay has changed nothing the tool can observe.
+    Dropping those on both sides makes the two compare equal, whatever the default
+    happens to be -- ``False``, ``True``, ``0``, or a string.
+
+    ``True is 1`` in Python, so identity rather than ``==`` guards booleans here:
+    an argument of ``1`` must not be mistaken for a declared default of ``True``.
+    """
+    if not isinstance(args, dict) or not defaults:
+        return args
+
+    def is_default(key: str, value: Any) -> bool:
+        if key not in defaults:
+            return False
+        default = defaults[key]
+        if isinstance(default, bool) or isinstance(value, bool):
+            return value is default
+        return value == default
+
+    return {k: v for k, v in args.items() if not is_default(k, v)}
+
+
+def _norm_tool_args(args: Any, defaults: dict[str, Any] | None = None) -> Any:
+    """Project tool-call arguments onto a coarser view, for comparison only.
+
+    A harness may replay a prior assistant tool call re-rendered rather than
+    byte-identical. Keeping arguments a dict in ``tool_call_dict`` already makes
+    the comparison immune to key order; two further client edits are equally free
+    of semantic content but still break equality:
+
+    * an argument filled in with the value the tool schema already declares as its
+      default (``replace_all`` on Edit, for instance), where the model omitted it;
+    * per-line right-stripping of string arguments carrying code payloads.
+
+    Neither edit is reversed -- the original bytes are never reconstructed from the
+    echo, and the caller substitutes the message it stored instead (see
+    ``restore_generated_messages``). Both sides are merely projected onto a view
+    that cannot see the difference.
+
+    ``defaults`` comes from the tool's own schema (see :func:`_tool_defaults`).
+    Without it, only the whitespace projection applies, so a filled-in default
+    still reads as a different call -- a missed restore, never a wrong one.
+    """
+    return _strip_trailing_ws(_drop_schema_defaults(args, defaults or {}))
+
+
+def _is_same_tool_call_echo(
+    held: dict[str, Any] | None,
+    incoming: dict[str, Any],
+    tool_defaults: dict[str, dict[str, Any]] | None = None,
+) -> bool:
+    """Whether ``incoming`` is ``held`` re-rendered by the harness.
+
+    Only tool-call arguments are compared through the coarser view of
+    :func:`_norm_tool_args`; everything else -- role, content, reasoning, tool
+    name, call count, and any other key -- still has to match exactly. A message
+    that differs in any of those is a different action and must not be mistaken
+    for an echo.
+    """
+    if not isinstance(held, dict) or held.get("role") != incoming.get("role"):
+        return False
+    h_tcs, i_tcs = held.get("tool_calls"), incoming.get("tool_calls")
+    if not h_tcs or not i_tcs or len(h_tcs) != len(i_tcs):
+        return False
+    if {k: v for k, v in held.items() if k != "tool_calls"} != {
+        k: v for k, v in incoming.items() if k != "tool_calls"
+    }:
+        return False
+    for h, i in zip(h_tcs, i_tcs, strict=True):  # equal lengths checked above
+        hf, if_ = h.get("function") or {}, i.get("function") or {}
+        name = hf.get("name")
+        if h.get("type") != i.get("type") or name != if_.get("name"):
+            return False
+        defaults = (tool_defaults or {}).get(name, {})
+        if _norm_tool_args(hf.get("arguments"), defaults) != _norm_tool_args(if_.get("arguments"), defaults):
+            return False
+    return True
+
+
 # ===========================================================================
 # drift classification — how an incoming turn's prompt relates to held tokens
 # ===========================================================================
@@ -346,6 +465,62 @@ class TrajectoryManager:
     def drop_session(self, sid: str) -> None:
         self._trees.pop(sid, None)
         self._turn_count.pop(sid, None)
+
+    def restore_generated_messages(
+        self,
+        sid: str,
+        messages: list[dict[str, Any]],
+        tools_schema: list[dict] | None = None,
+    ) -> list[dict[str, Any]]:
+        """Swap a harness's re-rendered assistant echoes back to what we generated.
+
+        A harness that replays a prior assistant turn re-rendered rather than
+        byte-identical makes the next prompt diverge from the tokens we hold on
+        both layers at once: the routing walk misses the node (message
+        inequality, so ``_try_merge_assistant_rewrite`` demotes that turn to
+        routing-only and its generated tokens stop training) and the token prefix
+        drifts (the re-rendered arguments tokenize differently, so the turn
+        classifies REALIGN and ``_align_to_prompt`` zeroes the span). Restoring
+        before the prompt is rendered removes the divergence at its source, so
+        the turn stays CLEAN and keeps its gradient.
+
+        Only an assistant message recognized as the same tool call re-rendered
+        is swapped (see :func:`_is_same_tool_call_echo`); anything else is left
+        as the harness sent it, and the walk stops there. Returns a new list;
+        ``messages`` is not mutated.
+
+        ``tools_schema`` supplies each tool's declared argument defaults, so an
+        argument the client filled in with its default is recognized exactly
+        rather than guessed at. Passing nothing is safe: the comparison just gets
+        stricter, costing a restore rather than making a wrong one.
+        """
+        root = self._trees.get(sid)
+        if root is None:
+            return messages
+
+        defaults = _tool_defaults(tools_schema)
+        out = list(messages)
+        node, depth = root, 0
+        while depth < len(out):
+            msg = out[depth]
+            exact = next((c for c in node.children if c.role == msg.get("role") and c.message == msg), None)
+            if exact is not None:
+                node, depth = exact, depth + 1
+                continue
+            # No exact child: this may be our own generated turn, echoed back
+            # re-rendered. Require a single generated assistant candidate --
+            # with more than one we cannot tell which the echo refers to, the
+            # same ambiguity _try_merge_assistant_rewrite declines to guess at.
+            echoes = [
+                c
+                for c in node.children
+                if c.role == "assistant" and c.turn is not None and _is_same_tool_call_echo(c.message, msg, defaults)
+            ]
+            if len(echoes) != 1:
+                break
+            out[depth] = echoes[0].message
+            node, depth = echoes[0], depth + 1
+        return out
 
     # -------------------- internals ----------------------------------------
 

--- a/tests/test_agent/test_trajectory_manager_branching.py
+++ b/tests/test_agent/test_trajectory_manager_branching.py
@@ -1135,6 +1135,294 @@ def test_3_8_long_mixed_session():
 # ===========================================================================
 
 
+def _tc(name: str, args: dict) -> dict:
+    """An assistant message carrying one tool call, canonical (tool_call_dict) shape."""
+    return {
+        "role": "assistant",
+        "content": "",
+        "tool_calls": [{"type": "function", "function": {"name": name, "arguments": args}}],
+    }
+
+
+# What the model generated: trailing whitespace inside the payload, and no
+# `replace_all` key (it emitted none).
+_EDIT_GEN = _tc("Edit", {"file_path": "/p.py", "old_string": "a  \n", "new_string": "b  \n"})
+# The harness echo of that same call: `replace_all` filled in with the value the
+# schema declares, payload right-stripped per line. Same action, different bytes.
+_EDIT_ECHO = _tc("Edit", {"file_path": "/p.py", "old_string": "a\n", "new_string": "b\n", "replace_all": False})
+
+# Tool schemas as the adapter hands them over. `Edit.replace_all` defaults to
+# False and `Fetch.follow_redirects` to True: a default of either polarity has to
+# work, which is what rules out "treat a False value as the default".
+_SCHEMA = [
+    {
+        "type": "function",
+        "function": {
+            "name": "Edit",
+            "parameters": {
+                "properties": {
+                    "file_path": {"type": "string"},
+                    "old_string": {"type": "string"},
+                    "new_string": {"type": "string"},
+                    "replace_all": {"type": "boolean", "default": False},
+                }
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "Fetch",
+            "parameters": {
+                "properties": {
+                    "url": {"type": "string"},
+                    "follow_redirects": {"type": "boolean", "default": True},
+                }
+            },
+        },
+    },
+]
+
+
+def test_3_9_restore_echo_keeps_turn_trainable():
+    """A harness echo that only fills in a declared default and right-strips string
+    args is the same tool call. Restoring it before the prompt is rendered keeps the
+    turn CLEAN, so its generated tokens still train -- without the restore the
+    routing walk misses the node, `_try_merge_assistant_rewrite` demotes that turn
+    to routing-only, and it trains on nothing."""
+    mgr = TrajectoryManager()
+    sid = "3.9"
+    s, u = sys_msg("S"), usr_msg("u")
+    t1 = tool_msg("t")
+
+    p1 = render_prompt([s, u])
+    r1 = render_response("edit")
+    mgr.record_turn(
+        sid,
+        turn=turn(p1, r1, finish_reason="tool_calls"),
+        prompt_messages=messages([s, u]),
+        response_message=_EDIT_GEN,
+    )
+
+    incoming = [*messages([s, u]), _EDIT_ECHO, t1.message]
+    restored = mgr.restore_generated_messages(sid, incoming, _SCHEMA)
+    assert restored[2] == _EDIT_GEN, "the echoed assistant message is restored"
+    assert incoming[2] == _EDIT_ECHO, "the caller's list is not mutated"
+    assert restored[0] is incoming[0] and restored[3] is incoming[3], "other messages pass through"
+
+    # Rendering the restored history reproduces the tokens we hold -> CLEAN.
+    p2 = p1 + r1 + t1.render() + [_GEN]
+    mgr.record_turn(
+        sid,
+        turn=turn(p2, render_response("done"), finish_reason="stop"),
+        prompt_messages=restored,
+        response_message={"role": "assistant", "content": "done"},
+    )
+
+    leaves = _leaves(mgr, sid)
+    assert len(leaves) == 1, "the restored echo descends the existing chain"
+    edit_node = leaves[0].path_from_root()[2]
+    assert edit_node.turn is not None, "the Edit turn keeps its TurnRecord"
+    assert "merged_rewrite" not in edit_node.metadata
+
+    samples = get_traj(mgr, sid, base_sample=Sample(index=0, prompt=""), reward=1.0)
+    assert len(samples) == 1
+    # Both generated turns train: the Edit (r:edit) and the follow-up (r:done).
+    assert goldens(samples) == [
+        "<sys> system:S </sys> <usr> user:u </usr> <gen> [r:edit] [</ast>] <tul> tool:t </tul> <gen> [r:done] [</ast>]",
+    ]
+    _check_invariants(samples)
+    _record("3.9 restored echo keeps the turn trainable", mgr, sid, samples)
+    print("PASS 3.9")
+
+
+def test_3_10_restore_echo_from_whitespace_alone():
+    """The recognition must not depend on a default having been filled in. Write's
+    schema declares none, so its echo differs only by the per-line rstrip of a
+    multi-line payload -- and that alone is enough to lose the turn. Covering Write
+    keeps each kind of client edit under test independently."""
+    body_gen = "def f(x):  \n    return x + 1  \n\nDEFAULTS = {}  \n"
+    body_echo = "def f(x):\n    return x + 1\n\nDEFAULTS = {}\n"
+    write_gen = _tc("Write", {"file_path": "/p.py", "content": body_gen})
+    write_echo = _tc("Write", {"file_path": "/p.py", "content": body_echo})
+    assert "replace_all" not in str(write_echo), "Write's echo carries no schema default"
+
+    mgr = TrajectoryManager()
+    sid = "3.9b"
+    s, u = sys_msg("S"), usr_msg("u")
+    t1 = tool_msg("t")
+
+    p1 = render_prompt([s, u])
+    r1 = render_response("write")
+    mgr.record_turn(
+        sid,
+        turn=turn(p1, r1, finish_reason="tool_calls"),
+        prompt_messages=messages([s, u]),
+        response_message=write_gen,
+    )
+
+    restored = mgr.restore_generated_messages(sid, [*messages([s, u]), write_echo, t1.message], _SCHEMA)
+    assert restored[2] == write_gen, "an rstrip-only echo is still the same call"
+
+    mgr.record_turn(
+        sid,
+        turn=turn(p1 + r1 + t1.render() + [_GEN], render_response("done"), finish_reason="stop"),
+        prompt_messages=restored,
+        response_message={"role": "assistant", "content": "done"},
+    )
+    assert len(_leaves(mgr, sid)) == 1
+    samples = get_traj(mgr, sid, base_sample=Sample(index=0, prompt=""), reward=1.0)
+    assert goldens(samples) == [
+        "<sys> system:S </sys> <usr> user:u </usr> <gen> [r:write] [</ast>] "
+        "<tul> tool:t </tul> <gen> [r:done] [</ast>]",
+    ]
+    _check_invariants(samples)
+    _record("3.10 Write echo restored from rstrip alone", mgr, sid, samples)
+    print("PASS 3.10")
+
+
+def test_3_11_restore_echo_with_either_default_polarity():
+    """The filled-in value has to be checked against the schema, not assumed to be
+    False. `Fetch.follow_redirects` defaults to True, so an echo that fills in
+    True is the same call, while one that fills in False is a different one --
+    the reverse of `Edit.replace_all`. Treating "a False value" as the default
+    would get both of these wrong."""
+    mgr = TrajectoryManager()
+    sid = "3.9c"
+    s, u = sys_msg("S"), usr_msg("u")
+    t1 = tool_msg("t")
+    gen = _tc("Fetch", {"url": "u"})  # model omitted follow_redirects
+    mgr.record_turn(
+        sid,
+        turn=turn(render_prompt([s, u]), render_response("fetch"), finish_reason="tool_calls"),
+        prompt_messages=messages([s, u]),
+        response_message=gen,
+    )
+
+    filled_default = _tc("Fetch", {"url": "u", "follow_redirects": True})  # == the declared default
+    overridden = _tc("Fetch", {"url": "u", "follow_redirects": False})  # a real change
+
+    out = mgr.restore_generated_messages(sid, [*messages([s, u]), filled_default, t1.message], _SCHEMA)
+    assert out[2] == gen, "filling in the declared default is the same call"
+    out = mgr.restore_generated_messages(sid, [*messages([s, u]), overridden, t1.message], _SCHEMA)
+    assert out[2] == overridden, "the non-default value is a different call"
+    print("PASS 3.14")
+
+
+def test_3_12_no_schema_falls_back_to_stricter_matching():
+    """Without a schema the defaults are unknown, so a filled-in default can no
+    longer be recognized. That must cost a restore, never cause a wrong one: the
+    echo is left as the harness sent it."""
+    mgr = TrajectoryManager()
+    sid = "3.9d"
+    s, u = sys_msg("S"), usr_msg("u")
+    t1 = tool_msg("t")
+    mgr.record_turn(
+        sid,
+        turn=turn(render_prompt([s, u]), render_response("edit-ns"), finish_reason="tool_calls"),
+        prompt_messages=messages([s, u]),
+        response_message=_EDIT_GEN,
+    )
+
+    incoming = [*messages([s, u]), _EDIT_ECHO, t1.message]
+    assert mgr.restore_generated_messages(sid, incoming)[2] == _EDIT_ECHO, "no schema -> no restore"
+    assert mgr.restore_generated_messages(sid, incoming, _SCHEMA)[2] == _EDIT_GEN, "with schema -> restored"
+
+    # An echo differing only by whitespace still works without a schema, since
+    # that projection needs no schema knowledge.
+    ws_only = _tc("Edit", {"file_path": "/p.py", "old_string": "a\n", "new_string": "b\n"})
+    assert mgr.restore_generated_messages(sid, [*messages([s, u]), ws_only, t1.message])[2] == _EDIT_GEN
+    print("PASS 3.12")
+
+
+def test_3_13_restore_declines_anything_but_an_echo():
+    """The restore must not rewrite history it does not recognize: swapping a
+    genuinely different action for the one we generated would silently corrupt
+    the training data. Only tool-call arguments are compared modulo the known
+    client normalizations; everything else must match exactly."""
+    mgr = TrajectoryManager()
+    sid = "3.10"
+    s, u = sys_msg("S"), usr_msg("u")
+    t1 = tool_msg("t")
+    mgr.record_turn(
+        sid,
+        turn=turn(render_prompt([s, u]), render_response("e"), finish_reason="tool_calls"),
+        prompt_messages=messages([s, u]),
+        response_message=_EDIT_GEN,
+    )
+
+    cases = {
+        "the real echo": (_EDIT_ECHO, True),
+        "different old_string": (
+            _tc("Edit", {"file_path": "/p.py", "old_string": "OTHER\n", "new_string": "b\n"}),
+            False,
+        ),
+        "replace_all=True": (
+            _tc("Edit", {"file_path": "/p.py", "old_string": "a\n", "new_string": "b\n", "replace_all": True}),
+            False,
+        ),
+        "different file": (
+            _tc("Edit", {"file_path": "/other.py", "old_string": "a\n", "new_string": "b\n"}),
+            False,
+        ),
+        "different tool": (_tc("Write", {"file_path": "/p.py", "content": "b\n"}), False),
+        "nested payload differs": (
+            _tc("MultiEdit", {"file_path": "/p.py", "edits": [{"old_string": "a\n", "new_string": "OTHER\n"}]}),
+            False,
+        ),
+        "no tool call at all": ({"role": "assistant", "content": "Let me reconsider."}, False),
+        "leading whitespace differs": (
+            _tc("Edit", {"file_path": "/p.py", "old_string": "  a\n", "new_string": "b  \n"}),
+            False,
+        ),
+    }
+    for label, (msg, should_restore) in cases.items():
+        out = mgr.restore_generated_messages(sid, [*messages([s, u]), msg, t1.message], _SCHEMA)
+        assert (out[2] == _EDIT_GEN) is should_restore, f"{label}: restore decision wrong"
+    print(f"PASS 3.10 ({len(cases)} cases)")
+
+
+def test_3_14_restore_across_a_long_rewriting_session():
+    """End-to-end along the adapter's path: every turn's history is restored
+    before rendering, exactly as ``_run_turn`` does, with the harness rewriting
+    each assistant echo. Every generated turn must stay trained and the session
+    must not fork."""
+    mgr = TrajectoryManager()
+    sid = "3.11"
+    s, u = sys_msg("S"), usr_msg("u")
+    n_turns = 5
+
+    hist = messages([s, u])
+    tokens = render_prompt([s, u])
+    for i in range(n_turns):
+        restored = mgr.restore_generated_messages(sid, hist, _SCHEMA)
+        gen = _tc("Edit", {"file_path": f"/f{i}.py", "old_string": f"x{i}  \n", "new_string": f"y{i}  \n"})
+        resp = render_response(f"edit{i}")
+        mgr.record_turn(
+            sid,
+            turn=turn(tokens, resp, finish_reason="tool_calls"),
+            prompt_messages=restored,
+            response_message=gen,
+        )
+        # The harness replays its own rewritten echo of that turn, plus a result.
+        echo = _tc(
+            "Edit",
+            {"file_path": f"/f{i}.py", "old_string": f"x{i}\n", "new_string": f"y{i}\n", "replace_all": False},
+        )
+        tool = tool_msg(f"r{i}")
+        hist = [*restored, echo, tool.message]
+        tokens = tokens + resp + tool.render() + [_GEN]
+
+    assert len(_leaves(mgr, sid)) == 1, "a restored session never forks"
+    samples = get_traj(mgr, sid, base_sample=Sample(index=0, prompt=""), reward=1.0)
+    assert len(samples) == 1
+    trained_turns = sum(1 for i in range(n_turns) if f"[r:edit{i}]" in goldens(samples)[0])
+    assert trained_turns == n_turns, f"all {n_turns} generated turns must train, got {trained_turns}"
+    _check_invariants(samples)
+    _record("3.14 restore across a long rewriting session", mgr, sid, samples)
+    print("PASS 3.14")
+
+
 def test_4_2_logprobs_length_mismatch_raises():
     """output_log_probs whose length != output_ids -> ValueError at record_turn."""
     mgr = TrajectoryManager()
@@ -1367,6 +1655,12 @@ _CASES = [
     test_3_6_tree_fork_plus_token_drift,
     test_3_7_deep_multi_leaf_dedup,
     test_3_8_long_mixed_session,
+    test_3_9_restore_echo_keeps_turn_trainable,
+    test_3_10_restore_echo_from_whitespace_alone,
+    test_3_11_restore_echo_with_either_default_polarity,
+    test_3_12_no_schema_falls_back_to_stricter_matching,
+    test_3_13_restore_declines_anything_but_an_echo,
+    test_3_14_restore_across_a_long_rewriting_session,
     test_4_2_logprobs_length_mismatch_raises,
     test_4_3_empty_prompt_messages_skipped,
     test_4_4_default_base_sample,


### PR DESCRIPTION
### Issue

In coding-agent RL, an assistant turn that calls `Edit` or `Write` can end up contributing **zero trained tokens**. The run reports nothing: no exception, no warning, and the same number of emitted `Sample`s. The only trace is a smaller `loss_mask` sum, which nothing watches.

Measured across a 50-step GRPO run on SWE-rebench problems with the Claude Code harness (8xH20 per node; 4224 trained samples, 171,539 assistant turns, 38.8M assistant tokens): **44.3% of all turns containing an `Edit` or `Write` should have been trained and were not.** `Bash` and `Read` turns were dropped less often than average (0.6x), so the model kept learning to read code and run tests while losing supervision on the step where it applies the fix.

Reproduce on a clean checkout — no GPU, sandbox, or model needed (`repro_edit_write_turn_dropped.py` for the demonstration, `verify.py` for the measurements in Validation below): https://gist.github.com/pollyloop/f7cafc2dd0854587e82acb4e31281e1b

```
scenario                            samples   mask   Edit   Write   Bash
------------------------------------------------------------------------
byte-exact echo (ideal)                   1      6      1       1      1
harness replayed it re-rendered           1      2      0       0      1
```

### Cause

A harness may replay a prior assistant tool call **re-rendered rather than byte-identical** — the term `_try_merge_assistant_rewrite` already uses for this. The replay is not just formatted differently; the argument values themselves are altered. With the Claude Code CLI, two things happen to the echo:

1. it fills in a tool-schema default the model omitted — `replace_all: False` appears on an `Edit` that never carried that key;
2. string arguments are right-stripped per line, so trailing whitespace inside a code payload disappears.

Neither changes what the tool does, but both break `==`.

That matters twice over, because a rewritten echo reaches the manager through two channels at once. `_run_turn` builds both from the same `translated` list:

```python
translated, tools_schema = self._translate(body)                    # the harness's bytes
prompt_ids = _render_token_ids(translated, ...)                     # -> layer 2
...
self.manager.record_turn(sid, turn=turn, prompt_messages=translated, ...)   # -> layer 1
```

The test suite already names these layers: **layer 1** is the routing tree, keyed on message identity; **layer 2** is linearization, keyed on the token prefix. The rewrite breaks both, and each one on its own is enough to lose the turn:

**Layer 1 — the routing tree.** `_find_mount_point` matches history by strict dict equality (`child.message == msg`, trajectory.py:361), so the walk stops one level above the assistant node. `_try_merge_assistant_rewrite` finds exactly one short assistant leaf there and absorbs it — `rewritten_node.turn = None` (:423) — and `_chain_to_samples` filters `turn is None` out of `asst_nodes`. The generated tokens survive only as `loss_mask=0` context.

**Layer 2 — the token prefix.** `prompt_ids` was rendered from the harness's arguments, so it no longer extends the tokens the builder holds. `classify_token_drift` sees the divergence inside the most recent response span and returns `REALIGN`, and `_align_to_prompt` overwrites that span with the prompt tail at `loss_mask=0` (:216-224). Same outcome, different route.

This is why the fix has to act on `translated` itself rather than on the matching predicate: both channels are downstream of it.

This is why the file-writing tools are hit: they carry at least one of those two things, and **either is enough on its own**. `Edit` has both. `Write` has no schema default at all (injection rate 0%), yet its multi-line `content` is right-stripped just the same — and it is dropped at the same rate. `Bash`/`Read` arguments pass through untouched.

Looking past this class of difference is already the intent here. `tool_call_dict` stores arguments as a dict rather than a JSON string specifically so that key order cannot break the comparison — its docstring says *"the trajectory manager matches history by dict equality, so a sampled leaf and its replayed echo compare equal regardless of key order."* A filled-in default and per-line trailing whitespace are the same kind of difference — no effect on what the tool does, but fatal to `==` — and are currently not absorbed.

### Fix

`TrajectoryManager.restore_generated_messages(sid, messages)` — swap a recognized echo back to the message we generated. The adapter calls it in `_run_turn`, between `_translate` and `_render_token_ids`:

```python
translated, tools_schema = self._translate(body)
translated = self.manager.restore_generated_messages(sid, translated)
prompt_ids = _render_token_ids(translated, tok, tools=tools_schema, add_generation_prompt=True)
```

That placement is what makes it fix both layers at once. It is after `_translate`, so there is something to compare against the tree; and before `_render_token_ids`, so `prompt_ids` is rendered from our own bytes rather than the harness's. The turn then classifies `CLEAN` and keeps its gradient.

Fixing only layer 1 would not be enough: `prompt_ids` would still come from the harness's bytes, layer 2 would still return `REALIGN`, and the same span would still be zeroed (Validation item 1, third row).

`_is_same_tool_call_echo` decides what counts as an echo. It does not try to reverse the harness's edits — nothing is recovered from the echo, and no attempt is made to guess how much whitespace was stripped. Instead it compares the two messages **through a coarser view that both sides map onto**:

- an argument equal to the default its **own tool schema declares** is dropped, since omitting an argument and passing its default are the same call. The schema is already in hand at the call site (`_translate` returns it one line earlier), so `restore_generated_messages` takes it and `_tool_defaults` reads `properties.*.default` out of it;
- strings are right-stripped per line.

If both sides agree there, the echo is the same call. Everything outside `tool_calls` — role, content, tool name, call count, any other key — must still match exactly.

With no schema passed, only the whitespace projection applies — the comparison gets stricter, which costs a restore rather than making a wrong one.

Recovering the original bytes is then trivial and lossless, because it does not come from the echo at all: `out[depth] = echoes[0].message` puts back the message we stored when the model produced it, whitespace and all.

`_find_mount_point` is therefore **left alone**, keeping strict dict equality: once the restore has run, `record_turn` receives the generated message and the exact-equality walk succeeds on its own (measured — Validation item 4).

Three files, `+472 −0`; no existing line is modified.

### Validation

Items 1, 3 and 4 are a script in the gist — `python3 verify.py` inside any checkout reproduces those three tables, and it detects whether the checkout is patched (on a pristine one it shows the bug and skips the fix-dependent parts). Items 2 and 5 are the test suite, so CI runs them here. Item 6 is the one thing you cannot re-run: it came from a cluster run, and the data is not public — treat it as corroboration of scale, not as evidence the fix is correct. That case rests on 1–5.

**1. Is the restore necessary, and is it sufficient?** (`verify.py`, item 1.) Four configurations. Each layer is observed from the outside — a read-only wrapper around `_try_merge_assistant_rewrite` (layer 1) and `classify_token_drift` (layer 2) that records which branch is taken and forwards unchanged, so what runs is the shipped code:

| configuration | mask | Edit | Write | Bash | layer 1 | layer 2 |
|---|---|---|---|---|---|---|
| byte-exact echo (ideal) | 6 | 1 | 1 | 1 | no merge | `clean` |
| harness rewrote the echo (`main` today) | 2 | 0 | 0 | 1 | 2 merges fired | not reached |
| + recognize echo, no restore | 2 | 0 | 0 | 1 | no merge | `realign` |
| + restore before render | 6 | 1 | 1 | 1 | no merge | `clean` |

Row 2 is `main`: layer 1 swallows the turn, which is why layer 2 never sees it. Row 3 is the layer-1-only fix — the merge now correctly declines, so the turn does reach layer 2, which diverges instead and zeroes the same span. The numbers do not budge. Row 4 fixes both layers and matches the ideal. `Bash` is unchanged throughout, as it must be.

**2. Does it ever restore something it shouldn't?** This is the risk the fix introduces, so it gets its own test (`test_3_13`). A harness that self-corrects or retries produces exactly these:

| incoming assistant message | restored? |
|---|---|
| the real echo | yes |
| a different `old_string` | no |
| a different file | no |
| a different tool (`Write`, not `Edit`) | no |
| plain text, no tool call | no |
| *leading* whitespace differs | no |
| `MultiEdit` whose nested payload differs | no |

The default-dropping deserves its own matrix, over a tool whose default is `False` (`Edit.replace_all`) and one whose default is `True` (`Fetch.follow_redirects` below) — `test_3_11` covers both:

The observed edit is always the same shape — the model omitted the argument and the harness filled one in — so what matters is whether the filled-in value is the declared default:

| declared default | harness filled in | same call? |
|---|---|---|
| `False` | `False` | yes |
| `False` | `True` | no |
| `True` | `True` | yes |
| `True` | `False` | no |

Rows 1 and 3 are the same case — the harness filled in exactly what the schema declares, whichever value that is — and both are recognized because the declared value is read rather than assumed. Rows 2 and 4 fill in something the schema does *not* declare, which is a genuinely different call, so they keep taking the existing path.

Worth noting for the bound on all of this: `restore_generated_messages` only rewrites `prompt_messages`, the context for the *next* turn. Training uses `turn.output_ids` — what the model actually sampled — which the function never touches.

**3. Does the comparison have to look past *both* kinds of edit?** Yes. Narrowing the view so it looks past only one of them (`verify.py`, item 3) leaves turns untrained:

| comparison looks past | Edit | Write |
|---|---|---|
| both (this PR) | 1 | 1 |
| trailing whitespace only | 0 | 1 |
| filled-in defaults only | 0 | 0 |

`Write` only needs trailing whitespace looked past, since its schema declares no default to fill in. `Edit` needs both, because the harness applies both to it at once — look past one and its `old_string` still compares unequal, so the echo goes unrecognized and the turn is lost exactly as on `main`.

**4. Would relaxing `_find_mount_point` help too?** No (`verify.py`, item 4). Instrumenting a session where the predicate is relaxed *as well*, every echo it recognizes was already handled by the restore: **0 of its decisions came from `_find_mount_point`**. Once the adapter restores before rendering, `record_turn` receives the generated message and exact equality succeeds on its own, so `record_turn`'s core path is left untouched.

**5. Tests.** Six new cases in `tests/test_agent/test_trajectory_manager_branching.py`, in the existing 3.x style:

- `test_3_9` — an `Edit` echo (both kinds of edit at once) is restored, the caller's list is not mutated, and the turn keeps its `TurnRecord` and trains;
- `test_3_10` — a `Write` echo differing *only* by the right-stripping, so each kind of edit is covered on its own;
- `test_3_11` — a tool whose declared default is `True`, where filling in `True` is the same call and filling in `False` is not: the reverse of `Edit.replace_all`;
- `test_3_12` — with no schema passed, a filled-in default is no longer recognized and the echo is left alone, while whitespace-only echoes still restore;
- `test_3_13` — the rejection table above;
- `test_3_14` — an end-to-end 5-turn session along the adapter's path with the harness rewriting every echo.

All six fail on `main` (`AttributeError: no attribute restore_generated_messages`) and pass with this change. Run the way CI runs them (`python tests/test_agent/<file>.py`, CPU torch, `pip install -e . --no-deps`):

| | main | this PR |
|---|---|---|
| `test_trajectory_manager_branching.py` | 35 passed | 41 passed |
| `test_adapters.py` | 14 passed, 1 skipped | 14 passed, 1 skipped |
| `test_harness.py` | 9 passed | 9 passed |
| `test_agent_rollout_cpu.py` | 4 passed | 4 passed |
| `pre-commit run` | — | clean |

`test_agent_rollout_cpu.py` covers the adapter change as well: it drives the real `_run_turn` over HTTP loopback, where `restore_generated_messages` is called 4 times. That is also why the repro is a gist rather than a new file under `tests/` — `agent-test`'s file list is enumerated in `pr-test.yml.j2`, so a new file would not actually run without editing the generated workflow.

**6. A real rollout, before and after.** Two runs over the same 16 SWE-rebench problems with the Claude Code harness. Same model, same sampling config, same problems; the only difference is whether the restore is applied. The two runs were checked rollout by rollout to confirm they saw the same problems in the same order.

| | restore off | restore on |
|---|---|---|
| Edit turns with `loss_mask=0` | 59.4% | 3.7% |
| Write turns with `loss_mask=0` | 50.0% | 0% |
| assistant tokens with `loss_mask=0` | 30.6% | 6.5% |
| samples emitted | 96 | 86 (−10.4%) |
| truncated sessions | 4/16 | 4/16 (unchanged) |

Of the 285 rewritten tool calls in these runs, all 285 were recognized and restored. The **fall** in sample count is independent corroboration rather than a side effect: those extra samples were dead-end forks, which is what the rewrite-merge existed to avoid in the first place.

What this does not show: 16 problems cannot measure a change in model quality, and I make no claim there. This is a correctness fix — generated tokens were being excluded from the loss.

### Notes

**Anything counting drift classifications will report more of them.** Every turn that survives to linearization gets classified by `classify_token_drift` as CLEAN, REALIGN or FORK. A turn the merge swallows never gets that far — `turn = None` drops it from `asst_nodes` before `_split_chain_into_builders` runs — so today it is absent from those counts entirely. This PR keeps those turns, so they are classified for the first time and the totals rise (1 classification before vs 2 after, on a 3-turn session). No turn drifts that did not drift before; turns that were invisible are now visible.

**Two cases this does not fix.** An argument filled in inside a *nested* object is not recognized, since only top-level arguments are compared against the schema; and a harness whose tool schemas omit `default` altogether leaves only the whitespace comparison, so a filled-in default is not recognized either. In both, the echo is left as the harness sent it and the turn is lost exactly as it is on `main` today — no improvement, but no new harm. The failure direction is the safe one: an echo that goes unrecognized costs that turn its gradient, whereas misrecognizing one would put the wrong message into the next prompt.

**The merge mechanism and its threshold are untouched.** This PR does not change `_try_merge_assistant_rewrite` or `fork_threshold_tokens`; it removes the drift that makes the merge fire, so a re-rendered echo no longer looks like a rewrite and there is no candidate to absorb. Worth noting separately, though: that function's docstring says the merge is "purely a cleanup" and that "forking is always safe". Structurally true, but the merge branch destroys a generated `TurnRecord` while the fork branch keeps it — so under any harness that re-renders its history, the choice between them is not signal-neutral, and the 1024 default silently decides how much of a turn survives. That assumption may deserve a look on its own; this PR just stops relying on it.

**#2174** is open against the same file and will likely conflict. Happy to rebase on top of it, or to hold this until it lands.

### Acknowledgement

Special thanks to the person who got this coding-agent RL pipeline running in our internal environment, which is where these measurements come from.

Analysis assisted by Claude Code.
