### PR TITLE
feat(agent): optionally preserve native parallel tool calls

### DIFF
--- a/slime/agent/adapters/openai.py
+++ b/slime/agent/adapters/openai.py
@@ -44,6 +44,10 @@ class OpenAIAdapter(BaseAdapter):
     max_token_keys = ("max_completion_tokens", "max_tokens", "max_output_tokens")
     stop_keys = ("stop",)
 
+    def __init__(self, *, preserve_parallel_tool_calls: bool = False, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.preserve_parallel_tool_calls = bool(preserve_parallel_tool_calls)
+
     def _register_routes(self, app: web.Application) -> None:
         app.router.add_post("/v1/chat/completions", self._run_turn)
 
@@ -59,7 +63,11 @@ class OpenAIAdapter(BaseAdapter):
         return translated, tools_schema
 
     def _build_reply(self, parsed, raw_finish, translated, tools_schema) -> Reply:
-        wire_message, manager_message, wire_finish = _build_reply_parts(parsed, raw_finish)
+        wire_message, manager_message, wire_finish = _build_reply_parts(
+            parsed,
+            raw_finish,
+            preserve_parallel_tool_calls=self.preserve_parallel_tool_calls,
+        )
         return Reply(
             manager_message=manager_message,
             finish_reason=manager_finish_reason(parsed.tool_uses, raw_finish),
@@ -208,7 +216,12 @@ def _tools_to_chat_tools(tools: list[dict] | None) -> list[dict] | None:
 # --- Reply building: parsed output -> OpenAI wire message + manager_message ---
 
 
-def _build_reply_parts(parsed: ParsedModelOutput, finish: str) -> tuple[dict[str, Any], dict[str, Any], str]:
+def _build_reply_parts(
+    parsed: ParsedModelOutput,
+    finish: str,
+    *,
+    preserve_parallel_tool_calls: bool = False,
+) -> tuple[dict[str, Any], dict[str, Any], str]:
     """Return (wire_message, manager_message, wire_finish).
 
     wire_message follows the OpenAI Chat-Completions spec: tool_calls[].id is a
@@ -259,7 +272,9 @@ def _build_reply_parts(parsed: ParsedModelOutput, finish: str) -> tuple[dict[str
     # Differences from wire_message, each needed to match the echo:
     #   * no reasoning_content -- some clients strip it on echo (the reasoning
     #     token ids are still kept in the trained tokens, only the text drops)
-    #   * only the first tool_call -- some clients drop extra parallel tool_calls
+    #   * by default only the first tool_call -- some clients drop extra parallel
+    #     tool_calls. Native clients that faithfully echo every call opt into
+    #     preserve_parallel_tool_calls so the policy may execute all of them.
     #   * empty content when tool_calls are present -- mirrors content=null above
     manager_message: dict[str, Any] = {
         "role": "assistant",
@@ -268,8 +283,9 @@ def _build_reply_parts(parsed: ParsedModelOutput, finish: str) -> tuple[dict[str
     if parsed.reasoning:
         wire_message["reasoning_content"] = parsed.reasoning
     if wire_tool_calls:
-        wire_message["tool_calls"] = wire_tool_calls[:1]
-        manager_message["tool_calls"] = manager_tool_calls[:1]
+        limit = None if preserve_parallel_tool_calls else 1
+        wire_message["tool_calls"] = wire_tool_calls[:limit]
+        manager_message["tool_calls"] = manager_tool_calls[:limit]
 
     if parsed.tool_uses:
         wire_finish = "tool_calls"

--- a/tests/test_agent/test_adapters.py
+++ b/tests/test_agent/test_adapters.py
@@ -28,7 +28,7 @@ if str(REPO_ROOT) not in sys.path:
 from tests.test_agent._fakes import FakeSGLangServer, FakeTokenizer  # noqa: E402
 
 from slime.agent.adapters import anthropic, openai  # noqa: E402
-from slime.agent.parsing import parse_model_output, parse_xml_tool_uses  # noqa: E402
+from slime.agent.parsing import ParsedModelOutput, parse_model_output, parse_xml_tool_uses  # noqa: E402
 from slime.utils.types import Sample  # noqa: E402
 
 NUM_GPUS = 0
@@ -158,6 +158,34 @@ def test_openai_translation_developer_to_system_and_tool_calls_to_dict():
         # tool_call_id dropped.
         {"role": "tool", "content": "found"},
     ]
+
+
+def test_openai_native_parallel_tool_calls_round_trip_into_manager_history():
+    parsed = ParsedModelOutput(
+        reasoning="",
+        text="",
+        tool_uses=[
+            {"name": "lookup", "input": {"q": "slime"}},
+            {"name": "read", "input": {"path": "README.md"}},
+        ],
+    )
+
+    default_wire, default_manager, _ = openai._build_reply_parts(parsed, "stop")
+    assert len(default_wire["tool_calls"]) == 1
+    assert len(default_manager["tool_calls"]) == 1
+
+    wire, manager, finish = openai._build_reply_parts(
+        parsed,
+        "stop",
+        preserve_parallel_tool_calls=True,
+    )
+    assert finish == "tool_calls"
+    assert len(wire["tool_calls"]) == 2
+    assert len(manager["tool_calls"]) == 2
+    # The native Harness echoes every OpenAI tool call on the next request.
+    # Translation drops only wire correlation ids and must reproduce exactly
+    # the manager leaf recorded for the previous model turn.
+    assert openai._translate_messages([wire]) == [manager]
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary

The OpenAI agent adapter currently truncates every parsed tool-call turn to the first call so clients that drop extra calls can replay history. That behavior prevents native clients which faithfully echo parallel calls from executing and training all model-selected actions.

This adds an opt-in `preserve_parallel_tool_calls=True` constructor flag. The default remains unchanged for existing Codex-style clients. In native mode, both the OpenAI wire reply and the trajectory-manager message retain the complete ordered call list.

## Why the opt-in is replay-safe

The native client echoes all `tool_calls` in its next Chat Completions request. `_translate_messages` removes only wire correlation IDs and JSON-decodes arguments, reproducing the exact manager message recorded for the preceding turn. The regression test checks this equality for two calls and also locks the legacy default at one call.

## Validation

- `ruff check slime/agent/adapters/openai.py tests/test_agent/test_adapters.py`
- `CUDA_VISIBLE_DEVICES= USE_TORCH=0 python -m pytest -q tests/test_agent`
- 65 passed, 1 skipped on a registered CPU worker
