### PR TITLE
test(dist): assert reload replays new_group timeout and options

### DIFF
--- a/tests/test_reloadable_process_group_world.py
+++ b/tests/test_reloadable_process_group_world.py
@@ -218,5 +218,64 @@ def test_unregistered_world_preserves_subgroup_only_behavior(monkeypatch):
     assert events == ["destroy_subgroups", "reload_subgroups"]
 
 
+@pytest.mark.unit
+def test_reload_replays_original_new_group_timeout_and_options(monkeypatch):
+    """Reload must replay timeout/pg_options, not ``{ranks, backend=nccl}``.
+
+    The multiprocess test in this file only checks that a reloaded group can
+    still ``barrier``. That still passes if reload drops a 2-hour NCCL timeout
+    and falls back to PyTorch's default — the offload/heal watchdog bug. Spy
+    on the constructor instead.
+    """
+    pid = 4242
+    calls: list[tuple[tuple, dict, object]] = []
+    timeout = timedelta(minutes=120)
+    pg_options = object()
+
+    class FakeGroup:
+        pass
+
+    def fake_new_group(*args, **kwargs):
+        group = FakeGroup()
+        calls.append((args, dict(kwargs), group))
+        return group
+
+    monkeypatch.setattr(rpg, "old_new_group_dict", {})
+    monkeypatch.setattr(rpg, "default_process_group_states", {})
+    monkeypatch.setattr(rpg.ReloadableProcessGroup, "GROUPS", {})
+    monkeypatch.setattr(rpg.os, "getpid", lambda: pid)
+    monkeypatch.setattr(rpg.dist, "new_group", fake_new_group)
+    monkeypatch.setattr(rpg.dist, "get_rank", lambda group: 0)
+    monkeypatch.setattr(rpg.dist, "get_world_size", lambda group=None: 2)
+    monkeypatch.setattr(rpg.dist, "get_backend", lambda: "nccl")
+    monkeypatch.setattr(rpg.dist, "destroy_process_group", lambda group: None)
+
+    rpg.monkey_patch_torch_dist()
+    group = rpg.dist.new_group(
+        [0, 1],
+        backend="nccl",
+        timeout=timeout,
+        pg_options=pg_options,
+        group_desc="TP",
+    )
+    assert isinstance(group, rpg.ReloadableProcessGroup)
+    first_inner = calls[-1][2]
+    assert group.group is first_inner
+
+    rpg.ReloadableProcessGroup.destroy_process_groups()
+    assert group.group is None
+
+    rpg.ReloadableProcessGroup.reload_process_groups()
+    reload_args, reload_kwargs, reloaded_inner = calls[-1]
+    assert group.group is reloaded_inner
+    assert reloaded_inner is not first_inner
+    assert reload_args == ([0, 1],)
+    assert reload_kwargs["backend"] == "nccl"
+    assert reload_kwargs["timeout"] is timeout
+    assert reload_kwargs["pg_options"] is pg_options
+    assert reload_kwargs["group_desc"] == "TP"
+    assert set(reload_kwargs) == {"backend", "timeout", "pg_options", "group_desc"}
+
+
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__]))


### PR DESCRIPTION
## What

CPU regression test that `reload_process_groups()` calls `new_group` with the original `timeout`, `pg_options`, and `group_desc`, not `{ranks, backend="nccl"}`.

## Why

Follow-up to #2095. The constructor replay landed in #2208; this is the assertion #2095 carried that did not.

#2208's multiprocess test checks that a reloaded group can still `barrier`. That still passes if reload drops a 2-hour NCCL timeout and falls back to PyTorch's default — the offload/heal watchdog bug. This test spies on the constructor.

Verified locally: passes on current main; fails if reload is patched back to `old_new_group(ranks=..., backend="nccl")`.

## Test

`pytest tests/test_reloadable_process_group_world.py::test_reload_replays_original_new_group_timeout_and_options -q`


Made with [Cursor](https://cursor.com)