### PR TITLE
fix: improve compatibility with older SGLang versions

### DIFF
--- a/slime/backends/sglang_utils/arguments.py
+++ b/slime/backends/sglang_utils/arguments.py
@@ -1,8 +1,11 @@
 import argparse
+import logging
 
 from sglang.srt.server_args import ServerArgs
 from sglang_router.launch_router import RouterArgs
 from slime.utils.http_utils import _wrap_ipv6
+
+logger = logging.getLogger(__name__)
 
 
 # TODO: use all sglang router arguments with `--sglang-router` prefix
@@ -152,7 +155,18 @@ def validate_args(args):
         ("sglang_ep_size", "sglang_expert_parallel_size"),
         ("sglang_moe_dp_size", "sglang_moe_data_parallel_size"),
     ):
-        value = getattr(args, current_name) if hasattr(args, current_name) else getattr(args, legacy_name)
+        if hasattr(args, current_name):
+            value = getattr(args, current_name)
+        elif hasattr(args, legacy_name):
+            value = getattr(args, legacy_name)
+        else:
+            logger.warning(
+                "The installed SGLang registered neither %s nor %s; "
+                "skipping compatibility alias normalization for this parameter.",
+                current_name,
+                legacy_name,
+            )
+            continue
         setattr(args, current_name, value)
         setattr(args, legacy_name, value)
 

--- a/slime/ray/rollout.py
+++ b/slime/ray/rollout.py
@@ -1096,7 +1096,10 @@ def _start_router(args, *, has_pd_disaggregation: bool = False, force_new: bool 
     router_args.disable_circuit_breaker = True
 
     # We will not use the health check from router.
-    router_args.disable_health_check = True
+    if hasattr(router_args, "disable_health_check"):
+        router_args.disable_health_check = True
+    else:
+        logger.warning("The installed SGLang does not provide the disable_health_check parameter.")
 
     logger.info(f"Launch router with args: {router_args}")
 


### PR DESCRIPTION
# Summary

Improve compatibility with SGLang releases that do not expose all of the argument aliases and router options expected by the latest Slime integration.

# Changes

- Skip SGLang parallelism aliases when neither the current nor legacy argument name is available, while continuing to synchronize aliases that are provided by the installed SGLang version.
- Set `disable_health_check` only when the installed `sglang-router` exposes that option, preventing unsupported dynamic attributes from being forwarded to the native Router constructor.

# Motivation

SGLang argument and router APIs vary between releases. Slime previously assumed that at least one name in every argument alias pair and the `disable_health_check` router option were always available. With releases that do not provide those attributes, validation or router startup could fail before rollout initialization.

The new capability checks preserve the existing behavior for versions that support these APIs and safely skip unavailable options for versions that do not.

# Testing

```bash
PYTHONPATH=. pytest -q tests/utils/test_sglang_arguments.py tests/test_megatron_argument_validation.py
```

Result: `20 passed`.
