### PR TITLE
fix(agent): keep Qwen3.5 agent token history append-only

### DIFF
--- a/examples/coding_agent_rl/README.md
+++ b/examples/coding_agent_rl/README.md
@@ -124,7 +124,7 @@ contract (read inside `slime/agent/`); `SWE_*` are this SWE example's task knobs
 | `SLIME_AGENT_CC_TARBALL` | — | Host path to the Claude Code CLI npm tarball. |
 | `SLIME_AGENT_CC_EXTRA_ARGS` | (see launcher) | Extra flags appended to the `claude` CLI invocation — registers the read-only `investigator` sub-agent, disables `WebFetch`/`WebSearch`, disables slash commands. |
 | `SLIME_AGENT_CC_EXTRA_ENVS` | unset | JSON object of extra env vars exported into the `claude` process — escape hatch for env-only knobs (`MAX_THINKING_TOKENS`, `BASH_MAX_TIMEOUT_MS`, ...). Merged last, so it can also override the built-in defaults. |
-| `SLIME_PRESERVE_REASONING_HISTORY` | `1` | Keep Qwen reasoning in replayed assistant turns so multi-turn token history remains append-only. Disable only when intentional history rewriting should create trajectory forks. |
+| `SLIME_PRESERVE_REASONING_HISTORY` | `1` | Preserve the server's canonical Qwen token history when Claude Code replays or normalizes earlier assistant turns. |
 | `SWE_AGENT_TIME_BUDGET_SEC` | `1800` | Wallclock budget for the in-sandbox agent CLI itself (think/edit/run). |
 | `SWE_EVAL_TIMEOUT_SEC` | `600` | Wallclock cap on the evaluator sandbox. |
 | `SWE_ROLLOUT_GUARD_SEC` | `agent+eval+180` | Outer safety net wrapping the whole rollout (boot + workspace + agent + diff + eval). Auto-derived if unset. |
@@ -140,12 +140,14 @@ The Anthropic adapter reuses `--sglang-tool-call-parser` and
 `--sglang-reasoning-parser` for output parsing, so those flags must match the
 served model.
 
-Qwen chat templates normally omit assistant reasoning before the latest
-user/tool turn. During RL this rewrites previously sampled tokens and can turn
-every agent turn into a false trajectory fork. The example enables
-`SLIME_PRESERVE_REASONING_HISTORY=1`, which uses an append-only Qwen template
-and restores generated reasoning when the client omits thinking blocks from
-replayed history. Real compaction or changed visible responses still fork.
+Qwen3/3.5 chat templates normally omit assistant reasoning before the latest
+user/tool turn. Claude Code may also normalize replayed text and tool calls.
+Re-rendering that message history changes previously sampled tokens and can
+turn every agent turn into a false trajectory fork. The example enables
+`SLIME_PRESERVE_REASONING_HISTORY=1`, which keeps the adapter's exact prior
+`prompt_ids + output_ids` and appends only the newly rendered observation and
+generation prompt. A strict prefix check rejects non-append-only continuation
+instead of silently emitting extra training Samples.
 
 ## String-in, Token-out Trajectories
 

--- a/examples/coding_agent_rl/README.md
+++ b/examples/coding_agent_rl/README.md
@@ -124,6 +124,7 @@ contract (read inside `slime/agent/`); `SWE_*` are this SWE example's task knobs
 | `SLIME_AGENT_CC_TARBALL` | — | Host path to the Claude Code CLI npm tarball. |
 | `SLIME_AGENT_CC_EXTRA_ARGS` | (see launcher) | Extra flags appended to the `claude` CLI invocation — registers the read-only `investigator` sub-agent, disables `WebFetch`/`WebSearch`, disables slash commands. |
 | `SLIME_AGENT_CC_EXTRA_ENVS` | unset | JSON object of extra env vars exported into the `claude` process — escape hatch for env-only knobs (`MAX_THINKING_TOKENS`, `BASH_MAX_TIMEOUT_MS`, ...). Merged last, so it can also override the built-in defaults. |
+| `SLIME_PRESERVE_REASONING_HISTORY` | `1` | Keep Qwen reasoning in replayed assistant turns so multi-turn token history remains append-only. Disable only when intentional history rewriting should create trajectory forks. |
 | `SWE_AGENT_TIME_BUDGET_SEC` | `1800` | Wallclock budget for the in-sandbox agent CLI itself (think/edit/run). |
 | `SWE_EVAL_TIMEOUT_SEC` | `600` | Wallclock cap on the evaluator sandbox. |
 | `SWE_ROLLOUT_GUARD_SEC` | `agent+eval+180` | Outer safety net wrapping the whole rollout (boot + workspace + agent + diff + eval). Auto-derived if unset. |
@@ -138,6 +139,13 @@ the emitted segments and does not drop them for length.
 The Anthropic adapter reuses `--sglang-tool-call-parser` and
 `--sglang-reasoning-parser` for output parsing, so those flags must match the
 served model.
+
+Qwen chat templates normally omit assistant reasoning before the latest
+user/tool turn. During RL this rewrites previously sampled tokens and can turn
+every agent turn into a false trajectory fork. The example enables
+`SLIME_PRESERVE_REASONING_HISTORY=1`, which uses an append-only Qwen template
+and restores generated reasoning when the client omits thinking blocks from
+replayed history. Real compaction or changed visible responses still fork.
 
 ## String-in, Token-out Trajectories
 

--- a/examples/coding_agent_rl/generate.py
+++ b/examples/coding_agent_rl/generate.py
@@ -60,6 +60,7 @@ class SweConfig:
     adapter_bind_host: str
     adapter_port: int
     fork_merge_threshold: int | None
+    preserve_reasoning_history: bool
     agent_time_budget_sec: int
     eval_timeout_sec: int
     rollout_guard_sec: int
@@ -72,6 +73,12 @@ class SweConfig:
         eval_timeout = int(os.environ.get("SWE_EVAL_TIMEOUT_SEC", "600"))
         guard = int(os.environ.get("SWE_ROLLOUT_GUARD_SEC", "0") or 0) or (agent_time_budget + eval_timeout + 180)
         fork = int(v) if (v := os.environ.get("SLIME_FORK_MERGE_MAX_RESPONSE_TOKENS")) else None
+        preserve_reasoning = os.environ.get("SLIME_PRESERVE_REASONING_HISTORY", "0").lower() in {
+            "1",
+            "true",
+            "yes",
+            "on",
+        }
         return cls(
             eval_protocol=os.environ.get("SWE_EVAL_PROTOCOL", swe.PROTOCOL_SCALESWE),
             train_protocol=os.environ.get("SWE_TRAIN_PROTOCOL", swe.PROTOCOL_SCALESWE),
@@ -79,6 +86,7 @@ class SweConfig:
             adapter_bind_host=os.environ.get("ADAPTER_BIND_HOST", "0.0.0.0"),
             adapter_port=int(os.environ.get("ADAPTER_PORT", "18001")),
             fork_merge_threshold=fork,
+            preserve_reasoning_history=preserve_reasoning,
             agent_time_budget_sec=agent_time_budget,
             eval_timeout_sec=eval_timeout,
             rollout_guard_sec=guard,
@@ -152,6 +160,7 @@ class _AdapterService(metaclass=SingletonMeta):
             sglang_url=sglang_url,
             tool_parser=self.tool_parser,
             reasoning_parser=self.reasoning_parser,
+            preserve_reasoning_history=CONFIG.preserve_reasoning_history,
             fork_threshold_tokens=CONFIG.fork_merge_threshold,
         )
         # handler_cancellation=True so a client disconnect cancels the handler
@@ -170,12 +179,14 @@ class _AdapterService(metaclass=SingletonMeta):
         )
         self.adapter_url = f"http://{CONFIG.adapter_public_host}:{self.app_handle.port}"
         logger.info(
-            "[coding_agent_rl] tokenizer=%s adapter=%s max_context_len=%s tool_parser=%s reasoning_parser=%s",
+            "[coding_agent_rl] tokenizer=%s adapter=%s max_context_len=%s tool_parser=%s reasoning_parser=%s "
+            "preserve_reasoning_history=%s",
             args.hf_checkpoint,
             self.adapter_url,
             self.max_context_len,
             self.tool_parser,
             self.reasoning_parser,
+            CONFIG.preserve_reasoning_history,
         )
 
 

--- a/examples/coding_agent_rl/run_qwen36_35b_a3b_swe_8nodes.sh
+++ b/examples/coding_agent_rl/run_qwen36_35b_a3b_swe_8nodes.sh
@@ -47,6 +47,7 @@ printf -v MOE_LAYER_FREQ "[%s]" "$(IFS=', '; echo "${arr[*]}")"
 # ============ context length ============
 MAX_CONTEXT_LEN="${MAX_CONTEXT_LEN:-96000}"
 MAX_GEN_LEN="${MAX_GEN_LEN:-32768}"
+export SLIME_PRESERVE_REASONING_HISTORY="${SLIME_PRESERVE_REASONING_HISTORY:-1}"
 
 # ============ paths — override before launching ============
 HF_CHECKPOINT="${HF_CHECKPOINT:-/path/to/Qwen3.6-35B-A3B}"

--- a/slime/agent/adapters/common.py
+++ b/slime/agent/adapters/common.py
@@ -26,20 +26,20 @@ from aiohttp import web
 from slime.agent.parsing import parse_model_output
 from slime.agent.trajectory import TrajectoryManager, TurnRecord
 
-
 __all__ = ["TurnRecord"]
 
 
 @dataclasses.dataclass
 class Session:
-    """Per-sid adapter state: sampling defaults and context budget.
+    """Per-sid adapter state: sampling defaults, context budget, and replay history.
 
     Trajectory state lives in the shared TrajectoryManager (BaseAdapter.manager),
-    not here.
+    while assistant_history only restores reasoning omitted by protocol clients.
     """
 
     sampling_defaults: dict = dataclasses.field(default_factory=dict)
     max_context_tokens: int = 0
+    assistant_history: list[dict] = dataclasses.field(default_factory=list)
 
 
 @dataclasses.dataclass
@@ -61,16 +61,70 @@ def _render_token_ids(
     *,
     tools: list[dict] | None,
     add_generation_prompt: bool = True,
+    chat_template: str | None = None,
 ) -> list[int]:
     """Render a chat-message list to token ids with the served chat template."""
-    enc = tokenizer.apply_chat_template(
-        messages,
-        tools=tools,
-        tokenize=True,
-        add_generation_prompt=add_generation_prompt,
-    )
+    kwargs = {
+        "tools": tools,
+        "tokenize": True,
+        "add_generation_prompt": add_generation_prompt,
+    }
+    if chat_template is not None:
+        kwargs["chat_template"] = chat_template
+    enc = tokenizer.apply_chat_template(messages, **kwargs)
     ids = enc["input_ids"] if hasattr(enc, "__getitem__") and "input_ids" in enc else enc
     return list(ids)
+
+
+_QWEN_REASONING_HISTORY_BRANCH = "{%- if loop.index0 > ns.last_query_index %}"
+
+
+def _reasoning_preserving_chat_template(tokenizer) -> str:
+    """Return a Qwen chat template that keeps prior assistant reasoning.
+
+    Qwen normally omits reasoning from assistant messages before the latest
+    user/tool turn. That is useful for inference, but it rewrites already
+    sampled token history during a multi-turn RL rollout. The opt-in adapter
+    mode replaces only that history guard and leaves the generation prompt and
+    the rest of the model-provided template unchanged.
+    """
+    template = getattr(tokenizer, "chat_template", None)
+    if not isinstance(template, str) or template.count(_QWEN_REASONING_HISTORY_BRANCH) != 1:
+        raise ValueError(
+            "preserve_reasoning_history requires a Qwen chat template containing "
+            f"exactly one {_QWEN_REASONING_HISTORY_BRANCH!r} guard"
+        )
+    return template.replace(_QWEN_REASONING_HISTORY_BRANCH, "{%- if true %}", 1)
+
+
+def _assistant_visible_signature(message: dict) -> tuple[Any, Any]:
+    return message.get("content"), message.get("tool_calls")
+
+
+def _restore_assistant_reasoning(messages: list[dict], assistant_history: list[dict]) -> int:
+    """Restore reasoning omitted when a client echoes assistant history.
+
+    Generated messages are matched in order by visible content and canonical
+    tool calls. A compacted or otherwise changed response does not match, so it
+    remains a genuine trajectory fork.
+    """
+    history_pos = 0
+    restored = 0
+    for message in messages:
+        if message.get("role") != "assistant":
+            continue
+        signature = _assistant_visible_signature(message)
+        for idx in range(history_pos, len(assistant_history)):
+            canonical = assistant_history[idx]
+            if _assistant_visible_signature(canonical) != signature:
+                continue
+            history_pos = idx + 1
+            reasoning = canonical.get("reasoning_content")
+            if reasoning and not message.get("reasoning_content"):
+                message["reasoning_content"] = reasoning
+                restored += 1
+            break
+    return restored
 
 
 def flatten_content(c: Any) -> str:
@@ -145,6 +199,7 @@ class BaseAdapter:
         sglang_url,
         tool_parser=None,
         reasoning_parser=None,
+        preserve_reasoning_history: bool = False,
         max_turns_per_sid: int | None = None,
         fork_threshold_tokens: int | None = None,
         debug_callback: Callable[..., None] | None = None,
@@ -153,6 +208,10 @@ class BaseAdapter:
         self.sglang_url = sglang_url.rstrip("/") if isinstance(sglang_url, str) else sglang_url
         self.tool_parser = tool_parser
         self.reasoning_parser = reasoning_parser
+        self.preserve_reasoning_history = bool(preserve_reasoning_history)
+        self.chat_template = (
+            _reasoning_preserving_chat_template(tokenizer) if self.preserve_reasoning_history else None
+        )
         self.store: dict[str, Any] = {}
         self.inflight: dict[str, set[asyncio.Task]] = {}
         self.closed: set[str] = set()
@@ -339,7 +398,22 @@ class BaseAdapter:
         t0 = time.monotonic()
         try:
             translated, tools_schema = self._translate(body)
-            prompt_ids = _render_token_ids(translated, tok, tools=tools_schema, add_generation_prompt=True)
+            if self.preserve_reasoning_history:
+                restored = _restore_assistant_reasoning(translated, s.assistant_history)
+                if restored:
+                    self.logger.debug(
+                        "[%s] sid=%s restored reasoning for %d assistant turn(s)",
+                        self.log_prefix,
+                        sid,
+                        restored,
+                    )
+            prompt_ids = _render_token_ids(
+                translated,
+                tok,
+                tools=tools_schema,
+                add_generation_prompt=True,
+                chat_template=self.chat_template,
+            )
 
             turn = await call_sglang_generate(prompt_ids, s, body, adapter=self, session_id=sid)
 
@@ -351,6 +425,9 @@ class BaseAdapter:
                 reasoning_parser_name=self.reasoning_parser,
             )
             reply = self._build_reply(parsed, turn.finish_reason, translated, tools_schema)
+            manager_message = reply.manager_message
+            if self.preserve_reasoning_history and parsed.reasoning and not manager_message.get("reasoning_content"):
+                manager_message = {**manager_message, "reasoning_content": parsed.reasoning}
             turn = dataclasses.replace(turn, ill_formed=parsed.ill_formed)
 
             in_tok, out_tok = len(prompt_ids), len(turn.output_ids)
@@ -377,7 +454,7 @@ class BaseAdapter:
                 sid,
                 translated,
                 tools_schema,
-                reply.manager_message,
+                manager_message,
                 turn,
             )
 
@@ -385,9 +462,10 @@ class BaseAdapter:
                 sid,
                 turn=turn,
                 prompt_messages=translated,
-                response_message=reply.manager_message,
+                response_message=manager_message,
                 metadata={"sid": sid},
             )
+            s.assistant_history.append(manager_message)
             return response
         finally:
             self.inflight.get(sid, set()).discard(task)

--- a/slime/agent/adapters/common.py
+++ b/slime/agent/adapters/common.py
@@ -13,6 +13,7 @@ protocols handle identically.
 from __future__ import annotations
 
 import asyncio
+import copy
 import dataclasses
 import logging
 import time
@@ -31,15 +32,16 @@ __all__ = ["TurnRecord"]
 
 @dataclasses.dataclass
 class Session:
-    """Per-sid adapter state: sampling defaults, context budget, and replay history.
+    """Per-sid adapter state: sampling defaults and context budget.
 
     Trajectory state lives in the shared TrajectoryManager (BaseAdapter.manager),
-    while assistant_history only restores reasoning omitted by protocol clients.
+    not here.
     """
 
     sampling_defaults: dict = dataclasses.field(default_factory=dict)
     max_context_tokens: int = 0
     assistant_history: list[dict] = dataclasses.field(default_factory=list)
+    last_turn_ids: list[int] = dataclasses.field(default_factory=list)
 
 
 @dataclasses.dataclass
@@ -80,51 +82,99 @@ _QWEN_REASONING_HISTORY_BRANCH = "{%- if loop.index0 > ns.last_query_index %}"
 
 
 def _reasoning_preserving_chat_template(tokenizer) -> str:
-    """Return a Qwen chat template that keeps prior assistant reasoning.
+    """Return the Qwen chat template variant needed for append-only RL turns.
 
-    Qwen normally omits reasoning from assistant messages before the latest
-    user/tool turn. That is useful for inference, but it rewrites already
-    sampled token history during a multi-turn RL rollout. The opt-in adapter
-    mode replaces only that history guard and leaves the generation prompt and
-    the rest of the model-provided template unchanged.
+    Qwen3/3.5 normally drops reasoning from assistant messages before the most
+    recent user message. That inference-time compaction rewrites already sampled
+    tokens, which breaks a multi-turn RL trajectory. In this explicit mode all
+    available ``reasoning_content`` is rendered while the normal open ``<think>``
+    generation prompt remains unchanged.
     """
     template = getattr(tokenizer, "chat_template", None)
-    if not isinstance(template, str) or template.count(_QWEN_REASONING_HISTORY_BRANCH) != 1:
+    if not isinstance(template, str) or _QWEN_REASONING_HISTORY_BRANCH not in template:
         raise ValueError(
             "preserve_reasoning_history requires a Qwen chat template containing "
-            f"exactly one {_QWEN_REASONING_HISTORY_BRANCH!r} guard"
+            f"{_QWEN_REASONING_HISTORY_BRANCH!r}"
         )
-    return template.replace(_QWEN_REASONING_HISTORY_BRANCH, "{%- if true %}", 1)
+    replacement = "{%- if true %}"
+    return template.replace(_QWEN_REASONING_HISTORY_BRANCH, replacement, 1)
 
 
 def _assistant_visible_signature(message: dict) -> tuple[Any, Any]:
     return message.get("content"), message.get("tool_calls")
 
 
-def _restore_assistant_reasoning(messages: list[dict], assistant_history: list[dict]) -> int:
-    """Restore reasoning omitted when a client echoes assistant history.
+def _restore_canonical_assistant_history(messages: list[dict], assistant_history: list[dict]) -> int:
+    """Replace client-echoed assistant turns with the server's canonical copy.
 
-    Generated messages are matched in order by visible content and canonical
-    tool calls. A compacted or otherwise changed response does not match, so it
-    remains a genuine trajectory fork.
+    Clients may omit reasoning and normalize text or tool-call arguments when
+    replaying a response. The adapter generated those turns and owns their exact
+    structured form, so align assistant messages from the newest turn backwards
+    and restore them wholesale. User and tool messages remain client-owned.
     """
-    history_pos = 0
+    positions = [i for i, message in enumerate(messages) if message.get("role") == "assistant"]
     restored = 0
-    for message in messages:
-        if message.get("role") != "assistant":
-            continue
-        signature = _assistant_visible_signature(message)
-        for idx in range(history_pos, len(assistant_history)):
-            canonical = assistant_history[idx]
-            if _assistant_visible_signature(canonical) != signature:
-                continue
-            history_pos = idx + 1
-            reasoning = canonical.get("reasoning_content")
-            if reasoning and not message.get("reasoning_content"):
-                message["reasoning_content"] = reasoning
-                restored += 1
-            break
+    for position, canonical in zip(reversed(positions), reversed(assistant_history), strict=False):
+        if messages[position] != canonical:
+            messages[position] = copy.deepcopy(canonical)
+            restored += 1
     return restored
+
+
+def _assert_append_only_prompt(previous_turn_ids: list[int], prompt_ids: list[int]) -> None:
+    """Require a new prompt to preserve every token sampled in the prior turn."""
+    if not previous_turn_ids:
+        return
+    if prompt_ids[: len(previous_turn_ids)] == previous_turn_ids:
+        return
+    common = 0
+    limit = min(len(previous_turn_ids), len(prompt_ids))
+    while common < limit and previous_turn_ids[common] == prompt_ids[common]:
+        common += 1
+    raise RuntimeError(
+        "non-append-only agent prompt: "
+        f"previous_tokens={len(previous_turn_ids)} prompt_tokens={len(prompt_ids)} common_prefix={common}"
+    )
+
+
+def _continue_from_canonical_turn(
+    messages: list[dict],
+    tokenizer,
+    *,
+    tools: list[dict] | None,
+    chat_template: str,
+    rendered_prompt_ids: list[int],
+    previous_turn_ids: list[int],
+    previous_response_message: dict,
+) -> list[int]:
+    """Append only the client messages added after the last sampled response.
+
+    A parsed assistant response is semantically equivalent to the sampled text,
+    but tool parsers and chat templates can normalize whitespace or argument
+    formatting. The sampled token ids are therefore the canonical history. We
+    use message identity only to locate the assistant boundary in the freshly
+    rendered prompt, then append the new suffix to those canonical ids.
+    """
+    assistant_positions = [i for i, message in enumerate(messages) if message.get("role") == "assistant"]
+    if not assistant_positions:
+        raise RuntimeError("append-only agent prompt has no replayed assistant message")
+    boundary = assistant_positions[-1]
+    if _assistant_visible_signature(messages[boundary]) != _assistant_visible_signature(previous_response_message):
+        raise RuntimeError("latest replayed assistant does not match the previous sampled response")
+
+    rendered_through_assistant = _render_token_ids(
+        messages[: boundary + 1],
+        tokenizer,
+        tools=tools,
+        add_generation_prompt=False,
+        chat_template=chat_template,
+    )
+    if rendered_prompt_ids[: len(rendered_through_assistant)] != rendered_through_assistant:
+        raise RuntimeError("chat template rewrote messages before the latest assistant boundary")
+
+    prompt_ids = previous_turn_ids + rendered_prompt_ids[len(rendered_through_assistant) :]
+    _assert_append_only_prompt(previous_turn_ids, prompt_ids)
+    return prompt_ids
 
 
 def flatten_content(c: Any) -> str:
@@ -399,21 +449,33 @@ class BaseAdapter:
         try:
             translated, tools_schema = self._translate(body)
             if self.preserve_reasoning_history:
-                restored = _restore_assistant_reasoning(translated, s.assistant_history)
+                restored = _restore_canonical_assistant_history(translated, s.assistant_history)
                 if restored:
                     self.logger.debug(
-                        "[%s] sid=%s restored reasoning for %d assistant turn(s)",
+                        "[%s] sid=%s restored canonical history for %d assistant turn(s)",
                         self.log_prefix,
                         sid,
                         restored,
                     )
-            prompt_ids = _render_token_ids(
+            rendered_prompt_ids = _render_token_ids(
                 translated,
                 tok,
                 tools=tools_schema,
                 add_generation_prompt=True,
                 chat_template=self.chat_template,
             )
+            if self.preserve_reasoning_history and s.last_turn_ids:
+                prompt_ids = _continue_from_canonical_turn(
+                    translated,
+                    tok,
+                    tools=tools_schema,
+                    chat_template=self.chat_template,
+                    rendered_prompt_ids=rendered_prompt_ids,
+                    previous_turn_ids=s.last_turn_ids,
+                    previous_response_message=s.assistant_history[-1],
+                )
+            else:
+                prompt_ids = rendered_prompt_ids
 
             turn = await call_sglang_generate(prompt_ids, s, body, adapter=self, session_id=sid)
 
@@ -425,9 +487,6 @@ class BaseAdapter:
                 reasoning_parser_name=self.reasoning_parser,
             )
             reply = self._build_reply(parsed, turn.finish_reason, translated, tools_schema)
-            manager_message = reply.manager_message
-            if self.preserve_reasoning_history and parsed.reasoning and not manager_message.get("reasoning_content"):
-                manager_message = {**manager_message, "reasoning_content": parsed.reasoning}
             turn = dataclasses.replace(turn, ill_formed=parsed.ill_formed)
 
             in_tok, out_tok = len(prompt_ids), len(turn.output_ids)
@@ -450,11 +509,14 @@ class BaseAdapter:
                     raise
                 return web.Response(status=499, text="client disconnected")
 
+            s.assistant_history.append(reply.manager_message)
+            s.last_turn_ids = prompt_ids + turn.output_ids
+
             self._run_debug_callback(
                 sid,
                 translated,
                 tools_schema,
-                manager_message,
+                reply.manager_message,
                 turn,
             )
 
@@ -462,10 +524,9 @@ class BaseAdapter:
                 sid,
                 turn=turn,
                 prompt_messages=translated,
-                response_message=manager_message,
+                response_message=reply.manager_message,
                 metadata={"sid": sid},
             )
-            s.assistant_history.append(manager_message)
             return response
         finally:
             self.inflight.get(sid, set()).discard(task)

--- a/tests/test_agent/test_adapters.py
+++ b/tests/test_agent/test_adapters.py
@@ -27,9 +27,14 @@ if str(REPO_ROOT) not in sys.path:
 
 from tests.test_agent._fakes import FakeSGLangServer, FakeTokenizer  # noqa: E402
 
-from slime.agent.adapters import anthropic, common, openai  # noqa: E402
-from slime.agent.adapters.common import _reasoning_preserving_chat_template, _restore_assistant_reasoning  # noqa: E402
-from slime.agent.parsing import ParsedModelOutput, parse_model_output, parse_xml_tool_uses  # noqa: E402
+from slime.agent.adapters import anthropic, openai  # noqa: E402
+from slime.agent.adapters.common import (  # noqa: E402
+    _assert_append_only_prompt,
+    _continue_from_canonical_turn,
+    _reasoning_preserving_chat_template,
+    _restore_canonical_assistant_history,
+)
+from slime.agent.parsing import parse_model_output, parse_xml_tool_uses  # noqa: E402
 from slime.utils.types import Sample  # noqa: E402
 
 NUM_GPUS = 0
@@ -43,47 +48,6 @@ NUM_GPUS = 0
 class _Headers:
     def __init__(self, headers: dict[str, str]) -> None:
         self.headers = headers
-
-
-class _QwenHistoryTokenizer(FakeTokenizer):
-    """Small Qwen-like template model for the history-preservation regression."""
-
-    chat_template = "before {%- if loop.index0 > ns.last_query_index %} with-reasoning {%- endif %} after"
-    _ROLE = {"system": 10, "user": 11, "assistant": 12, "tool": 13}
-    _END = 14
-    _THINK_START = 15
-    _THINK_END = 16
-
-    def apply_chat_template(
-        self,
-        messages,
-        tools=None,
-        tokenize=True,
-        add_generation_prompt=True,
-        chat_template=None,
-    ):
-        self.rendered.append((list(messages), tools))
-        preserve_history = chat_template is not None and "{%- if true %}" in chat_template
-        last_query_index = max(
-            (idx for idx, message in enumerate(messages) if message.get("role") in {"user", "tool"}),
-            default=-1,
-        )
-        out: list[int] = []
-        for idx, message in enumerate(messages):
-            role = message.get("role", "user")
-            out.append(self._ROLE.get(role, self._ROLE["user"]))
-            if role == "assistant" and (preserve_history or idx > last_query_index):
-                out.append(self._THINK_START)
-                out.extend(self.encode(message.get("reasoning_content") or ""))
-                out.append(self._THINK_END)
-            out.extend(self.encode(self._content_text({**message, "reasoning_content": ""})))
-            out.append(self._END)
-        if add_generation_prompt:
-            out.extend([self._ROLE["assistant"], self._THINK_START])
-        return out
-
-    def assistant_output(self, reasoning: str, content: str) -> list[int]:
-        return [*self.encode(reasoning), self._THINK_END, *self.encode(content), self._END]
 
 
 def _parse_sse(raw: str) -> list[tuple[str, object]]:
@@ -173,11 +137,15 @@ def test_anthropic_translation_keeps_tool_results_thinking_and_tools():
     ]
 
 
-def test_restore_assistant_reasoning_from_canonical_history():
-    tool_calls = [{"type": "function", "function": {"name": "lookup", "arguments": {"q": "slime"}}}]
+def test_restore_canonical_assistant_history_from_client_echo():
+    canonical_tool_calls = [{"type": "function", "function": {"name": "lookup", "arguments": {"q": "slime"}}}]
     messages = [
         {"role": "user", "content": "find slime"},
-        {"role": "assistant", "content": "", "tool_calls": tool_calls},
+        {
+            "role": "assistant",
+            "content": "normalized by client",
+            "tool_calls": [{"type": "function", "function": {"name": "lookup", "arguments": {"q": " slime "}}}],
+        },
         {"role": "tool", "content": "found"},
     ]
     history = [
@@ -185,15 +153,15 @@ def test_restore_assistant_reasoning_from_canonical_history():
             "role": "assistant",
             "content": "",
             "reasoning_content": "I should call lookup.",
-            "tool_calls": tool_calls,
+            "tool_calls": canonical_tool_calls,
         }
     ]
 
-    assert _restore_assistant_reasoning(messages, history) == 1
-    assert messages[1]["reasoning_content"] == "I should call lookup."
+    assert _restore_canonical_assistant_history(messages, history) == 1
+    assert messages[1] == history[0]
 
 
-def test_reasoning_preserving_template_only_replaces_qwen_history_guard():
+def test_reasoning_preserving_template_keeps_generation_prompt_unchanged():
     class Tokenizer:
         chat_template = (
             "before "
@@ -208,63 +176,37 @@ def test_reasoning_preserving_template_only_replaces_qwen_history_guard():
     assert rendered.endswith("generation:<think>\\n")
 
 
-def test_anthropic_preserves_qwen_reasoning_as_one_multiturn_sample(monkeypatch):
-    async def run_case():
-        tok = _QwenHistoryTokenizer()
-        first_output = tok.assistant_output("inspect first", "first answer")
-        second_output = tok.assistant_output("inspect second", "second answer")
-        parsed = [
-            ParsedModelOutput(reasoning="inspect first", text="first answer", tool_uses=[]),
-            ParsedModelOutput(reasoning="inspect second", text="second answer", tool_uses=[]),
-        ]
+def test_append_only_prompt_invariant():
+    _assert_append_only_prompt([1, 2, 3], [1, 2, 3, 4])
+    with pytest.raises(RuntimeError, match=r"previous_tokens=3 prompt_tokens=3 common_prefix=2"):
+        _assert_append_only_prompt([1, 2, 3], [1, 2, 9])
 
-        def fake_parse(*args, **kwargs):
-            return parsed.pop(0)
 
-        monkeypatch.setattr(common, "parse_model_output", fake_parse)
-        turns = [[(-0.1, token_id) for token_id in first_output], [(-0.2, token_id) for token_id in second_output]]
-        async with FakeSGLangServer(turns) as sglang:
-            adapter = anthropic.AnthropicAdapter(
-                tokenizer=tok,
-                sglang_url=sglang.url,
-                preserve_reasoning_history=True,
-            )
-            adapter.open_session("sid-qwen-history")
-            client = TestClient(TestServer(adapter.app))
-            await client.start_server()
-            try:
-                first = await client.post(
-                    "/v1/messages",
-                    headers={"Authorization": "Bearer sid-qwen-history"},
-                    json={"model": "m", "messages": [{"role": "user", "content": "solve"}]},
-                )
-                first_data = await first.json()
-                # Some clients do not echo thinking blocks in later requests.
-                visible_first = [block for block in first_data["content"] if block["type"] != "thinking"]
-                second = await client.post(
-                    "/v1/messages",
-                    headers={"Authorization": "Bearer sid-qwen-history"},
-                    json={
-                        "model": "m",
-                        "messages": [
-                            {"role": "user", "content": "solve"},
-                            {"role": "assistant", "content": visible_first},
-                            {"role": "user", "content": "continue"},
-                        ],
-                    },
-                )
-                await second.json()
-            finally:
-                await client.close()
-            samples = await _drain(adapter, "sid-qwen-history")
+def test_continue_from_canonical_turn_keeps_sampled_tokens_and_appends_new_suffix():
+    class NormalizingTokenizer:
+        def apply_chat_template(self, messages, *, add_generation_prompt, **kwargs):
+            if len(messages) == 2 and not add_generation_prompt:
+                return [1, 2, 90, 91]
+            if len(messages) == 3 and add_generation_prompt:
+                return [1, 2, 90, 91, 7, 8]
+            raise AssertionError((messages, add_generation_prompt, kwargs))
 
-        first_prompt = sglang.requests[0]["input_ids"]
-        second_prompt = sglang.requests[1]["input_ids"]
-        assert second_prompt[: len(first_prompt) + len(first_output)] == first_prompt + first_output
-        assert len(samples) == 1
-        assert sum(samples[0].loss_mask) == len(first_output) + len(second_output)
-
-    asyncio.run(run_case())
+    response = {"role": "assistant", "content": "visible"}
+    messages = [
+        {"role": "user", "content": "question"},
+        dict(response),
+        {"role": "tool", "content": "new observation"},
+    ]
+    prompt_ids = _continue_from_canonical_turn(
+        messages,
+        NormalizingTokenizer(),
+        tools=None,
+        chat_template="patched-qwen-template",
+        rendered_prompt_ids=[1, 2, 90, 91, 7, 8],
+        previous_turn_ids=[1, 2, 30, 31],
+        previous_response_message=response,
+    )
+    assert prompt_ids == [1, 2, 30, 31, 7, 8]
 
 
 def test_openai_translation_developer_to_system_and_tool_calls_to_dict():

--- a/tests/test_agent/test_adapters.py
+++ b/tests/test_agent/test_adapters.py
@@ -27,8 +27,9 @@ if str(REPO_ROOT) not in sys.path:
 
 from tests.test_agent._fakes import FakeSGLangServer, FakeTokenizer  # noqa: E402
 
-from slime.agent.adapters import anthropic, openai  # noqa: E402
-from slime.agent.parsing import parse_model_output, parse_xml_tool_uses  # noqa: E402
+from slime.agent.adapters import anthropic, common, openai  # noqa: E402
+from slime.agent.adapters.common import _reasoning_preserving_chat_template, _restore_assistant_reasoning  # noqa: E402
+from slime.agent.parsing import ParsedModelOutput, parse_model_output, parse_xml_tool_uses  # noqa: E402
 from slime.utils.types import Sample  # noqa: E402
 
 NUM_GPUS = 0
@@ -42,6 +43,47 @@ NUM_GPUS = 0
 class _Headers:
     def __init__(self, headers: dict[str, str]) -> None:
         self.headers = headers
+
+
+class _QwenHistoryTokenizer(FakeTokenizer):
+    """Small Qwen-like template model for the history-preservation regression."""
+
+    chat_template = "before {%- if loop.index0 > ns.last_query_index %} with-reasoning {%- endif %} after"
+    _ROLE = {"system": 10, "user": 11, "assistant": 12, "tool": 13}
+    _END = 14
+    _THINK_START = 15
+    _THINK_END = 16
+
+    def apply_chat_template(
+        self,
+        messages,
+        tools=None,
+        tokenize=True,
+        add_generation_prompt=True,
+        chat_template=None,
+    ):
+        self.rendered.append((list(messages), tools))
+        preserve_history = chat_template is not None and "{%- if true %}" in chat_template
+        last_query_index = max(
+            (idx for idx, message in enumerate(messages) if message.get("role") in {"user", "tool"}),
+            default=-1,
+        )
+        out: list[int] = []
+        for idx, message in enumerate(messages):
+            role = message.get("role", "user")
+            out.append(self._ROLE.get(role, self._ROLE["user"]))
+            if role == "assistant" and (preserve_history or idx > last_query_index):
+                out.append(self._THINK_START)
+                out.extend(self.encode(message.get("reasoning_content") or ""))
+                out.append(self._THINK_END)
+            out.extend(self.encode(self._content_text({**message, "reasoning_content": ""})))
+            out.append(self._END)
+        if add_generation_prompt:
+            out.extend([self._ROLE["assistant"], self._THINK_START])
+        return out
+
+    def assistant_output(self, reasoning: str, content: str) -> list[int]:
+        return [*self.encode(reasoning), self._THINK_END, *self.encode(content), self._END]
 
 
 def _parse_sse(raw: str) -> list[tuple[str, object]]:
@@ -129,6 +171,100 @@ def test_anthropic_translation_keeps_tool_results_thinking_and_tools():
     assert tools == [
         {"type": "function", "function": {"name": "lookup", "description": "search", "parameters": {"type": "object"}}}
     ]
+
+
+def test_restore_assistant_reasoning_from_canonical_history():
+    tool_calls = [{"type": "function", "function": {"name": "lookup", "arguments": {"q": "slime"}}}]
+    messages = [
+        {"role": "user", "content": "find slime"},
+        {"role": "assistant", "content": "", "tool_calls": tool_calls},
+        {"role": "tool", "content": "found"},
+    ]
+    history = [
+        {
+            "role": "assistant",
+            "content": "",
+            "reasoning_content": "I should call lookup.",
+            "tool_calls": tool_calls,
+        }
+    ]
+
+    assert _restore_assistant_reasoning(messages, history) == 1
+    assert messages[1]["reasoning_content"] == "I should call lookup."
+
+
+def test_reasoning_preserving_template_only_replaces_qwen_history_guard():
+    class Tokenizer:
+        chat_template = (
+            "before "
+            "{%- if loop.index0 > ns.last_query_index %}history-with-reasoning"
+            "{%- else %}history-without-reasoning{%- endif %} "
+            "generation:<think>\\n"
+        )
+
+    rendered = _reasoning_preserving_chat_template(Tokenizer())
+    assert "if true" in rendered
+    assert "if loop.index0 > ns.last_query_index" not in rendered
+    assert rendered.endswith("generation:<think>\\n")
+
+
+def test_anthropic_preserves_qwen_reasoning_as_one_multiturn_sample(monkeypatch):
+    async def run_case():
+        tok = _QwenHistoryTokenizer()
+        first_output = tok.assistant_output("inspect first", "first answer")
+        second_output = tok.assistant_output("inspect second", "second answer")
+        parsed = [
+            ParsedModelOutput(reasoning="inspect first", text="first answer", tool_uses=[]),
+            ParsedModelOutput(reasoning="inspect second", text="second answer", tool_uses=[]),
+        ]
+
+        def fake_parse(*args, **kwargs):
+            return parsed.pop(0)
+
+        monkeypatch.setattr(common, "parse_model_output", fake_parse)
+        turns = [[(-0.1, token_id) for token_id in first_output], [(-0.2, token_id) for token_id in second_output]]
+        async with FakeSGLangServer(turns) as sglang:
+            adapter = anthropic.AnthropicAdapter(
+                tokenizer=tok,
+                sglang_url=sglang.url,
+                preserve_reasoning_history=True,
+            )
+            adapter.open_session("sid-qwen-history")
+            client = TestClient(TestServer(adapter.app))
+            await client.start_server()
+            try:
+                first = await client.post(
+                    "/v1/messages",
+                    headers={"Authorization": "Bearer sid-qwen-history"},
+                    json={"model": "m", "messages": [{"role": "user", "content": "solve"}]},
+                )
+                first_data = await first.json()
+                # Some clients do not echo thinking blocks in later requests.
+                visible_first = [block for block in first_data["content"] if block["type"] != "thinking"]
+                second = await client.post(
+                    "/v1/messages",
+                    headers={"Authorization": "Bearer sid-qwen-history"},
+                    json={
+                        "model": "m",
+                        "messages": [
+                            {"role": "user", "content": "solve"},
+                            {"role": "assistant", "content": visible_first},
+                            {"role": "user", "content": "continue"},
+                        ],
+                    },
+                )
+                await second.json()
+            finally:
+                await client.close()
+            samples = await _drain(adapter, "sid-qwen-history")
+
+        first_prompt = sglang.requests[0]["input_ids"]
+        second_prompt = sglang.requests[1]["input_ids"]
+        assert second_prompt[: len(first_prompt) + len(first_output)] == first_prompt + first_output
+        assert len(samples) == 1
+        assert sum(samples[0].loss_mask) == len(first_output) + len(second_output)
+
+    asyncio.run(run_case())
 
 
 def test_openai_translation_developer_to_system_and_tool_calls_to_dict():


### PR DESCRIPTION
## Summary

In a Qwen3.5 coding-agent rollout, Claude Code replays the conversation as structured messages on every turn. Re-applying the Qwen chat template to that replay is not token-preserving:

- the Qwen3/3.5 template omits reasoning from assistant turns before the latest user/tool message;
- Claude Code may normalize replayed assistant text, whitespace, and tool-call arguments.

Slime therefore sees the next prompt diverge from the exact `prompt_ids + output_ids` sampled on the previous turn. `TrajectoryManager` correctly classifies that divergence as a fork, but in this case the fork is accidental: a single environment rollout can become many training Samples.

## Fix

This PR adds an opt-in append-only mode for the coding-agent Qwen setup:

- use a Qwen template variant that retains available historical reasoning while leaving the generation `<think>` prefix unchanged;
- keep each session's exact server-side `prompt_ids + output_ids` as the canonical token history;
- replace client-echoed assistant messages with the server's canonical structured responses;
- render only to identify the latest assistant boundary, then append the newly rendered tool/user observation and generation prompt to the canonical token prefix;
- fail explicitly when the next prompt is not append-only instead of silently emitting extra forked Samples.

The Qwen coding-agent example enables this through `SLIME_PRESERVE_REASONING_HISTORY=1`.

## Validation

Real Qwen3.5-35B-A3B + Claude Code + TMax rollout:

| | Before | After |
|---|---:|---:|
| Environment rollouts | 8 | 8 |
| Training Samples | 64 | 8 |
| Total trajectory tokens | 1,825,684 | 265,001 |

The corrected eight Samples contained 128 assistant action segments. All 128 retained reasoning through `</think>`, and `loss_mask`, `rollout_log_probs`, and `response_length` remained aligned. A training-only replay reduced the critic batch from eight microbatches to two; critic forward and backward completed without the previous CUDA OOM.

Local focused test result: `18 passed, 1 skipped` in `tests/test_agent/test_adapters.py`. The same adapter suite and real-tokenizer checks passed on the training node.

## Scope

This PR fixes false per-turn forks caused by Qwen3.5/Claude Code history re-templating. It does not change the semantics of legitimate context compaction, sub-agent branching, generic fully-async fan-out, group reward models, or GRPO grouping.

Related issue: #2288
