### PR TITLE
fix: allow custom eval in train-only mode

### DIFF
--- a/docs/en/developer_guide/debug.md
+++ b/docs/en/developer_guide/debug.md
@@ -42,6 +42,8 @@ Specifically, slime currently provides the following parameters for separate deb
 
     When enabled, slime will not load SGLang and will only initialize Megatron. You can use this method to debug the training part.
 
+    Periodic evaluation remains available when `--eval-function-path` explicitly names a custom evaluation function that does not depend on SGLang. slime rejects `--eval-interval` in train-only mode without such a function instead of silently skipping every evaluation.
+
 3.  `--save-debug-rollout-data /your/saved/debug/data_{rollout_id}.pt`
 
     When enabled, the results of each rollout will be saved. This can be used in conjunction with `--debug-rollout-only`. Note that the data is saved using the format: `args.save_debug_rollout_data.format(rollout_id=rollout_id)`.

--- a/docs/zh/developer_guide/debug.md
+++ b/docs/zh/developer_guide/debug.md
@@ -40,6 +40,8 @@ slime 支持将训练部分和推理部分分开进行调试，从而实现：
 
    开启后，slime 将不会加载 sglang，只初始化 megatron ，可以用这个方法来进行训练部分的调试。
 
+   如果 `--eval-function-path` 显式指定了一个不依赖 SGLang 的自定义评测函数，仍可使用周期性评测。训练单独调试模式下设置 `--eval-interval` 却未提供该函数时，slime 会直接报错，而不是静默跳过所有评测。
+
 2. `--save-debug-rollout-data /your/saved/debug/data_{rollout_id}.pt`
 
    开启后，会保存每次 rollout 的结果，可以和 `--debug-rollout-only` 配合使用。注意保存的方式为 `args.save_debug_rollout_data.format(rollout_id=rollout_id)`。

--- a/slime/ray/rollout.py
+++ b/slime/ray/rollout.py
@@ -604,9 +604,6 @@ class RolloutManager:
         return self._split_train_data_by_dp(data)
 
     def eval(self, rollout_id):
-        if self.args.debug_train_only:
-            # if debug train only, we don't generate evaluation data
-            return
         set_current_rollout_id(rollout_id)
         self.health_monitoring_resume()
 

--- a/slime/utils/arguments.py
+++ b/slime/utils/arguments.py
@@ -1834,6 +1834,12 @@ def slime_validate_args(args):
 
     if args.eval_interval is not None:
         assert args.eval_datasets, "Evaluation datasets must be configured when eval_interval is set."
+        skips_sglang = args.debug_train_only or args.load_debug_rollout_data is not None
+        if skips_sglang and args.eval_function_path is None:
+            raise ValueError(
+                "--debug-train-only skips SGLang initialization, so periodic evaluation requires an explicit "
+                "--eval-function-path that can run without SGLang."
+            )
 
     if args.save_interval is not None:
         assert args.save is not None, "'--save' is required when save_interval is set."

--- a/tests/test_megatron_argument_validation.py
+++ b/tests/test_megatron_argument_validation.py
@@ -331,6 +331,47 @@ def test_slime_validate_args_preserves_zero_rollout_gpus_without_colocate(monkey
 
 
 @pytest.mark.unit
+def test_debug_train_periodic_eval_requires_explicit_local_function(monkeypatch):
+    module = load_slime_arguments_module(monkeypatch)
+    args = make_slime_validate_args(
+        debug_train_only=True,
+        eval_interval=10,
+        eval_prompt_data=["heldout", "/tmp/heldout.jsonl"],
+    )
+
+    with pytest.raises(ValueError, match="eval-function-path.*without SGLang"):
+        module.slime_validate_args(args)
+
+
+@pytest.mark.unit
+def test_debug_train_periodic_eval_accepts_explicit_local_function(monkeypatch):
+    module = load_slime_arguments_module(monkeypatch)
+    args = make_slime_validate_args(
+        debug_train_only=True,
+        eval_interval=10,
+        eval_prompt_data=["heldout", "/tmp/heldout.jsonl"],
+        eval_function_path="custom.local_eval",
+    )
+
+    module.slime_validate_args(args)
+
+    assert args.eval_function_path == "custom.local_eval"
+
+
+@pytest.mark.unit
+def test_debug_rollout_replay_periodic_eval_requires_explicit_local_function(monkeypatch):
+    module = load_slime_arguments_module(monkeypatch)
+    args = make_slime_validate_args(
+        eval_interval=10,
+        eval_prompt_data=["heldout", "/tmp/heldout.jsonl"],
+        load_debug_rollout_data="/tmp/rollout_{rollout_id}.pt",
+    )
+
+    with pytest.raises(ValueError, match="eval-function-path.*without SGLang"):
+        module.slime_validate_args(args)
+
+
+@pytest.mark.unit
 def test_update_weight_delta_requires_disk_transport(monkeypatch):
     module = load_slime_arguments_module(monkeypatch)
     args = make_slime_validate_args(


### PR DESCRIPTION
## Summary

- run explicitly configured custom evaluation functions under `--debug-train-only`
- reject periodic eval without an explicit SGLang-independent eval function instead of silently skipping it
- document the supported train-only evaluation contract in English and Chinese

## Bug

`train.py` schedules periodic evaluation whenever `--eval-interval` is set, and argument validation requires evaluation datasets. However, `RolloutManager.eval` previously returned immediately whenever `debug_train_only` was true, so the accepted configuration silently produced no evaluation metrics.

The validation also covers `--load-debug-rollout-data`, which disables SGLang later in argument normalization.

## Test plan

- `PYTHONPATH=$PWD uv run --with pytest --with pyyaml --with omegaconf pytest -q tests/test_megatron_argument_validation.py`
- 21 passed
- `git diff --check`