### PR TITLE
feat: bound Megatron checkpoint retention

### DIFF
--- a/docs/en/get_started/usage.md
+++ b/docs/en/get_started/usage.md
@@ -130,6 +130,7 @@ When using slime, there are three parameters for loading and saving checkpoints:
   - `--ref-load`: The Megatron checkpoint for the reference model.
   - `--load`: The Megatron checkpoint for the actor. If `--load` is not set, or if the specified directory does not exist or does not contain `latest_checkpointed_iteration.txt`, the actor will be initialized from the `--ref-load` checkpoint.
   - `--save`: The path where the actor's checkpoints are saved.
+  - `--save-retain-count`: Optionally keep only the newest N completed Megatron checkpoints. Directories newer than `latest_checkpointed_iteration.txt` are treated as in-flight and are never deleted.
 
 Note:
 

--- a/docs/zh/get_started/usage.md
+++ b/docs/zh/get_started/usage.md
@@ -134,6 +134,7 @@ torch 格式是 megatron 的老存储格式，里面的结构大约是一些 `mp
 - `--ref-load`：reference model 用的 megatron ckpt；
 - `--load`：actor 用的 megatron ckpt，如果没有设置 `--load`，或者设置的目录不存在，目录中没有 `latest_checkpointed_iteration.txt`，都会直接从 `--ref-load` 的 ckpt 进行初始化；
 - `--save`：actor 保存的路径。
+- `--save-retain-count`：可选，仅保留最近 N 个已完成的 Megatron checkpoint。比 `latest_checkpointed_iteration.txt` 更新的目录会被视为仍在写入，不会被删除。
 
 注意：
 

--- a/slime/backends/megatron_utils/actor.py
+++ b/slime/backends/megatron_utils/actor.py
@@ -13,6 +13,7 @@ from torch_memory_saver import torch_memory_saver
 from transformers import AutoConfig, AutoTokenizer
 
 from slime.ray.train_actor import TrainRayActor
+from slime.utils.checkpoint_retention import prune_megatron_checkpoints
 from slime.utils.data import process_rollout_data
 from slime.utils.distributed_utils import get_gloo_group
 from slime.utils.logging_utils import init_tracking
@@ -576,17 +577,29 @@ class MegatronTrainRayActor(TrainRayActor):
             from megatron.training.async_utils import maybe_finalize_async_save
 
             maybe_finalize_async_save(blocking=True)
+            self._prune_checkpoint_history()
 
         save(rollout_id, self.model, self.optimizer, self.opt_param_scheduler)
 
         if force_sync and self.args.async_save:
             maybe_finalize_async_save(blocking=True)
 
+        if not self.args.async_save or force_sync:
+            self._prune_checkpoint_history()
+
         if self.args.save_hf is not None and self.role == "actor":
             save_hf_model_to_path(self.args, Path(self.args.save_hf.format(rollout_id=rollout_id)), self.model)
 
         if self.args.offload_train:
             self.sleep()
+
+    def _prune_checkpoint_history(self) -> None:
+        retain_count = self.args.save_retain_count
+        if retain_count is None or not is_megatron_main_rank():
+            return
+        removed = prune_megatron_checkpoints(self.args.save, retain_count)
+        if removed:
+            logger.info("Pruned %d old checkpoints: %s", len(removed), ", ".join(path.name for path in removed))
 
     @timer
     def update_weights(self) -> None:

--- a/slime/utils/arguments.py
+++ b/slime/utils/arguments.py
@@ -854,6 +854,15 @@ def get_slime_extra_args_provider(add_custom_arguments=None):
             reset_arg(parser, "--save", type=str, default=None)
             reset_arg(parser, "--save-interval", type=int, default=None)
             reset_arg(parser, "--async-save", action="store_true")
+            parser.add_argument(
+                "--save-retain-count",
+                type=int,
+                default=None,
+                help=(
+                    "Keep only this many completed Megatron checkpoints. "
+                    "Incomplete checkpoints newer than the completion marker are never deleted."
+                ),
+            )
             reset_arg(
                 parser,
                 "--no-save-optim",
@@ -1837,6 +1846,8 @@ def slime_validate_args(args):
 
     if args.save_interval is not None:
         assert args.save is not None, "'--save' is required when save_interval is set."
+    if args.save_retain_count is not None and args.save_retain_count < 1:
+        raise ValueError("--save-retain-count must be at least 1")
 
     assert not (args.kl_coef != 0 and args.kl_loss_coef != 0), "Only one of kl_coef and kl_loss_coef can be set"
 

--- a/slime/utils/checkpoint_retention.py
+++ b/slime/utils/checkpoint_retention.py
@@ -1,0 +1,50 @@
+"""Safe retention for completed Megatron checkpoint directories."""
+
+from __future__ import annotations
+
+import re
+import shutil
+from pathlib import Path
+
+
+_ITERATION_DIRECTORY = re.compile(r"iter_(\d{7})\Z")
+
+
+def prune_megatron_checkpoints(root: str | Path, retain_count: int) -> list[Path]:
+    """Remove oldest completed checkpoints while preserving recent history.
+
+    Megatron updates ``latest_checkpointed_iteration.txt`` only after a
+    checkpoint is complete. Directories newer than that marker may still be
+    in flight and are never considered for deletion.
+    """
+    if retain_count < 1:
+        raise ValueError("retain_count must be at least 1")
+
+    root = Path(root)
+    marker = root / "latest_checkpointed_iteration.txt"
+    try:
+        latest_text = marker.read_text().strip()
+    except FileNotFoundError:
+        return []
+    if not latest_text.isdigit():
+        return []
+    latest_iteration = int(latest_text)
+
+    completed = []
+    for path in root.iterdir():
+        match = _ITERATION_DIRECTORY.fullmatch(path.name)
+        if match is None or path.is_symlink() or not path.is_dir():
+            continue
+        iteration = int(match.group(1))
+        if iteration <= latest_iteration:
+            completed.append((iteration, path))
+    completed.sort()
+
+    removed = []
+    for _, path in completed[:-retain_count]:
+        try:
+            shutil.rmtree(path)
+        except FileNotFoundError:
+            continue
+        removed.append(path)
+    return removed

--- a/tests/test_megatron_argument_validation.py
+++ b/tests/test_megatron_argument_validation.py
@@ -197,6 +197,7 @@ def make_slime_validate_args(**overrides):
         eval_interval=None,
         save_interval=None,
         save=None,
+        save_retain_count=None,
         kl_loss_coef=0,
         advantage_estimator="grpo",
         normalize_advantages=False,
@@ -352,6 +353,15 @@ def test_update_weight_delta_requires_disk_transport(monkeypatch):
     )
 
     with pytest.raises(ValueError, match="requires --update-weight-transport=disk"):
+        module.slime_validate_args(args)
+
+
+@pytest.mark.unit
+def test_save_retain_count_must_be_positive(monkeypatch):
+    module = load_slime_arguments_module(monkeypatch)
+    args = make_slime_validate_args(save_retain_count=0)
+
+    with pytest.raises(ValueError, match="save-retain-count.*at least 1"):
         module.slime_validate_args(args)
 
 

--- a/tests/utils/test_checkpoint_retention.py
+++ b/tests/utils/test_checkpoint_retention.py
@@ -1,0 +1,51 @@
+from pathlib import Path
+
+import pytest
+
+from slime.utils.checkpoint_retention import prune_megatron_checkpoints
+
+
+def _checkpoint(root: Path, iteration: int) -> Path:
+    path = root / f"iter_{iteration:07d}"
+    path.mkdir()
+    (path / "state.distcp").write_text("checkpoint")
+    return path
+
+
+@pytest.mark.unit
+def test_prune_megatron_checkpoints_keeps_latest_completed_history(tmp_path):
+    checkpoints = [_checkpoint(tmp_path, iteration) for iteration in (10, 20, 30)]
+    (tmp_path / "latest_checkpointed_iteration.txt").write_text("30\n")
+
+    removed = prune_megatron_checkpoints(tmp_path, retain_count=2)
+
+    assert removed == [checkpoints[0]]
+    assert not checkpoints[0].exists()
+    assert checkpoints[1].is_dir()
+    assert checkpoints[2].is_dir()
+
+
+@pytest.mark.unit
+def test_prune_megatron_checkpoints_never_removes_inflight_directory(tmp_path):
+    completed = _checkpoint(tmp_path, 20)
+    inflight = _checkpoint(tmp_path, 30)
+    (tmp_path / "latest_checkpointed_iteration.txt").write_text("20\n")
+
+    assert prune_megatron_checkpoints(tmp_path, retain_count=1) == []
+    assert completed.is_dir()
+    assert inflight.is_dir()
+
+
+@pytest.mark.unit
+def test_prune_megatron_checkpoints_ignores_release_marker(tmp_path):
+    checkpoint = _checkpoint(tmp_path, 10)
+    (tmp_path / "latest_checkpointed_iteration.txt").write_text("release\n")
+
+    assert prune_megatron_checkpoints(tmp_path, retain_count=1) == []
+    assert checkpoint.is_dir()
+
+
+@pytest.mark.unit
+def test_prune_megatron_checkpoints_rejects_zero_retention(tmp_path):
+    with pytest.raises(ValueError, match="at least 1"):
+        prune_megatron_checkpoints(tmp_path, retain_count=0)


### PR DESCRIPTION
## Summary

- add opt-in `--save-retain-count` for long-running RL jobs
- prune only checkpoint directories at or below Megatron latest completed iteration marker
- never remove in-flight directories newer than the marker, symlinks, release checkpoints, or unrelated paths
- support synchronous and asynchronous checkpoint saves

## Motivation

Long jobs currently retain every multi-gigabyte Megatron checkpoint unless an external supervisor deletes them. This can exhaust local disks even when the job only needs a small resumable history. The retention operation runs only after synchronous completion, or after `maybe_finalize_async_save` confirms an asynchronous save.

The option is disabled by default.

## Test plan

- `PYTHONPATH=$PWD uv run --no-project --with pytest --with pyyaml --with omegaconf pytest -q tests/utils/test_checkpoint_retention.py tests/test_megatron_argument_validation.py`
- 24 passed
- `python3 -m py_compile slime/utils/checkpoint_retention.py slime/utils/arguments.py slime/backends/megatron_utils/actor.py tests/utils/test_checkpoint_retention.py`
- `git diff --check`