### PR TITLE
feat: report evaluation wall time

### DIFF
--- a/slime/ray/rollout.py
+++ b/slime/ray/rollout.py
@@ -607,13 +607,14 @@ class RolloutManager:
         if self.args.debug_train_only:
             # if debug train only, we don't generate evaluation data
             return
+        start_time = time.time()
         set_current_rollout_id(rollout_id)
         self.health_monitoring_resume()
 
         result = call_rollout_fn(self.eval_generate_rollout, self.args, rollout_id, self.data_source, evaluation=True)
         data = result.data
         self._save_debug_rollout_data(data, rollout_id=rollout_id, evaluation=True)
-        _log_eval_rollout_data(rollout_id, self.args, data, result.metrics)
+        _log_eval_rollout_data(rollout_id, self.args, data, _eval_metrics(result.metrics, time.time() - start_time))
 
     def save(self, rollout_id):
         self.data_source.save(rollout_id)
@@ -1296,6 +1297,12 @@ def _resolve_sglang_config(args) -> SglangConfig:
             )
         ]
     )
+
+
+def _eval_metrics(extra_metrics: dict[str, Any] | None, eval_time: float) -> dict[str, Any]:
+    metrics = dict(extra_metrics or {})
+    metrics["perf/eval_time"] = eval_time
+    return metrics
 
 
 def _log_eval_rollout_data(rollout_id, args, data, extra_metrics: dict[str, Any] | None = None):

--- a/tests/test_rollout_metrics.py
+++ b/tests/test_rollout_metrics.py
@@ -5,7 +5,7 @@ import numpy as np
 import pytest
 import torch
 
-from slime.ray.rollout import _compute_top_p_kept_vocab_metrics
+from slime.ray.rollout import _compute_top_p_kept_vocab_metrics, _eval_metrics
 from slime.utils.misc import decode_int32_meta_array
 from slime.utils.types import Sample
 
@@ -14,6 +14,16 @@ NUM_GPUS = 0
 
 def _make_args():
     return Namespace(sglang_speculative_algorithm=False, num_layers=2, moe_router_topk=2)
+
+
+@pytest.mark.unit
+def test_eval_metrics_preserve_custom_metrics_and_add_wall_time():
+    original = {"judge/score": 0.75}
+
+    metrics = _eval_metrics(original, eval_time=12.5)
+
+    assert metrics == {"judge/score": 0.75, "perf/eval_time": 12.5}
+    assert original == {"judge/score": 0.75}
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

- measure end-to-end evaluation wall time in `RolloutManager.eval`
- report it as `perf/eval_time` through the existing eval metrics path
- preserve custom evaluator metrics without mutating their dictionary

## Motivation

Rollout generation already reports `perf/rollout_time`, but periodic evaluation has no corresponding duration. On long-running jobs this makes evaluation pauses indistinguishable from rollout, training, or weight-sync stalls.

## Test plan

- added a unit test for custom metric preservation and wall-time reporting
- `python3 -m py_compile slime/ray/rollout.py tests/test_rollout_metrics.py`
- isolated `_eval_metrics` contract execution passed
- `git diff --check`

The full `tests/test_rollout_metrics.py` requires the project CUDA/SGLang test environment and is left to upstream CI.