### PR TITLE
docs: add standard single GPU GRPO run

### DIFF
--- a/docs/en/get_started/quick_start.md
+++ b/docs/en/get_started/quick_start.md
@@ -306,6 +306,8 @@ SGLANG_ARGS=(
 
 ### Colocated Actor and Rollout
 
+For a complete one-GPU development run of the standard synchronous GRPO loop, including online rollout, rule-based rewards, optimizer updates, periodic evaluation, and checkpoint saving, use [`scripts/run-qwen3-0.6B-single-gpu.sh`](../../../scripts/run-qwen3-0.6B-single-gpu.sh). The script expects a local Qwen3-0.6B Hugging Face checkpoint, a converted Megatron checkpoint, and the GSM8K train/test parquet files; every path can be overridden through the environment variables documented at the top of the script.
+
 Under the default configuration, training (Actor) and inference (Rollout) resources are specified separately. Ray allocates `actor_num_nodes * actor_num_gpus_per_node` GPUs to the training part and `rollout_num_gpus` GPUs to inference, that is, training and inference are separated. When `--rollout-num-gpus` is explicitly set to `0`, slime still parses SGLang arguments and launches the router, but does not launch local SGLang servers.
 
 **Standard (Disaggregated) Configuration**:

--- a/docs/zh/get_started/quick_start.md
+++ b/docs/zh/get_started/quick_start.md
@@ -305,6 +305,8 @@ SGLANG_ARGS=(
 
 ### Colocated Actor and Rollout
 
+如需在单张 GPU 上完整运行标准同步 GRPO 流程（包括在线 rollout、规则奖励、优化器更新、周期性评测和 checkpoint 保存），可使用 [`scripts/run-qwen3-0.6B-single-gpu.sh`](../../../scripts/run-qwen3-0.6B-single-gpu.sh)。脚本需要本地 Qwen3-0.6B Hugging Face checkpoint、转换后的 Megatron checkpoint，以及 GSM8K 的 train/test parquet 文件；所有路径都可以通过脚本开头记录的环境变量覆盖。
+
 在默认的配置下，训练（Actor）和推理（Rollout）的资源是分开指定的，通过 ray 给训练部分分配 `actor_num_nodes * actor_num_gpus_per_node` 张 GPU，给推理分配 `rollout_num_gpus` 张 GPU，也即训推分离。将 `--rollout-num-gpus` 显式设置为 `0` 时，slime 仍会解析 SGLang 参数并启动 router，但不会启动本地 SGLang server。
 
 **标准（分离）配置**：

--- a/scripts/run-qwen3-0.6B-single-gpu.sh
+++ b/scripts/run-qwen3-0.6B-single-gpu.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# Run the standard synchronous Slime GRPO loop on one GPU.
+#
+# Required inputs can be overridden with environment variables:
+#   HF_CHECKPOINT  Hugging Face Qwen3-0.6B checkpoint
+#   REF_LOAD       Converted Megatron torch_dist checkpoint
+#   PROMPT_DATA    GSM8K training parquet
+#   EVAL_DATA      GSM8K evaluation parquet
+#   SAVE_DIR       Output checkpoint directory
+#   LOAD_CHECKPOINT Checkpoint root to resume (defaults to SAVE_DIR when complete)
+#   MEGATRON_ROOT  Megatron-LM checkout used by Slime
+#   NUM_ROLLOUT    Absolute rollout/update target (default: 10)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+SLIME_ROOT="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
+# shellcheck source=./scripts/models/qwen3-0.6B.sh
+source "${SCRIPT_DIR}/models/qwen3-0.6B.sh"
+
+HF_CHECKPOINT="${HF_CHECKPOINT:-/root/models/Qwen3-0.6B}"
+REF_LOAD="${REF_LOAD:-/root/models/Qwen3-0.6B_torch_dist}"
+PROMPT_DATA="${PROMPT_DATA:-/root/datasets/gsm8k/train.parquet}"
+EVAL_DATA="${EVAL_DATA:-/root/datasets/gsm8k/test.parquet}"
+SAVE_DIR="${SAVE_DIR:-/root/checkpoints/qwen3-0.6B-single-gpu-grpo}"
+MEGATRON_ROOT="${MEGATRON_ROOT:-/root/Megatron-LM}"
+NUM_ROLLOUT="${NUM_ROLLOUT:-10}"
+SAVE_INTERVAL="${SAVE_INTERVAL:-5}"
+
+if [[ -z "${LOAD_CHECKPOINT:-}" ]]; then
+   if [[ -f "${SAVE_DIR}/latest_checkpointed_iteration.txt" ]]; then
+      LOAD_CHECKPOINT="$SAVE_DIR"
+   else
+      LOAD_CHECKPOINT="$REF_LOAD"
+   fi
+fi
+
+for path in "$HF_CHECKPOINT" "$REF_LOAD" "$LOAD_CHECKPOINT" "$PROMPT_DATA" "$EVAL_DATA" "$MEGATRON_ROOT"; do
+   if [[ ! -e "$path" ]]; then
+      echo "Missing required path: $path" >&2
+      exit 2
+   fi
+done
+mkdir -p "$SAVE_DIR"
+
+if ! ray status >/dev/null 2>&1; then
+   ray start --head --node-ip-address 127.0.0.1 --num-gpus 1 --disable-usage-stats
+fi
+
+cd "$SLIME_ROOT"
+ray job submit --address="http://127.0.0.1:8265" \
+   --runtime-env-json="{\"env_vars\":{\"PYTHONPATH\":\"${MEGATRON_ROOT}\",\"CUDA_DEVICE_MAX_CONNECTIONS\":\"1\"}}" \
+   -- python3 train.py \
+   --actor-num-nodes 1 \
+   --actor-num-gpus-per-node 1 \
+   --colocate \
+   --hf-checkpoint "$HF_CHECKPOINT" \
+   --ref-load "$REF_LOAD" \
+   --load "$LOAD_CHECKPOINT" \
+   --save "$SAVE_DIR" \
+   --save-interval "$SAVE_INTERVAL" \
+   --prompt-data "$PROMPT_DATA" \
+   --input-key messages \
+   --label-key label \
+   --apply-chat-template \
+   --rollout-shuffle \
+   --rm-type math \
+   --num-rollout "$NUM_ROLLOUT" \
+   --rollout-batch-size 2 \
+   --n-samples-per-prompt 4 \
+   --global-batch-size 8 \
+   --rollout-max-response-len 512 \
+   --rollout-temperature 0.8 \
+   --rollout-top-p 0.95 \
+   --eval-interval "$NUM_ROLLOUT" \
+   --skip-eval-before-train \
+   --eval-prompt-data gsm8k "$EVAL_DATA" \
+   --n-samples-per-eval-prompt 1 \
+   --eval-max-response-len 512 \
+   --eval-top-k 1 \
+   --advantage-estimator grpo \
+   --calculate-per-token-loss \
+   --use-kl-loss \
+   --kl-loss-coef 0.0 \
+   --kl-loss-type low_var_kl \
+   --eps-clip 0.2 \
+   --eps-clip-high 0.28 \
+   --optimizer adam \
+   --lr 1e-6 \
+   --lr-decay-style constant \
+   --weight-decay 0.1 \
+   --adam-beta1 0.9 \
+   --adam-beta2 0.98 \
+   --tensor-model-parallel-size 1 \
+   --pipeline-model-parallel-size 1 \
+   --context-parallel-size 1 \
+   --expert-model-parallel-size 1 \
+   --expert-tensor-parallel-size 1 \
+   --use-dynamic-batch-size \
+   --max-tokens-per-gpu 4096 \
+   --rollout-num-gpus-per-engine 1 \
+   --sglang-mem-fraction-static 0.45 \
+   --sglang-cuda-graph-max-bs 8 \
+   --attention-dropout 0.0 \
+   --hidden-dropout 0.0 \
+   --accumulate-allreduce-grads-in-fp32 \
+   --attention-softmax-in-fp32 \
+   --attention-backend flash \
+   "${MODEL_ARGS[@]}"

--- a/tests/test_single_gpu_script.py
+++ b/tests/test_single_gpu_script.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+
+import pytest
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "run-qwen3-0.6B-single-gpu.sh"
+
+
+@pytest.mark.unit
+def test_single_gpu_script_covers_standard_grpo_train_eval_and_resume_artifacts():
+    source = SCRIPT.read_text()
+
+    required_arguments = (
+        "--actor-num-gpus-per-node 1",
+        "--colocate",
+        "--num-rollout \"$NUM_ROLLOUT\"",
+        "--advantage-estimator grpo",
+        "--eval-prompt-data gsm8k \"$EVAL_DATA\"",
+        "--load \"$LOAD_CHECKPOINT\"",
+        "--save \"$SAVE_DIR\"",
+        "--save-interval \"$SAVE_INTERVAL\"",
+        "--tensor-model-parallel-size 1",
+        "--pipeline-model-parallel-size 1",
+        "--rollout-num-gpus-per-engine 1",
+    )
+    for argument in required_arguments:
+        assert argument in source
+
+    assert 'source "${SCRIPT_DIR}/models/qwen3-0.6B.sh"' in source
+    assert 'if [[ -f "${SAVE_DIR}/latest_checkpointed_iteration.txt" ]]' in source
+    assert "--debug-train-only" not in source
+    assert "--debug-rollout-only" not in source

--- a/tests/test_single_gpu_script.py
+++ b/tests/test_single_gpu_script.py
@@ -2,7 +2,6 @@ from pathlib import Path
 
 import pytest
 
-
 SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "run-qwen3-0.6B-single-gpu.sh"
 
 
@@ -13,12 +12,12 @@ def test_single_gpu_script_covers_standard_grpo_train_eval_and_resume_artifacts(
     required_arguments = (
         "--actor-num-gpus-per-node 1",
         "--colocate",
-        "--num-rollout \"$NUM_ROLLOUT\"",
+        '--num-rollout "$NUM_ROLLOUT"',
         "--advantage-estimator grpo",
-        "--eval-prompt-data gsm8k \"$EVAL_DATA\"",
-        "--load \"$LOAD_CHECKPOINT\"",
-        "--save \"$SAVE_DIR\"",
-        "--save-interval \"$SAVE_INTERVAL\"",
+        '--eval-prompt-data gsm8k "$EVAL_DATA"',
+        '--load "$LOAD_CHECKPOINT"',
+        '--save "$SAVE_DIR"',
+        '--save-interval "$SAVE_INTERVAL"',
         "--tensor-model-parallel-size 1",
         "--pipeline-model-parallel-size 1",
         "--rollout-num-gpus-per-engine 1",


### PR DESCRIPTION
## Summary

- add a Qwen3-0.6B one-GPU script for the standard synchronous Slime GRPO loop
- cover online SGLang rollout, math rewards, optimizer updates, final evaluation, checkpoint saving, and automatic resume from a completed save root
- keep model, data, Megatron, save, and rollout targets configurable through environment variables
- document the script in English and Chinese quick-start guides

## Motivation

This implements the minimal standard-flow reproduction requested by #1628. Existing one-GPU examples cover true-on-policy mode or a one-step platform smoke; this script exercises the ordinary `train.py` loop and produces resumable artifacts.

`NUM_ROLLOUT` is an absolute target, so a resumed run advances by setting it above the saved rollout ID.

## Test plan

- `bash -n scripts/run-qwen3-0.6B-single-gpu.sh`
- `shellcheck -x scripts/run-qwen3-0.6B-single-gpu.sh`
- `PYTHONPATH=$PWD uv run --no-project --with pytest pytest -q tests/test_single_gpu_script.py` — 1 passed
- `python3 -m py_compile tests/test_single_gpu_script.py`
- `git diff --check`

A full GPU execution requires the documented CUDA/Megatron/SGLang environment and local checkpoints, so it is left to upstream GPU CI.