### PR TITLE
fix: reject non-positive rollout temperature at parse time

### DIFF
--- a/slime/utils/arguments.py
+++ b/slime/utils/arguments.py
@@ -343,7 +343,7 @@ def get_slime_extra_args_provider(add_custom_arguments=None):
                 "--rollout-temperature",
                 type=float,
                 default=1.0,
-                help="the temperature for the inference engine during rollout.",
+                help="the temperature for the inference engine during rollout. Must be > 0.",
             )
             parser.add_argument(
                 "--rollout-top-p", type=float, default=1.0, help="the top-p for the inference engine during rollout."
@@ -1766,6 +1766,11 @@ def _resolve_eval_datasets(args) -> list[EvalDatasetConfig]:
 
 def slime_validate_args(args):
     args.eval_datasets = _resolve_eval_datasets(args)
+
+    if args.rollout_temperature <= 0:
+        raise ValueError(
+            "--rollout-temperature must be > 0; temperature 0 is greedy decoding and is not a valid RL policy."
+        )
 
     if args.kl_coef != 0 or args.use_kl_loss:
         if not os.path.exists(args.ref_load):

--- a/tests/test_megatron_argument_validation.py
+++ b/tests/test_megatron_argument_validation.py
@@ -255,6 +255,7 @@ def make_slime_validate_args(**overrides):
         update_weight_disk_dir=None,
         update_weight_local_checkpoint_dir=None,
         update_weight_mode="full",
+        rollout_temperature=1.0,
     )
     values.update(overrides)
     return types.SimpleNamespace(**values)
@@ -296,6 +297,16 @@ def test_slime_validate_args_rejects_equal_debug_data_paths(monkeypatch):
     )
 
     with pytest.raises(ValueError, match="--save-debug-train-data must not be equal"):
+        module.slime_validate_args(args)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("temperature", [0.0, -0.1])
+def test_slime_validate_args_rejects_non_positive_rollout_temperature(monkeypatch, temperature):
+    module = load_slime_arguments_module(monkeypatch)
+    args = make_slime_validate_args(rollout_temperature=temperature)
+
+    with pytest.raises(ValueError, match="--rollout-temperature must be > 0"):
         module.slime_validate_args(args)
 
 


### PR DESCRIPTION
## Problem

`--rollout-temperature 0` is greedy decoding. That is not a usable on-policy RL policy: the sampling distribution is a delta, while log-probs (and PPO ratios) still come from a softmax. Greedy RL should be rejected at config parse, not assumed away in loss code.

`--eval-temperature 0` is unchanged; greedy eval remains valid.

## Change

`slime_validate_args` raises if `rollout_temperature <= 0`.

## Test plan

- [x] `tests/test_megatron_argument_validation.py` — `0.0` and `-0.1` raise; existing validate-args cases still pass at the default `1.0`


Made with [Cursor](https://cursor.com)