### PR TITLE
fix(update-weight): gather legacy TE grouped experts

### DIFF
--- a/slime/backends/megatron_utils/update_weight/common.py
+++ b/slime/backends/megatron_utils/update_weight/common.py
@@ -11,6 +11,29 @@ from megatron.core.transformer.transformer_layer import get_transformer_layer_of
 from slime.backends.megatron_utils.misc_utils import strip_param_name_prefix
 from slime.utils.types import ParamInfo
 
+_TE_GROUPED_LINEAR_EXPERT_PARAM = re.compile(r"\.experts\.linear_fc([12])\.(weight|bias)\d+$")
+
+
+def _tp_partition_dim(name: str, param: torch.Tensor) -> int | None:
+    """Return the TP partition dimension, including legacy TEGroupedLinear metadata."""
+    if getattr(param, "parallel_mode", None) == "duplicated":
+        return None
+
+    if getattr(param, "tensor_model_parallel", False):
+        return param.partition_dim
+
+    # Older Megatron-LM revisions explicitly shard expert TEGroupedLinear parameters while
+    # clearing TE's parallel_mode, but do not stamp tensor_model_parallel/partition_dim. The
+    # exported expert names still identify the column-parallel fc1 and row-parallel fc2 shards.
+    match = _TE_GROUPED_LINEAR_EXPERT_PARAM.search(name)
+    if match is None:
+        return None
+
+    projection, kind = match.groups()
+    if projection == "2" and kind == "bias":
+        return None  # row-parallel bias is replicated
+    return 0 if projection == "1" else 1
+
 
 def all_gather_param(name: str, param: torch.nn.Parameter) -> torch.Tensor:
     """
@@ -21,8 +44,8 @@ def all_gather_param(name: str, param: torch.nn.Parameter) -> torch.Tensor:
     if "expert_bias" in name:
         return param
 
-    assert hasattr(param, "tensor_model_parallel"), f"{name} does not have tensor_model_parallel attribute"
-    if not param.tensor_model_parallel or getattr(param, "parallel_mode", None) == "duplicated":
+    partition_dim = _tp_partition_dim(name, param)
+    if partition_dim is None:
         return param.data
 
     if ".experts." in name:
@@ -40,9 +63,9 @@ def all_gather_param(name: str, param: torch.nn.Parameter) -> torch.Tensor:
 
     param_partitions = [torch.empty_like(param.data) for _ in range(tp_size)]
     dist.all_gather(param_partitions, param.data, group=tp_group)
-    partition_dim = param.partition_dim
-    assert param.partition_stride == 1 or (
-        param.partition_stride == 2 and "linear_fc1" in name
+    partition_stride = getattr(param, "partition_stride", 1)
+    assert partition_stride == 1 or (
+        partition_stride == 2 and "linear_fc1" in name
     ), "partition_stride != 1 is not supported"
     # TODO: here we did an extra copy during concat, maybe merge this with convert_to_hf is better?
     # TODO: check only GLU is used.
@@ -74,9 +97,12 @@ def all_gather_params_async(
         # Prepare async all_gather
         if "expert_bias" in info.name:
             gather_tasks.append((info, param, None, None, None))
-        elif not param.tensor_model_parallel or getattr(param, "parallel_mode", None) == "duplicated":
-            gather_tasks.append((info, param.data, None, None, None))
         else:
+            partition_dim = _tp_partition_dim(info.name, param)
+            if partition_dim is None:
+                gather_tasks.append((info, param.data, None, None, None))
+                continue
+
             # Start async all_gather
             if ".experts." in info.name:
                 tp_size = mpu.get_expert_tensor_parallel_world_size()
@@ -94,7 +120,7 @@ def all_gather_params_async(
 
             param_partitions = [torch.empty_like(param.data) for _ in range(tp_size)]
             handle = dist.all_gather(param_partitions, param.data, group=tp_group, async_op=True)
-            gather_tasks.append((info, None, handle, param_partitions, param.partition_dim))
+            gather_tasks.append((info, None, handle, param_partitions, partition_dim))
             handles.append(handle)
 
     # Phase 2: Wait for ALL async operations to complete at once

--- a/slime/backends/megatron_utils/update_weight/common.py
+++ b/slime/backends/megatron_utils/update_weight/common.py
@@ -19,7 +19,8 @@ def _tp_partition_dim(name: str, param: torch.Tensor) -> int | None:
     if getattr(param, "parallel_mode", None) == "duplicated":
         return None
 
-    if getattr(param, "tensor_model_parallel", False):
+    has_tp_metadata = hasattr(param, "tensor_model_parallel")
+    if has_tp_metadata and param.tensor_model_parallel:
         return param.partition_dim
 
     # Older Megatron-LM revisions explicitly shard expert TEGroupedLinear parameters while
@@ -27,6 +28,7 @@ def _tp_partition_dim(name: str, param: torch.Tensor) -> int | None:
     # exported expert names still identify the column-parallel fc1 and row-parallel fc2 shards.
     match = _TE_GROUPED_LINEAR_EXPERT_PARAM.search(name)
     if match is None:
+        assert has_tp_metadata, f"{name} does not have tensor_model_parallel attribute"
         return None
 
     projection, kind = match.groups()

--- a/tests/test_megatron_weight_gather.py
+++ b/tests/test_megatron_weight_gather.py
@@ -3,6 +3,7 @@ import sys
 import types
 from pathlib import Path
 
+import pytest
 import torch
 
 NUM_GPUS = 0
@@ -134,7 +135,7 @@ def test_legacy_grouped_row_bias_and_unrecognized_expert_stay_replicated(monkeyp
     module, _, _ = _load_common(monkeypatch)
     calls, _ = _install_fake_all_gather(monkeypatch, module)
     row_bias = _param([1, 2])
-    router = _param([3, 4])
+    router = _param([3, 4], tensor_model_parallel=False)
 
     row_result = module.all_gather_param(
         "module.module.decoder.layers.0.mlp.experts.linear_fc2.bias0",
@@ -148,6 +149,14 @@ def test_legacy_grouped_row_bias_and_unrecognized_expert_stay_replicated(monkeyp
     torch.testing.assert_close(row_result, row_bias)
     torch.testing.assert_close(router_result, router)
     assert calls == []
+
+
+def test_unrecognized_parameter_without_tp_metadata_still_fails_fast(monkeypatch):
+    module, _, _ = _load_common(monkeypatch)
+    param = _param([1, 2])
+
+    with pytest.raises(AssertionError, match="does not have tensor_model_parallel attribute"):
+        module.all_gather_param("module.module.decoder.layers.0.mlp.router.weight", param)
 
 
 def test_existing_tensor_parallel_metadata_keeps_regular_tp_group(monkeypatch):

--- a/tests/test_megatron_weight_gather.py
+++ b/tests/test_megatron_weight_gather.py
@@ -1,0 +1,174 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import torch
+
+NUM_GPUS = 0
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load_common(monkeypatch):
+    expert_group = object()
+    tensor_group = object()
+
+    slime_pkg = types.ModuleType("slime")
+    slime_pkg.__path__ = [str(REPO_ROOT / "slime")]
+    slime_backends_pkg = types.ModuleType("slime.backends")
+    slime_backends_pkg.__path__ = [str(REPO_ROOT / "slime" / "backends")]
+    megatron_utils_pkg = types.ModuleType("slime.backends.megatron_utils")
+    megatron_utils_pkg.__path__ = [str(REPO_ROOT / "slime" / "backends" / "megatron_utils")]
+    update_weight_pkg = types.ModuleType("slime.backends.megatron_utils.update_weight")
+    update_weight_pkg.__path__ = [str(REPO_ROOT / "slime" / "backends" / "megatron_utils" / "update_weight")]
+    slime_utils_pkg = types.ModuleType("slime.utils")
+    slime_utils_pkg.__path__ = [str(REPO_ROOT / "slime" / "utils")]
+
+    mpu_mod = types.ModuleType("megatron.core.mpu")
+    mpu_mod.get_expert_tensor_parallel_world_size = lambda: 2
+    mpu_mod.get_expert_tensor_parallel_group = lambda: expert_group
+    mpu_mod.get_tensor_model_parallel_world_size = lambda: 2
+    mpu_mod.get_tensor_model_parallel_group = lambda: tensor_group
+
+    megatron_mod = types.ModuleType("megatron")
+    megatron_core_mod = types.ModuleType("megatron.core")
+    megatron_core_mod.mpu = mpu_mod
+    transformer_pkg = types.ModuleType("megatron.core.transformer")
+    transformer_layer_mod = types.ModuleType("megatron.core.transformer.transformer_layer")
+    transformer_layer_mod.get_transformer_layer_offset = lambda *args, **kwargs: 0
+
+    misc_utils_mod = types.ModuleType("slime.backends.megatron_utils.misc_utils")
+    misc_utils_mod.strip_param_name_prefix = lambda name: name
+    slime_types_mod = types.ModuleType("slime.utils.types")
+    slime_types_mod.ParamInfo = object
+
+    modules = {
+        "slime": slime_pkg,
+        "slime.backends": slime_backends_pkg,
+        "slime.backends.megatron_utils": megatron_utils_pkg,
+        "slime.backends.megatron_utils.update_weight": update_weight_pkg,
+        "slime.backends.megatron_utils.misc_utils": misc_utils_mod,
+        "slime.utils": slime_utils_pkg,
+        "slime.utils.types": slime_types_mod,
+        "megatron": megatron_mod,
+        "megatron.core": megatron_core_mod,
+        "megatron.core.mpu": mpu_mod,
+        "megatron.core.transformer": transformer_pkg,
+        "megatron.core.transformer.transformer_layer": transformer_layer_mod,
+    }
+    for name, module in modules.items():
+        monkeypatch.setitem(sys.modules, name, module)
+
+    module_name = "slime.backends.megatron_utils.update_weight.common"
+    sys.modules.pop(module_name, None)
+    module_path = REPO_ROOT / "slime" / "backends" / "megatron_utils" / "update_weight" / "common.py"
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, module_name, module)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module, expert_group, tensor_group
+
+
+def _install_fake_all_gather(monkeypatch, module):
+    calls = []
+    handles = []
+
+    class _Handle:
+        waited = False
+
+        def wait(self):
+            self.waited = True
+
+    def _all_gather(outputs, value, *, group, async_op=False):
+        outputs[0].copy_(value)
+        outputs[1].copy_(value + 2)
+        calls.append((group, async_op))
+        if async_op:
+            handle = _Handle()
+            handles.append(handle)
+            return handle
+        return None
+
+    monkeypatch.setattr(module.dist, "all_gather", _all_gather)
+    return calls, handles
+
+
+def _param(value, **attrs):
+    param = torch.nn.Parameter(torch.tensor(value, dtype=torch.float32), requires_grad=False)
+    for name, attr_value in attrs.items():
+        setattr(param, name, attr_value)
+    return param
+
+
+def test_sync_gathers_legacy_grouped_fc1_without_tp_metadata(monkeypatch):
+    module, expert_group, _ = _load_common(monkeypatch)
+    calls, _ = _install_fake_all_gather(monkeypatch, module)
+    param = _param([1, 2])
+
+    result = module.all_gather_param(
+        "module.module.decoder.layers.0.mlp.experts.linear_fc1.weight0",
+        param,
+    )
+
+    torch.testing.assert_close(result, torch.tensor([1, 3, 2, 4], dtype=torch.float32))
+    assert calls == [(expert_group, False)]
+
+
+def test_sync_gathers_legacy_grouped_fc2_along_input_dimension(monkeypatch):
+    module, expert_group, _ = _load_common(monkeypatch)
+    calls, _ = _install_fake_all_gather(monkeypatch, module)
+    param = _param([[1, 2]])
+
+    result = module.all_gather_param(
+        "module.module.decoder.layers.0.mlp.experts.linear_fc2.weight0",
+        param,
+    )
+
+    torch.testing.assert_close(result, torch.tensor([[1, 2, 3, 4]], dtype=torch.float32))
+    assert calls == [(expert_group, False)]
+
+
+def test_legacy_grouped_row_bias_and_unrecognized_expert_stay_replicated(monkeypatch):
+    module, _, _ = _load_common(monkeypatch)
+    calls, _ = _install_fake_all_gather(monkeypatch, module)
+    row_bias = _param([1, 2])
+    router = _param([3, 4])
+
+    row_result = module.all_gather_param(
+        "module.module.decoder.layers.0.mlp.experts.linear_fc2.bias0",
+        row_bias,
+    )
+    router_result = module.all_gather_param(
+        "module.module.decoder.layers.0.mlp.experts.router.weight",
+        router,
+    )
+
+    torch.testing.assert_close(row_result, row_bias)
+    torch.testing.assert_close(router_result, router)
+    assert calls == []
+
+
+def test_existing_tensor_parallel_metadata_keeps_regular_tp_group(monkeypatch):
+    module, _, tensor_group = _load_common(monkeypatch)
+    calls, _ = _install_fake_all_gather(monkeypatch, module)
+    param = _param([1, 2], tensor_model_parallel=True, partition_dim=0, partition_stride=1)
+
+    result = module.all_gather_param("module.module.decoder.layers.0.self_attention.linear_qkv.weight", param)
+
+    torch.testing.assert_close(result, torch.tensor([1, 2, 3, 4], dtype=torch.float32))
+    assert calls == [(tensor_group, False)]
+
+
+def test_async_gathers_legacy_grouped_expert_with_false_metadata(monkeypatch):
+    module, expert_group, _ = _load_common(monkeypatch)
+    calls, handles = _install_fake_all_gather(monkeypatch, module)
+    param = _param([1, 2], tensor_model_parallel=False, partition_dim=-1, partition_stride=1)
+    info = types.SimpleNamespace(name="module.module.decoder.layers.0.mlp.experts.linear_fc1.weight0")
+
+    result = module.all_gather_params_async([(info, param)])
+
+    torch.testing.assert_close(result[0], torch.tensor([1, 3, 2, 4], dtype=torch.float32))
+    assert calls == [(expert_group, True)]
+    assert len(handles) == 1 and handles[0].waited


### PR DESCRIPTION
## Summary

- recover expert-TP partition metadata for legacy Megatron TEGroupedLinear parameter names
- gather affected expert shards in both synchronous and batched asynchronous weight-update paths
- keep row-parallel linear_fc2 biases and metadata-marked unrecognized expert parameters replicated
- preserve the original fail-fast behavior for unrelated parameters with completely missing TP metadata
- preserve the existing metadata-driven behavior for current Megatron versions

## Problem

In the Megatron-LM revision reported in #2280, expert TEGroupedLinear modules are explicitly sharded across ETP ranks while Transformer Engine receives parallel_mode=None. Those parameters therefore lack the tensor_model_parallel and partition_dim metadata that slime currently requires before entering its all-gather path.

With ETP=2, slime consequently forwards one local shard to SGLang instead of the reconstructed expert tensor. In the reported Qwen3.5-35B-A3B run, SGLang receives 256 elements where it expects 512 and partially updates the rollout model.

NVIDIA/Megatron-LM#5916 later fixed the missing metadata upstream, but slime images using the earlier revision remain affected.

## Fix

_tp_partition_dim first honors normal Megatron metadata. When that metadata is absent, it uses slime's stable exported TE grouped-expert names to recover only the partitioning that is unambiguous:

- linear_fc1.weightN and linear_fc1.biasN: column-parallel, dimension 0
- linear_fc2.weightN: row-parallel, dimension 1
- linear_fc2.biasN: replicated

The fallback is restricted to .experts.linear_fc[12].(weight|bias)N names. The existing expert-TP world-size check still makes ETP=1 a no-op, and parallel_mode=duplicated remains excluded.

The same helper is used by all_gather_param and all_gather_params_async, so direct and batched online updates make the same decision.

## Validation

- Windows Python 3.12 / PyTorch CPU: 6 passed
- Linux Python 3.12 / PyTorch 2.13 CPU: 5 passed
- project changed-file pre-commit suite: all hooks passed
- Ruff, Python compilation, and git diff --check: passed

The tests cover legacy fc1/fc2 reconstruction, the replicated row bias, an unrecognized parameter with explicit non-TP metadata, fail-fast behavior for unrelated missing metadata, existing regular-TP metadata, and the asynchronous gather/wait path.

I did not rerun the reported 48-H200 topology. The regression directly verifies the missing shard-to-full-tensor transition, expert-TP group selection, concatenation dimensions, GLU reorder, and both slime update paths.

Closes #2280
