### PR TITLE
perf(rollout): reuse filtered prompt token ids

### DIFF
--- a/slime/rollout/data_source.py
+++ b/slime/rollout/data_source.py
@@ -14,6 +14,18 @@ from slime.utils.types import Sample
 logger = logging.getLogger(__name__)
 
 
+def _should_cache_prompt_token_ids(args) -> bool:
+    return (
+        args.rollout_function_path == "slime.rollout.sglang_rollout.generate_rollout"
+        and args.custom_generate_function_path is None
+        and args.data_source_path
+        in {
+            "slime.rollout.data_source.RolloutDataSource",
+            "slime.rollout.data_source.RolloutDataSourceWithBuffer",
+        }
+    )
+
+
 class DataSource(abc.ABC):
     @abc.abstractmethod
     def get_samples(self, num_samples: int) -> list[list[Sample]]:
@@ -80,6 +92,7 @@ class RolloutDataSource(DataSource):
                 tool_key=args.tool_key,
                 apply_chat_template=args.apply_chat_template,
                 apply_chat_template_kwargs=args.apply_chat_template_kwargs,
+                cache_prompt_token_ids=_should_cache_prompt_token_ids(args),
                 seed=args.rollout_seed,
             )
             if self.args.rollout_shuffle:

--- a/slime/rollout/sglang_rollout.py
+++ b/slime/rollout/sglang_rollout.py
@@ -40,6 +40,7 @@ _PROCESSOR_PROMPT_KEYS = {"input_ids", "attention_mask"}
 
 
 def _prepare_prompt_ids(sample: Sample, tokenizer, processor: Any) -> list[int]:
+    cached_prompt_ids = sample.pop_cached_prompt_token_ids()
     raw_multimodal_inputs = sample.multimodal_inputs or {}
     has_multimodal_inputs = any(value is not None for value in raw_multimodal_inputs.values())
     reuse_existing_input_ids = bool(sample.tokens) and (
@@ -57,6 +58,9 @@ def _prepare_prompt_ids(sample: Sample, tokenizer, processor: Any) -> list[int]:
 
     if reuse_existing_input_ids:
         return sample.tokens
+
+    if cached_prompt_ids is not None and isinstance(sample.prompt, str) and not has_multimodal_inputs:
+        return cached_prompt_ids
 
     return tokenizer.encode(sample.prompt, add_special_tokens=False)
 
@@ -511,6 +515,9 @@ async def eval_rollout_single_dataset(
         if dataset_cfg.apply_chat_template_kwargs is not None
         else args.apply_chat_template_kwargs
     )
+    cache_prompt_token_ids = (
+        args.custom_generate_function_path is None and dataset_cfg.custom_generate_function_path is None
+    )
 
     cache_key = dataset_cfg.cache_key + (
         args.hf_checkpoint,
@@ -521,6 +528,7 @@ async def eval_rollout_single_dataset(
             if eval_apply_chat_template_kwargs is not None
             else None
         ),
+        cache_prompt_token_ids,
     )
     if cache_key not in EVAL_PROMPT_DATASET:
         tokenizer = load_tokenizer(args.hf_checkpoint, trust_remote_code=True)
@@ -537,6 +545,7 @@ async def eval_rollout_single_dataset(
             tool_key=dataset_cfg.tool_key,
             apply_chat_template=eval_apply_chat_template,
             apply_chat_template_kwargs=eval_apply_chat_template_kwargs,
+            cache_prompt_token_ids=cache_prompt_token_ids,
         )
     dataset = EVAL_PROMPT_DATASET[cache_key]
 

--- a/slime/utils/data.py
+++ b/slime/utils/data.py
@@ -84,7 +84,14 @@ def _parse_generalized_path(s: str):
     return s, None
 
 
-def filter_long_prompt(origin_samples: list[Sample], tokenizer, processor, max_length: int | None) -> list[Sample]:
+def filter_long_prompt(
+    origin_samples: list[Sample],
+    tokenizer,
+    processor,
+    max_length: int | None,
+    *,
+    cache_prompt_token_ids: bool = False,
+) -> list[Sample]:
     if max_length is None:
         return origin_samples
 
@@ -109,6 +116,8 @@ def filter_long_prompt(origin_samples: list[Sample], tokenizer, processor, max_l
             input_ids_list = tokenizer(prompts, add_special_tokens=False)["input_ids"]
             for (position, sample), input_ids in zip(text_only, input_ids_list, strict=True):
                 if len(input_ids) <= max_length:
+                    if cache_prompt_token_ids and isinstance(sample.prompt, str):
+                        sample.cache_prompt_token_ids(input_ids)
                     kept.append((position, sample))
         if multimodal:
             from slime.utils.processing_utils import process_vision_info
@@ -128,11 +137,15 @@ def filter_long_prompt(origin_samples: list[Sample], tokenizer, processor, max_l
     else:
         prompts = [sample.prompt for sample in origin_samples]
         input_ids_list = tokenizer(prompts, add_special_tokens=False)["input_ids"]
-        filtered_samples = [
-            sample
-            for sample, input_ids in zip(origin_samples, input_ids_list, strict=True)
-            if len(input_ids) <= max_length
-        ]
+        filtered_samples = []
+        for sample, input_ids in zip(origin_samples, input_ids_list, strict=True):
+            if len(input_ids) <= max_length:
+                has_multimodal_inputs = bool(sample.multimodal_inputs) and any(
+                    value is not None for value in sample.multimodal_inputs.values()
+                )
+                if cache_prompt_token_ids and isinstance(sample.prompt, str) and not has_multimodal_inputs:
+                    sample.cache_prompt_token_ids(input_ids)
+                filtered_samples.append(sample)
 
     logger.info(f"Filtered {len(origin_samples) - len(filtered_samples)} samples longer than max_length={max_length}.")
 
@@ -227,6 +240,7 @@ class Dataset:
         seed=42,
         apply_chat_template=False,
         apply_chat_template_kwargs=None,
+        cache_prompt_token_ids=False,
     ):
         origin_samples = []
         for data in read_file(path):
@@ -276,7 +290,13 @@ class Dataset:
             )
 
         if max_length is not None:
-            self.origin_samples = filter_long_prompt(origin_samples, tokenizer, processor, max_length)
+            self.origin_samples = filter_long_prompt(
+                origin_samples,
+                tokenizer,
+                processor,
+                max_length,
+                cache_prompt_token_ids=cache_prompt_token_ids,
+            )
         else:
             self.origin_samples = origin_samples
 

--- a/slime/utils/types.py
+++ b/slime/utils/types.py
@@ -1,3 +1,5 @@
+import sys
+from array import array
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any
@@ -107,6 +109,7 @@ class Sample:
     # prompt
     prompt: str | list[dict[str, str]] = ""
     tokens: list[int] = field(default_factory=list)
+    _prompt_token_ids_cache: bytes | None = field(default=None, init=False, repr=False, compare=False)
     multimodal_inputs: dict[str, Any] | None = None  # raw multimodal data, e.g. images, videos, etc.
     multimodal_train_inputs: dict[str, Any] | None = None  # processed multimodal data, e.g. pixel_values, etc.
     multimodal_train_input_id: str | None = None
@@ -221,6 +224,7 @@ class Sample:
 
     def to_dict(self):
         value = self.__dict__.copy()
+        value.pop("_prompt_token_ids_cache", None)
         value["status"] = self.status.value
         value["spec_info"] = self.spec_info.to_dict()
         value["prefix_cache_info"] = self.prefix_cache_info.to_dict()
@@ -229,6 +233,7 @@ class Sample:
     @staticmethod
     def from_dict(data: dict):
         data = dict(data)
+        data.pop("_prompt_token_ids_cache", None)
         data["status"] = Sample.Status(data["status"])
         data["spec_info"] = Sample.SpecInfo.from_dict(data.get("spec_info", {}))
         data["prefix_cache_info"] = Sample.PrefixCacheInfo.from_dict(data.get("prefix_cache_info", {}))
@@ -242,6 +247,37 @@ class Sample:
                 setattr(sample, key, value)
 
         return sample
+
+    def cache_prompt_token_ids(self, token_ids) -> bool:
+        """Store prompt token IDs in a compact, transient representation."""
+        try:
+            values = array("I", token_ids)
+        except (OverflowError, TypeError, ValueError):
+            self._prompt_token_ids_cache = None
+            return False
+
+        if values.itemsize != 4:
+            self._prompt_token_ids_cache = None
+            return False
+        if sys.byteorder != "little":
+            values.byteswap()
+        self._prompt_token_ids_cache = values.tobytes()
+        return True
+
+    def pop_cached_prompt_token_ids(self) -> list[int] | None:
+        """Consume cached prompt token IDs, returning ``None`` on a cache miss."""
+        payload = self._prompt_token_ids_cache
+        self._prompt_token_ids_cache = None
+        if payload is None or len(payload) % 4 != 0:
+            return None
+
+        values = array("I")
+        if values.itemsize != 4:
+            return None
+        values.frombytes(payload)
+        if sys.byteorder != "little":
+            values.byteswap()
+        return values.tolist()
 
     def get_reward_value(self, args) -> float:
         return self.reward if not args.reward_key else self.reward[args.reward_key]

--- a/tests/test_filter_long_prompt.py
+++ b/tests/test_filter_long_prompt.py
@@ -13,12 +13,18 @@ text-only prompt before any prompt carrying an image.
 
 from __future__ import annotations
 
+import asyncio
+import json
 import sys
 import types
 
 import pytest
 
-from slime.utils.data import filter_long_prompt
+import slime.rollout.sglang_rollout as sglang_rollout
+from slime.rollout.data_source import _should_cache_prompt_token_ids
+from slime.rollout.sglang_rollout import _prepare_prompt_ids
+from slime.utils.data import Dataset, filter_long_prompt
+from slime.utils.eval_config import EvalDatasetConfig
 from slime.utils.types import Sample
 
 
@@ -41,15 +47,26 @@ def stub_process_vision_info(monkeypatch):
 class _Tokenizer:
     """Batched tokenizer stand-in: prompt "pN:len" tokenizes to `len` ids."""
 
+    def __init__(self):
+        self.encode_calls = 0
+
     def __call__(self, prompts, add_special_tokens=False):
-        return {"input_ids": [[0] * _encoded_length(p) for p in prompts]}
+        return {"input_ids": [list(range(_encoded_length(p))) for p in prompts]}
+
+    def encode(self, prompt, add_special_tokens=False):
+        self.encode_calls += 1
+        return list(range(_encoded_length(prompt)))
 
 
 class _Processor:
     """Per-sample processor stand-in, same length convention."""
 
+    def __init__(self):
+        self.calls = 0
+
     def __call__(self, text=None, **kwargs):
-        return {"input_ids": [[0] * _encoded_length(text)]}
+        self.calls += 1
+        return {"input_ids": [list(range(_encoded_length(text)))]}
 
 
 def _encoded_length(prompt: str) -> int:
@@ -110,6 +127,276 @@ def test_no_processor_path_still_preserves_order():
     kept = filter_long_prompt(samples, _Tokenizer(), None, max_length=100)
 
     assert [s.prompt for s in kept] == ["p0:5", "p2:5"]
+    assert all(sample.pop_cached_prompt_token_ids() is None for sample in kept)
+
+
+@pytest.mark.unit
+def test_list_prompts_do_not_use_the_text_token_cache():
+    class ConversationTokenizer:
+        def __call__(self, prompts, add_special_tokens=False):
+            assert prompts == [[{"role": "user", "content": "hello"}]]
+            return {"input_ids": [[1, 2]]}
+
+    samples = [Sample(prompt=[{"role": "user", "content": "hello"}])]
+
+    kept = filter_long_prompt(
+        samples,
+        ConversationTokenizer(),
+        None,
+        max_length=100,
+        cache_prompt_token_ids=True,
+    )
+
+    assert kept == samples
+    assert kept[0].pop_cached_prompt_token_ids() is None
+
+
+@pytest.mark.unit
+def test_multimodal_inputs_do_not_use_cache_without_a_processor():
+    samples = _make_samples([(True, 3)])
+
+    kept = filter_long_prompt(
+        samples,
+        _Tokenizer(),
+        None,
+        max_length=100,
+        cache_prompt_token_ids=True,
+    )
+
+    assert kept == samples
+    assert kept[0].pop_cached_prompt_token_ids() is None
+
+
+@pytest.mark.unit
+def test_no_length_filter_does_not_create_a_cache():
+    samples = _make_samples([(False, 3)])
+
+    kept = filter_long_prompt(
+        samples,
+        _Tokenizer(),
+        None,
+        max_length=None,
+        cache_prompt_token_ids=True,
+    )
+
+    assert kept == samples
+    assert kept[0].pop_cached_prompt_token_ids() is None
+
+
+@pytest.mark.unit
+def test_caches_only_retained_text_prompt_ids(stub_process_vision_info):
+    samples = _make_samples([(False, 3), (True, 4), (False, 500)])
+
+    kept = filter_long_prompt(
+        samples,
+        _Tokenizer(),
+        _Processor(),
+        max_length=100,
+        cache_prompt_token_ids=True,
+    )
+
+    assert [sample.prompt for sample in kept] == ["p0:3", "p1:4"]
+    assert kept[0].pop_cached_prompt_token_ids() == [0, 1, 2]
+    assert kept[1].pop_cached_prompt_token_ids() is None
+    assert samples[2].pop_cached_prompt_token_ids() is None
+
+
+@pytest.mark.unit
+def test_invalid_token_ids_skip_cache_without_dropping_sample():
+    class InvalidTokenizer:
+        def __call__(self, prompts, add_special_tokens=False):
+            return {"input_ids": [[-1] for _ in prompts]}
+
+    samples = [Sample(prompt="prompt")]
+    kept = filter_long_prompt(
+        samples,
+        InvalidTokenizer(),
+        None,
+        max_length=10,
+        cache_prompt_token_ids=True,
+    )
+
+    assert kept == samples
+    assert kept[0].pop_cached_prompt_token_ids() is None
+
+
+@pytest.mark.unit
+def test_prepare_prompt_ids_consumes_cache_without_encoding():
+    sample = Sample(prompt="p0:3")
+    assert sample.cache_prompt_token_ids([7, 8, 9])
+    tokenizer = _Tokenizer()
+
+    assert _prepare_prompt_ids(sample, tokenizer, None) == [7, 8, 9]
+    assert tokenizer.encode_calls == 0
+    assert _prepare_prompt_ids(sample, tokenizer, None) == [0, 1, 2]
+    assert tokenizer.encode_calls == 1
+
+
+@pytest.mark.unit
+def test_prepare_prompt_ids_uses_an_empty_cached_prompt_without_encoding():
+    sample = Sample(prompt="p0:0")
+    assert sample.cache_prompt_token_ids([])
+    tokenizer = _Tokenizer()
+
+    assert _prepare_prompt_ids(sample, tokenizer, None) == []
+    assert tokenizer.encode_calls == 0
+
+
+@pytest.mark.unit
+def test_dataset_caches_ids_for_the_rendered_chat_template(tmp_path):
+    class TemplateTokenizer(_Tokenizer):
+        def apply_chat_template(self, messages, *, tools, tokenize, add_generation_prompt, **kwargs):
+            assert messages == [{"role": "user", "content": "hello"}]
+            assert tools == [{"type": "function", "function": {"name": "lookup"}}]
+            assert not tokenize
+            assert add_generation_prompt
+            return "p0:3"
+
+    path = tmp_path / "prompts.jsonl"
+    path.write_text(
+        json.dumps(
+            {
+                "text": "hello",
+                "tools": [{"type": "function", "function": {"name": "lookup"}}],
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    tokenizer = TemplateTokenizer()
+
+    dataset = Dataset(
+        str(path),
+        tokenizer,
+        processor=None,
+        max_length=10,
+        tool_key="tools",
+        apply_chat_template=True,
+        cache_prompt_token_ids=True,
+    )
+
+    assert dataset[0].prompt == "p0:3"
+    assert _prepare_prompt_ids(dataset[0], tokenizer, None) == [0, 1, 2]
+    assert tokenizer.encode_calls == 0
+
+
+@pytest.mark.unit
+def test_prepare_prompt_ids_preserves_existing_token_precedence():
+    sample = Sample(prompt="p0:3", tokens=[20, 21])
+    assert sample.cache_prompt_token_ids([7, 8, 9])
+    tokenizer = _Tokenizer()
+
+    assert _prepare_prompt_ids(sample, tokenizer, None) is sample.tokens
+    assert tokenizer.encode_calls == 0
+    assert sample.pop_cached_prompt_token_ids() is None
+
+
+@pytest.mark.unit
+def test_prepare_prompt_ids_preserves_multimodal_processor_precedence():
+    sample = Sample(prompt="p0:3", tokens=[20, 21], multimodal_inputs={"images": ["img"]})
+    assert sample.cache_prompt_token_ids([7, 8, 9])
+    tokenizer = _Tokenizer()
+    processor = _Processor()
+
+    assert _prepare_prompt_ids(sample, tokenizer, processor) == [0, 1, 2]
+    assert processor.calls == 1
+    assert tokenizer.encode_calls == 0
+    assert sample.pop_cached_prompt_token_ids() is None
+
+
+@pytest.mark.unit
+def test_processed_multimodal_inputs_allow_existing_tokens_to_win():
+    sample = Sample(
+        prompt="p0:3",
+        tokens=[20, 21],
+        multimodal_inputs={"images": ["img"]},
+        multimodal_train_inputs={"pixel_values": "processed"},
+    )
+    assert sample.cache_prompt_token_ids([7, 8, 9])
+    tokenizer = _Tokenizer()
+    processor = _Processor()
+
+    assert _prepare_prompt_ids(sample, tokenizer, processor) is sample.tokens
+    assert processor.calls == 0
+    assert tokenizer.encode_calls == 0
+    assert sample.pop_cached_prompt_token_ids() is None
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "override",
+    [
+        {},
+        {"data_source_path": "slime.rollout.data_source.RolloutDataSource"},
+        {"rollout_function_path": "custom.rollout"},
+        {"custom_generate_function_path": "custom.generate"},
+        {"data_source_path": "custom.DataSource"},
+    ],
+)
+def test_train_cache_is_enabled_only_for_the_default_rollout_contract(override):
+    values = {
+        "rollout_function_path": "slime.rollout.sglang_rollout.generate_rollout",
+        "custom_generate_function_path": None,
+        "data_source_path": "slime.rollout.data_source.RolloutDataSourceWithBuffer",
+    }
+    values.update(override)
+    args = types.SimpleNamespace(**values)
+
+    expected = not override or override == {"data_source_path": "slime.rollout.data_source.RolloutDataSource"}
+    assert _should_cache_prompt_token_ids(args) is expected
+
+
+@pytest.mark.unit
+def test_eval_dataset_cache_key_separates_default_and_custom_generate(monkeypatch):
+    dataset_calls = []
+
+    class EmptyDataset:
+        def __init__(self, **kwargs):
+            dataset_calls.append(kwargs)
+            self.samples = []
+
+    monkeypatch.setattr(sglang_rollout, "Dataset", EmptyDataset)
+    monkeypatch.setattr(sglang_rollout, "EVAL_PROMPT_DATASET", {})
+    monkeypatch.setattr(sglang_rollout, "load_tokenizer", lambda *args, **kwargs: object())
+    monkeypatch.setattr(sglang_rollout, "load_processor", lambda *args, **kwargs: None)
+
+    args = types.SimpleNamespace(
+        group_rm=False,
+        multimodal_keys=None,
+        apply_chat_template=False,
+        apply_chat_template_kwargs=None,
+        hf_checkpoint="checkpoint",
+        eval_max_prompt_len=128,
+        custom_generate_function_path=None,
+        rollout_stop=None,
+        rollout_stop_token_ids=None,
+        rollout_skip_special_tokens=True,
+        eval_min_new_tokens=None,
+        sglang_enable_deterministic_inference=False,
+        eval_reward_key=None,
+        reward_key=None,
+    )
+    dataset_cfg = EvalDatasetConfig(
+        name="eval",
+        path="unused.jsonl",
+        input_key="text",
+        metadata_key="metadata",
+        n_samples_per_eval_prompt=1,
+        temperature=1.0,
+        top_p=1.0,
+        top_k=-1,
+        max_response_len=16,
+    )
+
+    asyncio.run(sglang_rollout.eval_rollout_single_dataset(args, 0, dataset_cfg))
+    args.custom_generate_function_path = "custom.generate"
+    asyncio.run(sglang_rollout.eval_rollout_single_dataset(args, 0, dataset_cfg))
+    sglang_rollout.EVAL_PROMPT_DATASET.clear()
+    args.custom_generate_function_path = None
+    dataset_cfg.custom_generate_function_path = "dataset.generate"
+    asyncio.run(sglang_rollout.eval_rollout_single_dataset(args, 0, dataset_cfg))
+
+    assert [call["cache_prompt_token_ids"] for call in dataset_calls] == [True, False, False]
 
 
 if __name__ == "__main__":

--- a/tests/test_sample.py
+++ b/tests/test_sample.py
@@ -18,6 +18,8 @@ Pins two contracts that the rollout / training boundary depends on:
 from __future__ import annotations
 
 import argparse
+import copy
+import struct
 
 import pytest
 
@@ -170,6 +172,61 @@ def test_round_trip_through_default_constructed_sample():
     assert restored.status is Sample.Status.PENDING
     assert restored.tokens == []
     assert restored.metadata == {}
+
+
+@pytest.mark.unit
+def test_prompt_token_cache_round_trips_uint32_values_and_empty_prompts():
+    sample = Sample()
+
+    assert sample.cache_prompt_token_ids([])
+    assert sample.pop_cached_prompt_token_ids() == []
+    assert sample.cache_prompt_token_ids([0, 1, 2**32 - 1])
+    assert sample._prompt_token_ids_cache == struct.pack("<III", 0, 1, 2**32 - 1)
+    assert sample.pop_cached_prompt_token_ids() == [0, 1, 2**32 - 1]
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("token_ids", [[-1], [2**32], [1.5], ["1"]])
+def test_prompt_token_cache_rejects_values_outside_uint32(token_ids):
+    sample = Sample()
+
+    assert not sample.cache_prompt_token_ids(token_ids)
+    assert sample.pop_cached_prompt_token_ids() is None
+
+
+@pytest.mark.unit
+def test_prompt_token_cache_is_shared_by_deepcopy_and_consumed_per_sample():
+    source = Sample()
+    assert source.cache_prompt_token_ids([10, 11])
+    sibling = copy.deepcopy(source)
+
+    assert sibling._prompt_token_ids_cache is source._prompt_token_ids_cache
+    sibling_ids = sibling.pop_cached_prompt_token_ids()
+    sibling_ids.append(12)
+    assert sibling_ids == [10, 11, 12]
+    assert source.pop_cached_prompt_token_ids() == [10, 11]
+
+
+@pytest.mark.unit
+def test_prompt_token_cache_is_excluded_from_sample_serialization():
+    sample = _make_sample()
+    assert sample.cache_prompt_token_ids([10, 11])
+
+    serialized = sample.to_dict()
+    assert "_prompt_token_ids_cache" not in serialized
+
+    serialized["_prompt_token_ids_cache"] = b"\x0a\x00\x00\x00"
+    restored = Sample.from_dict(serialized)
+    assert restored.pop_cached_prompt_token_ids() is None
+
+
+@pytest.mark.unit
+def test_malformed_prompt_token_cache_is_consumed_as_a_miss():
+    sample = Sample()
+    sample._prompt_token_ids_cache = b"\x01"
+
+    assert sample.pop_cached_prompt_token_ids() is None
+    assert sample._prompt_token_ids_cache is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- retain token IDs already produced while filtering text prompts by max length
- store them as a compact transient uint32 payload and consume them once in the default SGLang rollout path
- keep custom rollout/generate/data-source contracts and multimodal processing unchanged

## Motivation

`filter_long_prompt()` currently tokenizes every retained text prompt to check its length, then `_prepare_prompt_ids()` encodes the same rendered prompt again before generation. This change reuses the first result for the stock train and eval paths.

The cache is intentionally limited to text prompts. Caching multimodal processor outputs would retain pixel tensors for the lifetime of the full Dataset and share mutable tensor storage across deep-copied siblings. The transient cache is excluded from `Sample.to_dict()` and fails closed to the existing tokenizer path.

Related to #1111.

## Validation

- pre-commit hooks: passed
- registered CPU test matrix: 51/51 files passed
- agent CPU suite: 64 passed, 1 skipped
- focused cache, serialization, eval, fully-async, and plugin contract coverage: passed
- 10,000-prompt local benchmark: second-pass `tokenizer.encode` calls reduced from 10,000 to 0; immediate total-time comparison improved from 2.65s to 0.57s on this machine
