### PR TITLE
fix(megatron): compact actor logits before projection

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -771,6 +771,10 @@ jobs:
             },
             {
               "num_gpus": 0,
+              "test_file": "test_megatron_compact_logits.py"
+            },
+            {
+              "num_gpus": 0,
               "test_file": "test_model_provider_freeze.py"
             },
             {

--- a/.github/workflows/pr-test.yml.j2
+++ b/.github/workflows/pr-test.yml.j2
@@ -118,6 +118,7 @@
         {'test_file': 'test_empty_colocated_weight_bucket.py', 'num_gpus': 0},
         {'test_file': 'test_expert_routing.py', 'num_gpus': 0},
         {'test_file': 'test_glm5_indexer_short_context.py', 'num_gpus': 0},
+        {'test_file': 'test_megatron_compact_logits.py', 'num_gpus': 0},
         {'test_file': 'test_model_provider_freeze.py', 'num_gpus': 0},
         {'test_file': 'test_glm52_layerwise_comparison.py', 'num_gpus': 0},
         {'test_file': 'test_layerwise_alignment.py', 'num_gpus': 0},

--- a/examples/coding_agent_rl/run_qwen36_35b_a3b_swe_8nodes.sh
+++ b/examples/coding_agent_rl/run_qwen36_35b_a3b_swe_8nodes.sh
@@ -144,9 +144,10 @@ PERF_ARGS=(
    --recompute-granularity full
    --recompute-method uniform
    --recompute-num-layers 1
-   # max-tokens-per-gpu is one CP rank's slice of MAX_CONTEXT_LEN; log-probs are
-   # chunked along T to avoid OOM on long single trajectories.
+   # max-tokens-per-gpu is one CP rank's slice of MAX_CONTEXT_LEN. Project only
+   # loss-masked rows, then chunk the remaining log-prob reduction work.
    --max-tokens-per-gpu $((MAX_CONTEXT_LEN / CP_SIZE))
+   --compact-actor-logits
    --log-probs-chunk-size 1024
    --use-dynamic-batch-size
 )

--- a/slime/backends/megatron_utils/compact_logits.py
+++ b/slime/backends/megatron_utils/compact_logits.py
@@ -1,0 +1,190 @@
+import inspect
+from contextlib import contextmanager
+from contextvars import ContextVar
+
+import torch
+from megatron.core.models.gpt import GPTModel
+from megatron.core.tensor_parallel import gather_from_sequence_parallel_region
+from megatron.core.tensor_parallel.layers import ColumnParallelLinear
+
+_COMPACT_ACTOR_LOGITS = ContextVar("slime_compact_actor_logits", default=False)
+
+try:
+    _BASE_POSTPROCESS_SIGNATURE = inspect.signature(GPTModel._postprocess)
+except (TypeError, ValueError):
+    _BASE_POSTPROCESS_SIGNATURE = None
+
+_CONFIG_LOGGER_ENABLED = getattr(GPTModel._postprocess, "__globals__", {}).get("has_config_logger_enabled")
+
+
+def can_compact_actor_logits(args) -> bool:
+    """Return whether compact logits preserve the selected built-in actor path."""
+    if not getattr(args, "compact_actor_logits", False):
+        return False
+    if getattr(args, "loss_type", None) not in {"policy_loss", "sft_loss"}:
+        return False
+
+    unsupported_values = (
+        getattr(args, "enable_mtp_training", False),
+        getattr(args, "custom_model_provider_path", None),
+        getattr(args, "custom_megatron_init_path", None),
+        getattr(args, "custom_megatron_before_log_prob_hook_path", None),
+        getattr(args, "custom_megatron_before_train_step_hook_path", None),
+        getattr(args, "custom_advantage_function_path", None),
+        getattr(args, "rollout_data_postprocess_path", None),
+        getattr(args, "custom_pg_loss_reducer_function_path", None),
+        getattr(args, "use_tis", False),
+        getattr(args, "get_mismatch_metrics", False),
+        getattr(args, "use_rollout_entropy", False),
+        getattr(args, "save_debug_train_data", None),
+        getattr(args, "use_rollout_logprobs", False),
+    )
+    if any(unsupported_values):
+        return False
+
+    return not (getattr(args, "advantage_estimator", None) == "ppo" and getattr(args, "kl_coef", 0) != 0)
+
+
+@contextmanager
+def compact_actor_logits(enabled: bool):
+    """Enable compact actor logits for the current pipeline schedule call."""
+    token = _COMPACT_ACTOR_LOGITS.set(bool(enabled))
+    try:
+        yield
+    finally:
+        _COMPACT_ACTOR_LOGITS.reset(token)
+
+
+class CompactLogitsGPTModel(GPTModel):
+    """Built-in actor model that can skip vocabulary projection for masked rows."""
+
+    def _postprocess(self, *args, **kwargs):
+        if not _COMPACT_ACTOR_LOGITS.get() or _BASE_POSTPROCESS_SIGNATURE is None:
+            return super()._postprocess(*args, **kwargs)
+
+        try:
+            bound = _BASE_POSTPROCESS_SIGNATURE.bind(self, *args, **kwargs)
+        except TypeError:
+            return super()._postprocess(*args, **kwargs)
+        bound.apply_defaults()
+        call_args = bound.arguments
+
+        if not getattr(self, "post_process", False):
+            return super()._postprocess(*args, **kwargs)
+
+        hidden_states = call_args.get("hidden_states")
+        labels = call_args.get("labels")
+        loss_mask = call_args.get("loss_mask")
+        inference_params = call_args.get("inference_params")
+        inference_context = call_args.get("inference_context")
+        mtp_in_postprocess = call_args.get("mtp_in_postprocess")
+        runtime_gather_output = call_args.get("runtime_gather_output")
+        mtp_kwargs = call_args.get("mtp_kwargs")
+
+        config = getattr(self, "config", None)
+        output_layer = getattr(self, "output_layer", None)
+        if config is None or not isinstance(output_layer, ColumnParallelLinear):
+            return super()._postprocess(*args, **kwargs)
+        if labels is not None or not isinstance(loss_mask, torch.Tensor):
+            return super()._postprocess(*args, **kwargs)
+        if inference_params is not None or inference_context is not None:
+            return super()._postprocess(*args, **kwargs)
+        if (
+            mtp_in_postprocess
+            or getattr(self, "mtp_process", False)
+            or getattr(config, "mtp_num_layers", None)
+            or mtp_kwargs
+        ):
+            return super()._postprocess(*args, **kwargs)
+        if not callable(_CONFIG_LOGGER_ENABLED):
+            return super()._postprocess(*args, **kwargs)
+        try:
+            if _CONFIG_LOGGER_ENABLED(config):
+                return super()._postprocess(*args, **kwargs)
+        except (AttributeError, TypeError):
+            return super()._postprocess(*args, **kwargs)
+        if getattr(config, "defer_embedding_wgrad_compute", False):
+            return super()._postprocess(*args, **kwargs)
+        if getattr(config, "cuda_graph_impl", "none") != "none":
+            return super()._postprocess(*args, **kwargs)
+        if not getattr(self, "parallel_output", False) or getattr(output_layer, "gather_output", True):
+            return super()._postprocess(*args, **kwargs)
+        if runtime_gather_output is not None and runtime_gather_output is not False:
+            return super()._postprocess(*args, **kwargs)
+
+        sequence_parallel = getattr(output_layer, "sequence_parallel", None)
+        if not isinstance(sequence_parallel, bool):
+            return super()._postprocess(*args, **kwargs)
+        if sequence_parallel != bool(getattr(config, "sequence_parallel", False)):
+            return super()._postprocess(*args, **kwargs)
+        if sequence_parallel and getattr(output_layer, "allreduce_dgrad", False):
+            return super()._postprocess(*args, **kwargs)
+        if sequence_parallel and getattr(output_layer, "disable_grad_reduce", False):
+            return super()._postprocess(*args, **kwargs)
+        if sequence_parallel and getattr(output_layer, "explicit_expert_comm", False):
+            return super()._postprocess(*args, **kwargs)
+
+        if not isinstance(hidden_states, torch.Tensor) or hidden_states.ndim != 3:
+            return super()._postprocess(*args, **kwargs)
+        if hidden_states.size(1) != 1 or loss_mask.ndim != 2 or loss_mask.size(0) != 1:
+            return super()._postprocess(*args, **kwargs)
+        if hidden_states.device != loss_mask.device:
+            return super()._postprocess(*args, **kwargs)
+
+        tp_group = getattr(output_layer, "tp_group", None)
+        if tp_group is None or not callable(getattr(tp_group, "size", None)):
+            return super()._postprocess(*args, **kwargs)
+        tp_size = tp_group.size()
+        if not isinstance(tp_size, int) or tp_size < 1:
+            return super()._postprocess(*args, **kwargs)
+        expected_sequence_length = hidden_states.size(0) * (tp_size if sequence_parallel else 1)
+        if loss_mask.size(1) != expected_sequence_length:
+            return super()._postprocess(*args, **kwargs)
+
+        vocab_size_per_partition = getattr(output_layer, "output_size_per_partition", None)
+        if not isinstance(vocab_size_per_partition, int) or vocab_size_per_partition < 1:
+            return super()._postprocess(*args, **kwargs)
+
+        output_weight = None
+        if getattr(self, "share_embeddings_and_output_weights", False):
+            shared_weight = getattr(self, "shared_embedding_or_output_weight", None)
+            if not callable(shared_weight):
+                return super()._postprocess(*args, **kwargs)
+            output_weight = shared_weight()
+        projection_weight = output_weight if output_weight is not None else getattr(output_layer, "weight", None)
+        if not isinstance(projection_weight, torch.Tensor) or projection_weight.ndim != 2:
+            return super()._postprocess(*args, **kwargs)
+        if projection_weight.shape != (vocab_size_per_partition, hidden_states.size(2)):
+            return super()._postprocess(*args, **kwargs)
+        if projection_weight.device != hidden_states.device:
+            return super()._postprocess(*args, **kwargs)
+
+        if sequence_parallel:
+            hidden_states = gather_from_sequence_parallel_region(
+                hidden_states,
+                tensor_parallel_output_grad=False,
+                group=tp_group,
+            )
+
+        selected_rows = loss_mask[0].to(dtype=torch.bool)
+        compact_hidden_states = hidden_states[:, 0, :][selected_rows].unsqueeze(1)
+
+        original_sequence_parallel = output_layer.sequence_parallel
+        try:
+            # The explicit gather above owns SP. The output layer's TP copy
+            # still performs the required dgrad all-reduce.
+            output_layer.sequence_parallel = False
+            if compact_hidden_states.size(0) == 0:
+                anchor = hidden_states.reshape(-1)[:1].sum() * 0
+                anchor = anchor + projection_weight.reshape(-1)[:1].sum() * 0
+                logits = hidden_states.new_empty((0, 1, vocab_size_per_partition)) + anchor
+            else:
+                logits, _ = output_layer(
+                    compact_hidden_states,
+                    weight=output_weight,
+                    runtime_gather_output=runtime_gather_output,
+                )
+        finally:
+            output_layer.sequence_parallel = original_sequence_parallel
+
+        return logits.transpose(0, 1).contiguous()

--- a/slime/backends/megatron_utils/loss.py
+++ b/slime/backends/megatron_utils/loss.py
@@ -332,6 +332,7 @@ def _fill_topp_mask_rows(
     length: int,
     vocab_start: int,
     vocab_end: int,
+    selected_row_mapping: list[int] | None = None,
 ) -> None:
     end = min(response_start + length, max(len(offsets) - 1, 0))
     for response_idx in range(response_start, end):
@@ -341,6 +342,10 @@ def _fill_topp_mask_rows(
             if vocab_start <= token_id < vocab_end
         ]
         row = local_start + response_idx - response_start
+        if selected_row_mapping is not None:
+            row = selected_row_mapping[row]
+            if row < 0:
+                continue
         keep[row].fill_(False)
         if local_ids:
             keep[row, torch.tensor(local_ids, device=keep.device, dtype=torch.long)] = True
@@ -355,12 +360,16 @@ def _build_topp_keep_mask(
     total_lengths: list[int],
     response_lengths: list[int],
     allgather_cp: bool,
+    selected_rows: torch.Tensor | None = None,
 ) -> torch.Tensor:
-    """Build a ``[T, vocab_local]`` boolean keep-mask aligned to local logits.
+    """Build a boolean keep-mask aligned to full or selected local logits rows.
 
     For response token ``r`` of a sample, the rollout top-p nucleus is
     ``ids[offsets[r]:offsets[r + 1]]``. Rows without a recorded nucleus stay
-    all-True, so only response rows with replay data are masked.
+    all-True, so only response rows with replay data are masked. If
+    ``selected_rows`` is provided, the output is ``[N, vocab_local]`` where N
+    is the number of selected rows, without allocating an intermediate
+    ``[T, vocab_local]`` mask.
     """
     cp_size = mpu.get_context_parallel_world_size()
     tp_rank = mpu.get_tensor_model_parallel_rank()
@@ -371,7 +380,19 @@ def _build_topp_keep_mask(
     top_p_token_ids = [t.tolist() if torch.is_tensor(t) else list(t) for t in top_p_token_ids]
     top_p_token_offsets = [t.tolist() if torch.is_tensor(t) else list(t) for t in top_p_token_offsets]
 
-    keep = torch.ones((T, vocab_local), dtype=torch.bool, device=device)
+    selected_row_mapping = None
+    num_rows = T
+    if selected_rows is not None:
+        selected_rows = selected_rows.reshape(-1).to(device=device, dtype=torch.bool)
+        if selected_rows.numel() != T:
+            raise ValueError(f"selected_rows must contain {T} entries, got {selected_rows.numel()}")
+        selected_positions = selected_rows.nonzero(as_tuple=False).squeeze(-1).tolist()
+        selected_row_mapping = [-1] * T
+        for selected_row, full_row in enumerate(selected_positions):
+            selected_row_mapping[full_row] = selected_row
+        num_rows = len(selected_positions)
+
+    keep = torch.ones((num_rows, vocab_local), dtype=torch.bool, device=device)
 
     if cp_size > 1 and not allgather_cp:
         local_base = 0
@@ -386,7 +407,17 @@ def _build_topp_keep_mask(
                 local_start = base + logits_offset[half][0] - chunks_offset[half][0]
                 length = logits_offset[half][1] - logits_offset[half][0]
                 response_start = tokens_offset[half][0] - prompt_length
-                _fill_topp_mask_rows(keep, ids, offsets, response_start, local_start, length, vocab_start, vocab_end)
+                _fill_topp_mask_rows(
+                    keep,
+                    ids,
+                    offsets,
+                    response_start,
+                    local_start,
+                    length,
+                    vocab_start,
+                    vocab_end,
+                    selected_row_mapping,
+                )
             local_base += 2 * chunk_size_cp
         return keep
 
@@ -413,6 +444,7 @@ def _build_topp_keep_mask(
                     e - s,
                     vocab_start,
                     vocab_end,
+                    selected_row_mapping,
                 )
             seq_start += total_length
         return keep
@@ -423,7 +455,17 @@ def _build_topp_keep_mask(
     ):
         end = offset + total_length
         start = end - response_length
-        _fill_topp_mask_rows(keep, ids, offsets, 0, start - 1, response_length, vocab_start, vocab_end)
+        _fill_topp_mask_rows(
+            keep,
+            ids,
+            offsets,
+            0,
+            start - 1,
+            response_length,
+            vocab_start,
+            vocab_end,
+            selected_row_mapping,
+        )
         offset += total_length
 
     return keep
@@ -521,12 +563,14 @@ def get_log_probs_and_entropy(
     non_loss_data: bool = True,
     top_p_token_ids: list[list[int]] | None = None,
     top_p_token_offsets: list[list[int]] | None = None,
+    full_loss_masks: torch.Tensor | None = None,
 ) -> dict[str, list[torch.Tensor]]:
     """Compute per-token log-probabilities (and optionally entropy) on responses.
 
-    Computes on the **full** logits ``[T, V]`` tensor at once (instead of
-    per-sample slicing) so backward traverses ``[T, V]`` only once, then
-    extracts per-sample response portions.
+    Logits may contain all T local sequence rows or only the N rows selected by
+    ``full_loss_masks``. Full logits retain the existing behavior. Compact
+    logits evaluate only selected rows and scatter scalar results back to the
+    full T-row layout before response portions are extracted.
 
     If rollout top-p replay is provided, the keep-mask is applied only to
     log-probabilities; entropy is always computed from the unmasked logits.
@@ -542,7 +586,7 @@ def get_log_probs_and_entropy(
     if rollout_temperature != 1.0:
         logits = logits / rollout_temperature
     logits = logits.contiguous()
-    T = logits.size(0)
+    logits_rows = logits.size(0)
     device = logits.device
     tp_group = mpu.get_tensor_model_parallel_group()
     chunk_size = args.log_probs_chunk_size
@@ -550,8 +594,26 @@ def get_log_probs_and_entropy(
     # the entropy term cannot affect the loss.
     with_entropy_grad = with_entropy and getattr(args, "entropy_coef", 0.0) != 0
 
-    # --- build full shifted-token target tensor ---
+    selected_rows = None
+    T = logits_rows
+    logits_to_evaluate = logits
+    if full_loss_masks is not None:
+        if full_loss_masks.ndim != 2 or full_loss_masks.size(0) != 1:
+            raise ValueError(f"full_loss_masks must have shape [1, T], got {tuple(full_loss_masks.shape)}")
+        full_row_mask = full_loss_masks.reshape(-1).to(device=device, dtype=torch.bool)
+        T = full_row_mask.numel()
+        if logits_rows != T:
+            selected_count = int(full_row_mask.sum().item())
+            if logits_rows != selected_count:
+                raise ValueError(
+                    "logits row count must match either full_loss_masks length "
+                    f"({T}) or selected row count ({selected_count}), got {logits_rows}"
+                )
+            selected_rows = full_row_mask
+
+    # --- build full shifted-token target tensor, then select evaluated rows ---
     full_tokens = _build_shifted_tokens(T, device, unconcat_tokens, total_lengths, response_lengths, args.allgather_cp)
+    tokens_to_evaluate = full_tokens if selected_rows is None else full_tokens[selected_rows]
 
     # --- build top-p nucleus keep-mask (logprob only; entropy stays unmasked) ---
     top_p_keep_mask = None
@@ -565,19 +627,44 @@ def get_log_probs_and_entropy(
             total_lengths,
             response_lengths,
             args.allgather_cp,
+            selected_rows=selected_rows,
         )
 
-    # --- compute on full [T,V] logits at once via calculate_log_probs_and_entropy ---
-    log_prob_full, entropy_full = calculate_log_probs_and_entropy(
-        logits,
-        full_tokens,
-        tp_group,
-        with_entropy=with_entropy,
-        with_entropy_grad=with_entropy_grad,
-        chunk_size=chunk_size,
-        log_prob_keep_mask=top_p_keep_mask,
-    )
-    log_prob_full = log_prob_full.squeeze(-1)  # [T, 1] -> [T]
+    # --- compute only evaluated rows via calculate_log_probs_and_entropy ---
+    if logits_to_evaluate.size(0) == 0:
+        # Avoid entering the vocab-parallel softmax collectives for an empty
+        # microbatch while keeping the policy-loss output connected to logits.
+        log_prob_rows = logits_to_evaluate.sum(dim=-1, keepdim=True)
+        entropy_rows = None
+        if with_entropy:
+            entropy_rows = logits_to_evaluate.sum(dim=-1)
+            if not with_entropy_grad:
+                entropy_rows = entropy_rows.detach()
+    else:
+        log_prob_rows, entropy_rows = calculate_log_probs_and_entropy(
+            logits_to_evaluate,
+            tokens_to_evaluate,
+            tp_group,
+            with_entropy=with_entropy,
+            with_entropy_grad=with_entropy_grad,
+            chunk_size=chunk_size,
+            log_prob_keep_mask=top_p_keep_mask,
+        )
+    log_prob_rows = log_prob_rows.squeeze(-1)
+
+    if selected_rows is None:
+        log_prob_full = log_prob_rows
+        entropy_full = entropy_rows
+    else:
+        # Keep empty compact outputs connected to the model graph while
+        # preserving the existing full response shapes for downstream code.
+        graph_anchor = 0 * logits.sum()
+        log_prob_full = logits.new_zeros(T).masked_scatter(selected_rows, log_prob_rows) + graph_anchor
+        entropy_full = None
+        if entropy_rows is not None:
+            entropy_full = logits.new_zeros(T).masked_scatter(selected_rows, entropy_rows)
+            if with_entropy_grad:
+                entropy_full = entropy_full + graph_anchor
 
     # --- extract per-sample response portions ---
     log_probs_list, entropy_list = _extract_per_sample(
@@ -973,6 +1060,7 @@ def policy_loss_function(
         total_lengths=total_lengths,
         response_lengths=response_lengths,
         with_entropy=True,
+        full_loss_masks=batch["full_loss_masks"] if getattr(args, "compact_actor_logits", False) else None,
         **get_rollout_top_p_logprob_kwargs(args, batch),
     )
 
@@ -1261,6 +1349,7 @@ def sft_loss_function(
         total_lengths=total_lengths,
         response_lengths=response_lengths,
         with_entropy=False,
+        full_loss_masks=batch["full_loss_masks"] if getattr(args, "compact_actor_logits", False) else None,
     )
 
     log_probs = log_probs_and_entropy["log_probs"]

--- a/slime/backends/megatron_utils/model.py
+++ b/slime/backends/megatron_utils/model.py
@@ -28,12 +28,14 @@ try:
     from megatron.core.pipeline_parallel.utils import unwrap_model
 except ImportError:
     from megatron.core.utils import unwrap_model
+
 from slime.observability import logging_utils, train_metric_utils
 from slime.utils.memory_utils import clear_memory
 
 from .checkpoint import load_checkpoint, save_checkpoint
+from .compact_logits import can_compact_actor_logits, compact_actor_logits
 from .data import DataIterator, get_batch
-from .loss import ROLLOUT_TOP_P_TOKEN_KEYS, get_rollout_top_p_logprob_kwargs, loss_function
+from .loss import ROLLOUT_TOP_P_TOKEN_KEYS, get_log_probs_and_entropy, get_rollout_top_p_logprob_kwargs, loss_function
 from .model_provider import get_model_provider_func
 from .stateless_adam import StatelessAdam
 
@@ -379,6 +381,8 @@ def forward_only(
         dict[str, list[torch.Tensor]]: Aggregated outputs keyed by ``store_prefix + key``.
     """
 
+    use_compact_logits = f is get_log_probs_and_entropy and can_compact_actor_logits(args)
+
     # reset data iterator
     for iterator in data_iterator:
         iterator.reset()
@@ -442,6 +446,8 @@ def forward_only(
             "response_lengths": response_lengths,
             "with_entropy": args.use_rollout_entropy,
         }
+        if use_compact_logits:
+            output_kwargs["full_loss_masks"] = batch["full_loss_masks"]
         if use_rollout_top_p_replay:
             output_kwargs.update(get_rollout_top_p_logprob_kwargs(args, batch))
 
@@ -472,15 +478,16 @@ def forward_only(
     )
     forward_step_with_progress = _wrap_forward_step_with_microbatch_pbar(forward_step, microbatch_pbar)
     for step_id in range(num_steps_per_rollout):
-        forward_data_store += forward_backward_func(
-            forward_step_func=forward_step_with_progress,
-            data_iterator=data_iterator,
-            model=model,
-            num_microbatches=num_microbatches[step_id],
-            seq_length=args.seq_length,
-            micro_batch_size=args.micro_batch_size,
-            forward_only=True,
-        )
+        with compact_actor_logits(use_compact_logits):
+            forward_data_store += forward_backward_func(
+                forward_step_func=forward_step_with_progress,
+                data_iterator=data_iterator,
+                model=model,
+                num_microbatches=num_microbatches[step_id],
+                seq_length=args.seq_length,
+                micro_batch_size=args.micro_batch_size,
+                forward_only=True,
+            )
     microbatch_pbar.close()
 
     # Move model back to the train mode.
@@ -645,16 +652,17 @@ def train_one_step(
 
     # Forward pass.
     forward_backward_func = get_forward_backward_func()
-    losses_reduced = forward_backward_func(
-        forward_step_func=_wrap_forward_step_with_microbatch_pbar(forward_step, microbatch_pbar),
-        data_iterator=data_iterator,
-        model=model,
-        num_microbatches=num_microbatches,
-        seq_length=args.seq_length,
-        micro_batch_size=args.micro_batch_size,
-        decoder_seq_length=args.decoder_seq_length,
-        forward_only=False,
-    )
+    with compact_actor_logits(can_compact_actor_logits(args)):
+        losses_reduced = forward_backward_func(
+            forward_step_func=_wrap_forward_step_with_microbatch_pbar(forward_step, microbatch_pbar),
+            data_iterator=data_iterator,
+            model=model,
+            num_microbatches=num_microbatches,
+            seq_length=args.seq_length,
+            micro_batch_size=args.micro_batch_size,
+            decoder_seq_length=args.decoder_seq_length,
+            forward_only=False,
+        )
 
     valid_step = True
     grad_norm = float("nan")

--- a/slime/backends/megatron_utils/model_provider.py
+++ b/slime/backends/megatron_utils/model_provider.py
@@ -17,6 +17,7 @@ from megatron.core.transformer.spec_utils import import_module
 from megatron.core.transformer.transformer_config import TransformerConfig
 from megatron.training.arguments import core_transformer_config_from_args
 
+from slime.backends.megatron_utils.compact_logits import CompactLogitsGPTModel, can_compact_actor_logits
 from slime.utils.misc import load_function
 
 _INDEXER_DIRECT_SUBMODULE_NAMES = frozenset(
@@ -228,8 +229,11 @@ def _get_model_provider_func(
             mtp_block_spec = get_gpt_mtp_block_spec(config, transformer_layer_spec, **mtp_kwargs)
             kwargs["mtp_block_spec"] = mtp_block_spec
 
+        model_cls = (
+            CompactLogitsGPTModel if role == "actor" and post_process and can_compact_actor_logits(args) else GPTModel
+        )
         with build_model_context(**build_model_context_args):
-            model = GPTModel(**kwargs)
+            model = model_cls(**kwargs)
 
         if post_process and role == "critic":
             model.output_layer = LinearForLastLayer(input_size=config.hidden_size, output_size=1, config=config)

--- a/slime/utils/arguments.py
+++ b/slime/utils/arguments.py
@@ -254,6 +254,15 @@ def get_slime_extra_args_provider(add_custom_arguments=None):
                 "--log-probs-chunk-size", type=int, default=-1, help="Chunk size to compute log probs to save memory"
             )
             parser.add_argument(
+                "--compact-actor-logits",
+                action="store_true",
+                help=(
+                    "Project vocabulary logits only for loss-masked actor tokens. "
+                    "This is an opt-in memory optimization for built-in policy/SFT paths; "
+                    "unsupported or custom paths retain full logits."
+                ),
+            )
+            parser.add_argument(
                 "--only-train-params-name-list",
                 type=str,
                 nargs="*",

--- a/tests/test_logprob_response_spans.py
+++ b/tests/test_logprob_response_spans.py
@@ -1,10 +1,12 @@
+from argparse import Namespace
+
 import _cp_dist_helpers  # noqa: F401
 import pytest
 import torch
 
 from megatron.core import mpu
-from slime.backends.megatron_utils.loss import _build_topp_keep_mask
-
+import slime.backends.megatron_utils.loss as megatron_loss
+from slime.backends.megatron_utils.loss import _build_topp_keep_mask, get_log_probs_and_entropy
 
 NUM_GPUS = 0
 
@@ -13,10 +15,32 @@ def _set_cp(monkeypatch, *, size: int, rank: int) -> None:
     monkeypatch.setattr(mpu, "get_context_parallel_world_size", lambda: size)
     monkeypatch.setattr(mpu, "get_context_parallel_rank", lambda: rank)
     monkeypatch.setattr(mpu, "get_tensor_model_parallel_rank", lambda: 0, raising=False)
+    monkeypatch.setattr(mpu, "get_tensor_model_parallel_group", lambda: None, raising=False)
 
 
 def _kept_ids(row: torch.Tensor) -> list[int]:
     return row.nonzero(as_tuple=False).squeeze(-1).tolist()
+
+
+def _logprob_args(*, chunk_size: int = -1) -> Namespace:
+    return Namespace(
+        allgather_cp=False,
+        entropy_coef=1.0,
+        log_probs_chunk_size=chunk_size,
+        rollout_temperature=0.7,
+    )
+
+
+def _packed_logprob_inputs() -> dict:
+    return {
+        "unconcat_tokens": [
+            torch.tensor([1, 2, 3, 4, 5], dtype=torch.long),
+            torch.tensor([6, 7, 8, 9], dtype=torch.long),
+        ],
+        "total_lengths": [5, 4],
+        "response_lengths": [2, 3],
+        "with_entropy": True,
+    }
 
 
 @pytest.mark.unit
@@ -43,6 +67,20 @@ def test_top_p_mask_aligns_with_zigzag_cp_response_rows(monkeypatch, rank, expec
     masked_rows = {row: _kept_ids(keep[row]) for row in range(keep.size(0)) if not keep[row].all()}
     assert masked_rows == expected
 
+    selected_rows = torch.tensor([True, False, True, False])
+    compact_keep = _build_topp_keep_mask(
+        4,
+        200,
+        torch.device("cpu"),
+        top_p_token_ids=[[104, 105, 106, 107]],
+        top_p_token_offsets=[[0, 1, 2, 3, 4]],
+        total_lengths=[8],
+        response_lengths=[4],
+        allgather_cp=False,
+        selected_rows=selected_rows,
+    )
+    assert torch.equal(compact_keep, keep[selected_rows])
+
 
 @pytest.mark.unit
 @pytest.mark.parametrize(
@@ -68,6 +106,20 @@ def test_top_p_mask_aligns_with_allgather_cp_response_rows(monkeypatch, rank, ex
     masked_rows = {row: _kept_ids(keep[row]) for row in range(keep.size(0)) if not keep[row].all()}
     assert masked_rows == expected
 
+    selected_rows = torch.tensor([False, True, True])
+    compact_keep = _build_topp_keep_mask(
+        3,
+        200,
+        torch.device("cpu"),
+        top_p_token_ids=[[102, 103, 104, 105]],
+        top_p_token_offsets=[[0, 1, 2, 3, 4]],
+        total_lengths=[6],
+        response_lengths=[4],
+        allgather_cp=True,
+        selected_rows=selected_rows,
+    )
+    assert torch.equal(compact_keep, keep[selected_rows])
+
 
 @pytest.mark.unit
 def test_top_p_mask_aligns_with_cp1_response_rows(monkeypatch):
@@ -85,6 +137,127 @@ def test_top_p_mask_aligns_with_cp1_response_rows(monkeypatch):
 
     masked_rows = {row: _kept_ids(keep[row]) for row in range(keep.size(0)) if not keep[row].all()}
     assert masked_rows == {2: [13], 3: [14], 5: [21], 6: [22], 7: [23]}
+
+    selected_rows = torch.tensor([False, False, True, False, True, True, False, True, False])
+    compact_keep = _build_topp_keep_mask(
+        9,
+        30,
+        torch.device("cpu"),
+        top_p_token_ids=[[13, 99, 14], [21, 22, 99, 23]],
+        top_p_token_offsets=[[0, 2, 3], [0, 1, 3, 4]],
+        total_lengths=[5, 4],
+        response_lengths=[2, 3],
+        allgather_cp=False,
+        selected_rows=selected_rows,
+    )
+    assert compact_keep.shape == (selected_rows.sum().item(), 30)
+    assert torch.equal(compact_keep, keep[selected_rows])
+
+
+@pytest.mark.unit
+def test_full_logits_with_sparse_mask_preserve_existing_outputs_and_gradients(monkeypatch):
+    _set_cp(monkeypatch, size=1, rank=0)
+    torch.manual_seed(2253)
+    logits_data = torch.randn(1, 9, 32)
+    full_loss_masks = torch.tensor([[0, 0, 1, 0, 0, 1, 0, 1, 0]])
+    legacy_logits = logits_data.clone().requires_grad_()
+    masked_logits = logits_data.clone().requires_grad_()
+    call_kwargs = {
+        "args": _logprob_args(),
+        **_packed_logprob_inputs(),
+    }
+
+    _, legacy = get_log_probs_and_entropy(legacy_logits, **call_kwargs)
+    _, masked = get_log_probs_and_entropy(masked_logits, full_loss_masks=full_loss_masks, **call_kwargs)
+
+    for key in ("log_probs", "entropy"):
+        legacy_values = torch.cat(legacy[key])
+        masked_values = torch.cat(masked[key])
+        assert torch.equal(masked_values, legacy_values)
+
+    legacy_loss = torch.cat(legacy["log_probs"]).sum() + torch.cat(legacy["entropy"]).sum()
+    masked_loss = torch.cat(masked["log_probs"]).sum() + torch.cat(masked["entropy"]).sum()
+    legacy_loss.backward()
+    masked_loss.backward()
+    assert torch.equal(masked_logits.grad, legacy_logits.grad)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("chunk_size", [-1, 2])
+def test_compact_logits_match_selected_full_rows_and_gradients(monkeypatch, chunk_size):
+    _set_cp(monkeypatch, size=1, rank=0)
+    torch.manual_seed(2253)
+    logits_data = torch.randn(1, 9, 32)
+    selected_rows = torch.tensor([False, False, True, False, False, True, False, True, False])
+    full_loss_masks = selected_rows.unsqueeze(0)
+    selected_response_rows = torch.tensor([True, False, True, False, True])
+    full_logits = logits_data.clone().requires_grad_()
+    compact_logits = logits_data[:, selected_rows].clone().requires_grad_()
+    call_kwargs = {
+        "args": _logprob_args(chunk_size=chunk_size),
+        "full_loss_masks": full_loss_masks,
+        **_packed_logprob_inputs(),
+    }
+
+    _, full = get_log_probs_and_entropy(full_logits, **call_kwargs)
+    _, compact = get_log_probs_and_entropy(compact_logits, **call_kwargs)
+
+    for key in ("log_probs", "entropy"):
+        full_values = torch.cat(full[key])
+        compact_values = torch.cat(compact[key])
+        assert torch.allclose(compact_values[selected_response_rows], full_values[selected_response_rows])
+        assert torch.equal(compact_values[~selected_response_rows], torch.zeros(2))
+
+    weights = selected_response_rows.float()
+    full_loss = (torch.cat(full["log_probs"]) * weights).sum() + (torch.cat(full["entropy"]) * weights).sum()
+    compact_loss = torch.cat(compact["log_probs"]).sum() + torch.cat(compact["entropy"]).sum()
+    full_loss.backward()
+    compact_loss.backward()
+    assert torch.allclose(compact_logits.grad, full_logits.grad[:, selected_rows])
+    assert torch.equal(full_logits.grad[:, ~selected_rows], torch.zeros_like(full_logits.grad[:, ~selected_rows]))
+
+
+@pytest.mark.unit
+def test_compact_logits_reject_invalid_row_count(monkeypatch):
+    _set_cp(monkeypatch, size=1, rank=0)
+    full_loss_masks = torch.tensor([[0, 0, 1, 0, 0, 1, 0, 1, 0]])
+
+    with pytest.raises(ValueError, match="logits row count must match"):
+        get_log_probs_and_entropy(
+            torch.randn(1, 4, 32),
+            args=_logprob_args(),
+            full_loss_masks=full_loss_masks,
+            **_packed_logprob_inputs(),
+        )
+
+
+@pytest.mark.unit
+def test_empty_compact_logits_keep_response_shapes_and_autograd(monkeypatch):
+    _set_cp(monkeypatch, size=1, rank=0)
+    logits = torch.empty((1, 0, 32), dtype=torch.float32, requires_grad=True)
+    full_loss_masks = torch.zeros((1, 9), dtype=torch.bool)
+
+    def fail_if_called(*_args, **_kwargs):
+        raise AssertionError("empty compact logits must skip vocab-parallel softmax")
+
+    monkeypatch.setattr(megatron_loss, "calculate_log_probs_and_entropy", fail_if_called)
+
+    _, outputs = get_log_probs_and_entropy(
+        logits,
+        args=_logprob_args(chunk_size=1),
+        full_loss_masks=full_loss_masks,
+        **_packed_logprob_inputs(),
+    )
+
+    assert [value.shape for value in outputs["log_probs"]] == [(2,), (3,)]
+    assert [value.shape for value in outputs["entropy"]] == [(2,), (3,)]
+    assert torch.count_nonzero(torch.cat(outputs["log_probs"])) == 0
+    assert torch.count_nonzero(torch.cat(outputs["entropy"])) == 0
+    loss = torch.cat(outputs["log_probs"]).sum() + torch.cat(outputs["entropy"]).sum()
+    assert loss.requires_grad
+    loss.backward()
+    assert logits.grad is not None
+    assert logits.grad.shape == logits.shape
 
 
 if __name__ == "__main__":

--- a/tests/test_megatron_compact_logits.py
+++ b/tests/test_megatron_compact_logits.py
@@ -1,0 +1,375 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+import torch
+
+NUM_GPUS = 0
+
+
+def has_config_logger_enabled(config) -> bool:
+    return bool(config.config_logger_enabled)
+
+
+def _run_output_layer(self, hidden_states, runtime_gather_output):
+    logits, _ = self.output_layer(
+        hidden_states,
+        weight=None,
+        runtime_gather_output=runtime_gather_output,
+    )
+    return logits.transpose(0, 1).contiguous()
+
+
+def _postprocess_with_mtp_kwargs(
+    self,
+    hidden_states,
+    input_ids=None,
+    position_ids=None,
+    labels=None,
+    rotary_pos_emb=None,
+    rotary_pos_cos=None,
+    rotary_pos_sin=None,
+    mtp_in_postprocess=None,
+    loss_mask=None,
+    decoder_input=None,
+    attention_mask=None,
+    inference_params=None,
+    packed_seq_params=None,
+    sequence_len_offset=None,
+    runtime_gather_output=None,
+    extra_block_kwargs=None,
+    inference_context=None,
+    mtp_kwargs=None,
+):
+    return _run_output_layer(self, hidden_states, runtime_gather_output)
+
+
+def _postprocess_without_mtp_kwargs(
+    self,
+    hidden_states,
+    input_ids=None,
+    position_ids=None,
+    labels=None,
+    rotary_pos_emb=None,
+    rotary_pos_cos=None,
+    rotary_pos_sin=None,
+    mtp_in_postprocess=None,
+    loss_mask=None,
+    decoder_input=None,
+    attention_mask=None,
+    inference_params=None,
+    packed_seq_params=None,
+    sequence_len_offset=None,
+    runtime_gather_output=None,
+    extra_block_kwargs=None,
+    inference_context=None,
+):
+    return _run_output_layer(self, hidden_states, runtime_gather_output)
+
+
+class _PostProcessNode:
+    def __init__(self, model, hidden_states, loss_mask):
+        self.model = model
+        self.hidden_states = hidden_states
+        self.loss_mask = loss_mask
+
+    def forward_impl(self):
+        return self.model._postprocess(hidden_states=self.hidden_states, loss_mask=self.loss_mask)
+
+
+def _build_schedule_plan(self, hidden_states, loss_mask):
+    return _PostProcessNode(self, hidden_states, loss_mask)
+
+
+class _Group:
+    def __init__(self, size=1):
+        self._size = size
+
+    def size(self):
+        return self._size
+
+
+class _ColumnParallelLinear(torch.nn.Module):
+    def __init__(self, hidden_size=3, vocab_size=5, *, sequence_parallel=False, tp_size=1):
+        super().__init__()
+        self.weight = torch.nn.Parameter(
+            torch.arange(vocab_size * hidden_size, dtype=torch.float32).reshape(vocab_size, hidden_size) / 10
+        )
+        self.bias = None
+        self.output_size_per_partition = vocab_size
+        self.sequence_parallel = sequence_parallel
+        self.gather_output = False
+        self.allreduce_dgrad = False
+        self.disable_grad_reduce = False
+        self.explicit_expert_comm = False
+        self.tp_group = _Group(tp_size)
+        self.calls = []
+        self.raise_on_forward = False
+
+    def forward(self, input_, weight=None, runtime_gather_output=None):
+        self.calls.append(input_.size(0))
+        if self.raise_on_forward:
+            raise RuntimeError("projection failed")
+        if self.sequence_parallel:
+            input_ = sys.modules["megatron.core.tensor_parallel"].gather_from_sequence_parallel_region(
+                input_, tensor_parallel_output_grad=True, group=self.tp_group
+            )
+        weight = self.weight if weight is None else weight
+        return torch.nn.functional.linear(input_, weight), None
+
+
+def _load_compact_logits(monkeypatch, *, with_mtp_kwargs=True):
+    gather_calls = []
+
+    def gather(input_, tensor_parallel_output_grad=True, group=None, **_kwargs):
+        gather_calls.append((tensor_parallel_output_grad, group))
+        if group.size() == 1:
+            return input_
+        return torch.cat((input_, input_ + 10), dim=0)
+
+    original = _postprocess_with_mtp_kwargs if with_mtp_kwargs else _postprocess_without_mtp_kwargs
+    gpt_model = type(
+        "GPTModel",
+        (torch.nn.Module,),
+        {"_postprocess": original, "build_schedule_plan": _build_schedule_plan},
+    )
+
+    modules = {
+        "megatron": types.ModuleType("megatron"),
+        "megatron.core": types.ModuleType("megatron.core"),
+        "megatron.core.models": types.ModuleType("megatron.core.models"),
+        "megatron.core.models.gpt": types.ModuleType("megatron.core.models.gpt"),
+        "megatron.core.tensor_parallel": types.ModuleType("megatron.core.tensor_parallel"),
+        "megatron.core.tensor_parallel.layers": types.ModuleType("megatron.core.tensor_parallel.layers"),
+    }
+    modules["megatron.core.models.gpt"].GPTModel = gpt_model
+    modules["megatron.core.tensor_parallel"].gather_from_sequence_parallel_region = gather
+    modules["megatron.core.tensor_parallel.layers"].ColumnParallelLinear = _ColumnParallelLinear
+    for name, module in modules.items():
+        monkeypatch.setitem(sys.modules, name, module)
+
+    module_path = Path(__file__).resolve().parents[1] / "slime" / "backends" / "megatron_utils" / "compact_logits.py"
+    module_name = f"test_compact_logits_{'mtp' if with_mtp_kwargs else 'legacy'}"
+    sys.modules.pop(module_name, None)
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module, gpt_model, gather_calls, original
+
+
+def _make_model(compact_logits, *, sequence_parallel=False, tp_size=1):
+    model = compact_logits.CompactLogitsGPTModel()
+    model.post_process = True
+    model.parallel_output = True
+    model.share_embeddings_and_output_weights = False
+    model.mtp_process = False
+    model.config = types.SimpleNamespace(
+        sequence_parallel=sequence_parallel,
+        mtp_num_layers=None,
+        config_logger_enabled=False,
+        defer_embedding_wgrad_compute=False,
+        cuda_graph_impl="none",
+    )
+    model.output_layer = _ColumnParallelLinear(sequence_parallel=sequence_parallel, tp_size=tp_size)
+    return model
+
+
+def _call(model, hidden_states, loss_mask, **kwargs):
+    return model._postprocess(hidden_states=hidden_states, loss_mask=loss_mask, **kwargs)
+
+
+@pytest.mark.unit
+def test_eligibility_is_opt_in_and_limited_to_builtin_masked_paths(monkeypatch):
+    compact_logits, _, _, _ = _load_compact_logits(monkeypatch)
+    args = types.SimpleNamespace(compact_actor_logits=True, loss_type="policy_loss")
+
+    assert compact_logits.can_compact_actor_logits(args)
+    args.loss_type = "sft_loss"
+    assert compact_logits.can_compact_actor_logits(args)
+    args.loss_type = "custom_loss"
+    assert not compact_logits.can_compact_actor_logits(args)
+    args.loss_type = "policy_loss"
+    args.compact_actor_logits = False
+    assert not compact_logits.can_compact_actor_logits(args)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("name", "value"),
+    [
+        ("enable_mtp_training", True),
+        ("custom_model_provider_path", "custom.provider"),
+        ("custom_megatron_init_path", "custom.init"),
+        ("custom_megatron_before_log_prob_hook_path", "custom.logprob_hook"),
+        ("custom_megatron_before_train_step_hook_path", "custom.train_hook"),
+        ("custom_advantage_function_path", "custom.advantage"),
+        ("rollout_data_postprocess_path", "custom.postprocess"),
+        ("custom_pg_loss_reducer_function_path", "custom.reducer"),
+        ("use_tis", True),
+        ("get_mismatch_metrics", True),
+        ("use_rollout_entropy", True),
+        ("save_debug_train_data", "debug.pt"),
+        ("use_rollout_logprobs", True),
+    ],
+)
+def test_eligibility_falls_back_when_off_mask_values_are_observable(monkeypatch, name, value):
+    compact_logits, _, _, _ = _load_compact_logits(monkeypatch)
+    args = types.SimpleNamespace(compact_actor_logits=True, loss_type="policy_loss")
+    setattr(args, name, value)
+
+    assert not compact_logits.can_compact_actor_logits(args)
+
+
+@pytest.mark.unit
+def test_eligibility_keeps_ppo_reward_kl_full(monkeypatch):
+    compact_logits, _, _, _ = _load_compact_logits(monkeypatch)
+    args = types.SimpleNamespace(
+        compact_actor_logits=True,
+        loss_type="policy_loss",
+        advantage_estimator="ppo",
+        kl_coef=0.1,
+    )
+
+    assert not compact_logits.can_compact_actor_logits(args)
+    args.kl_coef = 0
+    assert compact_logits.can_compact_actor_logits(args)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("with_mtp_kwargs", [False, True])
+def test_actor_subclass_compacts_without_mutating_base_model(monkeypatch, with_mtp_kwargs):
+    compact_logits, gpt_model, _, original = _load_compact_logits(monkeypatch, with_mtp_kwargs=with_mtp_kwargs)
+    model = _make_model(compact_logits)
+    base_model = gpt_model()
+    base_model.post_process = True
+    base_model.output_layer = _ColumnParallelLinear()
+    hidden = torch.arange(12, dtype=torch.float32).reshape(4, 1, 3)
+    mask = torch.tensor([[1, 0, 1, 0]])
+
+    assert gpt_model._postprocess is original
+    assert issubclass(compact_logits.CompactLogitsGPTModel, gpt_model)
+    with compact_logits.compact_actor_logits(True):
+        base_output = _call(base_model, hidden, mask)
+        compact_output = _call(model, hidden, mask)
+
+    assert base_output.shape == (1, 4, 5)
+    assert compact_output.shape == (1, 2, 5)
+    torch.testing.assert_close(compact_output, base_output[:, [0, 2]])
+
+
+@pytest.mark.unit
+def test_context_is_scoped_and_nested(monkeypatch):
+    compact_logits, _, _, _ = _load_compact_logits(monkeypatch)
+    model = _make_model(compact_logits)
+    hidden = torch.arange(12, dtype=torch.float32).reshape(4, 1, 3)
+    mask = torch.tensor([[1, 0, 1, 0]])
+
+    full = _call(model, hidden, mask)
+    with compact_logits.compact_actor_logits(True):
+        compact = _call(model, hidden, mask)
+        with compact_logits.compact_actor_logits(False):
+            nested_full = _call(model, hidden, mask)
+        compact_again = _call(model, hidden, mask)
+    restored_full = _call(model, hidden, mask)
+
+    assert full.shape == nested_full.shape == restored_full.shape == (1, 4, 5)
+    assert compact.shape == compact_again.shape == (1, 2, 5)
+    torch.testing.assert_close(compact, full[:, [0, 2]])
+
+
+@pytest.mark.unit
+def test_combined_schedule_node_dispatches_to_actor_subclass(monkeypatch):
+    compact_logits, gpt_model, _, _ = _load_compact_logits(monkeypatch)
+    model = _make_model(compact_logits)
+    hidden = torch.arange(12, dtype=torch.float32).reshape(4, 1, 3)
+    mask = torch.tensor([[1, 0, 1, 0]])
+    plan = model.build_schedule_plan(hidden, mask)
+
+    assert compact_logits.CompactLogitsGPTModel.build_schedule_plan is gpt_model.build_schedule_plan
+    with compact_logits.compact_actor_logits(True):
+        output = plan.forward_impl()
+
+    assert output.shape == (1, 2, 5)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "mutate,call_kwargs",
+    [
+        (lambda model: setattr(model, "post_process", False), {}),
+        (lambda model: setattr(model, "parallel_output", False), {}),
+        (lambda model: setattr(model.config, "mtp_num_layers", 1), {}),
+        (lambda model: setattr(model.config, "config_logger_enabled", True), {}),
+        (lambda model: setattr(model.config, "defer_embedding_wgrad_compute", True), {}),
+        (lambda model: setattr(model.config, "cuda_graph_impl", "local"), {}),
+        (lambda _model: None, {"labels": torch.ones(1, 4, dtype=torch.long)}),
+        (lambda _model: None, {"inference_context": object()}),
+        (lambda _model: None, {"runtime_gather_output": True}),
+    ],
+)
+def test_unsupported_paths_fall_back_before_projection(monkeypatch, mutate, call_kwargs):
+    compact_logits, _, _, _ = _load_compact_logits(monkeypatch)
+    model = _make_model(compact_logits)
+    mutate(model)
+    hidden = torch.arange(12, dtype=torch.float32).reshape(4, 1, 3)
+
+    with compact_logits.compact_actor_logits(True):
+        output = _call(model, hidden, torch.tensor([[1, 0, 1, 0]]), **call_kwargs)
+
+    assert output.shape == (1, 4, 5)
+    assert model.output_layer.calls == [4]
+
+
+@pytest.mark.unit
+def test_sequence_parallel_gathers_once_without_second_gradient_reduce(monkeypatch):
+    compact_logits, _, gather_calls, _ = _load_compact_logits(monkeypatch)
+    model = _make_model(compact_logits, sequence_parallel=True, tp_size=2)
+    hidden = torch.arange(6, dtype=torch.float32).reshape(2, 1, 3)
+    mask = torch.tensor([[1, 0, 0, 1]])
+
+    with compact_logits.compact_actor_logits(True):
+        output = _call(model, hidden, mask)
+
+    expected_hidden = torch.cat((hidden, hidden + 10), dim=0)[[0, 3]]
+    expected = torch.nn.functional.linear(expected_hidden, model.output_layer.weight).transpose(0, 1)
+    torch.testing.assert_close(output, expected)
+    assert gather_calls == [(False, model.output_layer.tp_group)]
+    assert model.output_layer.sequence_parallel is True
+
+
+@pytest.mark.unit
+def test_sequence_parallel_flag_is_restored_after_projection_error(monkeypatch):
+    compact_logits, _, _, _ = _load_compact_logits(monkeypatch)
+    model = _make_model(compact_logits, sequence_parallel=True, tp_size=2)
+    model.output_layer.raise_on_forward = True
+
+    with pytest.raises(RuntimeError, match="projection failed"):
+        with compact_logits.compact_actor_logits(True):
+            _call(model, torch.ones(2, 1, 3), torch.tensor([[1, 0, 0, 1]]))
+
+    assert model.output_layer.sequence_parallel is True
+
+
+@pytest.mark.unit
+def test_empty_mask_skips_projection_and_keeps_zero_gradient_edges(monkeypatch):
+    compact_logits, _, _, _ = _load_compact_logits(monkeypatch)
+    model = _make_model(compact_logits)
+    hidden = torch.arange(12, dtype=torch.float32).reshape(4, 1, 3).requires_grad_()
+
+    with compact_logits.compact_actor_logits(True):
+        output = _call(model, hidden, torch.zeros(1, 4))
+
+    assert output.shape == (1, 0, 5)
+    assert model.output_layer.calls == []
+    output.sum().backward()
+    assert hidden.grad is not None
+    assert model.output_layer.weight.grad is not None
+    assert torch.count_nonzero(hidden.grad) == 0
+    assert torch.count_nonzero(model.output_layer.weight.grad) == 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__]))

--- a/tests/test_model_provider_freeze.py
+++ b/tests/test_model_provider_freeze.py
@@ -9,6 +9,17 @@ import torch
 NUM_GPUS = 0
 
 
+class _FakeGPTModel(torch.nn.Module):
+    def __init__(self, **kwargs):
+        super().__init__()
+        self.config = kwargs["config"]
+        self.model_kwargs = kwargs
+
+
+class _FakeCompactLogitsGPTModel(_FakeGPTModel):
+    pass
+
+
 def _load_model_provider(monkeypatch):
     modules = {
         "megatron": types.ModuleType("megatron"),
@@ -23,17 +34,28 @@ def _load_model_provider(monkeypatch):
         ),
         "megatron.training": types.ModuleType("megatron.training"),
         "megatron.training.arguments": types.ModuleType("megatron.training.arguments"),
+        "slime.backends.megatron_utils.compact_logits": types.ModuleType(
+            "slime.backends.megatron_utils.compact_logits"
+        ),
         "slime.utils.misc": types.ModuleType("slime.utils.misc"),
     }
     modules["megatron.core"].tensor_parallel = types.SimpleNamespace()
-    modules["megatron.core.models.gpt"].GPTModel = torch.nn.Module
+    modules["megatron.core.models.gpt"].GPTModel = _FakeGPTModel
     layer_specs = modules["megatron.core.models.gpt.gpt_layer_specs"]
     layer_specs.get_gpt_decoder_block_spec = lambda *args, **kwargs: None
     layer_specs.get_gpt_layer_local_spec = lambda *args, **kwargs: None
     layer_specs.get_gpt_layer_with_transformer_engine_spec = lambda *args, **kwargs: None
     modules["megatron.core.transformer.spec_utils"].import_module = lambda value: value
     modules["megatron.core.transformer.transformer_config"].TransformerConfig = object
-    modules["megatron.training.arguments"].core_transformer_config_from_args = lambda args: object()
+    modules["megatron.training.arguments"].core_transformer_config_from_args = lambda args: types.SimpleNamespace(
+        hidden_size=8,
+        sequence_parallel=False,
+    )
+    compact_logits = modules["slime.backends.megatron_utils.compact_logits"]
+    compact_logits.CompactLogitsGPTModel = _FakeCompactLogitsGPTModel
+    compact_logits.can_compact_actor_logits = lambda args: bool(
+        getattr(args, "compact_actor_logits", False) and args.loss_type in {"policy_loss", "sft_loss"}
+    )
     modules["slime.utils.misc"].load_function = lambda value: value
     for name, module in modules.items():
         monkeypatch.setitem(sys.modules, name, module)
@@ -46,6 +68,33 @@ def _load_model_provider(monkeypatch):
     assert spec.loader is not None
     spec.loader.exec_module(module)
     return module
+
+
+def _provider_args(**overrides):
+    values = {
+        "compact_actor_logits": True,
+        "custom_model_provider_path": None,
+        "fp16_lm_cross_entropy": False,
+        "fp8_param_gather": False,
+        "loss_type": "policy_loss",
+        "max_position_embeddings": 128,
+        "moe_grouped_gemm": False,
+        "moe_use_legacy_grouped_gemm": False,
+        "mtp_num_layers": None,
+        "multi_latent_attention": False,
+        "num_experts": None,
+        "padded_vocab_size": 32,
+        "position_embedding_type": "rope",
+        "qk_layernorm": False,
+        "rotary_base": 10000,
+        "rotary_percent": 1.0,
+        "spec": None,
+        "transformer_impl": "local",
+        "untie_embeddings_and_output_weights": False,
+        "use_rope_scaling": False,
+    }
+    values.update(overrides)
+    return types.SimpleNamespace(**values)
 
 
 class _GLMIndexerAttention(torch.nn.Module):
@@ -121,6 +170,62 @@ def test_freeze_indexer_rejects_unrecognized_attention(monkeypatch):
 
     with pytest.raises(RuntimeError, match="no recognized DSA indexer"):
         model_provider.freeze_model_params(model, args)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("role", "post_process", "compact_actor_logits", "loss_type", "expected_type"),
+    [
+        ("actor", True, True, "policy_loss", _FakeCompactLogitsGPTModel),
+        ("actor", False, True, "policy_loss", _FakeGPTModel),
+        ("critic", True, True, "policy_loss", _FakeGPTModel),
+        ("actor", True, False, "policy_loss", _FakeGPTModel),
+        ("actor", True, True, "custom_loss", _FakeGPTModel),
+    ],
+)
+def test_compact_logits_subclass_is_owned_by_eligible_actor_postprocess_chunk(
+    monkeypatch,
+    role,
+    post_process,
+    compact_actor_logits,
+    loss_type,
+    expected_type,
+):
+    model_provider = _load_model_provider(monkeypatch)
+    args = _provider_args(compact_actor_logits=compact_actor_logits, loss_type=loss_type)
+
+    provider = model_provider._get_model_provider_func(args, role)
+    model = provider(pre_process=True, post_process=post_process)
+
+    assert type(model) is expected_type
+
+
+@pytest.mark.unit
+def test_compact_logits_does_not_replace_custom_model_providers(monkeypatch):
+    model_provider = _load_model_provider(monkeypatch)
+    custom_model = _FakeGPTModel(config=types.SimpleNamespace(hidden_size=8))
+    model_provider.load_function = lambda _path: lambda **_kwargs: custom_model
+    args = _provider_args(custom_model_provider_path="custom.provider")
+
+    provider = model_provider._get_model_provider_func(args, "actor")
+
+    assert provider() is custom_model
+
+
+@pytest.mark.unit
+def test_compact_logits_does_not_replace_callable_spec_model_provider(monkeypatch):
+    model_provider = _load_model_provider(monkeypatch)
+    custom_model = _FakeGPTModel(config=types.SimpleNamespace(hidden_size=8))
+
+    def custom_provider(pre_process=True, post_process=True, vp_stage=None):
+        return custom_model
+
+    model_provider.import_module = lambda _path: lambda _args, _config, _vp_stage: custom_provider
+    args = _provider_args(spec="custom.spec")
+
+    provider = model_provider._get_model_provider_func(args, "actor")
+
+    assert provider() is custom_model
 
 
 if __name__ == "__main__":

--- a/tests/test_ppo_logprob_entropy_gpu.py
+++ b/tests/test_ppo_logprob_entropy_gpu.py
@@ -10,7 +10,6 @@ import torch
 
 from slime.utils.ppo_utils import calculate_log_probs_and_entropy
 
-
 NUM_GPUS = 2
 
 # Megatron's JIT fused CE can differ from the same Python-level expression by
@@ -326,6 +325,139 @@ def _tp2_worker(rank: int, world_size: int, master_port: int) -> None:
                 with_entropy=with_entropy,
                 entropy_has_grad=entropy_has_grad,
             )
+
+        from megatron.core import parallel_state
+        from megatron.core.model_parallel_config import ModelParallelConfig
+        from megatron.core.models.gpt import GPTModel
+        from megatron.core.tensor_parallel.layers import ColumnParallelLinear
+
+        from slime.backends.megatron_utils.compact_logits import CompactLogitsGPTModel, compact_actor_logits
+
+        parallel_state.initialize_model_parallel(
+            tensor_model_parallel_size=world_size,
+            create_gloo_process_groups=False,
+        )
+        try:
+            tp_group = parallel_state.get_tensor_model_parallel_group()
+            hidden_size = 4
+            sequence_length = 6
+            vocab_size = 8
+            loss_mask = torch.tensor(
+                [[False, True, True, False, True, False]],
+                dtype=torch.bool,
+                device=device,
+            )
+            global_hidden = torch.linspace(
+                -1.25,
+                1.5,
+                steps=sequence_length * hidden_size,
+                dtype=torch.float32,
+                device=device,
+            ).view(sequence_length, 1, hidden_size)
+
+            def build_projection_model(model_cls, sequence_parallel: bool):
+                config = ModelParallelConfig(
+                    tensor_model_parallel_size=world_size,
+                    sequence_parallel=sequence_parallel,
+                    params_dtype=torch.float32,
+                    perform_initialization=False,
+                    use_cpu_initialization=False,
+                    gradient_accumulation_fusion=False,
+                )
+                config.mtp_num_layers = None
+                config.cuda_graph_impl = "none"
+                config.config_logger_dir = ""
+
+                model = model_cls.__new__(model_cls)
+                torch.nn.Module.__init__(model)
+                model.config = config
+                model.post_process = True
+                model.parallel_output = True
+                model.share_embeddings_and_output_weights = False
+                model.mtp_process = False
+                model.output_layer = ColumnParallelLinear(
+                    hidden_size,
+                    vocab_size,
+                    config=config,
+                    init_method=torch.nn.init.zeros_,
+                    bias=False,
+                    gather_output=False,
+                    tp_group=tp_group,
+                )
+                return model
+
+            def project(model, hidden_states: torch.Tensor, *, compact: bool) -> torch.Tensor:
+                with compact_actor_logits(compact):
+                    return model._postprocess(
+                        hidden_states=hidden_states,
+                        input_ids=None,
+                        position_ids=None,
+                        labels=None,
+                        rotary_pos_emb=None,
+                        rotary_pos_cos=None,
+                        rotary_pos_sin=None,
+                        loss_mask=loss_mask,
+                    )
+
+            for sequence_parallel in (False, True):
+                baseline_model = build_projection_model(GPTModel, sequence_parallel)
+                compact_model = build_projection_model(CompactLogitsGPTModel, sequence_parallel)
+                local_weight = torch.linspace(
+                    -0.8 + rank * 0.15,
+                    1.1 + rank * 0.15,
+                    steps=baseline_model.output_layer.weight.numel(),
+                    dtype=torch.float32,
+                    device=device,
+                ).view_as(baseline_model.output_layer.weight)
+                with torch.no_grad():
+                    baseline_model.output_layer.weight.copy_(local_weight)
+                    compact_model.output_layer.weight.copy_(local_weight)
+
+                local_hidden = global_hidden.chunk(world_size, dim=0)[rank] if sequence_parallel else global_hidden
+                baseline_hidden = local_hidden.detach().clone().requires_grad_()
+                compact_hidden = local_hidden.detach().clone().requires_grad_()
+
+                full_logits = project(baseline_model, baseline_hidden, compact=False)
+                selected_full_logits = full_logits[:, loss_mask[0], :]
+                compact_logits = project(compact_model, compact_hidden, compact=True)
+
+                assert compact_logits.shape == selected_full_logits.shape
+                assert compact_model.output_layer.sequence_parallel is sequence_parallel
+                torch.testing.assert_close(
+                    compact_logits,
+                    selected_full_logits,
+                    rtol=1e-5,
+                    atol=1e-6,
+                )
+
+                output_grad = torch.linspace(
+                    -0.7,
+                    0.9,
+                    steps=compact_logits.numel(),
+                    dtype=torch.float32,
+                    device=device,
+                ).view_as(compact_logits)
+                (selected_full_logits * output_grad).sum().backward()
+                (compact_logits * output_grad).sum().backward()
+
+                assert baseline_hidden.grad is not None
+                assert compact_hidden.grad is not None
+                assert baseline_model.output_layer.weight.grad is not None
+                assert compact_model.output_layer.weight.grad is not None
+                torch.testing.assert_close(
+                    compact_hidden.grad,
+                    baseline_hidden.grad,
+                    rtol=1e-5,
+                    atol=1e-6,
+                )
+                torch.testing.assert_close(
+                    compact_model.output_layer.weight.grad,
+                    baseline_model.output_layer.weight.grad,
+                    rtol=1e-5,
+                    atol=1e-6,
+                )
+        finally:
+            parallel_state.destroy_model_parallel()
     finally:
         dist.destroy_process_group()
 


### PR DESCRIPTION
## Summary

- Add an opt-in `--compact-actor-logits` path for built-in actor policy/SFT runs.
- Instantiate a Slime-owned `CompactLogitsGPTModel` only for eligible stock actor post-process chunks; critics, custom providers, non-final pipeline chunks, disabled configurations, and unsupported paths keep the original `GPTModel` behavior.
- Select `full_loss_masks` rows at the model post-process boundary, before full-vocabulary projection and fp32 conversion.
- Cover normal forward and combined 1F1B through normal instance-method dispatch, without modifying the process-global Megatron class or restoring the `megatron_patch` loader removed by #2316.
- Support compact log-probability/entropy computation with chunking, top-p replay, CP row mapping, empty masks, and autograd-safe scattering back to the existing response layout.
- Fail closed for MTP, config logging, custom model/loss/hooks, TIS/mismatch paths, debug capture, rollout log-probs, PPO reward-KL, and unsupported Megatron/output-layer configurations.
- Leave the optimization disabled by default; the Qwen3.6 coding-agent example opts in explicitly.

This avoids the full `[T, V]` projection/upcast peak described in #2253 while preserving the existing full-logit path wherever masked output values are not proven sufficient.

## Tests

- `80 passed` across compact model dispatch/provider ownership, compact loss/top-p/empty-mask behavior, policy loss, vocab-parallel log-probability/entropy, and CP invariance tests.
- New CPU test runs directly under the repository CI convention and is registered in both the workflow template and generated workflow.
- Ruff, Black, isort, compileall, workflow regeneration, YAML validation, shell syntax, and `git diff --check` passed.
- Added a real TP=2/NCCL parity test for sequence parallel off/on, selected logits, hidden gradients, output-weight gradients, and state restoration. The local host cannot run this CUDA/NCCL test, so it still requires the self-hosted changed-test job.
- The combined-schedule unit test verifies dynamic dispatch through a schedule node; pinned Megatron source was also audited to confirm `PostProcessNode` resolves `self.gpt_model._postprocess` at execution time.

Fixes #2253
