### PR TITLE
fix(args): reject unsupported colocated offload sync

### DIFF
--- a/slime/utils/arguments.py
+++ b/slime/utils/arguments.py
@@ -2041,6 +2041,23 @@ def slime_validate_args(args):
     if args.only_train_params_name_list and args.freeze_params_name_list:
         raise ValueError("You can only specify ONE of: --only-train-params-name-list, or --freeze-params-name-list.")
 
+    if (
+        args.train_backend == "megatron"
+        and args.colocate
+        and args.rollout_num_gpus > 0
+        and not args.debug_train_only
+        and args.offload_train
+        and args.update_weight_mode == "full"
+        and args.update_weight_transport == "nccl"
+    ):
+        raise ValueError(
+            "Colocated Megatron weight updates with --offload-train and "
+            "--update-weight-mode=full --update-weight-transport=nccl are unsupported: "
+            "colocated engines use CUDA IPC, which is incompatible with torch_memory_saver offload. "
+            "Use --update-weight-mode=full --update-weight-transport=disk with a shared "
+            "--update-weight-disk-dir, or disable training offload with --no-offload-train."
+        )
+
     # disk-backed sync (full or delta) writes on the trainer and reads on the engines: needs a shared dir
     if args.update_weight_transport == "disk" and not args.update_weight_disk_dir:
         raise ValueError(

--- a/tests/test_megatron_argument_validation.py
+++ b/tests/test_megatron_argument_validation.py
@@ -325,6 +325,8 @@ def test_slime_validate_args_preserves_larger_rollout_gpus_under_colocate(monkey
         actor_num_gpus_per_node=8,
         actor_num_nodes=1,
         rollout_num_gpus=12,
+        update_weight_transport="disk",
+        update_weight_disk_dir="/shared/weights",
     )
 
     module.slime_validate_args(args)
@@ -332,6 +334,85 @@ def test_slime_validate_args_preserves_larger_rollout_gpus_under_colocate(monkey
     assert args.rollout_num_gpus == 12
     assert args.offload_train is True
     assert args.offload_rollout is True
+
+
+@pytest.mark.unit
+def test_slime_validate_args_rejects_colocated_megatron_offload_with_full_nccl(monkeypatch):
+    module = load_slime_arguments_module(monkeypatch)
+    args = make_slime_validate_args(colocate=True, rollout_num_gpus=8)
+
+    with pytest.raises(ValueError, match="--update-weight-mode=full --update-weight-transport=disk") as exc_info:
+        module.slime_validate_args(args)
+
+    message = str(exc_info.value)
+    assert "--update-weight-transport=disk" in message
+    assert "--update-weight-disk-dir" in message
+    assert "--no-offload-train" in message
+    assert "delta" not in message
+
+
+@pytest.mark.unit
+def test_slime_validate_args_rejects_ppo_forced_colocated_offload_with_full_nccl(monkeypatch):
+    module = load_slime_arguments_module(monkeypatch)
+    args = make_slime_validate_args(
+        advantage_estimator="ppo",
+        colocate=True,
+        rollout_num_gpus=8,
+        offload_train=False,
+    )
+
+    with pytest.raises(ValueError, match="Colocated Megatron weight updates"):
+        module.slime_validate_args(args)
+
+
+@pytest.mark.unit
+def test_slime_validate_args_rejects_dangerous_custom_config(monkeypatch, tmp_path):
+    module = load_slime_arguments_module(monkeypatch)
+    custom_config = tmp_path / "dangerous.yaml"
+    custom_config.write_text(
+        "colocate: true\n"
+        "rollout_num_gpus: 8\n"
+        "offload_train: true\n"
+        "update_weight_mode: full\n"
+        "update_weight_transport: nccl\n"
+    )
+    args = make_slime_validate_args(
+        custom_config_path=str(custom_config),
+        update_weight_transport="disk",
+        update_weight_disk_dir="/shared/weights",
+    )
+
+    with pytest.raises(ValueError, match="Colocated Megatron weight updates"):
+        module.slime_validate_args(args)
+
+
+@pytest.mark.unit
+def test_slime_validate_args_allows_colocated_full_nccl_without_train_offload(monkeypatch):
+    module = load_slime_arguments_module(monkeypatch)
+    args = make_slime_validate_args(
+        colocate=True,
+        rollout_num_gpus=8,
+        offload_train=False,
+    )
+
+    module.slime_validate_args(args)
+
+    assert args.offload_train is False
+    assert args.offload_rollout is True
+
+
+@pytest.mark.unit
+def test_slime_validate_args_allows_debug_train_only_with_colocated_full_nccl(monkeypatch):
+    module = load_slime_arguments_module(monkeypatch)
+    args = make_slime_validate_args(
+        colocate=True,
+        rollout_num_gpus=8,
+        debug_train_only=True,
+    )
+
+    module.slime_validate_args(args)
+
+    assert args.offload_train is True
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

- Reject the known-incompatible Megatron configuration that combines colocated local rollout engines, training offload, full weight sync, and the NCCL transport.
- Run the validation after custom YAML overrides, so a dangerous `custom_config` cannot bypass it.
- Keep valid boundaries unchanged: no-offload, zero local rollout GPUs, `debug_train_only`, non-colocated runs, and full+disk sync.
- Point users to the two supported choices: full+disk with a shared `--update-weight-disk-dir`, or `--no-offload-train` when memory permits.

Colocated full sync currently uses `UpdateWeightFromTensor` and CUDA IPC even when `--update-weight-transport=nccl` is selected. torch_memory_saver-backed offload allocations are not compatible with that PyTorch CUDA IPC serialization path, so this turns a late `storage._share_cuda_()` failure into an actionable startup error.

This is the narrow fail-fast stage; it does not claim to add a new non-disk colocated transport.

## Tests

- `PYTHONPATH=. python tests/test_megatron_argument_validation.py -q` (`26 passed`)
- The regression matrix covers derived colocate defaults, PPO-forced offload, YAML overrides, explicit no-offload, zero rollout GPUs, debug-train-only, and full+disk.
- Ruff, Black, isort, autoflake, compileall, and `git diff --check` passed.

Refs #2188