### PR TITLE
docs: remove stale delta NCCL recommendation

### DIFF
--- a/docs/en/advanced/external-rollout-engines.md
+++ b/docs/en/advanced/external-rollout-engines.md
@@ -14,8 +14,9 @@ This page is a roadmap. Use it to decide when to use `--rollout-external-engine-
 | Trainer and external engines cannot form an NCCL group, but can see the same filesystem path | `--update-weight-mode full --update-weight-transport disk` |
 | Full checkpoints are too heavy for large-model cross-cluster or cross-DC sync | `--update-weight-mode delta --update-weight-transport disk` |
 | Rollout serving can use an independent SGLang environment, or even different GPU models/vendors | external engines + disk transport |
-| You want to validate delta wire/apply logic inside one datacenter | `--update-weight-mode delta --update-weight-transport nccl` |
 | You need frozen reference, reward, or tool-side models | Prefer `update_weights: false` in [SGLang Config](sglang-config.md#3-multi-model-serving) |
+
+Delta mode supports disk transport only. Use full mode when syncing weights over NCCL.
 
 ## What External Engine Does
 

--- a/docs/zh/advanced/external-rollout-engines.md
+++ b/docs/zh/advanced/external-rollout-engines.md
@@ -14,8 +14,9 @@ External rollout engine 指的是：SGLang engine 不由 slime 训练任务启�
 | 训练器和 external engine 不能建立 NCCL group，但能共享同一路径的文件系统 | `--update-weight-mode full --update-weight-transport disk` |
 | 大模型跨集群或跨数据中心同步，full checkpoint 太重 | `--update-weight-mode delta --update-weight-transport disk` |
 | rollout serving 想使用独立 SGLang 环境，甚至不同型号或不同厂家的 GPU | external engine + disk transport |
-| 想验证 delta wire/apply 逻辑，但仍在同一数据中心内 | `--update-weight-mode delta --update-weight-transport nccl` |
 | 需要 reference、reward、tool-side model 等冻结模型 | 优先用 [SGLang Config](sglang-config.md#3-多模型服务) 的 `update_weights: false` |
+
+delta mode 仅支持 disk transport。通过 NCCL 同步权重时请使用 full mode。
 
 ## External Engine 做了什么
 


### PR DESCRIPTION
## Summary

- Remove the obsolete delta+NCCL recommendation from the English and Chinese external rollout engine decision tables.
- State the current contract explicitly: delta mode supports disk transport only; NCCL weight sync uses full mode.

The distributed delta+NCCL updater introduced by #1806 was removed by #2089. Current argument validation rejects `--update-weight-mode delta --update-weight-transport nccl`, but these two roadmap entries still recommended that exact combination. This aligns the documentation with the current runtime instead of suggesting a path that no longer exists.

This documentation update does not claim to repair the historical grouped-MoE corruption path reported in #2209; that code was removed from current `main`.

## Tests

- English Sphinx build passed; only 50 pre-existing repository warnings, none from the changed page.
- Chinese Sphinx build passed; only 55 pre-existing repository warnings, none from the changed page.
- Verified generated HTML contains the new disk-only guidance.
- Pre-commit and `git show --check` passed.

Related to #2209