### PR TITLE
fix(glm5): guard TileLang sparse MLA merge pass

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -771,6 +771,10 @@ jobs:
             },
             {
               "num_gpus": 0,
+              "test_file": "test_glm5_tilelang_sparse_mla_version_guard.py"
+            },
+            {
+              "num_gpus": 0,
               "test_file": "test_model_provider_freeze.py"
             },
             {

--- a/.github/workflows/pr-test.yml.j2
+++ b/.github/workflows/pr-test.yml.j2
@@ -118,6 +118,7 @@
         {'test_file': 'test_empty_colocated_weight_bucket.py', 'num_gpus': 0},
         {'test_file': 'test_expert_routing.py', 'num_gpus': 0},
         {'test_file': 'test_glm5_indexer_short_context.py', 'num_gpus': 0},
+        {'test_file': 'test_glm5_tilelang_sparse_mla_version_guard.py', 'num_gpus': 0},
         {'test_file': 'test_model_provider_freeze.py', 'num_gpus': 0},
         {'test_file': 'test_glm52_layerwise_comparison.py', 'num_gpus': 0},
         {'test_file': 'test_layerwise_alignment.py', 'num_gpus': 0},

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ numba
 omegaconf
 openai
 openai-agents
+packaging
 pillow
 pylatexenc
 pyyaml

--- a/slime_plugins/models/glm5/ops/tilelang_sparse_mla_bwd.py
+++ b/slime_plugins/models/glm5/ops/tilelang_sparse_mla_bwd.py
@@ -2,7 +2,28 @@
 # Adapt from https://github.com/tile-ai/tilelang/blob/4ff81c7d40803d269569e157e847623e84553f78/examples/deepseek_v32/sparse_mla_bwd.py
 import tilelang
 import torch
+from packaging.version import InvalidVersion, Version
 from tilelang import language as T
+
+
+# tile-ai/tilelang#2204 fixed this shared-memory liveness regression in 0.1.11.
+_AGGRESSIVE_SHARED_MEMORY_MERGE_REGRESSION_START = Version("0.1.9.dev0")
+_AGGRESSIVE_SHARED_MEMORY_MERGE_FIX = Version("0.1.11")
+
+
+def _enable_aggressive_shared_memory_merge(tilelang_version):
+    # TileLang uses 0.0.dev0 when its package metadata is unavailable.
+    if not isinstance(tilelang_version, str) or tilelang_version == "0.0.dev0":
+        return False
+
+    try:
+        parsed_version = Version(tilelang_version)
+    except InvalidVersion:
+        return False
+
+    return not (
+        _AGGRESSIVE_SHARED_MEMORY_MERGE_REGRESSION_START <= parsed_version < _AGGRESSIVE_SHARED_MEMORY_MERGE_FIX
+    )
 
 
 @tilelang.jit(out_idx=[-1])
@@ -78,7 +99,9 @@ def postprocess(
     pass_configs={
         tilelang.PassConfigKey.TL_DISABLE_TMA_LOWER: True,
         tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True,
-        tilelang.PassConfigKey.TL_ENABLE_AGGRESSIVE_SHARED_MEMORY_MERGE: True,
+        tilelang.PassConfigKey.TL_ENABLE_AGGRESSIVE_SHARED_MEMORY_MERGE: _enable_aggressive_shared_memory_merge(
+            getattr(tilelang, "__version__", None)
+        ),
     },
 )
 def bwd(

--- a/tests/test_glm5_tilelang_sparse_mla_version_guard.py
+++ b/tests/test_glm5_tilelang_sparse_mla_version_guard.py
@@ -1,0 +1,71 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+NUM_GPUS = 0
+
+
+class _PassConfigKey:
+    TL_DISABLE_TMA_LOWER = "disable_tma_lower"
+    TL_DISABLE_WARP_SPECIALIZED = "disable_warp_specialized"
+    TL_ENABLE_AGGRESSIVE_SHARED_MEMORY_MERGE = "enable_aggressive_shared_memory_merge"
+
+
+def _load_sparse_mla_bwd(monkeypatch, tilelang_version):
+    captured_jit_options = {}
+    tilelang = types.ModuleType("tilelang")
+    tilelang.__version__ = tilelang_version
+    tilelang.PassConfigKey = _PassConfigKey
+
+    def jit(*jit_args, **jit_kwargs):
+        assert not jit_args
+
+        def decorate(function):
+            if function.__name__ == "bwd":
+                captured_jit_options.update(jit_kwargs)
+            return function
+
+        return decorate
+
+    tilelang.jit = jit
+    tilelang.language = types.SimpleNamespace(bfloat16="bfloat16", float32="float32", int32="int32")
+    monkeypatch.setitem(sys.modules, "tilelang", tilelang)
+
+    module_name = f"tilelang_sparse_mla_bwd_test_{id(tilelang)}"
+    source = Path(__file__).parents[1] / "slime_plugins/models/glm5/ops/tilelang_sparse_mla_bwd.py"
+    spec = importlib.util.spec_from_file_location(module_name, source)
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, module_name, module)
+    spec.loader.exec_module(module)
+    return module, captured_jit_options
+
+
+@pytest.mark.parametrize(
+    ("tilelang_version", "expected"),
+    [
+        ("0.1.8", True),
+        ("0.1.8.post1", True),
+        ("0.1.9.dev0", False),
+        ("0.1.9", False),
+        ("0.1.10+cu128", False),
+        ("0.1.11.dev0", False),
+        ("0.1.11", True),
+        ("0.1.12", True),
+        (None, False),
+        ("", False),
+        ("unknown", False),
+        ("0.0.dev0", False),
+    ],
+)
+def test_aggressive_shared_memory_merge_version_guard(monkeypatch, tilelang_version, expected):
+    module, jit_options = _load_sparse_mla_bwd(monkeypatch, tilelang_version)
+
+    assert module._enable_aggressive_shared_memory_merge(tilelang_version) is expected
+    assert jit_options["pass_configs"][_PassConfigKey.TL_ENABLE_AGGRESSIVE_SHARED_MEMORY_MERGE] is expected
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__]))


### PR DESCRIPTION
## Summary

- Disable `TL_ENABLE_AGGRESSIVE_SHARED_MEMORY_MERGE` for TileLang versions in the affected range `>=0.1.9.dev0,<0.1.11`.
- Preserve the optimization for pre-regression releases such as 0.1.8 and fixed releases starting at 0.1.11.
- Fail closed for missing, invalid, or TileLang `0.0.dev0` metadata.
- Declare `packaging` as a runtime dependency and add a CPU contract test that imports the real GLM5 backward module with stubbed TileLang versions and inspects the actual JIT pass configuration.

TileLang fixed the shared-memory liveness bug in tile-ai/tilelang#2204. Slime's CUDA 12 image still receives TileLang 0.1.9 through the pinned FlashQLA dependency, so a blanket dependency upgrade is not currently compatible with that image. The version guard keeps the optimization on known-safe versions while applying the documented workaround to the affected compiler releases.

## Tests

- `PYTHONPATH=. python tests/test_glm5_tilelang_sparse_mla_version_guard.py -q` (`12 passed`)
- `PYTHONPATH=. python tests/test_glm5_indexer_short_context.py -q` (`1 passed`)
- Workflow generation, Ruff, Black, isort, autoflake, YAML validation, compileall, and `git diff --check` passed.
- The local GPU is not SM90/Hopper, so the original numerical backward reproducer could not be run locally. The issue reporter has already validated that disabling this pass makes the H200 training path finite; the added local test verifies the exact version-to-JIT-config behavior.

Fixes #2201
