### PR TITLE
chore: remove backend-specific comment

### DIFF
--- a/slime/backends/sglang_utils/__init__.py
+++ b/slime/backends/sglang_utils/__init__.py
@@ -1,5 +1,3 @@
 from slime.utils import accelerator
 
-# Finalize the backend before importing any SGLang submodule. In a MUSA
-# runtime this loads musa_patch only after MUSA wins backend selection.
 accelerator.initialize_accelerator()


### PR DESCRIPTION
## Summary

Remove the backend-specific comment from the SGLang backend initialization module.

The accelerator initialization remains backend-neutral and unchanged.

## Changes

- Remove references to a specific accelerator backend from the generic SGLang backend entry point.
- Keep `accelerator.initialize_accelerator()` unchanged.
- Preserve existing runtime behavior.

## Testing

- `PYTHONPATH=. pytest -q tests/test_accelerator.py tests/test_reloadable_process_group_world.py`
  - 18 passed
- `git diff --check`
  - Passed