### PR TITLE
fix(opd): pin teacher scoring temperature to 1.0

### DIFF
--- a/slime/rollout/on_policy_distillation.py
+++ b/slime/rollout/on_policy_distillation.py
@@ -10,7 +10,7 @@ async def reward_func(args, sample, **kwargs):
         # "text": sample.prompt + sample.response,
         "input_ids": sample.tokens,
         "sampling_params": {
-            "temperature": args.rollout_temperature,
+            "temperature": 1.0,
             "max_new_tokens": 0,
             "skip_special_tokens": False,
         },


### PR DESCRIPTION
@zhuzilin 辛苦review一下，非常感谢！
pr https://github.com/THUDM/slime/pull/2085 把opd的teacher payload的`temperature`从`0.0` 改成了 `args.rollout_temperature`，但sgl内input的logp使用的都是`1.0`。因此会引起混淆。

sgl 的 SGLANG_RETURN_ORIGINAL_LOGPROB和temperature只影响output的logp，**input的logp不受影响（opd在这，max_new_tokens=0）**

下面是实际测试结果，**不同temperature并不影响input的各种logp**。
起serve：
```bash
python -m sglang.launch_server \
  --model /root/Qwen3-0.6B \
  --reasoning-parser qwen3 \
  --tool-call-parser qwen25
```

temperature=1.0的payload
```bash
curl -s http://127.0.0.1:30010/generate -H 'Content-Type: application/json' -d '{
  "input_ids": [3838,374,279,6722,315,9625,30,576,6722,315,9625,374,12095],
  "sampling_params": {"temperature": 1, "max_new_tokens": 0},
  "return_logprob": true,
  "logprob_start_len": 0
}'
```

结果(temperature=1.0)
<img width="1032" height="186" alt="image" src="https://github.com/user-attachments/assets/2f5f50f9-b6ec-49e2-bf47-926b859cbe8e" />

修改payload的temperature=2.0
结果如下(temperature=2.0)
<img width="1018" height="171" alt="image" src="https://github.com/user-attachments/assets/ac4a061e-761d-4391-b9de-a3e7fa5620a7" />


修改payload的temperature=0.5
结果如下(temperature=0.5)
<img width="1021" height="186" alt="image" src="https://github.com/user-attachments/assets/dd1820f1-8236-49a2-9246-e2a20d16888c" />



