### PR TITLE
perf(agent): isolate prompt rendering from event loop

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -885,6 +885,10 @@ jobs:
             },
             {
               "num_gpus": 0,
+              "test_file": "test_agent/test_adapter_tokenizer_worker.py"
+            },
+            {
+              "num_gpus": 0,
               "test_file": "test_agent/test_adapters.py"
             },
             {

--- a/.github/workflows/pr-test.yml.j2
+++ b/.github/workflows/pr-test.yml.j2
@@ -137,6 +137,7 @@
       'cpu': True,
       'tests': [
         {'test_file': 'test_agent/test_trajectory_manager_branching.py', 'num_gpus': 0},
+        {'test_file': 'test_agent/test_adapter_tokenizer_worker.py', 'num_gpus': 0},
         {'test_file': 'test_agent/test_adapters.py', 'num_gpus': 0},
         {'test_file': 'test_agent/test_harness.py', 'num_gpus': 0},
         {'test_file': 'test_agent/test_sandbox_exec_and_wait.py', 'num_gpus': 0},

--- a/slime/agent/adapters/common.py
+++ b/slime/agent/adapters/common.py
@@ -18,14 +18,15 @@ import logging
 import time
 import uuid
 from collections.abc import Callable
+from functools import partial
 from typing import Any
 
 import aiohttp
 from aiohttp import web
 
+from slime.agent.adapters.tokenizer_worker import TokenizerWorker
 from slime.agent.parsing import parse_model_output
 from slime.agent.trajectory import TrajectoryManager, TurnRecord
-
 
 __all__ = ["TurnRecord"]
 
@@ -148,7 +149,11 @@ class BaseAdapter:
         max_turns_per_sid: int | None = None,
         fork_threshold_tokens: int | None = None,
         debug_callback: Callable[..., None] | None = None,
+        tokenizer_max_pending: int = 8,
+        event_loop_lag_interval_seconds: float = 0.1,
     ) -> None:
+        if event_loop_lag_interval_seconds <= 0:
+            raise ValueError("event_loop_lag_interval_seconds must be positive")
         self.tokenizer = tokenizer
         self.sglang_url = sglang_url.rstrip("/") if isinstance(sglang_url, str) else sglang_url
         self.tool_parser = tool_parser
@@ -157,6 +162,8 @@ class BaseAdapter:
         self.inflight: dict[str, set[asyncio.Task]] = {}
         self.closed: set[str] = set()
         self.app = web.Application(client_max_size=64 * 1024 * 1024)
+        self._tokenizer_worker = TokenizerWorker(max_pending=tokenizer_max_pending)
+        self._event_loop_lag_interval_seconds = event_loop_lag_interval_seconds
 
         # one manager shared across all sids; per-sid trees live inside it.
         # fork_threshold_tokens left None means the manager uses its own default.
@@ -170,9 +177,31 @@ class BaseAdapter:
         self.max_turns_per_sid: int | None = max_turns_per_sid
         self._sid_turn_count: dict[str, int] = {}
 
+        self.app.cleanup_ctx.append(self._tokenizer_lifecycle)
         self.app.router.add_get("/healthz", _health)
         self.app.router.add_get("/v1/models", _health)
+        self.app.router.add_get("/debug/adapter_metrics", self._metrics)
         self._register_routes(self.app)
+
+    async def _tokenizer_lifecycle(self, app: web.Application):
+        self._tokenizer_worker.bind_to_current_loop()
+        lag_task = asyncio.create_task(
+            self._tokenizer_worker.monitor_event_loop_lag(self._event_loop_lag_interval_seconds),
+            name=f"{self.log_prefix}-event-loop-lag",
+        )
+        try:
+            yield
+        finally:
+            lag_task.cancel()
+            await asyncio.gather(lag_task, return_exceptions=True)
+            await self._tokenizer_worker.close()
+
+    async def _metrics(self, request: web.Request) -> web.Response:
+        return web.json_response(self.metrics_snapshot())
+
+    def metrics_snapshot(self) -> dict[str, object]:
+        """Return bounded tokenizer and event-loop metrics for this adapter."""
+        return {"tokenizer": self._tokenizer_worker.snapshot()}
 
     # -- wire hooks (subclass overrides) -------------------------------------
 
@@ -305,6 +334,15 @@ class BaseAdapter:
         self._sid_turn_count[sid] = prior + 1
         return None
 
+    def _release_turn_cap(self, sid: str) -> None:
+        if self.max_turns_per_sid is None:
+            return
+        remaining = self._sid_turn_count.get(sid, 0) - 1
+        if remaining > 0:
+            self._sid_turn_count[sid] = remaining
+        else:
+            self._sid_turn_count.pop(sid, None)
+
     def _run_debug_callback(self, sid, translated, tools_schema, manager_message, turn) -> None:
         """Run the optional debug-only data dump callback; unset in production."""
         callback = self.debug_callback
@@ -333,14 +371,31 @@ class BaseAdapter:
             return capped
 
         tok = self.tokenizer
-        s = self.store.setdefault(sid, Session())
         task = asyncio.current_task()
         self.inflight.setdefault(sid, set()).add(task)
         t0 = time.monotonic()
         try:
+            # shutdown_session can run from the rollout thread between the
+            # initial guard and inflight registration. Recheck after the task is
+            # visible so a drained sid cannot start tokenizer or SGLang work.
+            if sid in self.closed:
+                self._release_turn_cap(sid)
+                return web.Response(status=503, text="session closed")
             translated, tools_schema = self._translate(body)
-            prompt_ids = _render_token_ids(translated, tok, tools=tools_schema, add_generation_prompt=True)
+            prompt_ids = await self._tokenizer_worker.render(
+                partial(
+                    _render_token_ids,
+                    translated,
+                    tok,
+                    tools=tools_schema,
+                    add_generation_prompt=True,
+                )
+            )
+            if sid in self.closed:
+                self._release_turn_cap(sid)
+                return web.Response(status=503, text="session closed")
 
+            s = self.store.setdefault(sid, Session())
             turn = await call_sglang_generate(prompt_ids, s, body, adapter=self, session_id=sid)
 
             raw_output = tok.decode(turn.output_ids, skip_special_tokens=False) if turn.output_ids else ""
@@ -389,6 +444,10 @@ class BaseAdapter:
                 metadata={"sid": sid},
             )
             return response
+        except asyncio.CancelledError:
+            self._release_turn_cap(sid)
+            self._tokenizer_worker.record_request_cancellation()
+            raise
         finally:
             self.inflight.get(sid, set()).discard(task)
 

--- a/slime/agent/adapters/tokenizer_worker.py
+++ b/slime/agent/adapters/tokenizer_worker.py
@@ -62,6 +62,7 @@ class TokenizerWorker:
         self._loop: asyncio.AbstractEventLoop | None = None
         self._slots: asyncio.BoundedSemaphore | None = None
         self._acquire_tasks: set[asyncio.Task] = set()
+        self._close_cancelled_acquires: set[asyncio.Task] = set()
         self._futures: set[Future] = set()
         self._closed = False
         self._close_task: asyncio.Task | None = None
@@ -114,18 +115,26 @@ class TokenizerWorker:
         acquire_task = asyncio.create_task(self._slots.acquire())
         self._acquire_tasks.add(acquire_task)
         try:
-            await acquire_task
+            await asyncio.shield(acquire_task)
         except asyncio.CancelledError:
+            close_cancelled = acquire_task in self._close_cancelled_acquires
+            if not acquire_task.done():
+                acquire_task.cancel()
+            while not acquire_task.done():
+                try:
+                    await asyncio.shield(acquire_task)
+                except asyncio.CancelledError:
+                    pass
             if acquire_task.done() and not acquire_task.cancelled() and acquire_task.exception() is None:
                 self._slots.release()
-            current_task = asyncio.current_task()
-            if self._closed and current_task is not None and not current_task.cancelling():
+            if close_cancelled:
                 self._request_rejected_after_close()
                 raise RuntimeError("tokenizer worker is closed") from None
             self._request_cancelled_before_submit()
             raise
         finally:
             self._acquire_tasks.discard(acquire_task)
+            self._close_cancelled_acquires.discard(acquire_task)
 
         if self._closed:
             self._slots.release()
@@ -216,6 +225,7 @@ class TokenizerWorker:
         while self._acquire_tasks:
             acquire_tasks = list(self._acquire_tasks)
             for task in acquire_tasks:
+                self._close_cancelled_acquires.add(task)
                 task.cancel()
             await asyncio.gather(*acquire_tasks, return_exceptions=True)
             await asyncio.sleep(0)

--- a/slime/agent/adapters/tokenizer_worker.py
+++ b/slime/agent/adapters/tokenizer_worker.py
@@ -120,19 +120,13 @@ class TokenizerWorker:
             close_cancelled = acquire_task in self._close_cancelled_acquires
             if not acquire_task.done():
                 acquire_task.cancel()
-            while not acquire_task.done():
-                try:
-                    await asyncio.shield(acquire_task)
-                except asyncio.CancelledError:
-                    pass
-            if acquire_task.done() and not acquire_task.cancelled() and acquire_task.exception() is None:
-                self._slots.release()
+            acquire_task.add_done_callback(self._release_cancelled_acquire)
             if close_cancelled:
                 self._request_rejected_after_close()
                 raise RuntimeError("tokenizer worker is closed") from None
             self._request_cancelled_before_submit()
             raise
-        finally:
+        else:
             self._acquire_tasks.discard(acquire_task)
             self._close_cancelled_acquires.discard(acquire_task)
 
@@ -163,6 +157,13 @@ class TokenizerWorker:
         if result is None:
             raise RuntimeError("tokenizer render result was discarded")
         return result
+
+    def _release_cancelled_acquire(self, acquire_task: asyncio.Task) -> None:
+        self._acquire_tasks.discard(acquire_task)
+        self._close_cancelled_acquires.discard(acquire_task)
+        if not acquire_task.cancelled() and acquire_task.exception() is None:
+            assert self._slots is not None
+            self._slots.release()
 
     def _execute(self, job: _RenderJob) -> list[int] | None:
         started_at = time.monotonic()

--- a/slime/agent/adapters/tokenizer_worker.py
+++ b/slime/agent/adapters/tokenizer_worker.py
@@ -1,0 +1,335 @@
+"""Bounded prompt-render worker and lightweight adapter metrics."""
+
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+import threading
+import time
+from collections import deque
+from collections.abc import Callable
+from concurrent.futures import Future, ThreadPoolExecutor
+
+_METRIC_WINDOW_SIZE = 2048
+
+
+@dataclasses.dataclass
+class _RenderJob:
+    render: Callable[[], list[int]]
+    queued_at: float
+    discarded: threading.Event = dataclasses.field(default_factory=threading.Event)
+    dequeued: bool = False
+
+
+def _distribution(values: deque[float]) -> dict[str, float | int | None]:
+    ordered = sorted(values)
+    if not ordered:
+        return {"count": 0, "mean": None, "max": None, "p50": None, "p95": None, "p99": None}
+
+    def percentile(q: float) -> float:
+        position = (len(ordered) - 1) * q
+        lower = int(position)
+        upper = min(lower + 1, len(ordered) - 1)
+        fraction = position - lower
+        return ordered[lower] + (ordered[upper] - ordered[lower]) * fraction
+
+    return {
+        "count": len(ordered),
+        "mean": sum(ordered) / len(ordered),
+        "max": ordered[-1],
+        "p50": percentile(0.50),
+        "p95": percentile(0.95),
+        "p99": percentile(0.99),
+    }
+
+
+class TokenizerWorker:
+    """Run full-history prompt renders on one bounded, adapter-owned thread.
+
+    ``ThreadPoolExecutor`` bounds running threads but not its internal queue, so
+    an asyncio semaphore limits submitted jobs as well. A request cancellation
+    marks its job discarded; the permit is released only when the underlying
+    future is physically done. This prevents a cancellation storm from growing
+    either worker concurrency or queued tokenizer work without bound.
+    """
+
+    def __init__(self, *, max_pending: int = 8) -> None:
+        if max_pending < 1:
+            raise ValueError("tokenizer max_pending must be at least 1")
+
+        self.max_pending = max_pending
+        self._executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="slime-tokenizer")
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._slots: asyncio.BoundedSemaphore | None = None
+        self._acquire_tasks: set[asyncio.Task] = set()
+        self._futures: set[Future] = set()
+        self._closed = False
+        self._close_task: asyncio.Task | None = None
+
+        self._metrics_lock = threading.Lock()
+        self._created_at = time.monotonic()
+        self._requests_total = 0
+        self._submitted_total = 0
+        self._completed_total = 0
+        self._failed_total = 0
+        self._request_cancelled_total = 0
+        self._render_cancelled_total = 0
+        self._discarded_total = 0
+        self._discarded_before_render_total = 0
+        self._waiting = 0
+        self._waiting_peak = 0
+        self._outstanding = 0
+        self._outstanding_peak = 0
+        self._active = 0
+        self._active_peak = 0
+        self._busy_seconds = 0.0
+        self._active_started_at: float | None = None
+        self._prompt_tokens: deque[float] = deque(maxlen=_METRIC_WINDOW_SIZE)
+        self._render_latency_ms: deque[float] = deque(maxlen=_METRIC_WINDOW_SIZE)
+        self._queue_wait_ms: deque[float] = deque(maxlen=_METRIC_WINDOW_SIZE)
+        self._event_loop_lag_ms: deque[float] = deque(maxlen=_METRIC_WINDOW_SIZE)
+
+    @property
+    def closed(self) -> bool:
+        return self._closed
+
+    def bind_to_current_loop(self) -> None:
+        loop = asyncio.get_running_loop()
+        if self._loop is None:
+            self._loop = loop
+            self._slots = asyncio.BoundedSemaphore(self.max_pending)
+        elif self._loop is not loop:
+            raise RuntimeError("TokenizerWorker can only be used from its adapter event loop")
+
+    async def render(self, render: Callable[[], list[int]]) -> list[int]:
+        """Run one render without blocking the adapter event loop."""
+        self.bind_to_current_loop()
+        assert self._slots is not None
+        assert self._loop is not None
+        if self._closed:
+            raise RuntimeError("tokenizer worker is closed")
+
+        job = _RenderJob(render=render, queued_at=time.monotonic())
+        self._request_queued()
+        acquire_task = asyncio.create_task(self._slots.acquire())
+        self._acquire_tasks.add(acquire_task)
+        try:
+            await acquire_task
+        except asyncio.CancelledError:
+            if acquire_task.done() and not acquire_task.cancelled() and acquire_task.exception() is None:
+                self._slots.release()
+            current_task = asyncio.current_task()
+            if self._closed and current_task is not None and not current_task.cancelling():
+                self._request_rejected_after_close()
+                raise RuntimeError("tokenizer worker is closed") from None
+            self._request_cancelled_before_submit()
+            raise
+        finally:
+            self._acquire_tasks.discard(acquire_task)
+
+        if self._closed:
+            self._slots.release()
+            self._request_rejected_after_close()
+            raise RuntimeError("tokenizer worker is closed")
+
+        self._job_submitted()
+        try:
+            future = self._executor.submit(self._execute, job)
+        except BaseException:
+            self._slots.release()
+            self._submission_failed()
+            raise
+
+        self._futures.add(future)
+        future.add_done_callback(lambda done: self._schedule_future_done(done, job))
+        wrapped = asyncio.wrap_future(future)
+        wrapped.add_done_callback(_consume_future_exception)
+        try:
+            result = await asyncio.shield(wrapped)
+        except asyncio.CancelledError:
+            job.discarded.set()
+            self._request_cancelled_after_submit()
+            raise
+
+        if result is None:
+            raise RuntimeError("tokenizer render result was discarded")
+        return result
+
+    def _execute(self, job: _RenderJob) -> list[int] | None:
+        started_at = time.monotonic()
+        job.dequeued = True
+        if job.discarded.is_set():
+            self._job_discarded_before_render(started_at - job.queued_at)
+            return None
+
+        self._job_started(started_at - job.queued_at, started_at)
+        try:
+            prompt_ids = job.render()
+        except BaseException:
+            self._job_finished(started_at, failed=True)
+            raise
+        self._job_finished(started_at, prompt_tokens=len(prompt_ids))
+        return prompt_ids
+
+    def _future_done(self, future: Future, job: _RenderJob) -> None:
+        self._futures.discard(future)
+        assert self._slots is not None
+        self._slots.release()
+        with self._metrics_lock:
+            self._outstanding -= 1
+            if not job.dequeued:
+                self._waiting -= 1
+
+    def _schedule_future_done(self, future: Future, job: _RenderJob) -> None:
+        loop = self._loop
+        if loop is None or loop.is_closed():
+            return
+        try:
+            loop.call_soon_threadsafe(self._future_done, future, job)
+        except RuntimeError:
+            # The app loop can be force-stopped after its shutdown timeout while
+            # a third-party tokenizer call is still returning.
+            pass
+
+    async def monitor_event_loop_lag(self, interval_seconds: float) -> None:
+        """Sample scheduling delay while the adapter application is running."""
+        if interval_seconds <= 0:
+            raise ValueError("event-loop lag interval must be positive")
+        loop = asyncio.get_running_loop()
+        while True:
+            expected = loop.time() + interval_seconds
+            await asyncio.sleep(interval_seconds)
+            lag_ms = max(0.0, loop.time() - expected) * 1000.0
+            with self._metrics_lock:
+                self._event_loop_lag_ms.append(lag_ms)
+
+    async def close(self) -> None:
+        """Stop accepting renders and drain the bounded executor."""
+        self.bind_to_current_loop()
+        if self._close_task is None:
+            self._closed = True
+            self._close_task = asyncio.create_task(self._drain(), name="tokenizer-worker-close")
+            self._close_task.add_done_callback(_consume_future_exception)
+        await asyncio.shield(self._close_task)
+
+    async def _drain(self) -> None:
+        while self._acquire_tasks:
+            acquire_tasks = list(self._acquire_tasks)
+            for task in acquire_tasks:
+                task.cancel()
+            await asyncio.gather(*acquire_tasks, return_exceptions=True)
+            await asyncio.sleep(0)
+
+        self._executor.shutdown(wait=False, cancel_futures=False)
+        futures = list(self._futures)
+        if futures:
+            await asyncio.gather(*(asyncio.wrap_future(future) for future in futures), return_exceptions=True)
+        self._executor.shutdown(wait=True)
+        await asyncio.sleep(0)
+
+    def snapshot(self) -> dict[str, object]:
+        """Return a thread-safe JSON-serializable metrics snapshot."""
+        now = time.monotonic()
+        with self._metrics_lock:
+            busy_seconds = self._busy_seconds
+            if self._active and self._active_started_at is not None:
+                busy_seconds += now - self._active_started_at
+            elapsed_seconds = max(now - self._created_at, 1e-9)
+            queue_depth = max(self._outstanding - self._active, 0)
+            admission_waiters = max(self._waiting - queue_depth, 0)
+            return {
+                "worker": {
+                    "threads": 1,
+                    "max_outstanding": self.max_pending,
+                    "outstanding": self._outstanding,
+                    "outstanding_peak": self._outstanding_peak,
+                    "active": self._active,
+                    "active_peak": self._active_peak,
+                    "queue_depth": queue_depth,
+                    "admission_waiters": admission_waiters,
+                    "waiting_peak": self._waiting_peak,
+                    "utilization": min(busy_seconds / elapsed_seconds, 1.0),
+                },
+                "counters": {
+                    "requests_total": self._requests_total,
+                    "submitted_total": self._submitted_total,
+                    "completed_total": self._completed_total,
+                    "failed_total": self._failed_total,
+                    "request_cancelled_total": self._request_cancelled_total,
+                    "render_cancelled_total": self._render_cancelled_total,
+                    "discarded_total": self._discarded_total,
+                    "discarded_before_render_total": self._discarded_before_render_total,
+                },
+                "prompt_tokens": _distribution(self._prompt_tokens),
+                "render_latency_ms": _distribution(self._render_latency_ms),
+                "queue_wait_ms": _distribution(self._queue_wait_ms),
+                "event_loop_lag_ms": _distribution(self._event_loop_lag_ms),
+                "sample_window_size": _METRIC_WINDOW_SIZE,
+            }
+
+    def _request_queued(self) -> None:
+        with self._metrics_lock:
+            self._requests_total += 1
+            self._waiting += 1
+            self._waiting_peak = max(self._waiting_peak, self._waiting)
+
+    def _request_cancelled_before_submit(self) -> None:
+        with self._metrics_lock:
+            self._render_cancelled_total += 1
+            self._waiting -= 1
+
+    def _request_rejected_after_close(self) -> None:
+        with self._metrics_lock:
+            self._waiting -= 1
+
+    def _job_submitted(self) -> None:
+        with self._metrics_lock:
+            self._submitted_total += 1
+            self._outstanding += 1
+            self._outstanding_peak = max(self._outstanding_peak, self._outstanding)
+
+    def _submission_failed(self) -> None:
+        with self._metrics_lock:
+            self._failed_total += 1
+            self._waiting -= 1
+            self._outstanding -= 1
+
+    def _request_cancelled_after_submit(self) -> None:
+        with self._metrics_lock:
+            self._render_cancelled_total += 1
+            self._discarded_total += 1
+
+    def _job_discarded_before_render(self, queue_wait_seconds: float) -> None:
+        with self._metrics_lock:
+            self._waiting -= 1
+            self._discarded_before_render_total += 1
+            self._queue_wait_ms.append(queue_wait_seconds * 1000.0)
+
+    def _job_started(self, queue_wait_seconds: float, started_at: float) -> None:
+        with self._metrics_lock:
+            self._waiting -= 1
+            self._active += 1
+            self._active_peak = max(self._active_peak, self._active)
+            self._active_started_at = started_at
+            self._queue_wait_ms.append(queue_wait_seconds * 1000.0)
+
+    def _job_finished(self, started_at: float, *, prompt_tokens: int | None = None, failed: bool = False) -> None:
+        finished_at = time.monotonic()
+        with self._metrics_lock:
+            self._active -= 1
+            self._active_started_at = None
+            self._busy_seconds += finished_at - started_at
+            self._completed_total += 1
+            self._failed_total += int(failed)
+            self._render_latency_ms.append((finished_at - started_at) * 1000.0)
+            if prompt_tokens is not None:
+                self._prompt_tokens.append(float(prompt_tokens))
+
+    def record_request_cancellation(self) -> None:
+        with self._metrics_lock:
+            self._request_cancelled_total += 1
+
+
+def _consume_future_exception(future: asyncio.Future) -> None:
+    if not future.cancelled():
+        future.exception()

--- a/tests/test_agent/test_adapter_tokenizer_worker.py
+++ b/tests/test_agent/test_adapter_tokenizer_worker.py
@@ -56,6 +56,21 @@ class _BlockingTokenizer(FakeTokenizer):
                 self.active -= 1
 
 
+class _DelayedCancellationSemaphore(asyncio.BoundedSemaphore):
+    def __init__(self, value: int) -> None:
+        super().__init__(value)
+        self.cancellation_started = asyncio.Event()
+        self.finish_cancellation = asyncio.Event()
+
+    async def acquire(self) -> bool:
+        try:
+            return await super().acquire()
+        except asyncio.CancelledError:
+            self.cancellation_started.set()
+            await self.finish_cancellation.wait()
+            raise
+
+
 class _Request:
     def __init__(self, sid: str, body: dict) -> None:
         self.headers = {"Authorization": f"Bearer {sid}"}
@@ -217,6 +232,9 @@ def test_cancel_during_admission_handoff_returns_the_permit():
 def test_repeated_cancellation_does_not_wait_for_admission():
     async def run_case():
         worker = TokenizerWorker(max_pending=1)
+        worker.bind_to_current_loop()
+        slots = _DelayedCancellationSemaphore(1)
+        worker._slots = slots
         release = threading.Event()
         started = threading.Event()
 
@@ -233,9 +251,14 @@ def test_repeated_cancellation_does_not_wait_for_admission():
 
         second.cancel()
         asyncio.get_running_loop().call_soon(second.cancel)
+        await asyncio.wait_for(slots.cancellation_started.wait(), timeout=0.1)
         with pytest.raises(asyncio.CancelledError):
             await asyncio.wait_for(asyncio.shield(second), timeout=0.1)
         assert not first.done()
+        assert worker._acquire_tasks
+
+        slots.finish_cancellation.set()
+        await _wait_until(lambda: not worker._acquire_tasks)
 
         release.set()
         assert await first == [1]

--- a/tests/test_agent/test_adapter_tokenizer_worker.py
+++ b/tests/test_agent/test_adapter_tokenizer_worker.py
@@ -214,6 +214,42 @@ def test_cancel_during_admission_handoff_returns_the_permit():
     assert metrics["worker"]["admission_waiters"] == 0
 
 
+def test_repeated_cancellation_does_not_wait_for_admission():
+    async def run_case():
+        worker = TokenizerWorker(max_pending=1)
+        release = threading.Event()
+        started = threading.Event()
+
+        def blocking_render() -> list[int]:
+            started.set()
+            if not release.wait(timeout=5):
+                raise TimeoutError("test render was not released")
+            return [1]
+
+        first = asyncio.create_task(worker.render(blocking_render))
+        await _wait_until(started.is_set)
+        second = asyncio.create_task(worker.render(lambda: [2]))
+        await _wait_until(lambda: len(worker._acquire_tasks) == 1)
+
+        second.cancel()
+        asyncio.get_running_loop().call_soon(second.cancel)
+        with pytest.raises(asyncio.CancelledError):
+            await asyncio.wait_for(asyncio.shield(second), timeout=0.1)
+        assert not first.done()
+
+        release.set()
+        assert await first == [1]
+        assert await asyncio.wait_for(worker.render(lambda: [3]), timeout=0.25) == [3]
+        metrics = worker.snapshot()
+        await worker.close()
+        return metrics
+
+    metrics = asyncio.run(run_case())
+    assert metrics["worker"]["outstanding"] == 0
+    assert metrics["worker"]["admission_waiters"] == 0
+    assert metrics["counters"]["render_cancelled_total"] == 1
+
+
 def test_client_cancellation_stays_cancelled_after_worker_is_marked_closed():
     async def run_case():
         worker = TokenizerWorker(max_pending=1)

--- a/tests/test_agent/test_adapter_tokenizer_worker.py
+++ b/tests/test_agent/test_adapter_tokenizer_worker.py
@@ -190,7 +190,12 @@ def test_cancel_during_admission_handoff_returns_the_permit():
         second = asyncio.create_task(worker.render(lambda: [2]))
         await _wait_until(lambda: len(worker._acquire_tasks) == 1)
         acquire_task = next(iter(worker._acquire_tasks))
-        acquire_task.add_done_callback(lambda _done: second.cancel())
+
+        def cancel_twice(_done) -> None:
+            second.cancel()
+            asyncio.get_running_loop().call_soon(second.cancel)
+
+        acquire_task.add_done_callback(cancel_twice)
 
         release.set()
         assert await first == [1]
@@ -207,6 +212,41 @@ def test_cancel_during_admission_handoff_returns_the_permit():
     metrics = asyncio.run(run_case())
     assert metrics["worker"]["outstanding"] == 0
     assert metrics["worker"]["admission_waiters"] == 0
+
+
+def test_client_cancellation_stays_cancelled_after_worker_is_marked_closed():
+    async def run_case():
+        worker = TokenizerWorker(max_pending=1)
+        release = threading.Event()
+        started = threading.Event()
+
+        def blocking_render() -> list[int]:
+            started.set()
+            if not release.wait(timeout=5):
+                raise TimeoutError("test render was not released")
+            return [1]
+
+        first = asyncio.create_task(worker.render(blocking_render))
+        await _wait_until(started.is_set)
+        second = asyncio.create_task(worker.render(lambda: [2]))
+        await _wait_until(lambda: len(worker._acquire_tasks) == 1)
+
+        # Python 3.10 has no Task.cancelling(). Cancellation ownership is
+        # determined by the worker's explicit close marker, not its closed flag.
+        worker._closed = True
+        second.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await second
+
+        release.set()
+        assert await first == [1]
+        await worker.close()
+        return worker.snapshot()
+
+    metrics = asyncio.run(run_case())
+    assert metrics["worker"]["outstanding"] == 0
+    assert metrics["worker"]["admission_waiters"] == 0
+    assert metrics["counters"]["render_cancelled_total"] == 1
 
 
 def test_close_is_cancellation_safe_and_drains_admission_waiters():

--- a/tests/test_agent/test_adapter_tokenizer_worker.py
+++ b/tests/test_agent/test_adapter_tokenizer_worker.py
@@ -1,0 +1,373 @@
+"""CPU tests for bounded, cancellation-safe adapter prompt rendering."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import threading
+import time
+from functools import partial
+from pathlib import Path
+
+import pytest
+from aiohttp.test_utils import TestClient, TestServer
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from tests.test_agent._fakes import FakeSGLangServer, FakeTokenizer  # noqa: E402
+
+from slime.agent.adapters import anthropic  # noqa: E402
+from slime.agent.adapters import common as adapters_common  # noqa: E402
+from slime.agent.adapters.common import _render_token_ids  # noqa: E402
+from slime.agent.adapters.tokenizer_worker import TokenizerWorker  # noqa: E402
+
+NUM_GPUS = 0
+
+
+class _BlockingTokenizer(FakeTokenizer):
+    def __init__(self, release: threading.Event, *, outputs=None) -> None:
+        super().__init__(outputs=outputs)
+        self.release = release
+        self.started = threading.Event()
+        self._lock = threading.Lock()
+        self.calls = 0
+        self.active = 0
+        self.peak_active = 0
+
+    def apply_chat_template(self, messages, tools=None, tokenize=True, add_generation_prompt=True):
+        with self._lock:
+            self.calls += 1
+            self.active += 1
+            self.peak_active = max(self.peak_active, self.active)
+        self.started.set()
+        if not self.release.wait(timeout=5):
+            raise TimeoutError("test tokenizer was not released")
+        try:
+            return super().apply_chat_template(
+                messages,
+                tools=tools,
+                tokenize=tokenize,
+                add_generation_prompt=add_generation_prompt,
+            )
+        finally:
+            with self._lock:
+                self.active -= 1
+
+
+class _Request:
+    def __init__(self, sid: str, body: dict) -> None:
+        self.headers = {"Authorization": f"Bearer {sid}"}
+        self._body = body
+
+    async def json(self) -> dict:
+        return self._body
+
+
+async def _wait_until(predicate, *, timeout: float = 2.0) -> None:
+    deadline = time.monotonic() + timeout
+    while not predicate():
+        if time.monotonic() >= deadline:
+            raise AssertionError("condition was not reached before timeout")
+        await asyncio.sleep(0.005)
+
+
+@pytest.mark.parametrize(
+    ("messages", "tools"),
+    [
+        ([{"role": "user", "content": "hello"}], None),
+        (
+            [
+                {"role": "system", "content": "be precise"},
+                {"role": "user", "content": "look up slime"},
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [{"type": "function", "function": {"name": "lookup", "arguments": {"q": "slime"}}}],
+                },
+                {"role": "tool", "content": "found"},
+            ],
+            [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "lookup",
+                        "description": "search",
+                        "parameters": {"type": "object"},
+                    },
+                }
+            ],
+        ),
+        (
+            [
+                {"role": "user", "content": "compacted context"},
+                {"role": "assistant", "content": "re-rendered answer"},
+                {"role": "user", "content": "retry from this branch"},
+            ],
+            None,
+        ),
+    ],
+)
+def test_worker_render_matches_synchronous_full_history(messages, tools):
+    async def run_case():
+        tokenizer = FakeTokenizer()
+        expected = _render_token_ids(messages, tokenizer, tools=tools)
+        worker = TokenizerWorker(max_pending=2)
+        try:
+            actual = await worker.render(partial(_render_token_ids, messages, tokenizer, tools=tools))
+        finally:
+            await worker.close()
+        return expected, actual, tokenizer.rendered
+
+    expected, actual, rendered = asyncio.run(run_case())
+    assert actual == expected
+    assert rendered == [(messages, tools), (messages, tools)]
+
+
+def test_worker_bounds_submitted_work_across_cancellation():
+    async def run_case():
+        worker = TokenizerWorker(max_pending=2)
+        release = threading.Event()
+        started = threading.Event()
+        calls = 0
+
+        def blocking_render() -> list[int]:
+            nonlocal calls
+            calls += 1
+            started.set()
+            if not release.wait(timeout=5):
+                raise TimeoutError("test render was not released")
+            return [1, 2, 3]
+
+        tasks = [asyncio.create_task(worker.render(blocking_render)) for _ in range(6)]
+        await _wait_until(lambda: started.is_set() and worker.snapshot()["counters"]["requests_total"] == 6)
+        before_cancel = worker.snapshot()
+        assert before_cancel["worker"]["active"] == 1
+        assert before_cancel["worker"]["outstanding"] == 2
+        assert before_cancel["worker"]["admission_waiters"] == 4
+
+        for task in tasks:
+            task.cancel()
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+        assert all(isinstance(result, asyncio.CancelledError) for result in results)
+
+        # The running and executor-queued jobs still hold their permits until
+        # they physically finish/dequeue, even though their callers are gone.
+        after_cancel = worker.snapshot()
+        assert after_cancel["worker"]["outstanding"] == 2
+        assert after_cancel["worker"]["outstanding_peak"] == 2
+        assert calls == 1
+
+        release.set()
+        await _wait_until(lambda: worker.snapshot()["worker"]["outstanding"] == 0)
+        final = worker.snapshot()
+        await worker.close()
+        return calls, final
+
+    calls, metrics = asyncio.run(run_case())
+    assert calls == 1
+    assert metrics["worker"]["active_peak"] == 1
+    assert metrics["counters"]["render_cancelled_total"] == 6
+    assert metrics["counters"]["discarded_total"] == 2
+    assert metrics["counters"]["discarded_before_render_total"] == 1
+
+
+def test_cancel_during_admission_handoff_returns_the_permit():
+    async def run_case():
+        worker = TokenizerWorker(max_pending=1)
+        release = threading.Event()
+        started = threading.Event()
+
+        def blocking_render() -> list[int]:
+            started.set()
+            if not release.wait(timeout=5):
+                raise TimeoutError("test render was not released")
+            return [1]
+
+        first = asyncio.create_task(worker.render(blocking_render))
+        await _wait_until(started.is_set)
+        second = asyncio.create_task(worker.render(lambda: [2]))
+        await _wait_until(lambda: len(worker._acquire_tasks) == 1)
+        acquire_task = next(iter(worker._acquire_tasks))
+        acquire_task.add_done_callback(lambda _done: second.cancel())
+
+        release.set()
+        assert await first == [1]
+        with pytest.raises(asyncio.CancelledError):
+            await second
+
+        # A fresh render proves the handoff race did not permanently consume
+        # the worker's only permit.
+        assert await asyncio.wait_for(worker.render(lambda: [3]), timeout=0.25) == [3]
+        metrics = worker.snapshot()
+        await worker.close()
+        return metrics
+
+    metrics = asyncio.run(run_case())
+    assert metrics["worker"]["outstanding"] == 0
+    assert metrics["worker"]["admission_waiters"] == 0
+
+
+def test_close_is_cancellation_safe_and_drains_admission_waiters():
+    async def run_case():
+        worker = TokenizerWorker(max_pending=1)
+        release = threading.Event()
+        started = threading.Event()
+
+        def blocking_render() -> list[int]:
+            started.set()
+            if not release.wait(timeout=5):
+                raise TimeoutError("test render was not released")
+            return [1]
+
+        render_tasks = [asyncio.create_task(worker.render(blocking_render)) for _ in range(5)]
+        await _wait_until(lambda: started.is_set() and worker.snapshot()["worker"]["admission_waiters"] == 4)
+        threads = list(worker._executor._threads)
+
+        first_close = asyncio.create_task(worker.close())
+        await _wait_until(lambda: all(task.done() for task in render_tasks[1:]))
+        first_close.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await first_close
+
+        second_close = asyncio.create_task(worker.close())
+        await asyncio.sleep(0)
+        assert not second_close.done()
+        release.set()
+        results = await asyncio.gather(*render_tasks, return_exceptions=True)
+        await second_close
+        await worker.close()
+        return results, threads, worker.snapshot()
+
+    results, threads, metrics = asyncio.run(run_case())
+    assert results[0] == [1]
+    assert all(isinstance(result, RuntimeError) for result in results[1:])
+    assert all(not thread.is_alive() for thread in threads)
+    assert metrics["worker"]["outstanding"] == 0
+    assert metrics["worker"]["active"] == 0
+    assert metrics["worker"]["admission_waiters"] == 0
+
+
+def test_prompt_metrics_report_percentiles_from_bounded_window():
+    async def run_case():
+        worker = TokenizerWorker()
+        try:
+            for length in (1, 2, 3, 4):
+                await worker.render(lambda length=length: list(range(length)))
+            return worker.snapshot()
+        finally:
+            await worker.close()
+
+    metrics = asyncio.run(run_case())
+    prompt = metrics["prompt_tokens"]
+    assert prompt == {
+        "count": 4,
+        "mean": 2.5,
+        "max": 4.0,
+        "p50": 2.5,
+        "p95": pytest.approx(3.85),
+        "p99": pytest.approx(3.97),
+    }
+    assert metrics["render_latency_ms"]["count"] == 4
+    assert metrics["queue_wait_ms"]["count"] == 4
+    assert 0 <= metrics["worker"]["utilization"] <= 1
+
+
+def test_slow_render_keeps_health_and_metrics_responsive():
+    async def run_case():
+        release = threading.Event()
+        tokenizer = _BlockingTokenizer(release, outputs={(901,): "done"})
+        async with FakeSGLangServer([[(-0.1, 901)]]) as sglang:
+            adapter = anthropic.AnthropicAdapter(
+                tokenizer=tokenizer,
+                sglang_url=sglang.url,
+                event_loop_lag_interval_seconds=0.005,
+            )
+            client = TestClient(TestServer(adapter.app))
+            await client.start_server()
+            try:
+                post_task = asyncio.create_task(
+                    client.post(
+                        "/v1/messages",
+                        headers={"Authorization": "Bearer responsive"},
+                        json={"model": "m", "messages": [{"role": "user", "content": "hello"}]},
+                    )
+                )
+                await _wait_until(tokenizer.started.is_set)
+
+                started_at = time.monotonic()
+                health = await asyncio.wait_for(client.get("/healthz"), timeout=0.25)
+                assert health.status == 200
+                assert time.monotonic() - started_at < 0.25
+
+                await asyncio.sleep(0.015)
+                metrics_response = await asyncio.wait_for(client.get("/debug/adapter_metrics"), timeout=0.25)
+                metrics = await metrics_response.json()
+                assert metrics["tokenizer"]["worker"]["active"] == 1
+                assert metrics["tokenizer"]["event_loop_lag_ms"]["count"] > 0
+
+                release.set()
+                response = await asyncio.wait_for(post_task, timeout=1)
+                assert response.status == 200
+                await response.read()
+            finally:
+                release.set()
+                await client.close()
+
+        return adapter, sglang
+
+    adapter, sglang = asyncio.run(run_case())
+    assert sglang.requests[0]["input_ids"]
+    assert adapter._tokenizer_worker.closed
+
+
+def test_cancelled_render_never_calls_sglang_or_writes_session(monkeypatch):
+    async def run_case():
+        release = threading.Event()
+        tokenizer = _BlockingTokenizer(release)
+        adapter = anthropic.AnthropicAdapter(
+            tokenizer=tokenizer,
+            sglang_url="http://unused",
+            max_turns_per_sid=1,
+        )
+        sglang_calls: list[list[int]] = []
+
+        async def fake_generate(prompt_ids, session, body, *, adapter, session_id=None):
+            sglang_calls.append(list(prompt_ids))
+            raise AssertionError("cancelled render reached SGLang")
+
+        monkeypatch.setattr(adapters_common, "call_sglang_generate", fake_generate)
+        sid = "cancelled"
+        request = _Request(sid, {"model": "m", "messages": [{"role": "user", "content": "slow"}]})
+        turn_task = asyncio.create_task(adapter._run_turn(request))
+        await _wait_until(tokenizer.started.is_set)
+        turn_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await turn_task
+
+        assert sglang_calls == []
+        assert sid not in adapter.store
+        assert adapter.manager.turn_count(sid) == 0
+        assert not adapter.inflight.get(sid)
+        assert sid not in adapter._sid_turn_count
+
+        release.set()
+        await _wait_until(lambda: adapter.metrics_snapshot()["tokenizer"]["worker"]["outstanding"] == 0)
+        await asyncio.sleep(0)
+        assert sglang_calls == []
+        assert sid not in adapter.store
+        assert adapter.manager.turn_count(sid) == 0
+        metrics = adapter.metrics_snapshot()["tokenizer"]
+        await adapter._tokenizer_worker.close()
+        return sglang_calls, metrics
+
+    sglang_calls, metrics = asyncio.run(run_case())
+    assert sglang_calls == []
+    assert metrics["counters"]["request_cancelled_total"] == 1
+    assert metrics["counters"]["render_cancelled_total"] == 1
+    assert metrics["counters"]["discarded_total"] == 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary

- keep full-history `apply_chat_template(..., tokenize=True)` as the prompt-ID source of truth
- run prompt rendering on a single-thread, adapter-owned executor with a hard bound on submitted work; excess callers wait outside the executor queue
- retain capacity until the underlying future physically completes, skip canceled queued renders, and prevent canceled renders from reaching SGLang or creating session/trajectory state
- expose bounded recent-window metrics at `GET /debug/adapter_metrics` for prompt length, render latency, queue wait, worker utilization, event-loop lag, cancellations, and discarded work, including P50/P95/P99 distributions
- add CPU coverage for prompt-ID identity, event-loop responsiveness, admission bounds, repeated-cancellation races, and cleanup lifecycle

## Scope

This is an event-loop isolation and observability improvement. It deliberately keeps full-history rendering as the conservative fallback and does not claim to remove the cumulative O(N^2) tokenization cost. It remains orthogonal to the Qwen-specific append-only work in #2287.

Related to #2285.

## Validation

- `python -m pytest -q tests/test_agent`: 75 passed, 1 skipped
- registered direct CPU test: 11 passed
- repeated cancellation while admission is blocked returns within a bounded timeout and preserves the next permit
- Python 3.10-compatible cleanup/admission cancellation path, with no `Task.cancelling()` dependency
- Ruff, Black, isort, compileall, workflow regeneration, YAML parsing, and `git diff --check` passed
