### PR TITLE
Order pipeline weight-update process groups across rollout engines

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -587,6 +587,10 @@ jobs:
             },
             {
               "num_gpus": 0,
+              "test_file": "test_weight_update_group_ordering.py"
+            },
+            {
+              "num_gpus": 0,
               "test_file": "utils/test_megatron_role_config.py"
             },
             {

--- a/.github/workflows/pr-test.yml.j2
+++ b/.github/workflows/pr-test.yml.j2
@@ -72,6 +72,7 @@
       'extra_pip_deps': 'transformers wandb',
       'tests': [
         {'test_file': 'test_megatron_argument_validation.py', 'num_gpus': 0},
+        {'test_file': 'test_weight_update_group_ordering.py', 'num_gpus': 0},
         {'test_file': 'utils/test_megatron_role_config.py', 'num_gpus': 0},
         {'test_file': 'test_deep_ep_tms_patch.py', 'num_gpus': 0},
         {'test_file': 'test_stateless_adam.py', 'num_gpus': 0},

--- a/slime/backends/megatron_utils/update_weight/update_weight_from_distributed.py
+++ b/slime/backends/megatron_utils/update_weight/update_weight_from_distributed.py
@@ -4,6 +4,7 @@ import socket
 import time
 from argparse import Namespace
 from collections.abc import Callable, Iterator, Mapping, Sequence
+from datetime import timedelta
 
 import ray
 import torch
@@ -64,7 +65,14 @@ class UpdateWeightFromDistributed:
         engine_parallel_configs: Sequence[Mapping[str, object]] | None = None,
     ) -> None:
         """
-        Create "slime-pp_{pp_rank}" if PP source (DP=TP=0). Lock prevents concurrent transfers.
+        Create "slime-pp_{pp_rank}" if PP source (DP=TP=0).
+
+        Every training rank walks the PP ranks in the same order. This is
+        required because each synchronous rollout-engine actor blocks while
+        its SGLang server joins the requested process group. If two PP sources
+        submit groups concurrently, different engine actors can start them in
+        opposite orders and neither actor can service the request needed by
+        the other group.
         """
         self.rollout_engines = rollout_engines
         self.rollout_engine_lock = rollout_engine_lock
@@ -80,23 +88,57 @@ class UpdateWeightFromDistributed:
         if self._is_pp_src_rank:
             self._group_name = f"slime-pp_{pp_rank}"
 
-        if self._is_pp_src_rank:
-            if self._model_update_groups is not None:
-                disconnect_rollout_engines_from_distributed(
-                    self._group_name, self._model_update_groups, self.rollout_engines
-                )
-            self._model_update_groups = connect_rollout_engines_from_distributed(
-                self.args,
-                self._group_name,
-                rollout_engines,
-                engine_gpu_counts=engine_gpu_counts,
-            )
+        for current_pp_rank in range(mpu.get_pipeline_model_parallel_world_size()):
+            error = None
+            if self._is_pp_src_rank and pp_rank == current_pp_rank:
+                try:
+                    if self._model_update_groups is not None:
+                        disconnect_rollout_engines_from_distributed(
+                            self._group_name,
+                            self._model_update_groups,
+                            self.rollout_engines,
+                        )
+                        self._model_update_groups = None
+                    self._model_update_groups = connect_rollout_engines_from_distributed(
+                        self.args,
+                        self._group_name,
+                        rollout_engines,
+                        engine_gpu_counts=engine_gpu_counts,
+                    )
+                except BaseException as exc:
+                    error = exc
+            self._raise_on_ordered_phase_error(error, "connect", current_pp_rank)
 
     def disconnect_rollout_engines(self) -> None:
-        if not getattr(self, "_is_pp_src_rank", False) or self._model_update_groups is None:
+        pp_rank = mpu.get_pipeline_model_parallel_rank()
+        for current_pp_rank in range(mpu.get_pipeline_model_parallel_world_size()):
+            error = None
+            if (
+                getattr(self, "_is_pp_src_rank", False)
+                and pp_rank == current_pp_rank
+                and self._model_update_groups is not None
+            ):
+                try:
+                    disconnect_rollout_engines_from_distributed(
+                        self._group_name,
+                        self._model_update_groups,
+                        self.rollout_engines,
+                    )
+                    self._model_update_groups = None
+                except BaseException as exc:
+                    error = exc
+            self._raise_on_ordered_phase_error(error, "disconnect", current_pp_rank)
+
+    @staticmethod
+    def _raise_on_ordered_phase_error(error: BaseException | None, operation: str, pp_rank: int) -> None:
+        """Keep every training rank on the same ordered phase, including failures."""
+        failed = torch.tensor([error is not None], dtype=torch.uint8)
+        dist.all_reduce(failed, op=dist.ReduceOp.MAX, group=get_gloo_group())
+        if not failed.item():
             return
-        disconnect_rollout_engines_from_distributed(self._group_name, self._model_update_groups, self.rollout_engines)
-        self._model_update_groups = None
+        if error is not None:
+            raise error
+        raise RuntimeError(f"weight-update group {operation} failed on pipeline rank {pp_rank}")
 
     @torch.no_grad()
     def update_weights(self) -> None:
@@ -219,7 +261,12 @@ class UpdateWeightFromDistributed:
                 torch.empty_like(param.data, device=accelerator.current_device())
                 for _ in range(mpu.get_expert_model_parallel_world_size())
             ]
-            handle = dist.all_gather(params, param.data, group=mpu.get_expert_model_parallel_group(), async_op=True)
+            handle = dist.all_gather(
+                params,
+                param.data,
+                group=mpu.get_expert_model_parallel_group(),
+                async_op=True,
+            )
             handles.append(handle)
             for ep_rank, names in enumerate(all_names):
                 all_gathered_params[ep_rank].append((names[i], params[ep_rank]))
@@ -249,18 +296,19 @@ class UpdateWeightFromDistributed:
         while not ray.get(self.rollout_engine_lock.acquire.remote()):
             time.sleep(0.1)
 
-        refs = update_weights_from_distributed(
-            self._group_name,
-            self._model_update_groups,
-            self.weight_version,
-            self.rollout_engines,
-            converted_named_tensors,
-            load_format=load_format,
-        )
-
-        ray.get(refs)
-        converted_named_tensors.clear()
-        ray.get(self.rollout_engine_lock.release.remote())
+        try:
+            refs = update_weights_from_distributed(
+                self._group_name,
+                self._model_update_groups,
+                self.weight_version,
+                self.rollout_engines,
+                converted_named_tensors,
+                load_format=load_format,
+            )
+            ray.get(refs)
+            converted_named_tensors.clear()
+        finally:
+            ray.get(self.rollout_engine_lock.release.remote())
         pbar.update(1)
 
 
@@ -292,6 +340,13 @@ def connect_rollout_engines_from_distributed(
         cumulative.append(cumulative[-1] + c)
 
     backend = accelerator.weight_update_backend()
+    timeout_seconds = getattr(
+        args,
+        "update_weight_group_timeout_seconds",
+        getattr(args, "distributed_timeout_minutes", 5.0) * 60,
+    )
+    if timeout_seconds <= 0:
+        raise ValueError("weight-update group timeout must be greater than zero")
     refs = [
         engine.init_weights_update_group.remote(
             master_address=master_address,
@@ -303,15 +358,39 @@ def connect_rollout_engines_from_distributed(
         )
         for i, engine in enumerate(rollout_engines)
     ]
-    model_update_groups = init_process_group(
-        backend=backend,
-        init_method=f"tcp://{_wrap_ipv6(master_address)}:{master_port}",
-        world_size=world_size,
-        rank=0,
-        group_name=group_name,
-    )
-    ray.get(refs)
-    return model_update_groups
+    model_update_groups = None
+    try:
+        model_update_groups = init_process_group(
+            backend=backend,
+            init_method=f"tcp://{_wrap_ipv6(master_address)}:{master_port}",
+            world_size=world_size,
+            rank=0,
+            group_name=group_name,
+            timeout=timedelta(seconds=timeout_seconds),
+        )
+        ray.get(refs, timeout=timeout_seconds)
+        return model_update_groups
+    except BaseException:
+        for ref in refs:
+            try:
+                ray.cancel(ref, force=False)
+            except Exception:
+                pass
+        if model_update_groups is not None:
+            try:
+                dist.destroy_process_group(model_update_groups)
+            except Exception:
+                pass
+        # A synchronous engine actor can remain blocked inside SGLang's group
+        # join and cannot service a queued destroy request. Terminate only the
+        # actors associated with this failed group so Ray also reaps their
+        # server subprocesses.
+        for engine in rollout_engines:
+            try:
+                ray.kill(engine, no_restart=True)
+            except Exception:
+                pass
+        raise
 
 
 def disconnect_rollout_engines_from_distributed(group_name, model_update_groups, rollout_engines):

--- a/tests/test_weight_update_group_ordering.py
+++ b/tests/test_weight_update_group_ordering.py
@@ -7,6 +7,9 @@ import pytest
 from slime.backends.megatron_utils.update_weight import update_weight_from_distributed as update_module
 
 
+NUM_GPUS = 0
+
+
 class _OppositeArrivalScheduler:
     """Model two serial engine actors choosing opposite first requests."""
 
@@ -248,3 +251,7 @@ def test_failed_reconnect_does_not_retain_destroyed_group(monkeypatch):
 
     assert disconnected == [("slime-pp_0", old_group, ("engine-0",))]
     assert updater._model_update_groups is None
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__]))

--- a/tests/test_weight_update_group_ordering.py
+++ b/tests/test_weight_update_group_ordering.py
@@ -1,0 +1,250 @@
+import threading
+from datetime import timedelta
+from types import SimpleNamespace
+
+import pytest
+
+from slime.backends.megatron_utils.update_weight import update_weight_from_distributed as update_module
+
+
+class _OppositeArrivalScheduler:
+    """Model two serial engine actors choosing opposite first requests."""
+
+    def __init__(self):
+        self._condition = threading.Condition()
+        self._groups = []
+        self._ordered_phase_started = False
+        self._release_deadlock = threading.Event()
+        self.cycle_observed = False
+
+    @property
+    def groups(self):
+        with self._condition:
+            return list(self._groups)
+
+    def ordered_phase_started(self):
+        with self._condition:
+            self._ordered_phase_started = True
+            self._condition.notify_all()
+
+    def connect(self, _args, group_name, _engines, engine_gpu_counts=None):
+        del engine_gpu_counts
+        with self._condition:
+            self._groups.append(group_name)
+            self._condition.notify_all()
+            self._condition.wait_for(lambda: self._ordered_phase_started or len(self._groups) == 2)
+            if not self._ordered_phase_started and len(self._groups) == 2:
+                # Engine 0 starts PP0 while engine 1 starts PP1. Both serial
+                # actors are now blocked in different process-group joins.
+                self.cycle_observed = True
+
+        if self.cycle_observed:
+            self._release_deadlock.wait()
+        return object()
+
+    def release(self):
+        self._release_deadlock.set()
+
+
+def test_pp_weight_update_groups_are_connected_in_global_order(monkeypatch):
+    scheduler = _OppositeArrivalScheduler()
+    train_barrier = threading.Barrier(2)
+    rank_context = threading.local()
+
+    monkeypatch.setattr(
+        update_module.mpu,
+        "get_data_parallel_rank",
+        lambda with_context_parallel=True: 0,
+    )
+    monkeypatch.setattr(update_module.mpu, "get_tensor_model_parallel_rank", lambda: 0)
+    monkeypatch.setattr(
+        update_module.mpu,
+        "get_pipeline_model_parallel_rank",
+        lambda: rank_context.pp_rank,
+    )
+    monkeypatch.setattr(update_module.mpu, "get_pipeline_model_parallel_world_size", lambda: 2)
+    monkeypatch.setattr(update_module, "connect_rollout_engines_from_distributed", scheduler.connect)
+    monkeypatch.setattr(update_module, "get_gloo_group", lambda: object())
+
+    def all_reduce(failed, *, op, group):
+        del failed, op
+        del group
+        scheduler.ordered_phase_started()
+        train_barrier.wait(timeout=2)
+
+    monkeypatch.setattr(update_module.dist, "all_reduce", all_reduce)
+
+    updaters = []
+    for _ in range(2):
+        updater = update_module.UpdateWeightFromDistributed.__new__(update_module.UpdateWeightFromDistributed)
+        updater.args = SimpleNamespace(rollout_num_gpus_per_engine=1)
+        updater._model_update_groups = None
+        updaters.append(updater)
+
+    errors = []
+
+    def connect(pp_rank):
+        rank_context.pp_rank = pp_rank
+        try:
+            updaters[pp_rank].connect_rollout_engines(
+                rollout_engines=("engine-0", "engine-1"),
+                rollout_engine_lock=object(),
+                engine_gpu_counts=(1, 1),
+            )
+        except BaseException as exc:  # surface worker-thread failures in the test thread
+            errors.append(exc)
+
+    threads = [threading.Thread(target=connect, args=(rank,), daemon=True) for rank in range(2)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=1)
+
+    stuck = [thread.is_alive() for thread in threads]
+    scheduler.release()
+    for thread in threads:
+        thread.join(timeout=2)
+
+    assert not errors
+    assert not any(stuck), "opposite engine arrival order formed a PP0/PP1 connection cycle"
+    assert not scheduler.cycle_observed
+    assert scheduler.groups == ["slime-pp_0", "slime-pp_1"]
+
+
+class _RemoteMethod:
+    def __init__(self, ref):
+        self.ref = ref
+
+    def remote(self, **_kwargs):
+        return self.ref
+
+
+class _Engine:
+    def __init__(self, ref):
+        self.init_weights_update_group = _RemoteMethod(ref)
+
+
+class _Lock:
+    def __init__(self):
+        self.acquire = _RemoteMethod(True)
+        self.release = _RemoteMethod(None)
+
+
+def test_failed_group_join_cancels_refs_and_kills_associated_engines(monkeypatch):
+    engines = [_Engine("ref-0"), _Engine("ref-1")]
+    cancelled = []
+    killed = []
+
+    class _Socket:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return None
+
+        def bind(self, _address):
+            return None
+
+        def getsockname(self):
+            return "127.0.0.1", 12345
+
+    monkeypatch.setattr(update_module.socket, "socket", _Socket)
+    monkeypatch.setattr(update_module.ray._private.services, "get_node_ip_address", lambda: "127.0.0.1")
+    monkeypatch.setattr(update_module.accelerator, "weight_update_backend", lambda: "nccl")
+
+    def fail_group_creation(**kwargs):
+        assert kwargs["timeout"] == timedelta(seconds=0.25)
+        raise RuntimeError("injected group-join failure")
+
+    monkeypatch.setattr(update_module, "init_process_group", fail_group_creation)
+    monkeypatch.setattr(update_module.ray, "cancel", lambda ref, force: cancelled.append((ref, force)))
+    monkeypatch.setattr(
+        update_module.ray,
+        "kill",
+        lambda engine, no_restart: killed.append((engine, no_restart)),
+    )
+
+    args = SimpleNamespace(
+        rollout_num_gpus_per_engine=1,
+        update_weight_group_timeout_seconds=0.25,
+    )
+    with pytest.raises(RuntimeError, match="injected group-join failure"):
+        update_module.connect_rollout_engines_from_distributed(
+            args,
+            "slime-pp_0",
+            engines,
+            engine_gpu_counts=(1, 1),
+        )
+
+    assert cancelled == [("ref-0", False), ("ref-1", False)]
+    assert killed == [(engines[0], True), (engines[1], True)]
+
+
+def test_transfer_failure_releases_rollout_engine_lock(monkeypatch):
+    released = []
+    lock = _Lock()
+    lock.release.remote = lambda: released.append(True)
+
+    def get(refs, **_kwargs):
+        if refs == "transfer-ref":
+            raise RuntimeError("injected transfer failure")
+        return refs
+
+    monkeypatch.setattr(update_module.ray, "get", get)
+    monkeypatch.setattr(
+        update_module,
+        "update_weights_from_distributed",
+        lambda *_args, **_kwargs: "transfer-ref",
+    )
+
+    updater = update_module.UpdateWeightFromDistributed.__new__(update_module.UpdateWeightFromDistributed)
+    updater.rollout_engine_lock = lock
+    updater.rollout_engines = ()
+    updater._group_name = "slime-pp_0"
+    updater._model_update_groups = object()
+    updater.weight_version = 1
+
+    with pytest.raises(RuntimeError, match="injected transfer failure"):
+        updater._update_bucket_weights_from_distributed([("weight", object())])
+
+    assert released == [True]
+
+
+def test_failed_reconnect_does_not_retain_destroyed_group(monkeypatch):
+    old_group = object()
+    disconnected = []
+
+    monkeypatch.setattr(
+        update_module.mpu,
+        "get_data_parallel_rank",
+        lambda with_context_parallel=True: 0,
+    )
+    monkeypatch.setattr(update_module.mpu, "get_tensor_model_parallel_rank", lambda: 0)
+    monkeypatch.setattr(update_module.mpu, "get_pipeline_model_parallel_rank", lambda: 0)
+    monkeypatch.setattr(update_module.mpu, "get_pipeline_model_parallel_world_size", lambda: 1)
+    monkeypatch.setattr(update_module, "get_gloo_group", lambda: object())
+    monkeypatch.setattr(update_module.dist, "all_reduce", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        update_module,
+        "disconnect_rollout_engines_from_distributed",
+        lambda name, group, engines: disconnected.append((name, group, engines)),
+    )
+
+    def fail_connect(*_args, **_kwargs):
+        raise RuntimeError("injected reconnect failure")
+
+    monkeypatch.setattr(update_module, "connect_rollout_engines_from_distributed", fail_connect)
+
+    updater = update_module.UpdateWeightFromDistributed.__new__(update_module.UpdateWeightFromDistributed)
+    updater.args = SimpleNamespace(rollout_num_gpus_per_engine=1)
+    updater._model_update_groups = old_group
+
+    with pytest.raises(RuntimeError, match="injected reconnect failure"):
+        updater.connect_rollout_engines(
+            rollout_engines=("engine-0",),
+            rollout_engine_lock=object(),
+            engine_gpu_counts=(1,),
+        )
+
+    assert disconnected == [("slime-pp_0", old_group, ("engine-0",))]
+    assert updater._model_update_groups is None

--- a/tests/test_weight_update_group_ordering.py
+++ b/tests/test_weight_update_group_ordering.py
@@ -1,13 +1,54 @@
+import importlib.util
+import sys
 import threading
+import types
 from datetime import timedelta
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
 
-from slime.backends.megatron_utils.update_weight import update_weight_from_distributed as update_module
-
-
 NUM_GPUS = 0
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+
+@pytest.fixture
+def update_module(monkeypatch):
+    """Load the orchestration module without requiring Megatron in CPU CI."""
+    megatron_mod = types.ModuleType("megatron")
+    megatron_core_mod = types.ModuleType("megatron.core")
+    mpu_mod = types.ModuleType("megatron.core.mpu")
+    mpu_mod.get_data_parallel_rank = lambda with_context_parallel=True: 0
+    mpu_mod.get_tensor_model_parallel_rank = lambda: 0
+    mpu_mod.get_pipeline_model_parallel_rank = lambda: 0
+    mpu_mod.get_pipeline_model_parallel_world_size = lambda: 1
+    megatron_core_mod.mpu = mpu_mod
+    megatron_mod.core = megatron_core_mod
+
+    megatron_to_hf_mod = types.ModuleType("slime.backends.megatron_utils.megatron_to_hf")
+    megatron_to_hf_mod.convert_to_hf = lambda *args, **kwargs: []
+    common_mod = types.ModuleType("slime.backends.megatron_utils.update_weight.common")
+    common_mod.all_gather_param = lambda _name, param: param
+    common_mod.named_params_and_buffers = lambda _args, _model: ()
+
+    monkeypatch.setitem(sys.modules, "megatron", megatron_mod)
+    monkeypatch.setitem(sys.modules, "megatron.core", megatron_core_mod)
+    monkeypatch.setitem(sys.modules, "megatron.core.mpu", mpu_mod)
+    monkeypatch.setitem(sys.modules, "slime.backends.megatron_utils.megatron_to_hf", megatron_to_hf_mod)
+    monkeypatch.setitem(sys.modules, "slime.backends.megatron_utils.update_weight.common", common_mod)
+
+    module_name = "slime.backends.megatron_utils.update_weight.update_weight_from_distributed_cpu_test"
+    module_path = (
+        REPO_ROOT / "slime" / "backends" / "megatron_utils" / "update_weight" / "update_weight_from_distributed.py"
+    )
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, module_name, module)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
 
 
 class _OppositeArrivalScheduler:
@@ -49,7 +90,7 @@ class _OppositeArrivalScheduler:
         self._release_deadlock.set()
 
 
-def test_pp_weight_update_groups_are_connected_in_global_order(monkeypatch):
+def test_pp_weight_update_groups_are_connected_in_global_order(monkeypatch, update_module):
     scheduler = _OppositeArrivalScheduler()
     train_barrier = threading.Barrier(2)
     rank_context = threading.local()
@@ -133,7 +174,7 @@ class _Lock:
         self.release = _RemoteMethod(None)
 
 
-def test_failed_group_join_cancels_refs_and_kills_associated_engines(monkeypatch):
+def test_failed_group_join_cancels_refs_and_kills_associated_engines(monkeypatch, update_module):
     engines = [_Engine("ref-0"), _Engine("ref-1")]
     cancelled = []
     killed = []
@@ -183,7 +224,7 @@ def test_failed_group_join_cancels_refs_and_kills_associated_engines(monkeypatch
     assert killed == [(engines[0], True), (engines[1], True)]
 
 
-def test_transfer_failure_releases_rollout_engine_lock(monkeypatch):
+def test_transfer_failure_releases_rollout_engine_lock(monkeypatch, update_module):
     released = []
     lock = _Lock()
     lock.release.remote = lambda: released.append(True)
@@ -213,7 +254,7 @@ def test_transfer_failure_releases_rollout_engine_lock(monkeypatch):
     assert released == [True]
 
 
-def test_failed_reconnect_does_not_retain_destroyed_group(monkeypatch):
+def test_failed_reconnect_does_not_retain_destroyed_group(monkeypatch, update_module):
     old_group = object()
     disconnected = []
 


### PR DESCRIPTION
## Problem

In non-colocated full NCCL weight updates with pipeline-parallel training and multiple independent SGLang rollout engines, each PP source creates a custom `slime-pp_<rank>` group containing itself and every engine GPU.

The PP sources are Ray actors invoked concurrently. Each rollout-engine actor uses a blocking HTTP call to join a group and processes methods serially. If engine 0 starts PP0 while engine 1 starts PP1, each group waits for the request queued behind the other engine's blocking call. The existing rollout-engine lock only covers later broadcasts, so it cannot prevent this group-creation cycle.

## Fix

- Have all training ranks execute connect/disconnect phases in global PP-rank order.
- In phase `k`, only the DP=0/TP=0 source for PP rank `k` creates or destroys its device group.
- Use the existing all-training-rank Gloo group to propagate phase failure before advancing.
- Apply a finite group/Ray wait timeout inherited from the distributed timeout and clean partial groups/futures/blocked engine actors fail-stop.
- Clear destroyed local group state before reconnect and release the transfer lock in `finally`.

This adds synchronization only when engines connect or disconnect, not to the normal bucket update path.

## Tests

- The deterministic opposite-arrival regression fails on `a067ce6f` and passes with this change.
- Unit tests cover timeout cancellation/engine cleanup, transfer-lock release, and failed reconnect state.
- Four-A100 deterministic NCCL opposite-order test: 20/20 passed.
- NCCL create/update/destroy stress: 50/50 passed with source/engine checksum agreement.
- Controls: PP=1 with two independent engines 20/20; PP=2 with one TP=2 engine 20/20.
- A no-delay Ray arrival-order probe observed the dangerous opposite order in 8/200 rounds. This is the opportunity rate for that arrival ordering on the test host, not a measured online deadlock rate.
- Production Slime helper plus Ray/NCCL integration: 20 rounds and 40 broadcasts passed with matching checksums.
- Two real SGLang HTTP/model-runner servers plus two Slime PP source actors: both groups connected, both online updates succeeded, both engines advanced to weight version 2, and generation changed identically after the update.
- 27 related CPU tests and ruff, black, isort, compileall, and diff checks passed.

The patched production-helper connect times were 0.121 s for PP0 and 0.115 s for PP1, comparable to 0.113/0.119 s in an earlier 10-round integration run. No meaningful connect-time regression was observed in this test.

## Environment note

The full Slime launcher could not run in the available A100 environment because that environment's installed `sglang-kernel` package contained SM100 but not SM80 common operations. No dependency was changed for this PR. The target path was instead validated successfully with real A100-compatible SGLang HTTP/model runners, Slime PP source actors, NCCL group creation, online weight updates, and functional generation checks.

## Risk

Connect/disconnect now performs one small Gloo all-reduce per PP group. A genuine timeout terminates only the affected rollout-engine actors because a serial actor blocked inside SGLang cannot service a queued cleanup RPC; recovery must recreate those engines. The steady-state weight broadcast path is unchanged apart from ensuring its lock is released on exceptions.
