### PR TITLE
fix(observability): support W&B 0.28.2 run IDs

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -647,6 +647,10 @@ jobs:
             },
             {
               "num_gpus": 0,
+              "test_file": "observability/test_wandb_utils.py"
+            },
+            {
+              "num_gpus": 0,
               "test_file": "test_value_temperature.py"
             },
             {

--- a/.github/workflows/pr-test.yml.j2
+++ b/.github/workflows/pr-test.yml.j2
@@ -87,6 +87,7 @@
         {'test_file': 'test_advantage_whiten_cp.py', 'num_gpus': 0},
         {'test_file': 'test_logprob_response_spans.py', 'num_gpus': 0},
         {'test_file': 'observability/test_trace_utils.py', 'num_gpus': 0},
+        {'test_file': 'observability/test_wandb_utils.py', 'num_gpus': 0},
         {'test_file': 'test_value_temperature.py', 'num_gpus': 0},
         {'test_file': 'test_ppo_kl_metric.py', 'num_gpus': 0},
         {'test_file': 'test_cispo_loss.py', 'num_gpus': 0},

--- a/slime/observability/wandb_utils.py
+++ b/slime/observability/wandb_utils.py
@@ -3,6 +3,7 @@ import os
 from copy import deepcopy
 
 import wandb
+from wandb.sdk.lib.runid import generate_id
 
 logger = logging.getLogger(__name__)
 
@@ -43,7 +44,7 @@ def init_wandb_primary(args):
     # Prepare wandb init parameters
     # add random 6 length string with characters
     if args.wandb_random_suffix:
-        group = args.wandb_group + "_" + wandb.util.generate_id()
+        group = args.wandb_group + "_" + generate_id()
         run_name = f"{group}-RANK_{args.rank}"
     else:
         group = args.wandb_group

--- a/tests/observability/test_wandb_utils.py
+++ b/tests/observability/test_wandb_utils.py
@@ -1,0 +1,41 @@
+from types import SimpleNamespace
+
+import pytest
+
+from slime.observability import wandb_utils
+
+NUM_GPUS = 0
+
+
+@pytest.mark.unit
+def test_init_wandb_primary_generates_random_group_suffix(monkeypatch):
+    init_kwargs = {}
+    monkeypatch.setattr(wandb_utils, "generate_id", lambda: "fixed123")
+    monkeypatch.setattr(wandb_utils.wandb, "Settings", lambda **kwargs: kwargs)
+    monkeypatch.setattr(wandb_utils.wandb, "init", lambda **kwargs: init_kwargs.update(kwargs))
+    monkeypatch.setattr(wandb_utils.wandb, "run", SimpleNamespace(id="run-123"))
+    monkeypatch.setattr(wandb_utils, "_init_wandb_common", lambda: None)
+
+    args = SimpleNamespace(
+        use_wandb=True,
+        wandb_mode="offline",
+        wandb_key=None,
+        wandb_host=None,
+        wandb_random_suffix=True,
+        wandb_group="grpo",
+        wandb_team="team",
+        wandb_project="project",
+        wandb_dir=None,
+        rank=0,
+    )
+
+    wandb_utils.init_wandb_primary(args)
+
+    assert init_kwargs["group"] == "grpo_fixed123"
+    assert init_kwargs["name"] == "grpo_fixed123-RANK_0"
+    assert init_kwargs["settings"] == {"mode": "offline"}
+    assert args.wandb_run_id == "run-123"
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__]))


### PR DESCRIPTION
## Summary
- switch W&B run ID generation to wandb.sdk.lib.runid.generate_id
- add focused CPU coverage for random W&B group suffixes
- register the regression test in the CPU CI matrix

## Testing
- python tests/observability/test_wandb_utils.py with wandb==0.28.1
- python tests/observability/test_wandb_utils.py with wandb==0.28.2
- ruff check --line-length 200 --select E,F,I slime/observability/wandb_utils.py tests/observability/test_wandb_utils.py
- python -m py_compile slime/observability/wandb_utils.py tests/observability/test_wandb_utils.py
- PYTHONUTF8=1 python .github/workflows/generate_github_workflows.py

Closes #2332