### PR TITLE
fix(agent): abort timed-out SGLang requests via router workers

### DIFF
--- a/slime/agent/adapters/common.py
+++ b/slime/agent/adapters/common.py
@@ -515,22 +515,23 @@ async def call_sglang_generate(
 
 
 async def _abort_sglang_request(sglang_url: str, rid: str, logger: logging.Logger) -> None:
-    """Abort one request on every worker behind the SGLang router."""
+    """Abort one request on a worker or every worker behind the router."""
     try:
         timeout = aiohttp.ClientTimeout(total=5)
         async with aiohttp.ClientSession(timeout=timeout) as session:
-            async with session.get(f"{sglang_url}/workers") as response:
-                response.raise_for_status()
-                workers = (await response.json()).get("workers", [])
-
-            async def abort_worker(worker: dict[str, Any]) -> None:
-                url = worker["url"].rstrip("/")
+            async def abort_worker(url: str) -> None:
                 try:
                     async with session.post(
                         f"{url}/abort_request",
                         json={"rid": rid},
                     ) as response:
-                        response.raise_for_status()
+                        if response.status >= 400:
+                            logger.warning(
+                                "SGLang worker abort failed: url=%s rid=%s status=%s",
+                                url,
+                                rid,
+                                response.status,
+                            )
                 except Exception as exc:
                     logger.warning(
                         "SGLang worker abort failed: url=%s rid=%s error=%s",
@@ -539,7 +540,24 @@ async def _abort_sglang_request(sglang_url: str, rid: str, logger: logging.Logge
                         exc,
                     )
 
-            await asyncio.gather(*(abort_worker(worker) for worker in workers if isinstance(worker, dict)))
+            async with session.get(f"{sglang_url}/workers") as response:
+                if response.status == 404:
+                    await abort_worker(sglang_url)
+                    return
+                response.raise_for_status()
+                payload = await response.json()
+
+            if not isinstance(payload, dict):
+                logger.warning("Invalid SGLang workers response: url=%s rid=%s", sglang_url, rid)
+                return
+
+            worker_urls = [
+                worker["url"].rstrip("/")
+                for worker in payload.get("workers", [])
+                if isinstance(worker, dict) and isinstance(worker.get("url"), str) and worker["url"]
+            ]
+
+            await asyncio.gather(*(abort_worker(url) for url in worker_urls))
     except Exception as exc:
         logger.warning(
             "SGLang abort request failed: url=%s rid=%s error=%s",

--- a/slime/agent/adapters/common.py
+++ b/slime/agent/adapters/common.py
@@ -519,6 +519,7 @@ async def _abort_sglang_request(sglang_url: str, rid: str, logger: logging.Logge
     try:
         timeout = aiohttp.ClientTimeout(total=5)
         async with aiohttp.ClientSession(timeout=timeout) as session:
+
             async def abort_worker(url: str) -> None:
                 try:
                     async with session.post(f"{url}/abort_request", json={"rid": rid}):

--- a/slime/agent/adapters/common.py
+++ b/slime/agent/adapters/common.py
@@ -521,24 +521,10 @@ async def _abort_sglang_request(sglang_url: str, rid: str, logger: logging.Logge
         async with aiohttp.ClientSession(timeout=timeout) as session:
             async def abort_worker(url: str) -> None:
                 try:
-                    async with session.post(
-                        f"{url}/abort_request",
-                        json={"rid": rid},
-                    ) as response:
-                        if response.status >= 400:
-                            logger.warning(
-                                "SGLang worker abort failed: url=%s rid=%s status=%s",
-                                url,
-                                rid,
-                                response.status,
-                            )
-                except Exception as exc:
-                    logger.warning(
-                        "SGLang worker abort failed: url=%s rid=%s error=%s",
-                        url,
-                        rid,
-                        exc,
-                    )
+                    async with session.post(f"{url}/abort_request", json={"rid": rid}):
+                        pass
+                except Exception:
+                    pass
 
             async with session.get(f"{sglang_url}/workers") as response:
                 if response.status == 404:

--- a/slime/agent/adapters/common.py
+++ b/slime/agent/adapters/common.py
@@ -503,11 +503,7 @@ async def call_sglang_generate(
         # free the sglang slot eagerly on client cancel/timeout, else the
         # orphaned generation keeps occupying KV until its own length cap
         logger.debug("[%s] sid=%s rid=%s turn aborted: %s", adapter.log_prefix, session_id, rid, type(e).__name__)
-        try:
-            async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=5)) as s2:
-                await s2.post(f"{sglang_url}/abort_request", json={"rid": rid})
-        except Exception:
-            pass
+        await _abort_sglang_request(sglang_url, rid, logger)
         raise
 
     return TurnRecord(
@@ -516,6 +512,43 @@ async def call_sglang_generate(
         finish_reason=finish,
         output_log_probs=output_log_probs,
     )
+
+
+async def _abort_sglang_request(sglang_url: str, rid: str, logger: logging.Logger) -> None:
+    """Abort one request on every worker behind the SGLang router."""
+    try:
+        timeout = aiohttp.ClientTimeout(total=5)
+        async with aiohttp.ClientSession(timeout=timeout) as session:
+            async with session.get(f"{sglang_url}/workers") as response:
+                response.raise_for_status()
+                workers = (await response.json()).get("workers", [])
+
+            async def abort_worker(worker: dict[str, Any]) -> None:
+                url = worker["url"].rstrip("/")
+                try:
+                    async with session.post(
+                        f"{url}/abort_request",
+                        json={"rid": rid},
+                    ) as response:
+                        response.raise_for_status()
+                except Exception as exc:
+                    logger.warning(
+                        "SGLang worker abort failed: url=%s rid=%s error=%s",
+                        url,
+                        rid,
+                        exc,
+                    )
+
+            await asyncio.gather(
+                *(abort_worker(worker) for worker in workers if isinstance(worker, dict))
+            )
+    except Exception as exc:
+        logger.warning(
+            "SGLang abort request failed: url=%s rid=%s error=%s",
+            sglang_url,
+            rid,
+            exc,
+        )
 
 
 async def _health(request: web.Request) -> web.Response:

--- a/slime/agent/adapters/common.py
+++ b/slime/agent/adapters/common.py
@@ -539,9 +539,7 @@ async def _abort_sglang_request(sglang_url: str, rid: str, logger: logging.Logge
                         exc,
                     )
 
-            await asyncio.gather(
-                *(abort_worker(worker) for worker in workers if isinstance(worker, dict))
-            )
+            await asyncio.gather(*(abort_worker(worker) for worker in workers if isinstance(worker, dict)))
     except Exception as exc:
         logger.warning(
             "SGLang abort request failed: url=%s rid=%s error=%s",


### PR DESCRIPTION
## Background

In the agentic rollout path, each agent turn sends a request to SGLang through the SGLang router. When a request is cancelled or hits the client-side read timeout, Slime must explicitly abort the corresponding SGLang request to release its scheduler slot and KV-cache resources.

## Problem

`sglang_url` points to the SGLang router address, but the router does not expose or forward the `/abort_request` endpoint.

The existing cleanup logic sends:

```text
POST <router>/abort_request
```

This request returns HTTP 404 and the exception is silently ignored. As a result, the original request may continue decoding on the worker even though the client has already timed out. The retry request can then be routed to another DP worker, causing the old request and the retry request to run concurrently.

This leads to:

- Orphaned SGLang requests occupying KV-cache resources
- Duplicate computation after retries
- Multiple DP workers decoding requests from the same logical agent turn
- Longer tail latency and possible additional timeout failures

## Solution

This change adds a small helper, `_abort_sglang_request`, in `slime/agent/adapters/common.py`.

When a request is cancelled or times out:

1. Query the router's `/workers` endpoint.
2. Extract the backend worker URLs.
3. Send `/abort_request` with the original request `rid` to every worker concurrently.
4. Keep the abort request scoped to the specific `rid`; `abort_all` is never used.

Only the worker that owns the request will actually abort it. Requests with other IDs are not affected.

## Scope

- Modify only `slime/agent/adapters/common.py`
- No new dependencies
- No SGLang router changes
- No public API changes
- Preserve support for the current router-based SGLang deployment

## Validation

- `python3 -m py_compile slime/agent/adapters/common.py`
- `git diff --check`
- Manual async test with a fake router and two fake workers
- Verified that the same `rid` is sent to all backend workers