### PR TITLE
[cleanup] type BaseAdapter trajectory manager

### DIFF
--- a/slime/agent/adapters/common.py
+++ b/slime/agent/adapters/common.py
@@ -136,7 +136,7 @@ class BaseAdapter:
     # body keys that cap max_new_tokens and carry stop sequences, in priority order
     max_token_keys: tuple[str, ...] = ()
     stop_keys: tuple[str, ...] = ()
-    manager: Any
+    manager: TrajectoryManager
 
     def __init__(
         self,


### PR DESCRIPTION
## Summary
- annotate `BaseAdapter.manager` as `TrajectoryManager` instead of `Any`
- make the concrete trajectory manager easy to navigate from IDEs and improve static type information

## Validation
- `uvx --from ruff==0.14.7 ruff check slime/agent/adapters/common.py`
- `uvx black==24.3.0 --check slime/agent/adapters/common.py`