### PR TITLE
fix: preserve equals in extra environment values

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -787,6 +787,10 @@ jobs:
             },
             {
               "num_gpus": 0,
+              "test_file": "utils/test_command_utils.py"
+            },
+            {
+              "num_gpus": 0,
               "test_file": "utils/test_hf_checkpoint_saver.py"
             },
             {

--- a/.github/workflows/pr-test.yml.j2
+++ b/.github/workflows/pr-test.yml.j2
@@ -122,6 +122,7 @@
         {'test_file': 'test_glm52_layerwise_comparison.py', 'num_gpus': 0},
         {'test_file': 'test_layerwise_alignment.py', 'num_gpus': 0},
         {'test_file': 'test_tau_bench_token_delta.py', 'num_gpus': 0},
+        {'test_file': 'utils/test_command_utils.py', 'num_gpus': 0},
         {'test_file': 'utils/test_hf_checkpoint_saver.py', 'num_gpus': 0},
         {'test_file': 'utils/test_loss_mask_type_qwen35.py', 'num_gpus': 0},
         {'test_file': 'plugin_contracts/test_plugin_rollout_contracts.py', 'num_gpus': 0},

--- a/slime/utils/external_utils/command_utils.py
+++ b/slime/utils/external_utils/command_utils.py
@@ -181,7 +181,7 @@ def _parse_extra_env_vars(text: str):
     try:
         return json.loads(text)
     except ValueError:
-        return {kv[0]: kv[1] for item in text.split(" ") if item.strip() != "" if (kv := item.split("=")) or True}
+        return {kv[0]: kv[1] for item in text.split(" ") if item.strip() != "" if (kv := item.split("=", 1)) or True}
 
 
 def check_has_nvlink():

--- a/tests/utils/test_command_utils.py
+++ b/tests/utils/test_command_utils.py
@@ -1,0 +1,13 @@
+import pytest
+
+from slime.utils.external_utils.command_utils import _parse_extra_env_vars
+
+NUM_GPUS = 0
+
+
+def test_parse_extra_env_vars_preserves_equals_in_values():
+    assert _parse_extra_env_vars("TOKEN=abc== END=ok") == {"TOKEN": "abc==", "END": "ok"}
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__]))


### PR DESCRIPTION
## Summary

- Preserve `=` characters after the first separator in the space-separated `extra_env_vars` fallback parser.
- Add regression coverage to the always-on CPU test matrix.

## Problem

`_parse_extra_env_vars` split each assignment on every `=` and then kept only the second component. For example:

`TOKEN=abc== END=ok`

was parsed as:

`{"TOKEN": "abc", "END": "ok"}`

This corrupts padded or otherwise `=`-containing environment values.

## Change

Use `split("=", 1)` so only the key/value separator is consumed. JSON input handling and the existing fallback tokenization remain unchanged.

The new zero-GPU regression test is registered in the workflow template, and the generated workflow is updated with it.

## Testing

- `tests/utils/test_command_utils.py`: 1 passed
- `pre-commit run --all-files`
- Confirmed the generated `pr-test.yml` matches `pr-test.yml.j2`
- `git diff --check`
