### PR TITLE
require --ref-load when KL is enabled instead of crashing with a TypeError

### DIFF
--- a/slime/utils/arguments.py
+++ b/slime/utils/arguments.py
@@ -1779,6 +1779,11 @@ def slime_validate_args(args):
         )
 
     if args.kl_coef != 0 or args.use_kl_loss:
+        if args.ref_load is None:
+            raise ValueError(
+                "--ref-load is required when --kl-coef is non-zero or --use-kl-loss is enabled. "
+                "Please provide the reference model checkpoint path."
+            )
         if not os.path.exists(args.ref_load):
             raise FileNotFoundError(f"ref_load {args.ref_load} does not exist, please check the path.")
 

--- a/tests/test_megatron_argument_validation.py
+++ b/tests/test_megatron_argument_validation.py
@@ -306,6 +306,25 @@ def test_slime_validate_args_rejects_non_positive_rollout_temperature(monkeypatc
 
 
 @pytest.mark.unit
+@pytest.mark.parametrize("overrides", [{"kl_coef": 0.1}, {"use_kl_loss": True}])
+def test_slime_validate_args_requires_ref_load_when_kl_enabled(monkeypatch, overrides):
+    module = load_slime_arguments_module(monkeypatch)
+    args = make_slime_validate_args(ref_load=None, **overrides)
+
+    with pytest.raises(ValueError, match="--ref-load is required"):
+        module.slime_validate_args(args)
+
+
+@pytest.mark.unit
+def test_slime_validate_args_refuses_missing_ref_load_path(monkeypatch):
+    module = load_slime_arguments_module(monkeypatch)
+    args = make_slime_validate_args(kl_coef=0.1, ref_load="/does/not/exist")
+
+    with pytest.raises(FileNotFoundError, match="does not exist"):
+        module.slime_validate_args(args)
+
+
+@pytest.mark.unit
 def test_slime_validate_args_preserves_zero_rollout_gpus_under_colocate(monkeypatch):
     module = load_slime_arguments_module(monkeypatch)
     args = make_slime_validate_args(colocate=True, rollout_num_gpus=0)


### PR DESCRIPTION
Enabling KL (--kl-coef 0.1 or --use-kl-loss) without --ref-load used to die in slime_validate_args with `TypeError: _path_exists: path should be string, bytes, os.PathLike or integer, not NoneType`, because it stat'd args.ref_load before checking it was set. The sibling OPD check just below already guards for None first.

This adds the same guard: ref_load unset now raises a ValueError telling the user to pass --ref-load, and a ref_load that points nowhere still raises the original FileNotFoundError. Two unit tests cover both cases.