### PR TITLE
fix: avoid reading correction settings when TIS is disabled

### DIFF
--- a/examples/train_infer_mismatch_helper/mis.py
+++ b/examples/train_infer_mismatch_helper/mis.py
@@ -171,10 +171,6 @@ def compute_mis_weights(
 
     metrics: dict[str, list[torch.Tensor]] = {}
 
-    tis_lower_bound = args.tis_lower_bound if args.tis_lower_bound is not None else 1.0 / args.tis_upper_bound
-    rs_lower_bound = args.rs_lower_bound if args.rs_lower_bound is not None else tis_lower_bound
-    rs_upper_bound = args.rs_upper_bound if args.rs_upper_bound is not None else args.tis_upper_bound
-
     # Validate input lists have same length and each sequence has matching shapes
     assert (
         len(train_log_probs) == len(rollout_log_probs) == len(loss_masks)
@@ -207,6 +203,10 @@ def compute_mis_weights(
     # only calculate mismatch metrics if TIS is not used
     if not args.use_tis:
         return None, loss_masks, metrics
+
+    tis_lower_bound = args.tis_lower_bound if args.tis_lower_bound is not None else 1.0 / args.tis_upper_bound
+    rs_lower_bound = args.rs_lower_bound if args.rs_lower_bound is not None else tis_lower_bound
+    rs_upper_bound = args.rs_upper_bound if args.rs_upper_bound is not None else args.tis_upper_bound
 
     # handle each sequence independently
     for train_log_prob, rollout_log_prob, loss_mask in zip(

--- a/tests/test_rollout_metrics.py
+++ b/tests/test_rollout_metrics.py
@@ -1,5 +1,7 @@
 import base64
+import importlib.util
 from argparse import Namespace
+from pathlib import Path
 
 import numpy as np
 import pytest
@@ -12,8 +14,37 @@ from slime.utils.types import Sample
 NUM_GPUS = 0
 
 
+def _load_compute_mis_weights():
+    module_path = Path(__file__).resolve().parents[1] / "examples" / "train_infer_mismatch_helper" / "mis.py"
+    spec = importlib.util.spec_from_file_location("train_infer_mismatch_mis", module_path)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module.compute_mis_weights
+
+
+compute_mis_weights = _load_compute_mis_weights()
+
+
 def _make_args():
     return Namespace(sglang_speculative_algorithm=False, num_layers=2, moe_router_topk=2)
+
+
+@pytest.mark.unit
+def test_mismatch_metrics_do_not_require_tis_settings_when_tis_is_disabled():
+    loss_masks = [torch.ones(2)]
+
+    weights, modified_masks, metrics = compute_mis_weights(
+        Namespace(use_tis=False),
+        train_log_probs=[torch.tensor([-0.2, -0.4])],
+        rollout_log_probs=[torch.tensor([-0.3, -0.5])],
+        loss_masks=loss_masks,
+    )
+
+    assert weights is None
+    assert modified_masks == loss_masks
+    assert metrics
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Problem

When `--get-mismatch-metrics` uses the example `compute_mis_weights_with_cp` helper with TIS disabled, training fails on the first batch:

```text
AttributeError: 'Namespace' object has no attribute 'tis_lower_bound'
```

`compute_mis_weights` reads the correction bounds before checking `args.use_tis`. These settings are not defined or used when TIS is disabled, so the premature access raises an exception and prevents the mismatch metrics from being returned.

## Fix

Move the correction-bound calculation after the `args.use_tis` check. With `use_tis=False`, the helper returns the mismatch metrics and original loss masks without accessing correction settings. The TIS-enabled path is unchanged.

## Test plan

- [x] Added a regression test for `use_tis=False` without correction settings.
- [x] Verified that mismatch metrics and the original loss masks are returned.
- [x] `tests/test_rollout_metrics.py`: 12 passed.
- [x] Ruff, Black, and isort checks passed.
