### PR TITLE
fix: cancel pending rollout tasks after a failure

### DIFF
--- a/slime/rollout/sglang_rollout.py
+++ b/slime/rollout/sglang_rollout.py
@@ -356,7 +356,14 @@ async def generate_and_rm_group(
             asyncio.create_task(generate_and_rm(args, sample, current_sampling_params, evaluation=evaluation))
         )
 
-    group = await asyncio.gather(*tasks)
+    try:
+        group = await asyncio.gather(*tasks)
+    except BaseException:
+        for task in tasks:
+            if not task.done():
+                task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+        raise
 
     # for the rm that need the whole group, we will do the rm here
     if not state.aborted and args.group_rm:
@@ -454,7 +461,17 @@ async def generate_rollout_async(
         # wait for the generation to finish
         done, state.pendings = await asyncio.wait(state.pendings, return_when=asyncio.FIRST_COMPLETED)
         for task in done:
-            group: list[Sample] = task.result()
+            try:
+                group: list[Sample] = task.result()
+            except BaseException:
+                siblings = state.pendings | (done - {task})
+                for sibling in siblings:
+                    if not sibling.done():
+                        sibling.cancel()
+                await asyncio.gather(*siblings, return_exceptions=True)
+                state.reset()
+                pbar.close()
+                raise
 
             if do_print:
                 sample = group[0][0] if isinstance(group[0], list) else group[0]
@@ -637,7 +654,15 @@ async def eval_rollout_single_dataset(
     do_print = True
     pbar = tqdm(total=len(tasks), desc=f"Eval {dataset_cfg.name}", disable=not do_print)
     for coro in asyncio.as_completed(tasks):
-        sample = await coro
+        try:
+            sample = await coro
+        except BaseException:
+            for task in tasks:
+                if not task.done():
+                    task.cancel()
+            await asyncio.gather(*tasks, return_exceptions=True)
+            pbar.close()
+            raise
         if do_print:
             logged_sample = sample[0] if isinstance(sample, list) else sample
             logger.info(

--- a/tests/plugin_contracts/test_plugin_generate_contracts.py
+++ b/tests/plugin_contracts/test_plugin_generate_contracts.py
@@ -199,5 +199,33 @@ def test_generate_and_rm_group_rm_accepts_list_result_from_custom_generate(patch
     assert all(isinstance(sample, Sample) for sample in result)
 
 
+def test_generate_and_rm_group_cancels_siblings_after_failure(patch_generate_state, monkeypatch):
+    sglang_rollout = patch_generate_state
+    sibling_cancelled = asyncio.Event()
+
+    async def generate(args, sample: Sample, sampling_params: dict, evaluation: bool = False):
+        if sample.index == 0:
+            await asyncio.sleep(0)
+            raise RuntimeError("generation failed")
+        try:
+            await asyncio.Future()
+        except asyncio.CancelledError:
+            sibling_cancelled.set()
+            raise
+
+    monkeypatch.setattr(sglang_rollout, "generate_and_rm", generate)
+
+    async def run_case():
+        with pytest.raises(RuntimeError, match="generation failed"):
+            await sglang_rollout.generate_and_rm_group(
+                make_args(),
+                [Sample(index=0, prompt="first"), Sample(index=1, prompt="second")],
+                sampling_params={"temperature": 0.3},
+            )
+        assert sibling_cancelled.is_set()
+
+    asyncio.run(run_case())
+
+
 if __name__ == "__main__":
     run_contract_test_file()


### PR DESCRIPTION
## Problem

Training and evaluation launch rollout tasks concurrently at three levels: samples within a rollout group, rollout groups within a training batch, and samples within an evaluation batch.

When one task raises an exception, the exception is propagated but the unfinished sibling tasks are not cancelled. They can continue generation or reward computation after the rollout has failed, wasting resources and potentially leaving unobserved task exceptions in the event loop.

## Fix

At each concurrency boundary, cancel unfinished sibling tasks and wait for their cleanup before re-raising the original exception. The training path also resets its shared generation state, and both training and evaluation close their progress bars before returning the failure. Successful rollout behavior is unchanged.

## Test plan

- [x] Added a regression test where one generation task fails while a sibling is still running.
- [x] Verified that the sibling is cancelled and the original exception is preserved.
- [x] `tests/plugin_contracts/test_plugin_generate_contracts.py`: 5 passed.
- [x] `tests/test_streaming_rollout.py`: 26 passed.
- [x] Ruff, Black, and isort checks passed.
