### PR TITLE
feat(weight-sync): add engine-group wave scheduling

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -587,6 +587,14 @@ jobs:
             },
             {
               "num_gpus": 0,
+              "test_file": "test_engine_group_wave.py"
+            },
+            {
+              "num_gpus": 0,
+              "test_file": "test_engine_group_wave_distributed.py"
+            },
+            {
+              "num_gpus": 0,
               "test_file": "utils/test_megatron_role_config.py"
             },
             {

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -595,6 +595,10 @@ jobs:
             },
             {
               "num_gpus": 0,
+              "test_file": "test_weight_sync_callsite_benchmark.py"
+            },
+            {
+              "num_gpus": 0,
               "test_file": "utils/test_megatron_role_config.py"
             },
             {

--- a/.github/workflows/pr-test.yml.j2
+++ b/.github/workflows/pr-test.yml.j2
@@ -74,6 +74,7 @@
         {'test_file': 'test_megatron_argument_validation.py', 'num_gpus': 0},
         {'test_file': 'test_engine_group_wave.py', 'num_gpus': 0},
         {'test_file': 'test_engine_group_wave_distributed.py', 'num_gpus': 0},
+        {'test_file': 'test_weight_sync_callsite_benchmark.py', 'num_gpus': 0},
         {'test_file': 'utils/test_megatron_role_config.py', 'num_gpus': 0},
         {'test_file': 'test_deep_ep_tms_patch.py', 'num_gpus': 0},
         {'test_file': 'test_stateless_adam.py', 'num_gpus': 0},

--- a/.github/workflows/pr-test.yml.j2
+++ b/.github/workflows/pr-test.yml.j2
@@ -72,6 +72,8 @@
       'extra_pip_deps': 'transformers wandb',
       'tests': [
         {'test_file': 'test_megatron_argument_validation.py', 'num_gpus': 0},
+        {'test_file': 'test_engine_group_wave.py', 'num_gpus': 0},
+        {'test_file': 'test_engine_group_wave_distributed.py', 'num_gpus': 0},
         {'test_file': 'utils/test_megatron_role_config.py', 'num_gpus': 0},
         {'test_file': 'test_deep_ep_tms_patch.py', 'num_gpus': 0},
         {'test_file': 'test_stateless_adam.py', 'num_gpus': 0},

--- a/docs/en/advanced/weight-sync-wave-scheduling.md
+++ b/docs/en/advanced/weight-sync-wave-scheduling.md
@@ -12,8 +12,8 @@ without adding a hardware-specific time delay:
 An engine group here means one logical SGLang engine. Its tensor-, pipeline-, or
 multi-node workers remain one indivisible group. The scheduler walks the resolved
 engine list in stable order and admits at most the configured number at once.
-For five engines and a limit of two, the waves are therefore `(0, 1)`, `(2, 3)`,
-and `(4)`; no particular world size or number of engines is assumed.
+For four engines and a limit of three, the waves are therefore `(0, 1, 2)` and
+`(3)`; no particular world size or number of engines is assumed.
 
 The default is `0`, which keeps the existing all-at-once behavior. A value at
 least as large as the engine count is equivalent to the default. Negative values

--- a/docs/en/advanced/weight-sync-wave-scheduling.md
+++ b/docs/en/advanced/weight-sync-wave-scheduling.md
@@ -47,3 +47,58 @@ value that avoids the observed traffic or memory burst without increasing total
 weight-sync time or tail latency. This option limits concurrent engine groups;
 `--update-weight-buffer-size` independently controls the size of each weight
 bucket.
+
+## Production-callsite confirmation
+
+`tools/benchmark_weight_sync_callsite.py` invokes the production
+`update_weights_in_engine_group_waves` function with real process groups and
+synthetic payloads. It is intentionally a callsite/module probe: it does not
+replace the scheduler, change defaults, or claim Ray/SGLang load performance.
+
+Use a four-process launch to retain three real two-rank
+`[trainer, engine]` groups. A/B are engine groups 0 and 1; the third group is
+the competing operation that distinguishes the all-at-once and window-2
+policies. Only use device counts permitted by the test environment.
+
+Each command below creates exactly one independent process-run artifact:
+
+```bash
+torchrun --standalone --nproc-per-node=4 \
+  tools/benchmark_weight_sync_callsite.py \
+  --backend gloo --policy candidate_windowed \
+  --evidence-role selection --run-id selection-windowed-00 \
+  --order ab --output-json /tmp/selection-windowed-00.json
+```
+
+In a minimal PyTorch container without slime's Ray/Megatron control-plane
+dependencies, set `SLIME_CALLSITE_SOURCE_LOAD=1`. That opt-in mode loads the
+exact production source file while stubbing only unused actor/conversion
+imports; the artifact records `source_with_control_plane_stubs` so it cannot be
+silently mixed with an installed-runtime campaign.
+When the checkout's `.git` metadata is not mounted into the container, pass the
+tested revision as `SLIME_BENCHMARK_SOURCE_COMMIT`.
+
+Run every policy in both `selection` and `confirmation` roles in separate
+process launches (five launches per policy/role by default), alternating
+`--order ab` and `--order ba`. Then validate and summarize the immutable raw
+artifacts:
+
+```bash
+python tools/benchmark_weight_sync_callsite.py \
+  --summarize /tmp/weight-sync-callsite/*.json \
+  --min-runs-per-role 5 \
+  --summary-json /tmp/weight-sync-callsite-summary.json
+```
+
+The summary fails closed on duplicate process/run identity, incomplete rank
+coverage, payload mismatch, mixed runtime/message/topology cells, or too few
+independent runs. It reports communication A/B, rank-local pair makespan,
+receiver consumer waits, callsite return, device readiness, and whole-stage
+sync readiness separately. NCCL intervals are labeled `event_bracket`, never
+`kernel_observed`. The tool records PyTorch/CUDA/NCCL versions, launch-order
+configuration, dtype, message geometry, graph state, hostname, device identity,
+and exact process-group membership.
+
+This evidence does not establish end-to-end training throughput, SGLang load
+latency, multi-node behavior, or a production policy winner. The summarizer
+does not automatically select or apply a policy.

--- a/docs/en/advanced/weight-sync-wave-scheduling.md
+++ b/docs/en/advanced/weight-sync-wave-scheduling.md
@@ -1,0 +1,49 @@
+# Weight-Sync Engine Waves
+
+Large rollout deployments can make every SGLang engine receive or load the same
+weight bucket at once. That maximizes fan-out, but can also create a short burst
+of GPU, PCIe, NVLink, network, or storage traffic. slime can bound this fan-out
+without adding a hardware-specific time delay:
+
+```bash
+--update-weight-max-inflight-engine-groups 2
+```
+
+An engine group here means one logical SGLang engine. Its tensor-, pipeline-, or
+multi-node workers remain one indivisible group. The scheduler walks the resolved
+engine list in stable order and admits at most the configured number at once.
+For five engines and a limit of two, the waves are therefore `(0, 1)`, `(2, 3)`,
+and `(4)`; no particular world size or number of engines is assumed.
+
+The default is `0`, which keeps the existing all-at-once behavior. A value at
+least as large as the engine count is equivalent to the default. Negative values
+are rejected.
+
+## Supported transports
+
+- Non-colocated NCCL weight sync creates one process group per logical engine
+  only when a real bound is requested. Broadcasts for the engines in one wave
+  are launched asynchronously, and the next wave is not admitted until both the
+  NCCL work and engine-side load requests complete. The default continues to use
+  the original aggregate process group.
+- Colocated tensor/IPC sync coordinates the same deterministic waves across all
+  trainer ranks. A trainer control-group barrier closes each wave before source
+  buffers can be reused.
+- Full and delta disk sync apply the bound to checkpoint pulls and engine reload
+  requests.
+- Quantized post-load processing uses the same engine-group bound.
+
+The existing pause, flush, and weight-version boundaries are unchanged: an engine
+is not resumed early merely because its own wave completed. Disk-backed checkpoint
+pulls may run before the pause, but the serving weights are not changed by that
+prefetch. Consequently, wave admission does not introduce a new mixed-version
+serving interval.
+
+## Choosing a value
+
+Start with `0` as the throughput baseline, then compare small limits such as `1`,
+`2`, and `4` on the deployment topology that will run the job. Select the largest
+value that avoids the observed traffic or memory burst without increasing total
+weight-sync time or tail latency. This option limits concurrent engine groups;
+`--update-weight-buffer-size` independently controls the size of each weight
+bucket.

--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -84,6 +84,7 @@ Start by Use Case
    advanced/pd-disaggregation.md
    advanced/external-rollout-engines.md
    advanced/delta-weight-sync.md
+   advanced/weight-sync-wave-scheduling.md
    advanced/sglang-config.md
    advanced/megatron-config.md
    advanced/arch-support-beyond-megatron.md

--- a/docs/zh/advanced/weight-sync-wave-scheduling.md
+++ b/docs/zh/advanced/weight-sync-wave-scheduling.md
@@ -1,0 +1,42 @@
+# 权重同步 Engine Wave 调度
+
+大规模 rollout 部署可能让所有 SGLang engine 同时接收或加载同一个权重
+bucket。这样可以最大化 fan-out，但也可能瞬间占满 GPU、PCIe、NVLink、网络
+或存储带宽。slime 可以在不引入硬件相关固定延迟的情况下限制这种 fan-out：
+
+```bash
+--update-weight-max-inflight-engine-groups 2
+```
+
+这里的 engine group 指一个逻辑 SGLang engine。它内部的 tensor parallel、
+pipeline parallel 或多节点 worker 始终作为不可拆分的整体。调度器按解析后的
+engine 列表稳定分波，每波最多放行配置数量。例如五个 engine、上限为二时，
+wave 依次为 `(0, 1)`、`(2, 3)` 和 `(4)`；实现不假设特定 world size 或
+engine 数量。
+
+默认值为 `0`，保持原有 all-at-once 行为。配置值大于等于 engine 数量时也
+等价于默认行为；负数会在启动参数校验阶段被拒绝。
+
+## 支持的传输路径
+
+- 非 colocate NCCL 权重同步只在确实要求并发上限时，为每个逻辑 engine
+  创建独立 process group。同一 wave 内的 broadcast 异步发起，NCCL work
+  与 engine 侧加载请求全部完成后才放行下一波；默认行为仍使用原来的聚合
+  process group。
+- Colocate tensor/IPC 同步在所有 trainer rank 间使用相同的确定性 wave；
+  每波结束用 trainer 控制组 barrier 封口，然后才允许复用源 buffer。
+- Full 和 delta disk 同步会对 checkpoint pull 与 engine reload 请求应用
+  同一并发上限。
+- 量化模型的 post-load 处理也遵守同一 engine-group 上限。
+
+现有的 pause、flush 与权重版本边界保持不变：某个 engine 不会仅仅因为自己的
+wave 先完成就提前恢复 generation。disk checkpoint pull 可以在 pause 前预取，
+但该过程不会修改 serving 权重。因此 wave 放行本身不会引入新的新旧权重混用
+窗口。
+
+## 如何选择上限
+
+先用 `0` 建立吞吐基线，再在实际部署拓扑上比较 `1`、`2`、`4` 等较小上限。
+应选择既能消除观测到的流量或显存峰值、又不会增加权重同步总时间或尾延迟的
+最大值。该参数只限制并发 engine group 数量；每个权重 bucket 的大小仍由
+`--update-weight-buffer-size` 独立控制。

--- a/docs/zh/advanced/weight-sync-wave-scheduling.md
+++ b/docs/zh/advanced/weight-sync-wave-scheduling.md
@@ -40,3 +40,52 @@ wave 先完成就提前恢复 generation。disk checkpoint pull 可以在 pause 
 应选择既能消除观测到的流量或显存峰值、又不会增加权重同步总时间或尾延迟的
 最大值。该参数只限制并发 engine group 数量；每个权重 bucket 的大小仍由
 `--update-weight-buffer-size` 独立控制。
+
+## 生产调用点确认
+
+`tools/benchmark_weight_sync_callsite.py` 直接调用生产函数
+`update_weights_in_engine_group_waves`，使用真实 process group 和合成 payload。
+它是调用点/模块级探针：不会重写调度器、改变默认值，也不声称测到了
+Ray/SGLang 加载性能。
+
+四进程启动会保留三个真实的二 rank `[trainer, engine]` 通信组。A/B 是
+engine group 0 和 1；第三组是区分 all-at-once 与 window-2 的竞争操作。
+只使用当前测试环境允许的设备数量。
+
+下列每条命令只生成一个独立进程运行制品：
+
+```bash
+torchrun --standalone --nproc-per-node=4 \
+  tools/benchmark_weight_sync_callsite.py \
+  --backend gloo --policy candidate_windowed \
+  --evidence-role selection --run-id selection-windowed-00 \
+  --order ab --output-json /tmp/selection-windowed-00.json
+```
+
+若最小 PyTorch 容器缺少 slime 的 Ray/Megatron 控制面依赖，可显式设置
+`SLIME_CALLSITE_SOURCE_LOAD=1`。该模式加载完全相同的生产源文件，只替换本
+探针不会调用的 actor/conversion import；制品会记录
+`source_with_control_plane_stubs`，不能静默混入完整运行时 campaign。
+若容器内没有挂载 checkout 的 `.git` 元数据，请用
+`SLIME_BENCHMARK_SOURCE_COMMIT` 显式传入被测 revision。
+
+对每个 policy 分别以 `selection`、`confirmation` 角色启动独立进程（默认
+每个 policy/role 五次），并交替使用 `--order ab`、`--order ba`。随后校验、
+汇总不可变原始制品：
+
+```bash
+python tools/benchmark_weight_sync_callsite.py \
+  --summarize /tmp/weight-sync-callsite/*.json \
+  --min-runs-per-role 5 \
+  --summary-json /tmp/weight-sync-callsite-summary.json
+```
+
+遇到重复进程/运行身份、rank 覆盖不完整、payload 不一致、混用运行时/
+消息/拓扑 cell，或独立运行不足时，汇总器会 fail closed。它分别报告通信
+A/B、rank-local pair makespan、接收端 consumer wait、调用点返回、设备
+ready 和整个同步阶段 ready。NCCL 区间只标记为 `event_bracket`，绝不冒充
+`kernel_observed`。工具记录 PyTorch/CUDA/NCCL 版本、launch-order 配置、
+dtype、消息几何、graph 状态、主机/设备身份与精确 PG membership。
+
+这些证据不能证明端到端训练吞吐、SGLang 加载延迟、多机行为或某个生产
+策略必胜；汇总器不会自动选择或应用策略。

--- a/docs/zh/advanced/weight-sync-wave-scheduling.md
+++ b/docs/zh/advanced/weight-sync-wave-scheduling.md
@@ -10,9 +10,9 @@ bucket。这样可以最大化 fan-out，但也可能瞬间占满 GPU、PCIe、N
 
 这里的 engine group 指一个逻辑 SGLang engine。它内部的 tensor parallel、
 pipeline parallel 或多节点 worker 始终作为不可拆分的整体。调度器按解析后的
-engine 列表稳定分波，每波最多放行配置数量。例如五个 engine、上限为二时，
-wave 依次为 `(0, 1)`、`(2, 3)` 和 `(4)`；实现不假设特定 world size 或
-engine 数量。
+engine 列表稳定分波，每波最多放行配置数量。例如四个 engine、上限为三时，
+wave 依次为 `(0, 1, 2)` 和 `(3)`；实现不假设特定 world size 或 engine
+数量。
 
 默认值为 `0`，保持原有 all-at-once 行为。配置值大于等于 engine 数量时也
 等价于默认行为；负数会在启动参数校验阶段被拒绝。

--- a/docs/zh/index.rst
+++ b/docs/zh/index.rst
@@ -84,6 +84,7 @@ slime 的设计目标，是让这两大能力彼此强化，同时避免把系�
    advanced/pd-disaggregation.md
    advanced/external-rollout-engines.md
    advanced/delta-weight-sync.md
+   advanced/weight-sync-wave-scheduling.md
    advanced/sglang-config.md
    advanced/megatron-config.md
    advanced/arch-support-beyond-megatron.md

--- a/slime/backends/megatron_utils/update_weight/update_weight_from_disk_delta.py
+++ b/slime/backends/megatron_utils/update_weight/update_weight_from_disk_delta.py
@@ -22,6 +22,7 @@ from ray.actor import ActorHandle
 from slime.utils import accelerator
 from slime.utils.disk_delta import NUM_WORKERS, checksum, make_tensor_reader, overwrite_encode
 from slime.utils.distributed_utils import get_gloo_group
+from slime.utils.engine_group_wave import run_engine_group_waves
 
 from .update_weight_from_distributed import UpdateWeightFromDistributed
 
@@ -107,7 +108,16 @@ class UpdateWeightFromDiskDelta(UpdateWeightFromDistributed):
             os.makedirs(self.delta_dir, exist_ok=True)
             if self._post_write_hook is not None:
                 self._post_write_hook(self.args, self.delta_dir, list(self.rollout_engines))
-            pulls = [engine.pull_weights.remote(target_version=0) for engine in self.rollout_engines]
+            max_inflight_engine_groups = getattr(self.args, "update_weight_max_inflight_engine_groups", 0)
+            if 0 < max_inflight_engine_groups < len(self.rollout_engines):
+                run_engine_group_waves(
+                    self.rollout_engines,
+                    max_inflight_engine_groups,
+                    lambda _index, engine: engine.pull_weights.remote(target_version=0),
+                    ray.get,
+                )
+            else:
+                pulls = [engine.pull_weights.remote(target_version=0) for engine in self.rollout_engines]
         dist.barrier(group=get_gloo_group())
 
         read_hf = make_tensor_reader(self.args.hf_checkpoint)  # index the HF headers once
@@ -118,7 +128,8 @@ class UpdateWeightFromDiskDelta(UpdateWeightFromDistributed):
                 self._snapshot[name] = tensor.detach().cpu().contiguous().view(torch.uint8).numpy().reshape(-1)
                 logger.warning("seed: %s absent from hf_checkpoint; seeding from current weights", name)
         if dist.get_rank() == 0:
-            ray.get(pulls)
+            if pulls:
+                ray.get(pulls)
             logger.info(
                 "[disk delta] captured baseline snapshot of %d tensors from %s",
                 len(self._snapshot),
@@ -175,17 +186,23 @@ class UpdateWeightFromDiskDelta(UpdateWeightFromDistributed):
             self._post_write_hook(self.args, self._version_dir, list(self.rollout_engines))
         dist.barrier(group=get_gloo_group())
         if dist.get_rank() == 0:
-            ray.get([engine.pull_weights.remote(self.weight_version) for engine in self.rollout_engines])
+            max_inflight_engine_groups = getattr(self.args, "update_weight_max_inflight_engine_groups", 0)
+            run_engine_group_waves(
+                self.rollout_engines,
+                max_inflight_engine_groups,
+                lambda _index, engine: engine.pull_weights.remote(self.weight_version),
+                ray.get,
+            )
             ray.get([engine.pause_generation.remote() for engine in self.rollout_engines])
             ray.get([engine.flush_cache.remote() for engine in self.rollout_engines])
-            ray.get(
-                [
-                    engine.update_weights_from_disk.remote(
-                        model_path=self.args.update_weight_local_checkpoint_dir,
-                        weight_version=str(self.weight_version),
-                    )
-                    for engine in self.rollout_engines
-                ]
+            run_engine_group_waves(
+                self.rollout_engines,
+                max_inflight_engine_groups,
+                lambda _index, engine: engine.update_weights_from_disk.remote(
+                    model_path=self.args.update_weight_local_checkpoint_dir,
+                    weight_version=str(self.weight_version),
+                ),
+                ray.get,
             )
             ray.get([engine.continue_generation.remote() for engine in self.rollout_engines])
         dist.barrier(group=get_gloo_group())

--- a/slime/backends/megatron_utils/update_weight/update_weight_from_distributed.py
+++ b/slime/backends/megatron_utils/update_weight/update_weight_from_distributed.py
@@ -4,6 +4,7 @@ import socket
 import time
 from argparse import Namespace
 from collections.abc import Callable, Iterator, Mapping, Sequence
+from dataclasses import dataclass
 
 import ray
 import torch
@@ -15,10 +16,21 @@ from tqdm import tqdm
 
 from slime.utils import accelerator
 from slime.utils.distributed_utils import get_gloo_group, init_process_group
+from slime.utils.engine_group_wave import build_engine_group_waves, run_engine_group_waves
 from slime.utils.http_utils import _wrap_ipv6
 
 from ..megatron_to_hf import convert_to_hf
 from .common import all_gather_param, named_params_and_buffers
+
+
+@dataclass(frozen=True)
+class DistributedWeightUpdateGroup:
+    """One trainer process group and the rollout engines that join it."""
+
+    engine_indices: tuple[int, ...]
+    group_name: str
+    process_group: dist.ProcessGroup
+    rollout_engines: tuple[ActorHandle, ...]
 
 
 class UpdateWeightFromDistributed:
@@ -45,7 +57,7 @@ class UpdateWeightFromDistributed:
         self.model_name = model_name
         self.quantization_config = quantization_config
         self.weight_version = 0
-        self._model_update_groups = None
+        self._model_update_groups: list[DistributedWeightUpdateGroup] = []
         self.update_weight_metrics: dict[str, float] = {}
 
     def pop_metrics(self) -> dict[str, float]:
@@ -81,22 +93,21 @@ class UpdateWeightFromDistributed:
             self._group_name = f"slime-pp_{pp_rank}"
 
         if self._is_pp_src_rank:
-            if self._model_update_groups is not None:
-                disconnect_rollout_engines_from_distributed(
-                    self._group_name, self._model_update_groups, self.rollout_engines
-                )
-            self._model_update_groups = connect_rollout_engines_from_distributed(
+            if self._model_update_groups:
+                disconnect_rollout_engine_groups_from_distributed(self._model_update_groups)
+            self._model_update_groups = connect_rollout_engine_groups_from_distributed(
                 self.args,
                 self._group_name,
                 rollout_engines,
                 engine_gpu_counts=engine_gpu_counts,
+                max_inflight_engine_groups=getattr(self.args, "update_weight_max_inflight_engine_groups", 0),
             )
 
     def disconnect_rollout_engines(self) -> None:
-        if not getattr(self, "_is_pp_src_rank", False) or self._model_update_groups is None:
+        if not getattr(self, "_is_pp_src_rank", False) or not self._model_update_groups:
             return
-        disconnect_rollout_engines_from_distributed(self._group_name, self._model_update_groups, self.rollout_engines)
-        self._model_update_groups = None
+        disconnect_rollout_engine_groups_from_distributed(self._model_update_groups)
+        self._model_update_groups = []
 
     @torch.no_grad()
     def update_weights(self) -> None:
@@ -115,6 +126,7 @@ class UpdateWeightFromDistributed:
                     restore_weights_before_load=True,
                     post_process_quantization=False,
                     rollout_engines=self.rollout_engines,
+                    max_inflight_engine_groups=getattr(self.args, "update_weight_max_inflight_engine_groups", 0),
                 )
         dist.barrier(group=get_gloo_group())
 
@@ -128,6 +140,7 @@ class UpdateWeightFromDistributed:
                     restore_weights_before_load=False,
                     post_process_quantization=True,
                     rollout_engines=self.rollout_engines,
+                    max_inflight_engine_groups=getattr(self.args, "update_weight_max_inflight_engine_groups", 0),
                 )
             ray.get([engine.continue_generation.remote() for engine in self.rollout_engines])
         dist.barrier(group=get_gloo_group())
@@ -249,19 +262,19 @@ class UpdateWeightFromDistributed:
         while not ray.get(self.rollout_engine_lock.acquire.remote()):
             time.sleep(0.1)
 
-        refs = update_weights_from_distributed(
-            self._group_name,
-            self._model_update_groups,
-            self.weight_version,
-            self.rollout_engines,
-            converted_named_tensors,
-            load_format=load_format,
-        )
-
-        ray.get(refs)
+        try:
+            update_weights_in_engine_group_waves(
+                self._model_update_groups,
+                self.weight_version,
+                converted_named_tensors,
+                max_inflight_engine_groups=getattr(self.args, "update_weight_max_inflight_engine_groups", 0),
+                load_format=load_format,
+            )
+        finally:
+            ray.get(self.rollout_engine_lock.release.remote())
         converted_named_tensors.clear()
-        ray.get(self.rollout_engine_lock.release.remote())
-        pbar.update(1)
+        if pbar is not None:
+            pbar.update(1)
 
 
 def connect_rollout_engines_from_distributed(
@@ -314,6 +327,82 @@ def connect_rollout_engines_from_distributed(
     return model_update_groups
 
 
+def connect_rollout_engine_groups_from_distributed(
+    args: Namespace,
+    group_name: str,
+    rollout_engines: Sequence[ActorHandle],
+    engine_gpu_counts: Sequence[int] | None = None,
+    *,
+    max_inflight_engine_groups: int = 0,
+    total_engine_groups: int | None = None,
+    engine_index_offset: int = 0,
+) -> list[DistributedWeightUpdateGroup]:
+    """Create aggregate or per-engine process groups for weight-update waves.
+
+    The aggregate group preserves the existing data path when every engine may
+    run together. A bounded policy needs one process group per logical engine;
+    otherwise an aggregate NCCL broadcast would still require every engine to
+    enter the collective at once and could not be admitted in waves.
+    """
+    if engine_gpu_counts is None:
+        engine_gpu_counts = [args.rollout_num_gpus_per_engine] * len(rollout_engines)
+    if len(engine_gpu_counts) != len(rollout_engines):
+        raise ValueError("engine_gpu_counts must have one entry per rollout engine")
+    if any(gpu_count <= 0 for gpu_count in engine_gpu_counts):
+        raise ValueError("engine GPU counts must be positive")
+    if max_inflight_engine_groups < 0:
+        raise ValueError("max_inflight_engine_groups must be non-negative")
+    if not rollout_engines:
+        return []
+
+    total = total_engine_groups if total_engine_groups is not None else len(rollout_engines)
+    if total < len(rollout_engines):
+        raise ValueError("total_engine_groups cannot be smaller than the distributed engine count")
+    if engine_index_offset < 0 or engine_index_offset + len(rollout_engines) > total:
+        raise ValueError("distributed engine indices must fit within total_engine_groups")
+    use_waves = 0 < max_inflight_engine_groups < total
+
+    if not use_waves:
+        process_group = connect_rollout_engines_from_distributed(
+            args,
+            group_name,
+            rollout_engines,
+            engine_gpu_counts=engine_gpu_counts,
+        )
+        return [
+            DistributedWeightUpdateGroup(
+                engine_indices=tuple(range(engine_index_offset, engine_index_offset + len(rollout_engines))),
+                group_name=group_name,
+                process_group=process_group,
+                rollout_engines=tuple(rollout_engines),
+            )
+        ]
+
+    update_groups = []
+    try:
+        for local_index, (engine, gpu_count) in enumerate(zip(rollout_engines, engine_gpu_counts, strict=True)):
+            engine_index = engine_index_offset + local_index
+            engine_group_name = f"{group_name}-engine-{engine_index}"
+            process_group = connect_rollout_engines_from_distributed(
+                args,
+                engine_group_name,
+                [engine],
+                engine_gpu_counts=[gpu_count],
+            )
+            update_groups.append(
+                DistributedWeightUpdateGroup(
+                    engine_indices=(engine_index,),
+                    group_name=engine_group_name,
+                    process_group=process_group,
+                    rollout_engines=(engine,),
+                )
+            )
+    except Exception:
+        disconnect_rollout_engine_groups_from_distributed(update_groups)
+        raise
+    return update_groups
+
+
 def disconnect_rollout_engines_from_distributed(group_name, model_update_groups, rollout_engines):
     """
     Destroy the weight-update process group on training and engines.
@@ -321,6 +410,42 @@ def disconnect_rollout_engines_from_distributed(group_name, model_update_groups,
     refs = [engine.destroy_weights_update_group.remote(group_name) for engine in rollout_engines]
     dist.destroy_process_group(model_update_groups)
     ray.get(refs)
+
+
+def disconnect_rollout_engine_groups_from_distributed(
+    update_groups: Sequence[DistributedWeightUpdateGroup],
+) -> None:
+    """Destroy all process groups created for aggregate or waved updates."""
+    for update_group in update_groups:
+        disconnect_rollout_engines_from_distributed(
+            update_group.group_name,
+            update_group.process_group,
+            update_group.rollout_engines,
+        )
+
+
+def launch_weights_from_distributed(
+    group_name: str,
+    group: dist.ProcessGroup,
+    weight_version: int,
+    rollout_engines: Sequence[ActorHandle],
+    converted_named_tensors: Sequence[tuple[str, torch.Tensor]],
+    load_format: str | None = None,
+) -> tuple[list[ObjectRef], list[dist.Work]]:
+    """Launch engine receives and broadcasts without waiting for completion."""
+    refs = [
+        engine.update_weights_from_distributed.remote(
+            names=[name for name, _ in converted_named_tensors],
+            dtypes=[param.dtype for _, param in converted_named_tensors],
+            shapes=[param.shape for _, param in converted_named_tensors],
+            group_name=group_name,
+            weight_version=str(weight_version),
+            load_format=load_format,
+        )
+        for engine in rollout_engines
+    ]
+    handles = [dist.broadcast(param.data, 0, group=group, async_op=True) for _, param in converted_named_tensors]
+    return refs, handles
 
 
 def update_weights_from_distributed(
@@ -334,40 +459,67 @@ def update_weights_from_distributed(
     """
     Send metadata through Ray and tensors through the configured transport.
     """
-    refs = [
-        engine.update_weights_from_distributed.remote(
-            names=[name for name, _ in converted_named_tensors],
-            dtypes=[param.dtype for _, param in converted_named_tensors],
-            shapes=[param.shape for _, param in converted_named_tensors],
-            group_name=group_name,
-            weight_version=str(weight_version),
-            load_format=load_format,
-        )
-        for engine in rollout_engines
-    ]
-    handles = []
-    for _, param in converted_named_tensors:
-        handles.append(dist.broadcast(param.data, 0, group=group, async_op=True))
+    refs, handles = launch_weights_from_distributed(
+        group_name,
+        group,
+        weight_version,
+        rollout_engines,
+        converted_named_tensors,
+        load_format=load_format,
+    )
     for handle in handles:
         handle.wait()
 
     return refs
 
 
+def update_weights_in_engine_group_waves(
+    update_groups: Sequence[DistributedWeightUpdateGroup],
+    weight_version: int,
+    converted_named_tensors: Sequence[tuple[str, torch.Tensor]],
+    *,
+    max_inflight_engine_groups: int,
+    load_format: str | None = None,
+) -> list[ObjectRef]:
+    """Transfer one bucket to bounded waves of independent engine groups."""
+    all_refs = []
+    for wave in build_engine_group_waves(update_groups, max_inflight_engine_groups):
+        wave_refs = []
+        wave_handles = []
+        for _index, update_group in wave:
+            refs, handles = launch_weights_from_distributed(
+                update_group.group_name,
+                update_group.process_group,
+                weight_version,
+                update_group.rollout_engines,
+                converted_named_tensors,
+                load_format=load_format,
+            )
+            wave_refs.extend(refs)
+            wave_handles.extend(handles)
+        for handle in wave_handles:
+            handle.wait()
+        if wave_refs:
+            ray.get(wave_refs)
+        all_refs.extend(wave_refs)
+    return all_refs
+
+
 def post_process_weights(
     restore_weights_before_load: bool,
     post_process_quantization: bool,
     rollout_engines: Sequence[ActorHandle],
+    max_inflight_engine_groups: int = 0,
 ):
     """
     Trigger post-process for int4/fp4 quantization on all rollout engines.
     """
-    ray.get(
-        [
-            engine.post_process_weights.remote(
-                restore_weights_before_load=restore_weights_before_load,
-                post_process_quantization=post_process_quantization,
-            )
-            for engine in rollout_engines
-        ]
+    run_engine_group_waves(
+        rollout_engines,
+        max_inflight_engine_groups,
+        lambda _index, engine: engine.post_process_weights.remote(
+            restore_weights_before_load=restore_weights_before_load,
+            post_process_quantization=post_process_quantization,
+        ),
+        ray.get,
     )

--- a/slime/backends/megatron_utils/update_weight/update_weight_from_tensor.py
+++ b/slime/backends/megatron_utils/update_weight/update_weight_from_tensor.py
@@ -13,6 +13,7 @@ from tqdm import tqdm
 
 from slime.utils import accelerator
 from slime.utils.distributed_utils import get_gloo_group
+from slime.utils.engine_group_wave import build_engine_group_waves
 from slime.utils.types import ParamInfo
 
 from ..megatron_to_hf import convert_to_hf
@@ -20,8 +21,9 @@ from ..sglang import FlattenedTensorBucket, MultiprocessingSerializer
 from .expert_routing import configure_expert_routing
 from .hf_weight_iterator_direct import HfWeightIteratorDirect
 from .update_weight_from_distributed import (
-    connect_rollout_engines_from_distributed,
-    disconnect_rollout_engines_from_distributed,
+    connect_rollout_engine_groups_from_distributed,
+    disconnect_rollout_engine_groups_from_distributed,
+    launch_weights_from_distributed,
     post_process_weights,
     update_weights_from_distributed,
 )
@@ -90,7 +92,11 @@ class UpdateWeightFromTensor:
         self._ipc_gather_group = None
         self._ipc_gather_src = None
         self._ipc_engine = None
-        self._model_update_groups = None
+        self._ipc_engine_index = None
+        self._model_update_groups = []
+        self._total_engine_groups = 0
+        self._max_inflight_engine_groups = getattr(args, "update_weight_max_inflight_engine_groups", 0)
+        self._wave_scheduling_enabled = False
         self._expert_transfer_plan = []
 
     def connect_rollout_engines(
@@ -106,6 +112,9 @@ class UpdateWeightFromTensor:
         for distributed. Map ranks to colocated IPC engines.
         """
         self.rollout_engines = rollout_engines
+        self._total_engine_groups = len(rollout_engines)
+        self._max_inflight_engine_groups = getattr(self.args, "update_weight_max_inflight_engine_groups", 0)
+        self._wave_scheduling_enabled = 0 < self._max_inflight_engine_groups < self._total_engine_groups
 
         if engine_gpu_counts is None:
             engine_gpu_counts = [self.args.rollout_num_gpus_per_engine] * len(rollout_engines)
@@ -138,16 +147,17 @@ class UpdateWeightFromTensor:
             )
             self._group_name = "slime"
             if self._is_distributed_src_rank:
-                if self._model_update_groups is not None:
-                    disconnect_rollout_engines_from_distributed(
-                        self._group_name, self._model_update_groups, self.distributed_rollout_engines
-                    )
+                if self._model_update_groups:
+                    disconnect_rollout_engine_groups_from_distributed(self._model_update_groups)
 
-                self._model_update_groups = connect_rollout_engines_from_distributed(
+                self._model_update_groups = connect_rollout_engine_groups_from_distributed(
                     self.args,
                     self._group_name,
                     self.distributed_rollout_engines,
                     engine_gpu_counts=distributed_gpu_counts,
+                    max_inflight_engine_groups=self._max_inflight_engine_groups,
+                    total_engine_groups=self._total_engine_groups,
+                    engine_index_offset=colocate_engine_nums,
                 )
 
         colocate_gpu_offsets = engine_gpu_offsets[:colocate_engine_nums]
@@ -167,11 +177,13 @@ class UpdateWeightFromTensor:
                     self._ipc_gather_src = colocate_gpu_offsets[i]
 
         # Map training ranks to colocated engine actors.
+        self._ipc_engine_index = None
         for i, engine in enumerate(self.rollout_engines):
             start = colocate_gpu_offsets[i]
             end = start + colocate_gpu_counts[i]
             if start <= self.rank < end:
                 self._ipc_engine = engine
+                self._ipc_engine_index = i
 
         self._non_expert_param_info_buckets, self._expert_transfer_plan = configure_expert_routing(
             args=self.args,
@@ -289,6 +301,7 @@ class UpdateWeightFromTensor:
                     restore_weights_before_load=True,
                     post_process_quantization=False,
                     rollout_engines=self.rollout_engines,
+                    max_inflight_engine_groups=self._max_inflight_engine_groups,
                 )
         dist.barrier(group=get_gloo_group())
 
@@ -327,11 +340,15 @@ class UpdateWeightFromTensor:
                     restore_weights_before_load=False,
                     post_process_quantization=True,
                     rollout_engines=self.rollout_engines,
+                    max_inflight_engine_groups=self._max_inflight_engine_groups,
                 )
             ray.get([engine.continue_generation.remote() for engine in self.rollout_engines])
         dist.barrier(group=get_gloo_group())
 
     def _send_hf_params(self, hf_named_tensors) -> tuple[list[ObjectRef], Any]:
+        if self._wave_scheduling_enabled:
+            return self._send_hf_params_in_waves(hf_named_tensors)
+
         all_refs = []
 
         refs_colocated, long_lived_tensors = _send_to_colocated_engine(
@@ -344,17 +361,64 @@ class UpdateWeightFromTensor:
         all_refs.extend(refs_colocated)
 
         if self.use_distribute and self._is_distributed_src_rank:
+            update_group = self._model_update_groups[0]
             refs_distributed = update_weights_from_distributed(
-                self._group_name,
-                self._model_update_groups,
+                update_group.group_name,
+                update_group.process_group,
                 self.weight_version,
-                self.distributed_rollout_engines,
+                update_group.rollout_engines,
                 hf_named_tensors,
             )
             if refs_distributed:
                 all_refs.extend(refs_distributed)
 
         return all_refs, long_lived_tensors
+
+    def _send_hf_params_in_waves(self, hf_named_tensors) -> tuple[list[ObjectRef], None]:
+        """Send one bucket in globally coordinated colocated/distributed waves."""
+        engine_indices = tuple(range(self._total_engine_groups))
+        for wave in build_engine_group_waves(engine_indices, self._max_inflight_engine_groups):
+            active_indices = {engine_index for _position, engine_index in wave}
+            wave_refs = []
+            wave_handles = []
+            wave_long_lived_tensors = None
+
+            if self._ipc_engine_index in active_indices:
+                refs_colocated, wave_long_lived_tensors = _send_to_colocated_engine(
+                    hf_named_tensors,
+                    ipc_engine=self._ipc_engine,
+                    ipc_gather_src=self._ipc_gather_src,
+                    ipc_gather_group=self._ipc_gather_group,
+                    weight_version=self.weight_version,
+                )
+                wave_refs.extend(refs_colocated)
+
+            if self.use_distribute and self._is_distributed_src_rank:
+                for update_group in self._model_update_groups:
+                    if not active_indices.intersection(update_group.engine_indices):
+                        continue
+                    refs, handles = launch_weights_from_distributed(
+                        update_group.group_name,
+                        update_group.process_group,
+                        self.weight_version,
+                        update_group.rollout_engines,
+                        hf_named_tensors,
+                    )
+                    wave_refs.extend(refs)
+                    wave_handles.extend(handles)
+
+            for handle in wave_handles:
+                handle.wait()
+            if wave_refs:
+                ray.get(wave_refs)
+
+            # Every training rank advances together, so IPC producers cannot
+            # release a bucket while another rank in the engine is still using it.
+            dist.barrier(group=get_gloo_group())
+            del wave_long_lived_tensors
+
+        # Every Ray ref and IPC consumer completed at its wave boundary.
+        return [], None
 
 
 def _send_to_colocated_engine(

--- a/slime/ray/actor_group.py
+++ b/slime/ray/actor_group.py
@@ -8,6 +8,7 @@ from ray.util.placement_group import PlacementGroup
 from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 
 from slime.ray.utils import NOSET_VISIBLE_DEVICES_ENV_VARS_LIST, add_default_ray_env_vars
+from slime.utils.engine_group_wave import run_engine_group_waves
 
 
 class RayTrainGroup:
@@ -233,24 +234,30 @@ class RayTrainGroup:
             if not self.args.update_weight_disk_keep_files:
                 shutil.rmtree(disk_weight_dir, ignore_errors=True)
             return
+        max_inflight_engine_groups = getattr(self.args, "update_weight_max_inflight_engine_groups", 0)
         if self.args.update_weight_local_checkpoint_dir:
             # each host pulls the published checkpoint onto local disk (e.g. NVMe) and
             # the engines reload from there; the pull is disk-only, so it runs before
             # pause and overlaps generation
-            ray.get([engine.pull_weights.remote(int(weight_version)) for engine in engines])
+            run_engine_group_waves(
+                engines,
+                max_inflight_engine_groups,
+                lambda _index, engine: engine.pull_weights.remote(int(weight_version)),
+                ray.get,
+            )
             model_path = self.args.update_weight_local_checkpoint_dir
         else:
             model_path = str(disk_weight_dir)
         ray.get([engine.pause_generation.remote() for engine in engines])
         ray.get([engine.flush_cache.remote() for engine in engines])
-        ray.get(
-            [
-                engine.update_weights_from_disk.remote(
-                    model_path=model_path,
-                    weight_version=weight_version,
-                )
-                for engine in engines
-            ]
+        run_engine_group_waves(
+            engines,
+            max_inflight_engine_groups,
+            lambda _index, engine: engine.update_weights_from_disk.remote(
+                model_path=model_path,
+                weight_version=weight_version,
+            ),
+            ray.get,
         )
         if self.args.ci_test:
             engine_versions = ray.get([engine.get_weight_version.remote() for engine in engines])

--- a/slime/utils/arguments.py
+++ b/slime/utils/arguments.py
@@ -546,6 +546,15 @@ def get_slime_extra_args_provider(add_custom_arguments=None):
                 ),
             )
             parser.add_argument(
+                "--update-weight-max-inflight-engine-groups",
+                type=int,
+                default=0,
+                help=(
+                    "Maximum number of rollout engine groups that may receive or load one weight bucket "
+                    "concurrently. 0 keeps the existing all-at-once behavior."
+                ),
+            )
+            parser.add_argument(
                 "--update-weights-interval",
                 type=int,
                 default=1,
@@ -2049,6 +2058,8 @@ def slime_validate_args(args):
             "--update-weight-transport=disk requires --update-weight-disk-dir to point at "
             "a filesystem shared between the trainer and the rollout engines."
         )
+    if getattr(args, "update_weight_max_inflight_engine_groups", 0) < 0:
+        raise ValueError("--update-weight-max-inflight-engine-groups must be non-negative.")
     if args.release_train:
         if args.use_critic:
             raise ValueError("--release-train does not support critic training yet.")

--- a/slime/utils/engine_group_wave.py
+++ b/slime/utils/engine_group_wave.py
@@ -1,0 +1,42 @@
+"""Deterministic wave planning for rollout-engine operations."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from typing import TypeVar
+
+
+T = TypeVar("T")
+R = TypeVar("R")
+
+
+def build_engine_group_waves(
+    engine_groups: Sequence[T],
+    max_inflight_engine_groups: int,
+) -> tuple[tuple[tuple[int, T], ...], ...]:
+    """Partition engine groups into stable, bounded waves.
+
+    Each item is paired with its original index so callers can coordinate the
+    same wave across trainer ranks. ``0`` preserves the existing all-at-once
+    behavior. A limit larger than the number of groups is also one wave.
+    """
+    if max_inflight_engine_groups < 0:
+        raise ValueError("max_inflight_engine_groups must be non-negative")
+    if not engine_groups:
+        return ()
+
+    wave_size = max_inflight_engine_groups or len(engine_groups)
+    indexed_groups = tuple(enumerate(engine_groups))
+    return tuple(indexed_groups[start : start + wave_size] for start in range(0, len(indexed_groups), wave_size))
+
+
+def run_engine_group_waves(
+    engine_groups: Sequence[T],
+    max_inflight_engine_groups: int,
+    submit: Callable[[int, T], R],
+    wait: Callable[[list[R]], object],
+) -> None:
+    """Submit each wave concurrently and wait before admitting the next one."""
+    for wave in build_engine_group_waves(engine_groups, max_inflight_engine_groups):
+        pending = [submit(index, engine_group) for index, engine_group in wave]
+        wait(pending)

--- a/tests/test_empty_colocated_weight_bucket.py
+++ b/tests/test_empty_colocated_weight_bucket.py
@@ -127,8 +127,9 @@ def _install_fake_deps(monkeypatch):
     update_from_distributed_mod = types.ModuleType(
         "slime.backends.megatron_utils.update_weight.update_weight_from_distributed"
     )
-    update_from_distributed_mod.connect_rollout_engines_from_distributed = lambda *args, **kwargs: None
-    update_from_distributed_mod.disconnect_rollout_engines_from_distributed = lambda *args, **kwargs: None
+    update_from_distributed_mod.connect_rollout_engine_groups_from_distributed = lambda *args, **kwargs: []
+    update_from_distributed_mod.disconnect_rollout_engine_groups_from_distributed = lambda *args, **kwargs: None
+    update_from_distributed_mod.launch_weights_from_distributed = lambda *args, **kwargs: ([], [])
     update_from_distributed_mod.post_process_weights = lambda *args, **kwargs: None
     update_from_distributed_mod.update_weights_from_distributed = lambda *args, **kwargs: []
 

--- a/tests/test_engine_group_wave.py
+++ b/tests/test_engine_group_wave.py
@@ -15,7 +15,7 @@ NUM_GPUS = 0
 
 
 @pytest.mark.unit
-@pytest.mark.parametrize("engine_count", [1, 2, 4, 7])
+@pytest.mark.parametrize("engine_count", [1, 2, 4])
 def test_zero_limit_preserves_all_at_once(engine_count):
     engines = [f"engine-{index}" for index in range(engine_count)]
 
@@ -26,20 +26,19 @@ def test_zero_limit_preserves_all_at_once(engine_count):
 
 @pytest.mark.unit
 def test_positive_limit_builds_stable_bounded_waves():
-    engines = [f"engine-{index}" for index in range(5)]
+    engines = [f"engine-{index}" for index in range(4)]
 
-    waves = build_engine_group_waves(engines, 2)
+    waves = build_engine_group_waves(engines, 3)
 
     assert waves == (
-        ((0, "engine-0"), (1, "engine-1")),
-        ((2, "engine-2"), (3, "engine-3")),
-        ((4, "engine-4"),),
+        ((0, "engine-0"), (1, "engine-1"), (2, "engine-2")),
+        ((3, "engine-3"),),
     )
 
 
 @pytest.mark.unit
 def test_limit_larger_than_population_is_one_wave():
-    assert build_engine_group_waves(["a", "b"], 8) == (((0, "a"), (1, "b")),)
+    assert build_engine_group_waves(["a", "b"], 4) == (((0, "a"), (1, "b")),)
 
 
 @pytest.mark.unit
@@ -64,17 +63,15 @@ def test_runner_waits_before_submitting_the_next_wave():
     def wait(refs):
         events.append(("wait", tuple(refs)))
 
-    run_engine_group_waves(["a", "b", "c", "d", "e"], 2, submit, wait)
+    run_engine_group_waves(["a", "b", "c", "d"], 3, submit, wait)
 
     assert events == [
         ("submit", 0, "a"),
         ("submit", 1, "b"),
-        ("wait", ("ref-0", "ref-1")),
         ("submit", 2, "c"),
+        ("wait", ("ref-0", "ref-1", "ref-2")),
         ("submit", 3, "d"),
-        ("wait", ("ref-2", "ref-3")),
-        ("submit", 4, "e"),
-        ("wait", ("ref-4",)),
+        ("wait", ("ref-3",)),
     ]
 
 

--- a/tests/test_engine_group_wave.py
+++ b/tests/test_engine_group_wave.py
@@ -1,0 +1,82 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from slime.utils.engine_group_wave import build_engine_group_waves, run_engine_group_waves
+
+
+NUM_GPUS = 0
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("engine_count", [1, 2, 4, 7])
+def test_zero_limit_preserves_all_at_once(engine_count):
+    engines = [f"engine-{index}" for index in range(engine_count)]
+
+    waves = build_engine_group_waves(engines, 0)
+
+    assert waves == (tuple(enumerate(engines)),)
+
+
+@pytest.mark.unit
+def test_positive_limit_builds_stable_bounded_waves():
+    engines = [f"engine-{index}" for index in range(5)]
+
+    waves = build_engine_group_waves(engines, 2)
+
+    assert waves == (
+        ((0, "engine-0"), (1, "engine-1")),
+        ((2, "engine-2"), (3, "engine-3")),
+        ((4, "engine-4"),),
+    )
+
+
+@pytest.mark.unit
+def test_limit_larger_than_population_is_one_wave():
+    assert build_engine_group_waves(["a", "b"], 8) == (((0, "a"), (1, "b")),)
+
+
+@pytest.mark.unit
+def test_empty_population_has_no_waves():
+    assert build_engine_group_waves([], 1) == ()
+
+
+@pytest.mark.unit
+def test_negative_limit_is_rejected():
+    with pytest.raises(ValueError, match="must be non-negative"):
+        build_engine_group_waves(["engine"], -1)
+
+
+@pytest.mark.unit
+def test_runner_waits_before_submitting_the_next_wave():
+    events = []
+
+    def submit(index, engine):
+        events.append(("submit", index, engine))
+        return f"ref-{index}"
+
+    def wait(refs):
+        events.append(("wait", tuple(refs)))
+
+    run_engine_group_waves(["a", "b", "c", "d", "e"], 2, submit, wait)
+
+    assert events == [
+        ("submit", 0, "a"),
+        ("submit", 1, "b"),
+        ("wait", ("ref-0", "ref-1")),
+        ("submit", 2, "c"),
+        ("submit", 3, "d"),
+        ("wait", ("ref-2", "ref-3")),
+        ("submit", 4, "e"),
+        ("wait", ("ref-4",)),
+    ]
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__]))

--- a/tests/test_engine_group_wave_distributed.py
+++ b/tests/test_engine_group_wave_distributed.py
@@ -1,0 +1,295 @@
+import importlib.util
+import sys
+import types
+from argparse import Namespace
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+NUM_GPUS = 0
+
+
+def _load_distributed_update_module(monkeypatch):
+    slime_pkg = types.ModuleType("slime")
+    slime_pkg.__path__ = [str(REPO_ROOT / "slime")]
+    slime_utils_pkg = types.ModuleType("slime.utils")
+    slime_utils_pkg.__path__ = [str(REPO_ROOT / "slime" / "utils")]
+    slime_backends_pkg = types.ModuleType("slime.backends")
+    slime_backends_pkg.__path__ = [str(REPO_ROOT / "slime" / "backends")]
+    megatron_utils_pkg = types.ModuleType("slime.backends.megatron_utils")
+    megatron_utils_pkg.__path__ = [str(REPO_ROOT / "slime" / "backends" / "megatron_utils")]
+    update_weight_pkg = types.ModuleType("slime.backends.megatron_utils.update_weight")
+    update_weight_pkg.__path__ = [str(REPO_ROOT / "slime" / "backends" / "megatron_utils" / "update_weight")]
+
+    ray_mod = types.ModuleType("ray")
+    ray_mod.ObjectRef = object
+    ray_mod.get = lambda refs: refs
+    ray_actor_mod = types.ModuleType("ray.actor")
+    ray_actor_mod.ActorHandle = object
+
+    dist_mod = types.ModuleType("torch.distributed")
+    dist_mod.ProcessGroup = object
+    dist_mod.Work = object
+    torch_mod = types.ModuleType("torch")
+    torch_mod.Tensor = object
+    torch_mod.nn = types.SimpleNamespace(Module=object)
+    torch_mod.no_grad = lambda: (lambda function: function)
+    torch_mod.distributed = dist_mod
+
+    megatron_mod = types.ModuleType("megatron")
+    megatron_core_mod = types.ModuleType("megatron.core")
+    mpu_mod = types.ModuleType("megatron.core.mpu")
+    megatron_core_mod.mpu = mpu_mod
+
+    accelerator_mod = types.ModuleType("slime.utils.accelerator")
+    distributed_utils_mod = types.ModuleType("slime.utils.distributed_utils")
+    distributed_utils_mod.get_gloo_group = lambda: object()
+    distributed_utils_mod.init_process_group = lambda **kwargs: object()
+    http_utils_mod = types.ModuleType("slime.utils.http_utils")
+    http_utils_mod._wrap_ipv6 = lambda address: address
+    megatron_to_hf_mod = types.ModuleType("slime.backends.megatron_utils.megatron_to_hf")
+    megatron_to_hf_mod.convert_to_hf = lambda *args, **kwargs: []
+    common_mod = types.ModuleType("slime.backends.megatron_utils.update_weight.common")
+    common_mod.all_gather_param = lambda _name, param: param
+    common_mod.named_params_and_buffers = lambda *_args, **_kwargs: []
+    tqdm_mod = types.ModuleType("tqdm")
+    tqdm_mod.tqdm = object
+
+    fake_modules = {
+        "slime": slime_pkg,
+        "slime.utils": slime_utils_pkg,
+        "slime.backends": slime_backends_pkg,
+        "slime.backends.megatron_utils": megatron_utils_pkg,
+        "slime.backends.megatron_utils.update_weight": update_weight_pkg,
+        "ray": ray_mod,
+        "ray.actor": ray_actor_mod,
+        "torch": torch_mod,
+        "torch.distributed": dist_mod,
+        "megatron": megatron_mod,
+        "megatron.core": megatron_core_mod,
+        "megatron.core.mpu": mpu_mod,
+        "slime.utils.accelerator": accelerator_mod,
+        "slime.utils.distributed_utils": distributed_utils_mod,
+        "slime.utils.http_utils": http_utils_mod,
+        "slime.backends.megatron_utils.megatron_to_hf": megatron_to_hf_mod,
+        "slime.backends.megatron_utils.update_weight.common": common_mod,
+        "tqdm": tqdm_mod,
+    }
+    for name, module in fake_modules.items():
+        monkeypatch.setitem(sys.modules, name, module)
+
+    module_name = "slime.backends.megatron_utils.update_weight.update_weight_from_distributed"
+    sys.modules.pop(module_name, None)
+    module_path = (
+        REPO_ROOT / "slime" / "backends" / "megatron_utils" / "update_weight" / "update_weight_from_distributed.py"
+    )
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, module_name, module)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("limit", [0, 3, 8])
+def test_unbounded_distributed_topology_keeps_one_aggregate_group(monkeypatch, limit):
+    module = _load_distributed_update_module(monkeypatch)
+    calls = []
+
+    def connect(_args, name, engines, engine_gpu_counts=None):
+        calls.append((name, tuple(engines), tuple(engine_gpu_counts)))
+        return f"pg-{name}"
+
+    monkeypatch.setattr(module, "connect_rollout_engines_from_distributed", connect)
+    engines = ["engine-0", "engine-1", "engine-2"]
+
+    groups = module.connect_rollout_engine_groups_from_distributed(
+        Namespace(rollout_num_gpus_per_engine=1),
+        "slime",
+        engines,
+        engine_gpu_counts=[1, 2, 3],
+        max_inflight_engine_groups=limit,
+    )
+
+    assert calls == [("slime", tuple(engines), (1, 2, 3))]
+    assert len(groups) == 1
+    assert groups[0].engine_indices == (0, 1, 2)
+    assert groups[0].rollout_engines == tuple(engines)
+
+
+@pytest.mark.unit
+def test_partial_group_setup_is_torn_down_on_failure(monkeypatch):
+    module = _load_distributed_update_module(monkeypatch)
+    disconnected = []
+
+    def connect(_args, name, _engines, engine_gpu_counts=None):
+        assert engine_gpu_counts is not None
+        if name.endswith("-1"):
+            raise RuntimeError("engine setup failed")
+        return f"pg-{name}"
+
+    monkeypatch.setattr(module, "connect_rollout_engines_from_distributed", connect)
+    monkeypatch.setattr(
+        module,
+        "disconnect_rollout_engine_groups_from_distributed",
+        lambda groups: disconnected.extend(groups),
+    )
+
+    with pytest.raises(RuntimeError, match="engine setup failed"):
+        module.connect_rollout_engine_groups_from_distributed(
+            Namespace(rollout_num_gpus_per_engine=1),
+            "slime",
+            ["engine-a", "engine-b", "engine-c"],
+            max_inflight_engine_groups=1,
+        )
+
+    assert len(disconnected) == 1
+    assert disconnected[0].group_name == "slime-engine-0"
+
+
+@pytest.mark.unit
+def test_distributed_launch_starts_all_bucket_broadcasts_asynchronously(monkeypatch):
+    module = _load_distributed_update_module(monkeypatch)
+    remote_calls = []
+    broadcasts = []
+
+    class RemoteMethod:
+        def remote(self, **kwargs):
+            remote_calls.append(kwargs)
+            return "engine-ref"
+
+    class Engine:
+        update_weights_from_distributed = RemoteMethod()
+
+    class Tensor:
+        def __init__(self, name, dtype, shape):
+            self.data = f"data-{name}"
+            self.dtype = dtype
+            self.shape = shape
+
+    def broadcast(data, source, *, group, async_op):
+        broadcasts.append((data, source, group, async_op))
+        return f"work-{data}"
+
+    monkeypatch.setattr(module.dist, "broadcast", broadcast, raising=False)
+    named_tensors = [
+        ("weight-a", Tensor("a", "bf16", (2, 4))),
+        ("weight-b", Tensor("b", "fp32", (3,))),
+    ]
+
+    refs, works = module.launch_weights_from_distributed(
+        "slime-engine-0",
+        "pg-0",
+        17,
+        [Engine()],
+        named_tensors,
+        load_format="flattened_bucket",
+    )
+
+    assert refs == ["engine-ref"]
+    assert works == ["work-data-a", "work-data-b"]
+    assert broadcasts == [
+        ("data-a", 0, "pg-0", True),
+        ("data-b", 0, "pg-0", True),
+    ]
+    assert remote_calls == [
+        {
+            "names": ["weight-a", "weight-b"],
+            "dtypes": ["bf16", "fp32"],
+            "shapes": [(2, 4), (3,)],
+            "group_name": "slime-engine-0",
+            "weight_version": "17",
+            "load_format": "flattened_bucket",
+        }
+    ]
+
+
+@pytest.mark.unit
+def test_bounded_distributed_topology_builds_one_group_per_engine(monkeypatch):
+    module = _load_distributed_update_module(monkeypatch)
+    calls = []
+
+    def connect(_args, name, engines, engine_gpu_counts=None):
+        calls.append((name, tuple(engines), tuple(engine_gpu_counts)))
+        return f"pg-{name}"
+
+    monkeypatch.setattr(module, "connect_rollout_engines_from_distributed", connect)
+
+    groups = module.connect_rollout_engine_groups_from_distributed(
+        Namespace(rollout_num_gpus_per_engine=1),
+        "slime",
+        ["engine-a", "engine-b", "engine-c"],
+        engine_gpu_counts=[1, 3, 2],
+        max_inflight_engine_groups=2,
+        total_engine_groups=5,
+        engine_index_offset=2,
+    )
+
+    assert calls == [
+        ("slime-engine-2", ("engine-a",), (1,)),
+        ("slime-engine-3", ("engine-b",), (3,)),
+        ("slime-engine-4", ("engine-c",), (2,)),
+    ]
+    assert [group.engine_indices for group in groups] == [(2,), (3,), (4,)]
+
+
+@pytest.mark.unit
+def test_distributed_wave_waits_before_admitting_next_engines(monkeypatch):
+    module = _load_distributed_update_module(monkeypatch)
+    events = []
+
+    class Work:
+        def __init__(self, engine_index):
+            self.engine_index = engine_index
+
+        def wait(self):
+            events.append(("work.wait", self.engine_index))
+
+    groups = [
+        module.DistributedWeightUpdateGroup(
+            engine_indices=(index,),
+            group_name=f"group-{index}",
+            process_group=f"pg-{index}",
+            rollout_engines=(f"engine-{index}",),
+        )
+        for index in range(5)
+    ]
+
+    def launch(group_name, _group, _version, _engines, _tensors, load_format=None):
+        engine_index = int(group_name.rsplit("-", 1)[1])
+        events.append(("launch", engine_index, load_format))
+        return [f"ref-{engine_index}"], [Work(engine_index)]
+
+    monkeypatch.setattr(module, "launch_weights_from_distributed", launch)
+    monkeypatch.setattr(module.ray, "get", lambda refs: events.append(("ray.get", tuple(refs))))
+
+    module.update_weights_in_engine_group_waves(
+        groups,
+        weight_version=9,
+        converted_named_tensors=[],
+        max_inflight_engine_groups=2,
+        load_format="test",
+    )
+
+    assert events == [
+        ("launch", 0, "test"),
+        ("launch", 1, "test"),
+        ("work.wait", 0),
+        ("work.wait", 1),
+        ("ray.get", ("ref-0", "ref-1")),
+        ("launch", 2, "test"),
+        ("launch", 3, "test"),
+        ("work.wait", 2),
+        ("work.wait", 3),
+        ("ray.get", ("ref-2", "ref-3")),
+        ("launch", 4, "test"),
+        ("work.wait", 4),
+        ("ray.get", ("ref-4",)),
+    ]
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__]))

--- a/tests/test_engine_group_wave_distributed.py
+++ b/tests/test_engine_group_wave_distributed.py
@@ -94,7 +94,7 @@ def _load_distributed_update_module(monkeypatch):
 
 
 @pytest.mark.unit
-@pytest.mark.parametrize("limit", [0, 3, 8])
+@pytest.mark.parametrize("limit", [0, 2, 4])
 def test_unbounded_distributed_topology_keeps_one_aggregate_group(monkeypatch, limit):
     module = _load_distributed_update_module(monkeypatch)
     calls = []
@@ -104,19 +104,19 @@ def test_unbounded_distributed_topology_keeps_one_aggregate_group(monkeypatch, l
         return f"pg-{name}"
 
     monkeypatch.setattr(module, "connect_rollout_engines_from_distributed", connect)
-    engines = ["engine-0", "engine-1", "engine-2"]
+    engines = ["engine-0", "engine-1"]
 
     groups = module.connect_rollout_engine_groups_from_distributed(
         Namespace(rollout_num_gpus_per_engine=1),
         "slime",
         engines,
-        engine_gpu_counts=[1, 2, 3],
+        engine_gpu_counts=[1, 2],
         max_inflight_engine_groups=limit,
     )
 
-    assert calls == [("slime", tuple(engines), (1, 2, 3))]
+    assert calls == [("slime", tuple(engines), (1, 2))]
     assert len(groups) == 1
-    assert groups[0].engine_indices == (0, 1, 2)
+    assert groups[0].engine_indices == (0, 1)
     assert groups[0].rollout_engines == tuple(engines)
 
 
@@ -142,7 +142,7 @@ def test_partial_group_setup_is_torn_down_on_failure(monkeypatch):
         module.connect_rollout_engine_groups_from_distributed(
             Namespace(rollout_num_gpus_per_engine=1),
             "slime",
-            ["engine-a", "engine-b", "engine-c"],
+            ["engine-a", "engine-b"],
             max_inflight_engine_groups=1,
         )
 
@@ -221,19 +221,18 @@ def test_bounded_distributed_topology_builds_one_group_per_engine(monkeypatch):
     groups = module.connect_rollout_engine_groups_from_distributed(
         Namespace(rollout_num_gpus_per_engine=1),
         "slime",
-        ["engine-a", "engine-b", "engine-c"],
-        engine_gpu_counts=[1, 3, 2],
+        ["engine-a", "engine-b"],
+        engine_gpu_counts=[1, 2],
         max_inflight_engine_groups=2,
-        total_engine_groups=5,
+        total_engine_groups=4,
         engine_index_offset=2,
     )
 
     assert calls == [
         ("slime-engine-2", ("engine-a",), (1,)),
-        ("slime-engine-3", ("engine-b",), (3,)),
-        ("slime-engine-4", ("engine-c",), (2,)),
+        ("slime-engine-3", ("engine-b",), (2,)),
     ]
-    assert [group.engine_indices for group in groups] == [(2,), (3,), (4,)]
+    assert [group.engine_indices for group in groups] == [(2,), (3,)]
 
 
 @pytest.mark.unit
@@ -255,7 +254,7 @@ def test_distributed_wave_waits_before_admitting_next_engines(monkeypatch):
             process_group=f"pg-{index}",
             rollout_engines=(f"engine-{index}",),
         )
-        for index in range(5)
+        for index in range(4)
     ]
 
     def launch(group_name, _group, _version, _engines, _tensors, load_format=None):
@@ -270,24 +269,21 @@ def test_distributed_wave_waits_before_admitting_next_engines(monkeypatch):
         groups,
         weight_version=9,
         converted_named_tensors=[],
-        max_inflight_engine_groups=2,
+        max_inflight_engine_groups=3,
         load_format="test",
     )
 
     assert events == [
         ("launch", 0, "test"),
         ("launch", 1, "test"),
+        ("launch", 2, "test"),
         ("work.wait", 0),
         ("work.wait", 1),
-        ("ray.get", ("ref-0", "ref-1")),
-        ("launch", 2, "test"),
-        ("launch", 3, "test"),
         ("work.wait", 2),
+        ("ray.get", ("ref-0", "ref-1", "ref-2")),
+        ("launch", 3, "test"),
         ("work.wait", 3),
-        ("ray.get", ("ref-2", "ref-3")),
-        ("launch", 4, "test"),
-        ("work.wait", 4),
-        ("ray.get", ("ref-4",)),
+        ("ray.get", ("ref-3",)),
     ]
 
 

--- a/tests/test_megatron_argument_validation.py
+++ b/tests/test_megatron_argument_validation.py
@@ -177,6 +177,15 @@ def test_update_weight_disk_dir_required_for_disk_transport(monkeypatch):
         module.slime_validate_args(args)
 
 
+@pytest.mark.unit
+def test_update_weight_engine_group_wave_limit_must_be_non_negative(monkeypatch):
+    module = load_slime_arguments_module(monkeypatch)
+    args = make_slime_validate_args(update_weight_max_inflight_engine_groups=-1)
+
+    with pytest.raises(ValueError, match="max-inflight-engine-groups"):
+        module.slime_validate_args(args)
+
+
 def make_slime_validate_args(**overrides):
     values = dict(
         eval_config=None,
@@ -401,6 +410,26 @@ def test_force_fp8_ue8m0_scale_argument(monkeypatch):
 
     assert defaults.force_fp8_ue8m0_scale is False
     assert configured.force_fp8_ue8m0_scale is True
+
+
+@pytest.mark.unit
+def test_update_weight_engine_group_wave_argument(monkeypatch):
+    module = load_slime_arguments_module(monkeypatch)
+    parser = argparse.ArgumentParser()
+    module.get_slime_extra_args_provider()(parser)
+
+    defaults = parser.parse_args(["--rollout-batch-size", "1"])
+    configured = parser.parse_args(
+        [
+            "--rollout-batch-size",
+            "1",
+            "--update-weight-max-inflight-engine-groups",
+            "3",
+        ]
+    )
+
+    assert defaults.update_weight_max_inflight_engine_groups == 0
+    assert configured.update_weight_max_inflight_engine_groups == 3
 
 
 if __name__ == "__main__":

--- a/tests/test_weight_sync_callsite_benchmark.py
+++ b/tests/test_weight_sync_callsite_benchmark.py
@@ -1,0 +1,187 @@
+import copy
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from tools.benchmark_weight_sync_callsite import (
+    EVIDENCE_ROLES,
+    POLICIES,
+    SCHEMA,
+    _load_production_callsite_from_source,
+    artifact_digest,
+    ordered_engine_indices,
+    parse_size,
+    resolve_policy,
+    summarize_artifacts,
+    verify_artifact,
+)
+
+
+NUM_GPUS = 0
+
+
+def test_policy_matrix_uses_production_native_limits_for_logical_four_rank_layout():
+    assert resolve_policy("isolated_a", 3, 2).active_engine_indices == (0,)
+    assert resolve_policy("isolated_b", 3, 2).active_engine_indices == (1,)
+    assert resolve_policy("baseline_overlap", 3, 2).max_inflight_engine_groups == 0
+    assert resolve_policy("current_legal", 3, 2).max_inflight_engine_groups == 3
+    assert resolve_policy("candidate_serialized", 3, 2).max_inflight_engine_groups == 1
+    assert resolve_policy("candidate_windowed", 3, 2).max_inflight_engine_groups == 2
+
+
+def test_policy_resolution_is_generic_and_has_no_special_world_size_branch():
+    resolved = resolve_policy("candidate_windowed", engine_count=7, window_size=4)
+
+    assert resolved.active_engine_indices == tuple(range(7))
+    assert resolved.max_inflight_engine_groups == 4
+
+
+def test_ba_order_only_swaps_the_named_pair():
+    assert ordered_engine_indices((0, 1, 2), "ab") == (0, 1, 2)
+    assert ordered_engine_indices((0, 1, 2), "ba") == (1, 0, 2)
+
+
+def test_parse_size_checks_exact_positive_elements():
+    assert parse_size("1MiB") == 1 << 20
+    assert parse_size("2.5MB") == 2_500_000
+    with pytest.raises(Exception, match="positive"):
+        parse_size("0")
+
+
+def test_minimal_container_source_loader_uses_the_production_function():
+    module = _load_production_callsite_from_source()
+
+    assert module.update_weights_in_engine_group_waves.__module__.endswith("update_weight_from_distributed")
+    assert module.update_weights_in_engine_group_waves.__code__.co_filename.endswith(
+        "slime/backends/megatron_utils/update_weight/update_weight_from_distributed.py"
+    )
+
+
+def _artifact(policy, role, run_index, *, world_size=4):
+    metrics = {
+        name: {"p50": float(run_index + 1), "p95": float(run_index + 2), "min": 1.0, "max": 3.0}
+        for name in (
+            "comm_a_ms",
+            "comm_b_ms",
+            "rank_local_pair_makespan_ms",
+            "realized_b_minus_a_launch_offset_us",
+            "consumer_a_wait_ms",
+            "consumer_b_wait_ms",
+            "consumer_ready_ms",
+            "callsite_return_ms",
+            "controller_device_ready_ms",
+            "step_sync_ready_ms",
+        )
+    }
+    payload = {
+        "schema": SCHEMA,
+        "run_id": f"{policy}-{role}-{run_index}",
+        "process_launch_id": f"launch-{policy}-{role}-{run_index}",
+        "evidence_role": role,
+        "policy": policy,
+        "order": "ab" if run_index % 2 == 0 else "ba",
+        "resolved_policy": {},
+        "timing_scope": {},
+        "compatibility": {
+            "backend": "gloo",
+            "python": "3.12.0",
+            "pytorch": "2.11.0",
+            "cuda_runtime": None,
+            "nccl": None,
+            "nccl_launch_order_implicit": None,
+            "dtype": "float32",
+            "message_bytes": 1024,
+            "tensor_elements": 256,
+            "launched_world_size": world_size,
+            "engine_group_count": world_size - 1,
+            "process_group_membership": [[0, rank] for rank in range(1, world_size)],
+            "graph_capture": False,
+            "hostname": "test-host",
+            "device": None,
+            "container_image_digest": None,
+        },
+        "iterations": [],
+        "summary": metrics,
+        "observed_ranks": list(range(world_size)),
+        "payload_validated": True,
+        "claim_limits": ["fixture"],
+    }
+    payload["artifact_sha256"] = artifact_digest(payload)
+    return payload
+
+
+def _write_campaign(tmp_path, runs_per_role=2):
+    paths = []
+    for policy in POLICIES:
+        for role in EVIDENCE_ROLES:
+            for run_index in range(runs_per_role):
+                path = tmp_path / f"{policy}-{role}-{run_index}.json"
+                path.write_text(json.dumps(_artifact(policy, role, run_index)))
+                paths.append(path)
+    return paths
+
+
+def test_campaign_counts_independent_processes_not_iterations(tmp_path):
+    paths = _write_campaign(tmp_path)
+
+    result = summarize_artifacts(paths, min_runs_per_role=2)
+
+    assert result["artifact_count"] == len(POLICIES) * len(EVIDENCE_ROLES) * 2
+    assert result["selection_and_confirmation_disjoint"] is True
+    assert result["automatic_policy_selection"] is False
+    for policy in POLICIES:
+        for role in EVIDENCE_ROLES:
+            summary = result["policy_summaries"][policy][role]
+            assert summary["independent_process_runs"] == 2
+            assert summary["orders"] == ["ab", "ba"]
+
+
+def test_campaign_fails_closed_on_too_few_independent_runs(tmp_path):
+    paths = _write_campaign(tmp_path, runs_per_role=1)
+
+    with pytest.raises(ValueError, match="requires 2 independent process runs"):
+        summarize_artifacts(paths, min_runs_per_role=2)
+
+
+def test_campaign_rejects_cross_cell_evidence(tmp_path):
+    paths = _write_campaign(tmp_path)
+    changed = json.loads(paths[-1].read_text())
+    changed["compatibility"]["message_bytes"] *= 2
+    changed["artifact_sha256"] = artifact_digest(changed)
+    paths[-1].write_text(json.dumps(changed))
+
+    with pytest.raises(ValueError, match="incompatible"):
+        summarize_artifacts(paths, min_runs_per_role=2)
+
+
+def test_campaign_rejects_reused_process_launch_identity(tmp_path):
+    paths = _write_campaign(tmp_path)
+    first = json.loads(paths[0].read_text())
+    second = json.loads(paths[1].read_text())
+    second["process_launch_id"] = first["process_launch_id"]
+    second["artifact_sha256"] = artifact_digest(second)
+    paths[1].write_text(json.dumps(second))
+
+    with pytest.raises(ValueError, match="process_launch_id values must be unique"):
+        summarize_artifacts(paths, min_runs_per_role=2)
+
+
+def test_artifact_digest_detects_timing_mutation():
+    payload = _artifact("baseline_overlap", "selection", 0)
+    verify_artifact(payload)
+    mutated = copy.deepcopy(payload)
+    mutated["summary"]["step_sync_ready_ms"]["p50"] += 1
+
+    with pytest.raises(ValueError, match="digest mismatch"):
+        verify_artifact(mutated)
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__]))

--- a/tools/benchmark_weight_sync_callsite.py
+++ b/tools/benchmark_weight_sync_callsite.py
@@ -1,0 +1,813 @@
+"""Measure engine-wave policies at slime's production weight-sync callsite.
+
+This probe invokes ``update_weights_in_engine_group_waves`` directly.  It does
+not reimplement the scheduler and it never changes slime's runtime defaults.
+Each engine uses the production two-rank ``[trainer, engine]`` process-group
+shape; the launched world may contain any number of such engine groups.
+
+One distributed process launch records exactly one policy/evidence-role/run.
+Use separate launches for selection and confirmation, then summarize the raw
+artifacts with ``--summarize``.  Continuous iterations inside one launch are
+never counted as independent runs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.util
+import json
+import os
+import platform
+import socket
+import subprocess
+import sys
+import time
+import types
+import uuid
+from collections.abc import Sequence
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+import torch
+import torch.distributed as dist
+
+
+POLICIES = (
+    "isolated_a",
+    "isolated_b",
+    "baseline_overlap",
+    "current_legal",
+    "candidate_serialized",
+    "candidate_windowed",
+)
+EVIDENCE_ROLES = ("selection", "confirmation")
+SCHEMA = "slime.weight_sync_callsite.v1"
+
+
+@dataclass(frozen=True)
+class CallsitePolicy:
+    active_engine_indices: tuple[int, ...]
+    max_inflight_engine_groups: int
+
+
+@dataclass
+class LaunchObservation:
+    engine_index: int
+    host_launch_ns: int
+    host_wait_return_ns: int | None = None
+    start_event: torch.cuda.Event | None = None
+    completion_event: torch.cuda.Event | None = None
+
+
+class _ReadyRemoteMethod:
+    """Minimal actor method used only to cross the real callsite boundary."""
+
+    def __init__(self, engine_index: int) -> None:
+        self.engine_index = engine_index
+
+    def remote(self, **metadata: Any) -> dict[str, Any]:
+        return {"engine_index": self.engine_index, "metadata": metadata}
+
+
+class _ReadyEngine:
+    def __init__(self, engine_index: int) -> None:
+        self.update_weights_from_distributed = _ReadyRemoteMethod(engine_index)
+
+
+class _ObservedWork:
+    def __init__(self, work: Any, observation: LaunchObservation, device: torch.device) -> None:
+        self._work = work
+        self._observation = observation
+        self._device = device
+
+    def wait(self) -> object:
+        result = self._work.wait()
+        if self._device.type == "cuda":
+            completion = torch.cuda.Event(enable_timing=True)
+            completion.record(torch.cuda.current_stream(self._device))
+            self._observation.completion_event = completion
+        self._observation.host_wait_return_ns = time.perf_counter_ns()
+        return result
+
+
+def parse_size(value: str) -> int:
+    suffixes = {
+        "b": 1,
+        "kib": 1 << 10,
+        "mib": 1 << 20,
+        "gib": 1 << 30,
+        "kb": 1_000,
+        "mb": 1_000_000,
+        "gb": 1_000_000_000,
+    }
+    normalized = value.strip().lower().replace("_", "")
+    for suffix in sorted(suffixes, key=len, reverse=True):
+        if normalized.endswith(suffix):
+            number = float(normalized[: -len(suffix)])
+            result = number * suffixes[suffix]
+            if result <= 0 or not result.is_integer():
+                raise argparse.ArgumentTypeError(f"invalid positive byte size: {value}")
+            return int(result)
+    try:
+        result = int(normalized)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"invalid byte size: {value}") from exc
+    if result <= 0:
+        raise argparse.ArgumentTypeError(f"invalid positive byte size: {value}")
+    return result
+
+
+def resolve_policy(policy: str, engine_count: int, window_size: int) -> CallsitePolicy:
+    """Resolve benchmark labels to the production callsite's native limit."""
+    if policy not in POLICIES:
+        raise ValueError(f"unsupported policy: {policy}")
+    if engine_count < 2:
+        raise ValueError("the A/B callsite probe requires at least two engine groups")
+    if window_size < 1:
+        raise ValueError("window_size must be positive")
+
+    all_engines = tuple(range(engine_count))
+    if policy == "isolated_a":
+        return CallsitePolicy((0,), 0)
+    if policy == "isolated_b":
+        return CallsitePolicy((1,), 0)
+    if policy == "baseline_overlap":
+        return CallsitePolicy(all_engines, 0)
+    if policy == "current_legal":
+        return CallsitePolicy(all_engines, engine_count)
+    if policy == "candidate_serialized":
+        return CallsitePolicy(all_engines, 1)
+    return CallsitePolicy(all_engines, min(window_size, engine_count))
+
+
+def ordered_engine_indices(indices: Sequence[int], order: str) -> tuple[int, ...]:
+    if order == "ab":
+        return tuple(indices)
+    if order == "ba":
+        reordered = list(indices)
+        if 0 in reordered and 1 in reordered:
+            first = reordered.index(0)
+            second = reordered.index(1)
+            reordered[first], reordered[second] = reordered[second], reordered[first]
+        return tuple(reordered)
+    raise ValueError(f"unsupported A/B order: {order}")
+
+
+def percentile(values: Sequence[float], quantile: float) -> float | None:
+    if not values:
+        return None
+    ordered = sorted(values)
+    position = (len(ordered) - 1) * quantile
+    lower = int(position)
+    upper = min(lower + 1, len(ordered) - 1)
+    fraction = position - lower
+    return float(ordered[lower] * (1.0 - fraction) + ordered[upper] * fraction)
+
+
+def summarize_values(values: Sequence[float]) -> dict[str, float | None]:
+    return {
+        "p50": percentile(values, 0.50),
+        "p95": percentile(values, 0.95),
+        "min": min(values) if values else None,
+        "max": max(values) if values else None,
+    }
+
+
+def _canonical_json(payload: object) -> bytes:
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode()
+
+
+def artifact_digest(payload: dict[str, Any]) -> str:
+    unsigned = {key: value for key, value in payload.items() if key != "artifact_sha256"}
+    return hashlib.sha256(_canonical_json(unsigned)).hexdigest()
+
+
+def verify_artifact(payload: dict[str, Any]) -> None:
+    if payload.get("schema") != SCHEMA:
+        raise ValueError(f"unsupported schema: {payload.get('schema')!r}")
+    claimed = payload.get("artifact_sha256")
+    realized = artifact_digest(payload)
+    if claimed != realized:
+        raise ValueError(f"artifact digest mismatch: expected {claimed}, computed {realized}")
+    if payload.get("evidence_role") not in EVIDENCE_ROLES:
+        raise ValueError("invalid evidence_role")
+    if payload.get("policy") not in POLICIES:
+        raise ValueError("invalid policy")
+    expected_ranks = list(range(payload["compatibility"]["launched_world_size"]))
+    if payload.get("observed_ranks") != expected_ranks:
+        raise ValueError("artifact does not cover every launched rank")
+    if not payload.get("payload_validated"):
+        raise ValueError("artifact did not validate the received payload")
+
+
+def _nccl_version() -> str | None:
+    if not torch.cuda.is_available() or not hasattr(torch.cuda, "nccl"):
+        return None
+    version = torch.cuda.nccl.version()
+    if isinstance(version, tuple):
+        return ".".join(str(item) for item in version)
+    return str(version)
+
+
+def _device_metadata(device: torch.device) -> dict[str, Any] | None:
+    if device.type != "cuda":
+        return None
+    properties = torch.cuda.get_device_properties(device)
+    return {
+        "name": properties.name,
+        "total_memory_bytes": properties.total_memory,
+        "uuid": getattr(properties, "uuid", None),
+        "pci_bus_id": getattr(properties, "pci_bus_id", None),
+    }
+
+
+def _source_commit() -> str | None:
+    declared = os.environ.get("SLIME_BENCHMARK_SOURCE_COMMIT")
+    if declared:
+        return declared
+    try:
+        return subprocess.check_output(
+            ["git", "rev-parse", "HEAD"],
+            cwd=Path(__file__).resolve().parents[1],
+            stderr=subprocess.DEVNULL,
+            text=True,
+            timeout=5,
+        ).strip()
+    except (OSError, subprocess.SubprocessError):
+        return None
+
+
+def _numa_nodes() -> str | None:
+    path = Path("/sys/devices/system/node/online")
+    try:
+        return path.read_text().strip()
+    except OSError:
+        return None
+
+
+def build_compatibility(
+    *,
+    backend: str,
+    dtype: torch.dtype,
+    message_bytes: int,
+    world_size: int,
+    engine_count: int,
+    device: torch.device,
+    callsite_import_mode: str,
+) -> dict[str, Any]:
+    return {
+        "backend": backend,
+        "source_commit": _source_commit(),
+        "python": platform.python_version(),
+        "cpu_machine": platform.machine(),
+        "cpu_count": os.cpu_count(),
+        "numa_nodes_online": _numa_nodes(),
+        "pytorch": torch.__version__,
+        "cuda_runtime": torch.version.cuda,
+        "nccl": _nccl_version(),
+        "nccl_launch_order_implicit": os.environ.get("NCCL_LAUNCH_ORDER_IMPLICIT"),
+        "dtype": str(dtype).removeprefix("torch."),
+        "message_bytes": message_bytes,
+        "tensor_elements": message_bytes // torch.empty((), dtype=dtype).element_size(),
+        "launched_world_size": world_size,
+        "engine_group_count": engine_count,
+        "process_group_membership": [[0, engine_rank] for engine_rank in range(1, world_size)],
+        "callsite_import_mode": callsite_import_mode,
+        "graph_capture": False,
+        "hostname": socket.gethostname(),
+        "cuda_visible_devices": os.environ.get("CUDA_VISIBLE_DEVICES"),
+        "device": _device_metadata(device),
+        "container_image_digest": os.environ.get("SLIME_BENCHMARK_CONTAINER_DIGEST"),
+    }
+
+
+def _load_production_callsite_from_source() -> Any:
+    """Load the exact source file while stubbing unrelated control-plane imports.
+
+    This mode exists for minimal PyTorch benchmark containers. The exercised
+    scheduler, process-group operations, tensors, and Work handles are real;
+    only Ray actor references and Megatron conversion helpers that the probe
+    never calls are replaced. It is opt-in and recorded in the artifact.
+    """
+    repo_root = Path(__file__).resolve().parents[1]
+    package_paths = {
+        "slime.backends.megatron_utils": repo_root / "slime" / "backends" / "megatron_utils",
+        "slime.backends.megatron_utils.update_weight": (
+            repo_root / "slime" / "backends" / "megatron_utils" / "update_weight"
+        ),
+    }
+    for name, path in package_paths.items():
+        package = types.ModuleType(name)
+        package.__path__ = [str(path)]
+        sys.modules[name] = package
+
+    ray_module = types.ModuleType("ray")
+    ray_module.ObjectRef = object
+    ray_module.get = lambda refs: refs
+    ray_actor_module = types.ModuleType("ray.actor")
+    ray_actor_module.ActorHandle = object
+    megatron_module = types.ModuleType("megatron")
+    megatron_core_module = types.ModuleType("megatron.core")
+    megatron_core_module.mpu = types.ModuleType("megatron.core.mpu")
+    accelerator_module = types.ModuleType("slime.utils.accelerator")
+    distributed_utils_module = types.ModuleType("slime.utils.distributed_utils")
+    distributed_utils_module.get_gloo_group = lambda: None
+    distributed_utils_module.init_process_group = lambda **_kwargs: None
+    http_utils_module = types.ModuleType("slime.utils.http_utils")
+    http_utils_module._wrap_ipv6 = lambda address: address
+    converter_module = types.ModuleType("slime.backends.megatron_utils.megatron_to_hf")
+    converter_module.convert_to_hf = lambda *_args, **_kwargs: []
+    common_module = types.ModuleType("slime.backends.megatron_utils.update_weight.common")
+    common_module.all_gather_param = lambda _name, param: param
+    common_module.named_params_and_buffers = lambda *_args, **_kwargs: []
+    sys.modules.update(
+        {
+            "ray": ray_module,
+            "ray.actor": ray_actor_module,
+            "megatron": megatron_module,
+            "megatron.core": megatron_core_module,
+            "megatron.core.mpu": megatron_core_module.mpu,
+            "slime.utils.accelerator": accelerator_module,
+            "slime.utils.distributed_utils": distributed_utils_module,
+            "slime.utils.http_utils": http_utils_module,
+            "slime.backends.megatron_utils.megatron_to_hf": converter_module,
+            "slime.backends.megatron_utils.update_weight.common": common_module,
+        }
+    )
+
+    module_name = "slime.backends.megatron_utils.update_weight.update_weight_from_distributed"
+    module_path = package_paths["slime.backends.megatron_utils.update_weight"] / "update_weight_from_distributed.py"
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load production callsite from {module_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _load_production_callsite() -> tuple[Any, str]:
+    repo_root = Path(__file__).resolve().parents[1]
+    if str(repo_root) not in sys.path:
+        sys.path.insert(0, str(repo_root))
+    try:
+        from slime.backends.megatron_utils.update_weight import update_weight_from_distributed
+
+        return update_weight_from_distributed, "installed_runtime"
+    except ModuleNotFoundError:
+        if os.environ.get("SLIME_CALLSITE_SOURCE_LOAD") != "1":
+            raise RuntimeError(
+                "the installed slime control-plane dependencies are incomplete; "
+                "set SLIME_CALLSITE_SOURCE_LOAD=1 to use the recorded source-loader mode"
+            ) from None
+        return _load_production_callsite_from_source(), "source_with_control_plane_stubs"
+
+
+def _make_engine_groups(backend: str, world_size: int) -> tuple[list[Any], Any]:
+    groups = []
+    for engine_rank in range(1, world_size):
+        groups.append(dist.new_group(ranks=[0, engine_rank], backend=backend))
+    control_group = (
+        dist.group.WORLD if backend == "gloo" else dist.new_group(ranks=list(range(world_size)), backend="gloo")
+    )
+    return groups, control_group
+
+
+def _sync_device(device: torch.device) -> None:
+    if device.type == "cuda":
+        torch.cuda.synchronize(device)
+
+
+def _run_one_iteration(
+    *,
+    module: Any,
+    policy: CallsitePolicy,
+    order: str,
+    process_groups: Sequence[Any],
+    control_group: Any,
+    rank: int,
+    device: torch.device,
+    dtype: torch.dtype,
+    tensor_elements: int,
+    iteration: int,
+) -> dict[str, Any]:
+    active_indices = ordered_engine_indices(policy.active_engine_indices, order)
+    value = float((iteration % 17) + 1)
+    sender_tensor = torch.full((tensor_elements,), value, device=device, dtype=dtype) if rank == 0 else None
+    receiver_tensor = (
+        torch.zeros((tensor_elements,), device=device, dtype=dtype)
+        if rank > 0 and rank - 1 in active_indices
+        else None
+    )
+
+    dist.barrier(group=control_group)
+    iteration_start_ns = time.perf_counter_ns()
+    rank_record: dict[str, Any] = {"rank": rank, "consumer": None}
+    controller_observations: list[LaunchObservation] = []
+
+    if rank == 0:
+        original_launch = module.launch_weights_from_distributed
+        original_ray_get = module.ray.get
+        index_by_group_name = {f"callsite-engine-{index}": index for index in active_indices}
+
+        def observed_launch(
+            group_name: str,
+            group: Any,
+            weight_version: int,
+            rollout_engines: Sequence[Any],
+            converted_named_tensors: Sequence[tuple[str, torch.Tensor]],
+            load_format: str | None = None,
+        ) -> tuple[list[Any], list[Any]]:
+            engine_index = index_by_group_name[group_name]
+            observation = LaunchObservation(engine_index=engine_index, host_launch_ns=time.perf_counter_ns())
+            if device.type == "cuda":
+                observation.start_event = torch.cuda.Event(enable_timing=True)
+                observation.start_event.record(torch.cuda.current_stream(device))
+            refs, works = original_launch(
+                group_name,
+                group,
+                weight_version,
+                rollout_engines,
+                converted_named_tensors,
+                load_format=load_format,
+            )
+            controller_observations.append(observation)
+            return refs, [_ObservedWork(work, observation, device) for work in works]
+
+        module.launch_weights_from_distributed = observed_launch
+        module.ray.get = lambda refs: refs
+        try:
+            update_groups = [
+                module.DistributedWeightUpdateGroup(
+                    engine_indices=(index,),
+                    group_name=f"callsite-engine-{index}",
+                    process_group=process_groups[index],
+                    rollout_engines=(_ReadyEngine(index),),
+                )
+                for index in active_indices
+            ]
+            module.update_weights_in_engine_group_waves(
+                update_groups,
+                weight_version=iteration + 1,
+                converted_named_tensors=[("probe.weight", sender_tensor)],
+                max_inflight_engine_groups=policy.max_inflight_engine_groups,
+                load_format="callsite_probe",
+            )
+        finally:
+            module.launch_weights_from_distributed = original_launch
+            module.ray.get = original_ray_get
+        callsite_return_ns = time.perf_counter_ns()
+        _sync_device(device)
+        controller_ready_ns = time.perf_counter_ns()
+        observations = []
+        for item in controller_observations:
+            if item.host_wait_return_ns is None:
+                raise RuntimeError("production callsite returned without waiting for a collective")
+            if item.start_event is not None:
+                if item.completion_event is None:
+                    raise RuntimeError("CUDA collective did not record a completion dependency")
+                duration_ms = item.start_event.elapsed_time(item.completion_event)
+                timing_kind = "event_bracket"
+            else:
+                duration_ms = (item.host_wait_return_ns - item.host_launch_ns) / 1_000_000
+                timing_kind = "host_blocking_interval"
+            observations.append(
+                {
+                    "engine_index": item.engine_index,
+                    "host_launch_ns": item.host_launch_ns,
+                    "host_wait_return_ns": item.host_wait_return_ns,
+                    "duration_ms": duration_ms,
+                    "timing_kind": timing_kind,
+                }
+            )
+        rank_record.update(
+            {
+                "controller_observations": observations,
+                "callsite_return_ms": (callsite_return_ns - iteration_start_ns) / 1_000_000,
+                "controller_device_ready_ms": (controller_ready_ns - iteration_start_ns) / 1_000_000,
+            }
+        )
+    elif rank - 1 in active_indices:
+        engine_index = rank - 1
+        consumer_wait_start_ns = time.perf_counter_ns()
+        work = dist.broadcast(receiver_tensor, src=0, group=process_groups[engine_index], async_op=True)
+        work.wait()
+        _sync_device(device)
+        consumer_ready_ns = time.perf_counter_ns()
+        expected = torch.full_like(receiver_tensor, value)
+        payload_valid = bool(torch.equal(receiver_tensor, expected))
+        rank_record["consumer"] = {
+            "engine_index": engine_index,
+            "wait_ms": (consumer_ready_ns - consumer_wait_start_ns) / 1_000_000,
+            "ready_ms": (consumer_ready_ns - iteration_start_ns) / 1_000_000,
+            "payload_valid": payload_valid,
+        }
+
+    dist.barrier(group=control_group)
+    sync_ready_ns = time.perf_counter_ns()
+    rank_record["step_sync_ready_ms"] = (sync_ready_ns - iteration_start_ns) / 1_000_000
+    gathered: list[dict[str, Any] | None] | None = [None] * dist.get_world_size() if rank == 0 else None
+    dist.gather_object(rank_record, gathered, dst=0, group=control_group)
+
+    if rank != 0:
+        return {}
+    assert gathered is not None
+    records = [item for item in gathered if item is not None]
+    controller = records[0]
+    observations_by_engine = {item["engine_index"]: item for item in controller["controller_observations"]}
+    consumers_by_engine = {
+        item["consumer"]["engine_index"]: item["consumer"] for item in records if item.get("consumer") is not None
+    }
+    pair = [observations_by_engine[index] for index in (0, 1) if index in observations_by_engine]
+    pair_makespan_ms = None
+    realized_offset_us = None
+    if len(pair) == 2:
+        pair_makespan_ms = (
+            max(item["host_wait_return_ns"] for item in pair) - min(item["host_launch_ns"] for item in pair)
+        ) / 1_000_000
+        realized_offset_us = (
+            observations_by_engine[1]["host_launch_ns"] - observations_by_engine[0]["host_launch_ns"]
+        ) / 1_000
+    return {
+        "iteration": iteration,
+        "controller_observations": controller["controller_observations"],
+        "comm_a_ms": observations_by_engine.get(0, {}).get("duration_ms"),
+        "comm_b_ms": observations_by_engine.get(1, {}).get("duration_ms"),
+        "rank_local_pair_makespan_ms": pair_makespan_ms,
+        "realized_b_minus_a_launch_offset_us": realized_offset_us,
+        "consumer_a_wait_ms": consumers_by_engine.get(0, {}).get("wait_ms"),
+        "consumer_b_wait_ms": consumers_by_engine.get(1, {}).get("wait_ms"),
+        "consumer_ready_ms": max(
+            (item["ready_ms"] for item in consumers_by_engine.values()),
+            default=None,
+        ),
+        "callsite_return_ms": controller["callsite_return_ms"],
+        "controller_device_ready_ms": controller["controller_device_ready_ms"],
+        "step_sync_ready_ms": max(item["step_sync_ready_ms"] for item in records),
+        "payload_valid": all(item["payload_valid"] for item in consumers_by_engine.values()),
+        "observed_ranks": sorted(item["rank"] for item in records),
+    }
+
+
+def _metric_summary(iterations: Sequence[dict[str, Any]], key: str) -> dict[str, float | None]:
+    return summarize_values([float(item[key]) for item in iterations if item.get(key) is not None])
+
+
+def run_distributed(args: argparse.Namespace) -> None:
+    if not dist.is_available():
+        raise RuntimeError("torch.distributed is unavailable")
+    backend = args.backend
+    if backend == "auto":
+        backend = "nccl" if torch.cuda.is_available() else "gloo"
+    if backend == "nccl" and not torch.cuda.is_available():
+        raise RuntimeError("NCCL requested without CUDA")
+
+    rank = int(os.environ["RANK"])
+    local_rank = int(os.environ.get("LOCAL_RANK", rank))
+    device = torch.device("cuda", local_rank) if backend == "nccl" else torch.device("cpu")
+    if device.type == "cuda":
+        torch.cuda.set_device(device)
+    dist.init_process_group(backend=backend)
+    try:
+        world_size = dist.get_world_size()
+        engine_count = world_size - 1
+        resolved = resolve_policy(args.policy, engine_count, args.window_size)
+        process_groups, control_group = _make_engine_groups(backend, world_size)
+        dtype = getattr(torch, args.dtype)
+        element_size = torch.empty((), dtype=dtype).element_size()
+        if args.message_bytes % element_size:
+            raise ValueError("message_bytes must be divisible by dtype element size")
+        tensor_elements = args.message_bytes // element_size
+
+        launch_id = str(uuid.uuid4()) if rank == 0 else None
+        launch_id_box = [launch_id]
+        dist.broadcast_object_list(launch_id_box, src=0, group=control_group)
+        launch_id = launch_id_box[0]
+        module, callsite_import_mode = _load_production_callsite()
+
+        for warmup_index in range(args.warmup):
+            _run_one_iteration(
+                module=module,
+                policy=resolved,
+                order=args.order,
+                process_groups=process_groups,
+                control_group=control_group,
+                rank=rank,
+                device=device,
+                dtype=dtype,
+                tensor_elements=tensor_elements,
+                iteration=-(warmup_index + 1),
+            )
+        iterations = []
+        for iteration in range(args.iterations):
+            result = _run_one_iteration(
+                module=module,
+                policy=resolved,
+                order=args.order,
+                process_groups=process_groups,
+                control_group=control_group,
+                rank=rank,
+                device=device,
+                dtype=dtype,
+                tensor_elements=tensor_elements,
+                iteration=iteration,
+            )
+            if rank == 0:
+                iterations.append(result)
+
+        if rank == 0:
+            compatibility = build_compatibility(
+                backend=backend,
+                dtype=dtype,
+                message_bytes=args.message_bytes,
+                world_size=world_size,
+                engine_count=engine_count,
+                device=device,
+                callsite_import_mode=callsite_import_mode,
+            )
+            payload = {
+                "schema": SCHEMA,
+                "run_id": args.run_id,
+                "process_launch_id": launch_id,
+                "evidence_role": args.evidence_role,
+                "policy": args.policy,
+                "order": args.order,
+                "resolved_policy": asdict(resolved),
+                "timing_scope": {
+                    "communication": "rank-local host interval for Gloo; CUDA event bracket for NCCL",
+                    "pair": "controller-rank host launch through Work.wait return",
+                    "consumer": "receiver Work.wait plus device synchronization and payload read",
+                    "sync_ready": "same-host control barrier after every receiver consumed the payload",
+                    "kernel_observed": False,
+                },
+                "compatibility": compatibility,
+                "iterations": iterations,
+                "summary": {
+                    key: _metric_summary(iterations, key)
+                    for key in (
+                        "comm_a_ms",
+                        "comm_b_ms",
+                        "rank_local_pair_makespan_ms",
+                        "realized_b_minus_a_launch_offset_us",
+                        "consumer_a_wait_ms",
+                        "consumer_b_wait_ms",
+                        "consumer_ready_ms",
+                        "callsite_return_ms",
+                        "controller_device_ready_ms",
+                        "step_sync_ready_ms",
+                    )
+                },
+                "observed_ranks": iterations[0]["observed_ranks"],
+                "payload_validated": all(item["payload_valid"] for item in iterations),
+                "claim_limits": [
+                    "This is the production scheduler callsite with synthetic tensors and ready metadata refs.",
+                    "It is not a Ray/SGLang load benchmark or an end-to-end training throughput claim.",
+                    "Event brackets are not labeled as profiler-observed kernel durations.",
+                    "One process launch is one independent run regardless of iteration count.",
+                ],
+            }
+            payload["artifact_sha256"] = artifact_digest(payload)
+            verify_artifact(payload)
+            output = Path(args.output_json)
+            output.parent.mkdir(parents=True, exist_ok=True)
+            output.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    finally:
+        dist.destroy_process_group()
+
+
+def compatibility_cell(payload: dict[str, Any]) -> bytes:
+    return _canonical_json(payload["compatibility"])
+
+
+def summarize_artifacts(paths: Sequence[Path], *, min_runs_per_role: int) -> dict[str, Any]:
+    if min_runs_per_role < 1:
+        raise ValueError("min_runs_per_role must be positive")
+    artifacts = [json.loads(path.read_text()) for path in paths]
+    if not artifacts:
+        raise ValueError("at least one artifact is required")
+    for artifact in artifacts:
+        verify_artifact(artifact)
+    reference_cell = compatibility_cell(artifacts[0])
+    if any(compatibility_cell(artifact) != reference_cell for artifact in artifacts[1:]):
+        raise ValueError("artifacts cross an incompatible runtime/message/topology cell")
+
+    run_ids = [artifact["run_id"] for artifact in artifacts]
+    launch_ids = [artifact["process_launch_id"] for artifact in artifacts]
+    if len(run_ids) != len(set(run_ids)):
+        raise ValueError("run_id values must be unique")
+    if len(launch_ids) != len(set(launch_ids)):
+        raise ValueError("process_launch_id values must be unique")
+
+    counts: dict[str, dict[str, int]] = {policy: {role: 0 for role in EVIDENCE_ROLES} for policy in POLICIES}
+    for artifact in artifacts:
+        counts[artifact["policy"]][artifact["evidence_role"]] += 1
+    missing = [
+        f"{policy}/{role}={count}"
+        for policy, by_role in counts.items()
+        for role, count in by_role.items()
+        if count < min_runs_per_role
+    ]
+    if missing:
+        raise ValueError(
+            f"each policy/evidence role requires {min_runs_per_role} independent process runs; " + ", ".join(missing)
+        )
+
+    metric_names = (
+        "comm_a_ms",
+        "comm_b_ms",
+        "rank_local_pair_makespan_ms",
+        "consumer_a_wait_ms",
+        "consumer_b_wait_ms",
+        "consumer_ready_ms",
+        "callsite_return_ms",
+        "controller_device_ready_ms",
+        "step_sync_ready_ms",
+    )
+    policy_summaries = {}
+    for policy in POLICIES:
+        policy_summaries[policy] = {}
+        for role in EVIDENCE_ROLES:
+            selected = [
+                artifact
+                for artifact in artifacts
+                if artifact["policy"] == policy and artifact["evidence_role"] == role
+            ]
+            policy_summaries[policy][role] = {
+                "independent_process_runs": len(selected),
+                "orders": sorted({artifact["order"] for artifact in selected}),
+                "metrics": {
+                    metric: summarize_values(
+                        [
+                            float(artifact["summary"][metric]["p50"])
+                            for artifact in selected
+                            if artifact["summary"][metric]["p50"] is not None
+                        ]
+                    )
+                    for metric in metric_names
+                },
+            }
+
+    result = {
+        "schema": "slime.weight_sync_callsite_campaign.v1",
+        "compatibility": artifacts[0]["compatibility"],
+        "artifact_count": len(artifacts),
+        "minimum_independent_runs_per_policy_role": min_runs_per_role,
+        "policy_summaries": policy_summaries,
+        "selection_and_confirmation_disjoint": True,
+        "automatic_policy_selection": False,
+        "claim_limits": artifacts[0]["claim_limits"],
+        "input_artifact_sha256": sorted(artifact["artifact_sha256"] for artifact in artifacts),
+    }
+    result["artifact_sha256"] = artifact_digest(result)
+    return result
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--summarize", nargs="+", type=Path)
+    parser.add_argument("--summary-json", type=Path)
+    parser.add_argument("--min-runs-per-role", type=int, default=5)
+    parser.add_argument("--backend", choices=("auto", "gloo", "nccl"), default="auto")
+    parser.add_argument("--policy", choices=POLICIES)
+    parser.add_argument("--evidence-role", choices=EVIDENCE_ROLES)
+    parser.add_argument("--run-id")
+    parser.add_argument("--order", choices=("ab", "ba"), default="ab")
+    parser.add_argument("--message-bytes", type=parse_size, default=parse_size("1MiB"))
+    parser.add_argument("--dtype", choices=("float32", "float16", "bfloat16"), default="float32")
+    parser.add_argument("--window-size", type=int, default=2)
+    parser.add_argument("--warmup", type=int, default=2)
+    parser.add_argument("--iterations", type=int, default=5)
+    parser.add_argument("--output-json", type=Path)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    if args.summarize:
+        if not args.summary_json:
+            raise SystemExit("--summary-json is required with --summarize")
+        result = summarize_artifacts(args.summarize, min_runs_per_role=args.min_runs_per_role)
+        args.summary_json.parent.mkdir(parents=True, exist_ok=True)
+        args.summary_json.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n")
+        print(f"wrote {args.summary_json} ({result['artifact_count']} independent process artifacts)")
+        return 0
+
+    required = {
+        "--policy": args.policy,
+        "--evidence-role": args.evidence_role,
+        "--run-id": args.run_id,
+        "--output-json": args.output_json,
+    }
+    missing = [flag for flag, value in required.items() if value is None]
+    if missing:
+        raise SystemExit("missing distributed-run arguments: " + ", ".join(missing))
+    if args.warmup < 0 or args.iterations < 1:
+        raise SystemExit("--warmup must be non-negative and --iterations must be positive")
+    run_distributed(args)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Draft update — 2026-09-05

Includes the 2/4-scale follow-up and production wave-helper callsite validation. The callsite harness uses control-plane stubs; it is not a complete Ray/SGLang engine-load run. No production performance claim is made.

AI assistance: OpenAI Codex. Remains Draft; implementation, CPU/Gloo checks and production GPU validation are separate acceptance gates. No new GPU results were generated during publication.

The original submission description and validation history follow.

---

## Summary

- add optional deterministic wave admission for logical rollout engine groups during weight sync
- apply the same bound to non-colocated NCCL, colocated tensor/IPC, full and delta disk reloads, and quantized post-load processing
- add English/Chinese documentation and CPU-only CI coverage

## Motivation

Updating every rollout engine at once maximizes fan-out, but can create a short burst across GPU memory, PCIe/NVLink, network, or storage. A deployment should be able to cap that fan-out without hardware-specific sleeps and without assuming a particular rank count.

## Semantics and compatibility

`--update-weight-max-inflight-engine-groups N` admits at most `N` logical SGLang engines at a time. An engine remains indivisible across its TP, PP, and multi-node workers. Admission follows stable engine order; for example, five engines at a limit of two form `(0, 1)`, `(2, 3)`, `(4)`.

The default is `0`, preserving the existing all-at-once path and aggregate process-group topology. A value greater than or equal to the resolved engine count is also effectively unbounded. There are no world-size, rank-count, or six-rank special cases.

Pause, flush, source-buffer reuse, and weight-version commit boundaries remain outside individual waves, so one completed wave does not resume serving early.

## Validation

Correctness validation completed before publication:

- scheduler contract tests cover empty, bounded, unbounded, oversized-limit, invalid-limit, and non-special engine counts (`1`, `2`, `4`, `5`, and `7`)
- distributed contract tests check default aggregate topology, bounded per-engine topology, partial setup cleanup, asynchronous launches within a wave, and completion before the next wave is admitted
- affected argument-validation and colocated-weight-bucket regression tests passed
- repository pre-commit hooks and `git diff --check` passed
- a single-card CUDA/NCCL smoke was limited to physical GPU 6; it checks that the CUDA path remains viable but cannot validate multi-engine wave behavior

Performance validation is deliberately limited: event-order tests verify that active logical engine groups never exceed the configured bound, but no throughput or latency claim is made from synthetic tests. A real Ray/SGLang end-to-end run was **not** performed. Before merge, the option should be benchmarked on the target multi-engine topology against the default (`0`), including weight-sync duration and rollout tail latency.

## Duplicate check

I searched current open issues and PRs for engine-group waves, staggered/bounded weight updates, in-flight engine scheduling, process groups, and the exact new option name. I found no substantive duplicate. #2331 is related but distinct: it orders pipeline process-group connect/disconnect, while this PR controls steady-state weight-transfer/reload admission.

## AI assistance and required review

This implementation, tests, documentation, and PR text were prepared with OpenAI Codex assistance. A human contributor/maintainer must review **every changed line**, validate the design assumptions, and reproduce the relevant tests and deployment benchmark before this draft is considered ready to merge.
