### PR TITLE
feat(weight-sync): bound in-flight weight-sync buckets

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -767,6 +767,10 @@ jobs:
             },
             {
               "num_gpus": 0,
+              "test_file": "test_weight_sync_credit.py"
+            },
+            {
+              "num_gpus": 0,
               "test_file": "test_expert_routing.py"
             },
             {

--- a/.github/workflows/pr-test.yml.j2
+++ b/.github/workflows/pr-test.yml.j2
@@ -117,6 +117,7 @@
         {'test_file': 'test_external_sglang_engines.py', 'num_gpus': 0},
         {'test_file': 'test_streaming_rollout.py', 'num_gpus': 0},
         {'test_file': 'test_empty_colocated_weight_bucket.py', 'num_gpus': 0},
+        {'test_file': 'test_weight_sync_credit.py', 'num_gpus': 0},
         {'test_file': 'test_expert_routing.py', 'num_gpus': 0},
         {'test_file': 'test_glm5_indexer_short_context.py', 'num_gpus': 0},
         {'test_file': 'test_model_provider_freeze.py', 'num_gpus': 0},

--- a/docs/en/get_started/customization.md
+++ b/docs/en/get_started/customization.md
@@ -491,12 +491,29 @@ Both values default to `0`, which preserves the existing one-bucket-at-a-time pa
 or both to opt in. Bucket bytes are counted once, regardless of how many rollout engines consume
 the bucket. Colocated updates use the largest contribution across trainer ranks so every rank
 flushes at the same collective boundary. Completion and credit release remain FIFO, and every
-window is fully drained before its weight version is committed. If one bucket is larger than a
-configured byte limit, slime raises an error instead of waiting indefinitely.
+window is fully drained before its weight version is committed. A version is committed only after
+post-processing finishes and the rollout consumers resume. If one bucket is larger than a configured
+byte limit, slime raises an error instead of waiting indefinitely.
+
+The byte credit counts logical bucket payload, not allocator or transport duplication. Slime records
+rank-local peaks for logical in-flight bytes, transport-outstanding bytes, IPC staging-resident bytes,
+and pending consumer objects under `perf/update_weights_*`. These counters are kept separate because a
+colocated flattened IPC buffer can make staging residency larger than the logical byte credit. They are
+observability, not an additional admission budget. Staging residency counts explicit producer-owned
+staging tensor objects; it does not estimate allocator fragmentation or CUDA IPC limbo after references
+are dropped. `perf/update_weights_sync_seconds` measures, on one control clock, from synchronization
+start until all target consumers have completed loading,
+post-processing has finished, and generation has resumed.
+
+Within a colocated engine's existing Gloo TP group, the source rank propagates the Ray load
+acknowledgement before any member returns the corresponding credit. This does not add a global CUDA
+synchronize. A load failure poisons the active version: it cannot be committed or reused, and the actor
+group must follow its normal abort/restart path. A lost process is not treated as a successful consensus.
 
 The credit window applies to ordinary full-weight buckets in distributed and colocated updates.
 Explicitly routed expert transfers remain serial so they can safely reuse their staging buffers;
-their bucket size is still checked against the byte limit. Disk and delta transports do not have
+their bucket size is still checked against the byte limit, and the reusable staging pool is included in
+the staging-residency metric. Disk and delta transports do not have
 an in-memory bucket data plane and reject nonzero in-flight credit settings.
 
 ## Testing Custom Function Paths

--- a/docs/en/get_started/customization.md
+++ b/docs/en/get_started/customization.md
@@ -477,6 +477,28 @@ therefore an sglang server argument rather than a slime hook: pass
 published weights (e.g. refresh the mount's view). See
 [Delta Weight Sync](../advanced/delta-weight-sync.md) for the full mechanism.
 
+### 20. Weight-Sync In-Flight Credits
+
+Full tensor/NCCL weight sync can keep several converted buckets in flight instead of waiting
+after every bucket. The window is controlled by two independent limits:
+
+| Argument | Meaning |
+| --- | --- |
+| `--update-weight-max-inflight-buckets` | Maximum number of logical buckets in flight. `0` disables this dimension. |
+| `--update-weight-max-inflight-bytes` | Maximum bytes across logical buckets in flight. `0` disables this dimension. |
+
+Both values default to `0`, which preserves the existing one-bucket-at-a-time path. Set either
+or both to opt in. Bucket bytes are counted once, regardless of how many rollout engines consume
+the bucket. Colocated updates use the largest contribution across trainer ranks so every rank
+flushes at the same collective boundary. Completion and credit release remain FIFO, and every
+window is fully drained before its weight version is committed. If one bucket is larger than a
+configured byte limit, slime raises an error instead of waiting indefinitely.
+
+The credit window applies to ordinary full-weight buckets in distributed and colocated updates.
+Explicitly routed expert transfers remain serial so they can safely reuse their staging buffers;
+their bucket size is still checked against the byte limit. Disk and delta transports do not have
+an in-memory bucket data plane and reject nonzero in-flight credit settings.
+
 ## Testing Custom Function Paths
 
 slime also provides CPU-only contract tests for customization interfaces. These tests resolve components through import-path strings, so they can validate both built-in hooks and user-defined implementations passed through the same CLI arguments used by training.

--- a/docs/zh/get_started/customization.md
+++ b/docs/zh/get_started/customization.md
@@ -489,11 +489,27 @@ full tensor/NCCL 权重同步可以同时推进多个已转换的 bucket，而�
 两个参数默认都是 `0`，因此默认仍走原有的逐 bucket 阻塞路径；设置任意一个即可启用窗口。
 逻辑 bucket 只统计一份字节，不会按 rollout engine fan-out 重复计数；colocated 更新会取所有
 trainer rank 中最大的本地 bucket 大小，确保每个 rank 在相同的 collective 边界 flush。bucket
-始终按 FIFO 顺序完成和归还 credit，并且一个 weight version 必须完全 drain 后才能 commit。
+始终按 FIFO 顺序完成和归还 credit，并且一个 weight version 只有在窗口完全 drain、后处理完成、
+rollout consumer 恢复之后才能 commit。
 如果单个 bucket 已经大于配置的字节上限，slime 会直接报错，而不是无限等待。
 
+byte credit 统计的是逻辑 bucket payload，不把 allocator 或 transport 产生的副本混为同一数值。
+slime 会在 `perf/update_weights_*` 下分别记录各 rank 的逻辑在飞字节、transport outstanding 字节、
+IPC staging resident 字节和待 consumer 对象数的峰值。colocated flattened IPC buffer 可能让 staging
+驻留量大于逻辑 byte credit，因此这些量必须分开解释；它们是观测指标，不是新增的 admission budget。
+staging residency 只统计 producer 明确持有的 staging tensor 对象，不估算 allocator fragmentation，
+也不把 producer 丢弃引用后的 CUDA IPC limbo 伪装成已测量值。`perf/update_weights_sync_seconds` 使用同一
+控制端时钟，测量从同步开始到所有目标 consumer 完成加载、
+后处理结束且 generation 恢复的时间。
+
+在 colocated engine 既有的 Gloo TP group 内，source rank 会先把 Ray load acknowledgement 传播给所有
+成员，然后各 rank 才归还对应 credit；这里不会增加全局 CUDA synchronize。加载失败会 poison 当前
+version，使其不能 commit 或复用，actor group 必须走框架原有的 abort/restart 路径；进程丢失不会被
+伪装成成功 consensus。
+
 credit 窗口覆盖 distributed 和 colocated 更新中的普通 full-weight bucket。显式路由的 expert
-传输为了安全复用 staging buffer，仍保持串行，但其 bucket 大小仍受 byte credit 检查。
+传输为了安全复用 staging buffer，仍保持串行，但其 bucket 大小仍受 byte credit 检查，且复用的
+staging pool 会计入 staging-residency 指标。
 disk 和 delta transport 没有内存在飞 bucket 数据面，因此非零 credit 配置会被拒绝。
 
 ## 自定义函数路径的测试

--- a/docs/zh/get_started/customization.md
+++ b/docs/zh/get_started/customization.md
@@ -476,6 +476,26 @@ engine 读取之前，在每个训练 rank 上调用。用于在非 POSIX 共享
 `hook(source_dir: str, target_version: int)`——在 `/pull_weights` 读取已发布权重之前调用
 （例如刷新挂载视图）。完整机制见 [Delta 权重同步](../advanced/delta-weight-sync.md)。
 
+### 20. 权重同步在飞 Credit
+
+full tensor/NCCL 权重同步可以同时推进多个已转换的 bucket，而不必在每个 bucket 后立即等待。
+窗口由两个相互独立的上限控制：
+
+| 参数 | 含义 |
+| --- | --- |
+| `--update-weight-max-inflight-buckets` | 在飞逻辑 bucket 数量上限；`0` 表示不限制这个维度。 |
+| `--update-weight-max-inflight-bytes` | 在飞逻辑 bucket 总字节数上限；`0` 表示不限制这个维度。 |
+
+两个参数默认都是 `0`，因此默认仍走原有的逐 bucket 阻塞路径；设置任意一个即可启用窗口。
+逻辑 bucket 只统计一份字节，不会按 rollout engine fan-out 重复计数；colocated 更新会取所有
+trainer rank 中最大的本地 bucket 大小，确保每个 rank 在相同的 collective 边界 flush。bucket
+始终按 FIFO 顺序完成和归还 credit，并且一个 weight version 必须完全 drain 后才能 commit。
+如果单个 bucket 已经大于配置的字节上限，slime 会直接报错，而不是无限等待。
+
+credit 窗口覆盖 distributed 和 colocated 更新中的普通 full-weight bucket。显式路由的 expert
+传输为了安全复用 staging buffer，仍保持串行，但其 bucket 大小仍受 byte credit 检查。
+disk 和 delta transport 没有内存在飞 bucket 数据面，因此非零 credit 配置会被拒绝。
+
 ## 自定义函数路径的测试
 
 slime 现在也提供了一组 CPU 契约测试，用于校验这些 customization 接口。测试会通过字符串形式的导入路径来动态加载组件，因此既能回归仓库内置 hook，也能验证用户通过和训练时完全相同的 CLI 参数传入的自定义实现。

--- a/slime/backends/megatron_utils/update_weight/update_weight_from_distributed.py
+++ b/slime/backends/megatron_utils/update_weight/update_weight_from_distributed.py
@@ -109,6 +109,7 @@ class UpdateWeightFromDistributed:
         """
         Pause → flush → _send_weights → continue. Progress on PP source.
         """
+        sync_started = time.perf_counter()
         self.weight_version += 1
 
         if dist.get_rank() == 0:
@@ -126,19 +127,28 @@ class UpdateWeightFromDistributed:
 
         pbar = tqdm(desc=f"[{self._group_name}] Update weights", total=0) if self._is_pp_src_rank else None
         self._weight_sync_credit.begin_version(self.weight_version)
-        self._send_weights(pbar)
-        self._weight_sync_credit.commit_version(self.weight_version)
+        try:
+            self._send_weights(pbar)
 
-        if dist.get_rank() == 0:
-            # int4/fp4 post_process
-            if self.quantization_config and self.quantization_config["quant_method"] in ["compressed-tensors"]:
-                post_process_weights(
-                    restore_weights_before_load=False,
-                    post_process_quantization=True,
-                    rollout_engines=self.rollout_engines,
-                )
-            ray.get([engine.continue_generation.remote() for engine in self.rollout_engines])
-        dist.barrier(group=get_gloo_group())
+            if dist.get_rank() == 0:
+                # int4/fp4 post_process
+                if self.quantization_config and self.quantization_config["quant_method"] in ["compressed-tensors"]:
+                    post_process_weights(
+                        restore_weights_before_load=False,
+                        post_process_quantization=True,
+                        rollout_engines=self.rollout_engines,
+                    )
+                ray.get([engine.continue_generation.remote() for engine in self.rollout_engines])
+            dist.barrier(group=get_gloo_group())
+        except BaseException as error:
+            self._weight_sync_credit.fail_version(self.weight_version, error)
+            raise
+
+        # A version is committed only after all bucket resources are drained,
+        # post-processing has completed, and consumers have resumed.
+        self._weight_sync_credit.commit_version(self.weight_version)
+        self.update_weight_metrics.update(self._weight_sync_credit.metrics())
+        self.update_weight_metrics["perf/update_weights_sync_seconds"] = time.perf_counter() - sync_started
 
     def _send_weights(self, pbar: tqdm | None) -> None:
         """
@@ -153,8 +163,7 @@ class UpdateWeightFromDistributed:
                 for hf_chunk in chunk_iter:
                     self._on_chunk(hf_chunk)
                     reservation = self._reserve_weight_bucket(hf_chunk)
-                    self._update_bucket_weights_from_distributed(hf_chunk, pbar=pbar)
-                    self._weight_sync_credit.release(reservation)
+                    self._update_bucket_weights_from_distributed(hf_chunk, reservation, pbar=pbar)
             dist.barrier(group=get_gloo_group())
 
     def _reserve_weight_bucket(self, hf_chunk: Sequence[tuple[str, torch.Tensor]]) -> WeightBucketReservation:
@@ -213,13 +222,24 @@ class UpdateWeightFromDistributed:
                     self.rollout_engines,
                     converted_named_tensors,
                 )
+                self._weight_sync_credit.mark_launched(
+                    reservation,
+                    transport_bytes=reservation.bucket_bytes if handles else 0,
+                    staging_bytes=0,
+                    consumer_objects=len(refs),
+                )
                 launched.append((reservation, converted_named_tensors, refs, handles))
 
-            for reservation, converted_named_tensors, refs, handles in launched:
+            while launched:
+                reservation, converted_named_tensors, refs, handles = launched.pop(0)
                 for handle in handles:
                     handle.wait()
+                self._weight_sync_credit.mark_transport_complete(reservation)
                 ray.get(refs)
+                self._weight_sync_credit.mark_consumers_complete(reservation)
                 converted_named_tensors.clear()
+                del converted_named_tensors, refs, handles
+                self._weight_sync_credit.mark_staging_released(reservation)
                 self._weight_sync_credit.release(reservation)
                 if pbar is not None:
                     pbar.update(1)
@@ -321,6 +341,7 @@ class UpdateWeightFromDistributed:
     def _update_bucket_weights_from_distributed(
         self,
         converted_named_tensors: list[tuple[str, torch.Tensor]],
+        reservation: WeightBucketReservation,
         pbar: tqdm | None = None,
         load_format: str | None = None,
     ) -> None:
@@ -331,19 +352,33 @@ class UpdateWeightFromDistributed:
         while not ray.get(self.rollout_engine_lock.acquire.remote()):
             time.sleep(0.1)
 
-        refs = update_weights_from_distributed(
-            self._group_name,
-            self._model_update_groups,
-            self.weight_version,
-            self.rollout_engines,
-            converted_named_tensors,
-            load_format=load_format,
-        )
-
-        ray.get(refs)
-        converted_named_tensors.clear()
-        ray.get(self.rollout_engine_lock.release.remote())
-        pbar.update(1)
+        try:
+            refs, handles = launch_weights_from_distributed(
+                self._group_name,
+                self._model_update_groups,
+                self.weight_version,
+                self.rollout_engines,
+                converted_named_tensors,
+                load_format=load_format,
+            )
+            self._weight_sync_credit.mark_launched(
+                reservation,
+                transport_bytes=reservation.bucket_bytes if handles else 0,
+                staging_bytes=0,
+                consumer_objects=len(refs),
+            )
+            for handle in handles:
+                handle.wait()
+            self._weight_sync_credit.mark_transport_complete(reservation)
+            ray.get(refs)
+            self._weight_sync_credit.mark_consumers_complete(reservation)
+            converted_named_tensors.clear()
+            self._weight_sync_credit.mark_staging_released(reservation)
+            self._weight_sync_credit.release(reservation)
+        finally:
+            ray.get(self.rollout_engine_lock.release.remote())
+        if pbar is not None:
+            pbar.update(1)
 
 
 def connect_rollout_engines_from_distributed(

--- a/slime/backends/megatron_utils/update_weight/update_weight_from_distributed.py
+++ b/slime/backends/megatron_utils/update_weight/update_weight_from_distributed.py
@@ -4,6 +4,7 @@ import socket
 import time
 from argparse import Namespace
 from collections.abc import Callable, Iterator, Mapping, Sequence
+from typing import Any
 
 import ray
 import torch
@@ -19,6 +20,7 @@ from slime.utils.http_utils import _wrap_ipv6
 
 from ..megatron_to_hf import convert_to_hf
 from .common import all_gather_param, named_params_and_buffers
+from .weight_sync_credit import WeightBucketReservation, WeightSyncCreditController
 
 
 class UpdateWeightFromDistributed:
@@ -47,6 +49,10 @@ class UpdateWeightFromDistributed:
         self.weight_version = 0
         self._model_update_groups = None
         self.update_weight_metrics: dict[str, float] = {}
+        self._weight_sync_credit = WeightSyncCreditController(
+            max_inflight_buckets=getattr(args, "update_weight_max_inflight_buckets", 0),
+            max_inflight_bytes=getattr(args, "update_weight_max_inflight_bytes", 0),
+        )
 
     def pop_metrics(self) -> dict[str, float]:
         """
@@ -119,7 +125,9 @@ class UpdateWeightFromDistributed:
         dist.barrier(group=get_gloo_group())
 
         pbar = tqdm(desc=f"[{self._group_name}] Update weights", total=0) if self._is_pp_src_rank else None
+        self._weight_sync_credit.begin_version(self.weight_version)
         self._send_weights(pbar)
+        self._weight_sync_credit.commit_version(self.weight_version)
 
         if dist.get_rank() == 0:
             # int4/fp4 post_process
@@ -139,10 +147,84 @@ class UpdateWeightFromDistributed:
         override ``_on_chunk`` to inject per-chunk behaviour.
         """
         for chunk_iter in (self._iter_non_expert_chunks(), self._iter_expert_chunks()):
-            for hf_chunk in chunk_iter:
-                self._on_chunk(hf_chunk)
-                self._update_bucket_weights_from_distributed(hf_chunk, pbar=pbar)
+            if self._weight_sync_credit.enabled:
+                self._send_weight_bucket_windows(chunk_iter, pbar=pbar)
+            else:
+                for hf_chunk in chunk_iter:
+                    self._on_chunk(hf_chunk)
+                    reservation = self._reserve_weight_bucket(hf_chunk)
+                    self._update_bucket_weights_from_distributed(hf_chunk, pbar=pbar)
+                    self._weight_sync_credit.release(reservation)
             dist.barrier(group=get_gloo_group())
+
+    def _reserve_weight_bucket(self, hf_chunk: Sequence[tuple[str, torch.Tensor]]) -> WeightBucketReservation:
+        bucket_bytes = sum(tensor.numel() * tensor.element_size() for _, tensor in hf_chunk)
+        reservation = self._weight_sync_credit.reserve(bucket_bytes)
+        if reservation is None:
+            raise RuntimeError("weight bucket credits are full")
+        return reservation
+
+    def _send_weight_bucket_windows(
+        self,
+        chunk_iter: Iterator[list[tuple[str, torch.Tensor]]],
+        pbar: tqdm | None,
+    ) -> None:
+        pending: list[tuple[WeightBucketReservation, list[tuple[str, torch.Tensor]]]] = []
+        for hf_chunk in chunk_iter:
+            self._on_chunk(hf_chunk)
+            bucket_bytes = sum(tensor.numel() * tensor.element_size() for _, tensor in hf_chunk)
+            reservation = self._weight_sync_credit.reserve(bucket_bytes)
+            if reservation is None:
+                self._flush_weight_bucket_window(pending, pbar=pbar)
+                pending = []
+                reservation = self._weight_sync_credit.reserve(bucket_bytes)
+                if reservation is None:
+                    raise RuntimeError("weight bucket credit did not admit an empty window")
+            pending.append((reservation, hf_chunk))
+            if self._weight_sync_credit.full:
+                self._flush_weight_bucket_window(pending, pbar=pbar)
+                pending = []
+
+        if pending:
+            self._flush_weight_bucket_window(pending, pbar=pbar)
+
+    def _flush_weight_bucket_window(
+        self,
+        pending: Sequence[tuple[WeightBucketReservation, list[tuple[str, torch.Tensor]]]],
+        pbar: tqdm | None,
+    ) -> None:
+        while not ray.get(self.rollout_engine_lock.acquire.remote()):
+            time.sleep(0.1)
+
+        launched: list[
+            tuple[
+                WeightBucketReservation,
+                list[tuple[str, torch.Tensor]],
+                list[ObjectRef],
+                list[Any],
+            ]
+        ] = []
+        try:
+            for reservation, converted_named_tensors in pending:
+                refs, handles = launch_weights_from_distributed(
+                    self._group_name,
+                    self._model_update_groups,
+                    self.weight_version,
+                    self.rollout_engines,
+                    converted_named_tensors,
+                )
+                launched.append((reservation, converted_named_tensors, refs, handles))
+
+            for reservation, converted_named_tensors, refs, handles in launched:
+                for handle in handles:
+                    handle.wait()
+                ray.get(refs)
+                converted_named_tensors.clear()
+                self._weight_sync_credit.release(reservation)
+                if pbar is not None:
+                    pbar.update(1)
+        finally:
+            ray.get(self.rollout_engine_lock.release.remote())
 
     def _on_chunk(self, hf_chunk: list[tuple[str, torch.Tensor]]) -> None:
         """
@@ -334,6 +416,28 @@ def update_weights_from_distributed(
     """
     Send metadata through Ray and tensors through the configured transport.
     """
+    refs, handles = launch_weights_from_distributed(
+        group_name,
+        group,
+        weight_version,
+        rollout_engines,
+        converted_named_tensors,
+        load_format=load_format,
+    )
+    for handle in handles:
+        handle.wait()
+    return refs
+
+
+def launch_weights_from_distributed(
+    group_name: str,
+    group: dist.ProcessGroup,
+    weight_version: int,
+    rollout_engines: Sequence[ActorHandle],
+    converted_named_tensors: Sequence[tuple[str, torch.Tensor]],
+    load_format: str | None = None,
+) -> tuple[list[ObjectRef], list[Any]]:
+    """Launch one bucket without waiting for its device collectives."""
     refs = [
         engine.update_weights_from_distributed.remote(
             names=[name for name, _ in converted_named_tensors],
@@ -348,10 +452,7 @@ def update_weights_from_distributed(
     handles = []
     for _, param in converted_named_tensors:
         handles.append(dist.broadcast(param.data, 0, group=group, async_op=True))
-    for handle in handles:
-        handle.wait()
-
-    return refs
+    return refs, handles
 
 
 def post_process_weights(

--- a/slime/backends/megatron_utils/update_weight/update_weight_from_tensor.py
+++ b/slime/backends/megatron_utils/update_weight/update_weight_from_tensor.py
@@ -1,6 +1,7 @@
 from argparse import Namespace
 from collections import defaultdict
 from collections.abc import Callable, Iterator, Mapping, Sequence
+from time import perf_counter
 from typing import Any
 
 import ray
@@ -47,6 +48,19 @@ def _build_flattened_tensor_data(
         "flattened_tensor": flattened_tensor_bucket.get_flattened_tensor(),
         "metadata": flattened_tensor_bucket.get_metadata(),
     }
+
+
+def _tensor_tree_nbytes(value: Any) -> int:
+    """Count tensor storage represented by a nested staging object."""
+    numel = getattr(value, "numel", None)
+    element_size = getattr(value, "element_size", None)
+    if callable(numel) and callable(element_size):
+        return int(numel()) * int(element_size())
+    if isinstance(value, Mapping):
+        return sum(_tensor_tree_nbytes(item) for item in value.values())
+    if isinstance(value, (list, tuple)):
+        return sum(_tensor_tree_nbytes(item) for item in value)
+    return 0
 
 
 class UpdateWeightFromTensor:
@@ -110,6 +124,7 @@ class UpdateWeightFromTensor:
         Split colocated/distributed engines. Global source rank (DP=TP=PP=0) creates NCCL
         for distributed. Map ranks to colocated IPC engines.
         """
+        self._all_rollout_engines = rollout_engines
         self.rollout_engines = rollout_engines
 
         if engine_gpu_counts is None:
@@ -196,6 +211,65 @@ class UpdateWeightFromTensor:
         out, self.update_weight_metrics = self.update_weight_metrics, {}
         return out
 
+    def _consumer_engines(self) -> Sequence[ActorHandle]:
+        """Return colocated and distributed consumers as one lifecycle unit."""
+        return getattr(self, "_all_rollout_engines", self.rollout_engines)
+
+    def _wait_for_bucket_completion(
+        self,
+        reservation: WeightBucketReservation,
+        handles: Sequence[Any],
+        refs: Sequence[ObjectRef],
+    ) -> None:
+        """Wait for transport/load and share the engine acknowledgement within its TP group."""
+        local_error: Exception | None = None
+        try:
+            for handle in handles:
+                handle.wait()
+            ray.get(refs)
+        except Exception as error:
+            local_error = error
+
+        group_error: str | None = None
+        if self._ipc_gather_group is not None:
+            error_message = (
+                f"{type(local_error).__name__}: {local_error}"
+                if self.rank == self._ipc_gather_src and local_error is not None
+                else None
+            )
+            status = [error_message]
+            dist.broadcast_object_list(
+                status,
+                src=self._ipc_gather_src,
+                group=self._ipc_gather_group,
+            )
+            group_error = status[0]
+
+        if local_error is not None:
+            raise local_error
+        if group_error is not None:
+            raise RuntimeError(f"weight consumer failed on engine source rank: {group_error}")
+
+        # For colocated CUDA IPC, the Ray response is the first observable
+        # receive/load acknowledgement. Do not claim an earlier transport
+        # boundary when there is no separate Work handle.
+        self._weight_sync_credit.mark_transport_complete(reservation)
+        self._weight_sync_credit.mark_consumers_complete(reservation)
+
+    def _mark_bucket_launched(
+        self,
+        reservation: WeightBucketReservation,
+        refs: Sequence[ObjectRef],
+        handles: Sequence[Any],
+        long_lived_tensors: Any,
+    ) -> None:
+        self._weight_sync_credit.mark_launched(
+            reservation,
+            transport_bytes=reservation.bucket_bytes if refs or handles else 0,
+            staging_bytes=_tensor_tree_nbytes(long_lived_tensors),
+            consumer_objects=len(refs),
+        )
+
     def _prepare_expert_weight_batch(
         self,
         transfers: Sequence[Any],
@@ -269,11 +343,15 @@ class UpdateWeightFromTensor:
                     megatron_local_weights,
                     staging_buffers,
                 )
+                self._weight_sync_credit.set_persistent_staging_bytes(_tensor_tree_nbytes(staging_buffers))
                 reservation = self._reserve_weight_bucket(hf_named_tensors)
                 refs, handles, long_lived_tensors = self._send_hf_params(hf_named_tensors)
-                for handle in handles:
-                    handle.wait()
-                ray.get(refs)
+                self._mark_bucket_launched(reservation, refs, handles, long_lived_tensors)
+                self._wait_for_bucket_completion(reservation, handles, refs)
+                hf_named_tensors.clear()
+                if isinstance(long_lived_tensors, list):
+                    long_lived_tensors.clear()
+                self._weight_sync_credit.mark_staging_released(reservation)
                 self._weight_sync_credit.release(reservation)
                 dist.barrier(group=get_gloo_group())
                 accelerator.synchronize()
@@ -281,6 +359,7 @@ class UpdateWeightFromTensor:
                 accelerator.ipc_collect()
                 accelerator.empty_cache()
         del staging_buffers
+        self._weight_sync_credit.set_persistent_staging_bytes(0)
         accelerator.empty_cache()
 
     @torch.no_grad()
@@ -288,67 +367,81 @@ class UpdateWeightFromTensor:
         """
         version++, flush caches, process buckets. Progress on rank 0.
         """
+        sync_started = perf_counter()
         self.weight_version += 1
 
         if self.rank == 0:
-            ray.get([engine.pause_generation.remote() for engine in self.rollout_engines])
-            ray.get([engine.flush_cache.remote() for engine in self.rollout_engines])
+            consumer_engines = self._consumer_engines()
+            ray.get([engine.pause_generation.remote() for engine in consumer_engines])
+            ray.get([engine.flush_cache.remote() for engine in consumer_engines])
             if self.quantization_config and self.quantization_config["quant_method"] in ["compressed-tensors"]:
                 post_process_weights(
                     restore_weights_before_load=True,
                     post_process_quantization=False,
-                    rollout_engines=self.rollout_engines,
+                    rollout_engines=consumer_engines,
                 )
         dist.barrier(group=get_gloo_group())
 
         self._weight_sync_credit.begin_version(self.weight_version)
-        megatron_local_weights = self.weights_getter()
+        try:
+            megatron_local_weights = self.weights_getter()
 
-        param_info_buckets = (
-            self._non_expert_param_info_buckets if self._expert_transfer_plan else self._full_param_info_buckets
-        )
-        hf_chunks = self._hf_weight_iterator.get_hf_weight_chunks(
-            megatron_local_weights,
-            param_info_buckets=param_info_buckets,
-        )
-        if self._weight_sync_credit.enabled:
-            self._send_weight_bucket_windows(hf_chunks)
-        else:
-            for hf_named_tensors in hf_chunks:
-                reservation = self._reserve_weight_bucket(hf_named_tensors)
-                refs, handles, long_lived_tensors = self._send_hf_params(hf_named_tensors)
-                for handle in handles:
-                    handle.wait()
-                ray.get(refs)
-                self._weight_sync_credit.release(reservation)
-                # Free GPU tensors so the caching allocator can reuse the blocks,
-                # then release CUDA IPC cache entries whose consumers (sglang engines)
-                # have already closed their IPC handles.
-                del refs, handles, long_lived_tensors, hf_named_tensors
-                accelerator.ipc_collect()
-                accelerator.empty_cache()
+            param_info_buckets = (
+                self._non_expert_param_info_buckets if self._expert_transfer_plan else self._full_param_info_buckets
+            )
+            hf_chunks = self._hf_weight_iterator.get_hf_weight_chunks(
+                megatron_local_weights,
+                param_info_buckets=param_info_buckets,
+            )
+            if self._weight_sync_credit.enabled:
+                self._send_weight_bucket_windows(hf_chunks)
+            else:
+                for hf_named_tensors in hf_chunks:
+                    reservation = self._reserve_weight_bucket(hf_named_tensors)
+                    refs, handles, long_lived_tensors = self._send_hf_params(hf_named_tensors)
+                    self._mark_bucket_launched(reservation, refs, handles, long_lived_tensors)
+                    self._wait_for_bucket_completion(reservation, handles, refs)
+                    hf_named_tensors.clear()
+                    if isinstance(long_lived_tensors, list):
+                        long_lived_tensors.clear()
+                    self._weight_sync_credit.mark_staging_released(reservation)
+                    self._weight_sync_credit.release(reservation)
+                    # Free GPU tensors so the caching allocator can reuse the blocks,
+                    # then release CUDA IPC cache entries whose consumers (sglang engines)
+                    # have already closed their IPC handles.
+                    del refs, handles, long_lived_tensors, hf_named_tensors
+                    accelerator.ipc_collect()
+                    accelerator.empty_cache()
 
-        if self._expert_transfer_plan:
-            self._update_expert_weights(megatron_local_weights)
+            if self._expert_transfer_plan:
+                self._update_expert_weights(megatron_local_weights)
 
-        del megatron_local_weights
-        dist.barrier(group=get_gloo_group())
-        # After the barrier all engines have returned, so every rank's last-chunk
-        # IPC handles are now released by the consumers.  Clean them up.
-        accelerator.ipc_collect()
-        accelerator.empty_cache()
+            del megatron_local_weights
+            dist.barrier(group=get_gloo_group())
+            # After the barrier all engines have returned, so every rank's last-chunk
+            # IPC handles are now released by the consumers.  Clean them up.
+            accelerator.ipc_collect()
+            accelerator.empty_cache()
+
+            # int4/fp4 post_process
+            if self.rank == 0:
+                if self.quantization_config and self.quantization_config["quant_method"] in ["compressed-tensors"]:
+                    post_process_weights(
+                        restore_weights_before_load=False,
+                        post_process_quantization=True,
+                        rollout_engines=self._consumer_engines(),
+                    )
+                ray.get([engine.continue_generation.remote() for engine in self._consumer_engines()])
+            dist.barrier(group=get_gloo_group())
+        except BaseException as error:
+            self._weight_sync_credit.fail_version(self.weight_version, error)
+            raise
+
+        # Commit is the control-plane publication boundary: all loads and
+        # post-processing completed and every consumer has resumed.
         self._weight_sync_credit.commit_version(self.weight_version)
-
-        # int4/fp4 post_process
-        if self.rank == 0:
-            if self.quantization_config and self.quantization_config["quant_method"] in ["compressed-tensors"]:
-                post_process_weights(
-                    restore_weights_before_load=False,
-                    post_process_quantization=True,
-                    rollout_engines=self.rollout_engines,
-                )
-            ray.get([engine.continue_generation.remote() for engine in self.rollout_engines])
-        dist.barrier(group=get_gloo_group())
+        self.update_weight_metrics.update(self._weight_sync_credit.metrics())
+        self.update_weight_metrics["perf/update_weights_sync_seconds"] = perf_counter() - sync_started
 
     def _reserve_weight_bucket(self, hf_named_tensors: Sequence[tuple[str, torch.Tensor]]) -> WeightBucketReservation:
         bucket_bytes = self._weight_bucket_bytes(hf_named_tensors)
@@ -397,13 +490,17 @@ class UpdateWeightFromTensor:
         launched = []
         for reservation, hf_named_tensors in pending:
             refs, handles, long_lived_tensors = self._send_hf_params(hf_named_tensors)
+            self._mark_bucket_launched(reservation, refs, handles, long_lived_tensors)
             launched.append((reservation, hf_named_tensors, refs, handles, long_lived_tensors))
 
-        for reservation, hf_named_tensors, refs, handles, _long_lived_tensors in launched:
-            for handle in handles:
-                handle.wait()
-            ray.get(refs)
+        while launched:
+            reservation, hf_named_tensors, refs, handles, long_lived_tensors = launched.pop(0)
+            self._wait_for_bucket_completion(reservation, handles, refs)
             hf_named_tensors.clear()
+            if isinstance(long_lived_tensors, list):
+                long_lived_tensors.clear()
+            del hf_named_tensors, refs, handles, long_lived_tensors
+            self._weight_sync_credit.mark_staging_released(reservation)
             self._weight_sync_credit.release(reservation)
 
         accelerator.ipc_collect()

--- a/slime/backends/megatron_utils/update_weight/update_weight_from_tensor.py
+++ b/slime/backends/megatron_utils/update_weight/update_weight_from_tensor.py
@@ -1,6 +1,6 @@
 from argparse import Namespace
 from collections import defaultdict
-from collections.abc import Callable, Mapping, Sequence
+from collections.abc import Callable, Iterator, Mapping, Sequence
 from typing import Any
 
 import ray
@@ -22,9 +22,10 @@ from .hf_weight_iterator_direct import HfWeightIteratorDirect
 from .update_weight_from_distributed import (
     connect_rollout_engines_from_distributed,
     disconnect_rollout_engines_from_distributed,
+    launch_weights_from_distributed,
     post_process_weights,
-    update_weights_from_distributed,
 )
+from .weight_sync_credit import WeightBucketReservation, WeightSyncCreditController
 
 
 def _build_flattened_tensor_data(
@@ -77,6 +78,10 @@ class UpdateWeightFromTensor:
         self.quantization_config = quantization_config
         self.weight_version = 0
         self.update_weight_metrics: dict[str, float] = {}
+        self._weight_sync_credit = WeightSyncCreditController(
+            max_inflight_buckets=getattr(args, "update_weight_max_inflight_buckets", 0),
+            max_inflight_bytes=getattr(args, "update_weight_max_inflight_bytes", 0),
+        )
 
         self._hf_weight_iterator = HfWeightIteratorDirect(
             args=args, model=model, model_name=model_name, quantization_config=quantization_config
@@ -264,11 +269,15 @@ class UpdateWeightFromTensor:
                     megatron_local_weights,
                     staging_buffers,
                 )
-                refs, long_lived_tensors = self._send_hf_params(hf_named_tensors)
+                reservation = self._reserve_weight_bucket(hf_named_tensors)
+                refs, handles, long_lived_tensors = self._send_hf_params(hf_named_tensors)
+                for handle in handles:
+                    handle.wait()
                 ray.get(refs)
+                self._weight_sync_credit.release(reservation)
                 dist.barrier(group=get_gloo_group())
                 accelerator.synchronize()
-                del refs, long_lived_tensors, hf_named_tensors
+                del refs, handles, long_lived_tensors, hf_named_tensors
                 accelerator.ipc_collect()
                 accelerator.empty_cache()
         del staging_buffers
@@ -292,23 +301,32 @@ class UpdateWeightFromTensor:
                 )
         dist.barrier(group=get_gloo_group())
 
+        self._weight_sync_credit.begin_version(self.weight_version)
         megatron_local_weights = self.weights_getter()
 
         param_info_buckets = (
             self._non_expert_param_info_buckets if self._expert_transfer_plan else self._full_param_info_buckets
         )
-        for hf_named_tensors in self._hf_weight_iterator.get_hf_weight_chunks(
+        hf_chunks = self._hf_weight_iterator.get_hf_weight_chunks(
             megatron_local_weights,
             param_info_buckets=param_info_buckets,
-        ):
-            refs, long_lived_tensors = self._send_hf_params(hf_named_tensors)
-            ray.get(refs)
-            # Free GPU tensors so the caching allocator can reuse the blocks,
-            # then release CUDA IPC cache entries whose consumers (sglang engines)
-            # have already closed their IPC handles.
-            del refs, long_lived_tensors, hf_named_tensors
-            accelerator.ipc_collect()
-            accelerator.empty_cache()
+        )
+        if self._weight_sync_credit.enabled:
+            self._send_weight_bucket_windows(hf_chunks)
+        else:
+            for hf_named_tensors in hf_chunks:
+                reservation = self._reserve_weight_bucket(hf_named_tensors)
+                refs, handles, long_lived_tensors = self._send_hf_params(hf_named_tensors)
+                for handle in handles:
+                    handle.wait()
+                ray.get(refs)
+                self._weight_sync_credit.release(reservation)
+                # Free GPU tensors so the caching allocator can reuse the blocks,
+                # then release CUDA IPC cache entries whose consumers (sglang engines)
+                # have already closed their IPC handles.
+                del refs, handles, long_lived_tensors, hf_named_tensors
+                accelerator.ipc_collect()
+                accelerator.empty_cache()
 
         if self._expert_transfer_plan:
             self._update_expert_weights(megatron_local_weights)
@@ -319,6 +337,7 @@ class UpdateWeightFromTensor:
         # IPC handles are now released by the consumers.  Clean them up.
         accelerator.ipc_collect()
         accelerator.empty_cache()
+        self._weight_sync_credit.commit_version(self.weight_version)
 
         # int4/fp4 post_process
         if self.rank == 0:
@@ -331,8 +350,68 @@ class UpdateWeightFromTensor:
             ray.get([engine.continue_generation.remote() for engine in self.rollout_engines])
         dist.barrier(group=get_gloo_group())
 
-    def _send_hf_params(self, hf_named_tensors) -> tuple[list[ObjectRef], Any]:
+    def _reserve_weight_bucket(self, hf_named_tensors: Sequence[tuple[str, torch.Tensor]]) -> WeightBucketReservation:
+        bucket_bytes = self._weight_bucket_bytes(hf_named_tensors)
+        reservation = self._weight_sync_credit.reserve(bucket_bytes)
+        if reservation is None:
+            raise RuntimeError("weight bucket credits are full")
+        return reservation
+
+    def _weight_bucket_bytes(self, hf_named_tensors: Sequence[tuple[str, torch.Tensor]]) -> int:
+        bucket_bytes = sum(tensor.numel() * tensor.element_size() for _, tensor in hf_named_tensors)
+        if self._weight_sync_credit.max_inflight_bytes:
+            # Every rank must flush at the same bucket boundary before the next
+            # gather_object. Use the largest local representation so byte-credit
+            # decisions stay identical even when a rank contributes no tensors.
+            global_bucket_bytes = torch.tensor(bucket_bytes, dtype=torch.int64, device="cpu")
+            dist.all_reduce(global_bucket_bytes, op=dist.ReduceOp.MAX, group=get_gloo_group())
+            bucket_bytes = int(global_bucket_bytes.item())
+        return bucket_bytes
+
+    def _send_weight_bucket_windows(
+        self,
+        hf_chunks: Iterator[list[tuple[str, torch.Tensor]]],
+    ) -> None:
+        pending: list[tuple[WeightBucketReservation, list[tuple[str, torch.Tensor]]]] = []
+        for hf_named_tensors in hf_chunks:
+            bucket_bytes = self._weight_bucket_bytes(hf_named_tensors)
+            reservation = self._weight_sync_credit.reserve(bucket_bytes)
+            if reservation is None:
+                self._flush_weight_bucket_window(pending)
+                pending = []
+                reservation = self._weight_sync_credit.reserve(bucket_bytes)
+                if reservation is None:
+                    raise RuntimeError("weight bucket credit did not admit an empty window")
+            pending.append((reservation, hf_named_tensors))
+            if self._weight_sync_credit.full:
+                self._flush_weight_bucket_window(pending)
+                pending = []
+
+        if pending:
+            self._flush_weight_bucket_window(pending)
+
+    def _flush_weight_bucket_window(
+        self,
+        pending: Sequence[tuple[WeightBucketReservation, list[tuple[str, torch.Tensor]]]],
+    ) -> None:
+        launched = []
+        for reservation, hf_named_tensors in pending:
+            refs, handles, long_lived_tensors = self._send_hf_params(hf_named_tensors)
+            launched.append((reservation, hf_named_tensors, refs, handles, long_lived_tensors))
+
+        for reservation, hf_named_tensors, refs, handles, _long_lived_tensors in launched:
+            for handle in handles:
+                handle.wait()
+            ray.get(refs)
+            hf_named_tensors.clear()
+            self._weight_sync_credit.release(reservation)
+
+        accelerator.ipc_collect()
+        accelerator.empty_cache()
+
+    def _send_hf_params(self, hf_named_tensors) -> tuple[list[ObjectRef], list[Any], Any]:
         all_refs = []
+        all_handles = []
 
         refs_colocated, long_lived_tensors = _send_to_colocated_engine(
             hf_named_tensors,
@@ -344,7 +423,7 @@ class UpdateWeightFromTensor:
         all_refs.extend(refs_colocated)
 
         if self.use_distribute and self._is_distributed_src_rank:
-            refs_distributed = update_weights_from_distributed(
+            refs_distributed, handles_distributed = launch_weights_from_distributed(
                 self._group_name,
                 self._model_update_groups,
                 self.weight_version,
@@ -353,8 +432,9 @@ class UpdateWeightFromTensor:
             )
             if refs_distributed:
                 all_refs.extend(refs_distributed)
+            all_handles.extend(handles_distributed)
 
-        return all_refs, long_lived_tensors
+        return all_refs, all_handles, long_lived_tensors
 
 
 def _send_to_colocated_engine(

--- a/slime/backends/megatron_utils/update_weight/weight_sync_credit.py
+++ b/slime/backends/megatron_utils/update_weight/weight_sync_credit.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class WeightBucketReservation:
+    """Credit held by one logical weight bucket."""
+
+    weight_version: int
+    bucket_id: int
+    bucket_bytes: int
+
+
+class WeightSyncCreditController:
+    """Track bounded, ordered weight buckets for one updater.
+
+    A zero limit disables that credit dimension. When both limits are zero,
+    callers keep the legacy synchronous transfer path while still using the
+    version/order checks in this controller.
+    """
+
+    def __init__(self, max_inflight_buckets: int = 0, max_inflight_bytes: int = 0) -> None:
+        if max_inflight_buckets < 0:
+            raise ValueError("max_inflight_buckets must be non-negative")
+        if max_inflight_bytes < 0:
+            raise ValueError("max_inflight_bytes must be non-negative")
+
+        self.max_inflight_buckets = max_inflight_buckets
+        self.max_inflight_bytes = max_inflight_bytes
+        self._active_version: int | None = None
+        self._last_committed_version: int | None = None
+        self._next_bucket_id = 0
+        self._inflight: deque[WeightBucketReservation] = deque()
+        self._inflight_bytes = 0
+
+    @property
+    def enabled(self) -> bool:
+        return self.max_inflight_buckets > 0 or self.max_inflight_bytes > 0
+
+    @property
+    def inflight_buckets(self) -> int:
+        return len(self._inflight)
+
+    @property
+    def inflight_bytes(self) -> int:
+        return self._inflight_bytes
+
+    @property
+    def full(self) -> bool:
+        return bool(
+            (self.max_inflight_buckets and len(self._inflight) >= self.max_inflight_buckets)
+            or (self.max_inflight_bytes and self._inflight_bytes >= self.max_inflight_bytes)
+        )
+
+    def begin_version(self, weight_version: int) -> None:
+        if self._active_version is not None:
+            raise RuntimeError(f"weight version {self._active_version} is still active")
+        if self._inflight:
+            raise RuntimeError("cannot begin a weight version with buckets still in flight")
+        if self._last_committed_version is not None and weight_version <= self._last_committed_version:
+            raise ValueError(
+                f"weight version {weight_version} must be newer than committed version {self._last_committed_version}"
+            )
+
+        self._active_version = weight_version
+        self._next_bucket_id = 0
+
+    def reserve(self, bucket_bytes: int) -> WeightBucketReservation | None:
+        """Reserve the next bucket, or return ``None`` when credits are full."""
+        if self._active_version is None:
+            raise RuntimeError("begin_version must be called before reserving a bucket")
+        if bucket_bytes < 0:
+            raise ValueError("bucket_bytes must be non-negative")
+        if self.max_inflight_bytes and bucket_bytes > self.max_inflight_bytes:
+            raise ValueError(
+                f"weight bucket requires {bucket_bytes} bytes, larger than "
+                f"--update-weight-max-inflight-bytes={self.max_inflight_bytes}"
+            )
+        if self.max_inflight_buckets and len(self._inflight) >= self.max_inflight_buckets:
+            return None
+        if self.max_inflight_bytes and self._inflight_bytes + bucket_bytes > self.max_inflight_bytes:
+            return None
+
+        reservation = WeightBucketReservation(
+            weight_version=self._active_version,
+            bucket_id=self._next_bucket_id,
+            bucket_bytes=bucket_bytes,
+        )
+        self._next_bucket_id += 1
+        self._inflight.append(reservation)
+        self._inflight_bytes += bucket_bytes
+        return reservation
+
+    def release(self, reservation: WeightBucketReservation) -> None:
+        """Release the oldest bucket, preserving engine load order."""
+        if not self._inflight:
+            raise RuntimeError("no weight bucket credit is in flight")
+        oldest = self._inflight[0]
+        if reservation != oldest:
+            raise RuntimeError(
+                f"weight buckets must complete in order: expected bucket {oldest.bucket_id}, "
+                f"got bucket {reservation.bucket_id}"
+            )
+
+        self._inflight.popleft()
+        self._inflight_bytes -= reservation.bucket_bytes
+
+    def commit_version(self, weight_version: int) -> None:
+        if weight_version != self._active_version:
+            raise RuntimeError(f"cannot commit inactive weight version {weight_version}")
+        if self._inflight:
+            raise RuntimeError(
+                f"cannot commit weight version {weight_version} with {len(self._inflight)} bucket(s) in flight"
+            )
+
+        self._last_committed_version = weight_version
+        self._active_version = None

--- a/slime/backends/megatron_utils/update_weight/weight_sync_credit.py
+++ b/slime/backends/megatron_utils/update_weight/weight_sync_credit.py
@@ -13,6 +13,31 @@ class WeightBucketReservation:
     bucket_bytes: int
 
 
+@dataclass(frozen=True, slots=True)
+class WeightSyncLifecycleSnapshot:
+    """Rank-local accounting for the active or most recently committed version."""
+
+    active_version: int | None
+    failed_reason: str | None
+    inflight_buckets: int
+    inflight_bytes: int
+    transport_outstanding_bytes: int
+    staging_resident_bytes: int
+    pending_consumer_objects: int
+    peak_inflight_buckets: int
+    peak_inflight_bytes: int
+    peak_transport_outstanding_bytes: int
+    peak_staging_resident_bytes: int
+    peak_pending_consumer_objects: int
+
+
+@dataclass(slots=True)
+class _BucketLifecycle:
+    transport_bytes: int
+    staging_bytes: int
+    consumer_objects: int
+
+
 class WeightSyncCreditController:
     """Track bounded, ordered weight buckets for one updater.
 
@@ -34,6 +59,17 @@ class WeightSyncCreditController:
         self._next_bucket_id = 0
         self._inflight: deque[WeightBucketReservation] = deque()
         self._inflight_bytes = 0
+        self._bucket_lifecycles: dict[WeightBucketReservation, _BucketLifecycle] = {}
+        self._transport_outstanding_bytes = 0
+        self._staging_resident_bytes = 0
+        self._persistent_staging_bytes = 0
+        self._pending_consumer_objects = 0
+        self._peak_inflight_buckets = 0
+        self._peak_inflight_bytes = 0
+        self._peak_transport_outstanding_bytes = 0
+        self._peak_staging_resident_bytes = 0
+        self._peak_pending_consumer_objects = 0
+        self._failed_reason: str | None = None
 
     @property
     def enabled(self) -> bool:
@@ -54,11 +90,41 @@ class WeightSyncCreditController:
             or (self.max_inflight_bytes and self._inflight_bytes >= self.max_inflight_bytes)
         )
 
+    @property
+    def snapshot(self) -> WeightSyncLifecycleSnapshot:
+        return WeightSyncLifecycleSnapshot(
+            active_version=self._active_version,
+            failed_reason=self._failed_reason,
+            inflight_buckets=len(self._inflight),
+            inflight_bytes=self._inflight_bytes,
+            transport_outstanding_bytes=self._transport_outstanding_bytes,
+            staging_resident_bytes=self._staging_resident_bytes,
+            pending_consumer_objects=self._pending_consumer_objects,
+            peak_inflight_buckets=self._peak_inflight_buckets,
+            peak_inflight_bytes=self._peak_inflight_bytes,
+            peak_transport_outstanding_bytes=self._peak_transport_outstanding_bytes,
+            peak_staging_resident_bytes=self._peak_staging_resident_bytes,
+            peak_pending_consumer_objects=self._peak_pending_consumer_objects,
+        )
+
+    def metrics(self) -> dict[str, float]:
+        """Return peak rank-local lifecycle counters for the current version."""
+        snapshot = self.snapshot
+        return {
+            "perf/update_weights_peak_inflight_buckets": float(snapshot.peak_inflight_buckets),
+            "perf/update_weights_peak_logical_inflight_bytes": float(snapshot.peak_inflight_bytes),
+            "perf/update_weights_peak_transport_outstanding_bytes": float(snapshot.peak_transport_outstanding_bytes),
+            "perf/update_weights_peak_staging_resident_bytes": float(snapshot.peak_staging_resident_bytes),
+            "perf/update_weights_peak_pending_consumer_objects": float(snapshot.peak_pending_consumer_objects),
+        }
+
     def begin_version(self, weight_version: int) -> None:
         if self._active_version is not None:
             raise RuntimeError(f"weight version {self._active_version} is still active")
         if self._inflight:
             raise RuntimeError("cannot begin a weight version with buckets still in flight")
+        if self._bucket_lifecycles or self._transport_outstanding_bytes or self._staging_resident_bytes:
+            raise RuntimeError("cannot begin a weight version with lifecycle resources still resident")
         if self._last_committed_version is not None and weight_version <= self._last_committed_version:
             raise ValueError(
                 f"weight version {weight_version} must be newer than committed version {self._last_committed_version}"
@@ -66,6 +132,12 @@ class WeightSyncCreditController:
 
         self._active_version = weight_version
         self._next_bucket_id = 0
+        self._failed_reason = None
+        self._peak_inflight_buckets = 0
+        self._peak_inflight_bytes = 0
+        self._peak_transport_outstanding_bytes = 0
+        self._peak_staging_resident_bytes = 0
+        self._peak_pending_consumer_objects = 0
 
     def reserve(self, bucket_bytes: int) -> WeightBucketReservation | None:
         """Reserve the next bucket, or return ``None`` when credits are full."""
@@ -91,7 +163,84 @@ class WeightSyncCreditController:
         self._next_bucket_id += 1
         self._inflight.append(reservation)
         self._inflight_bytes += bucket_bytes
+        self._peak_inflight_buckets = max(self._peak_inflight_buckets, len(self._inflight))
+        self._peak_inflight_bytes = max(self._peak_inflight_bytes, self._inflight_bytes)
         return reservation
+
+    def mark_launched(
+        self,
+        reservation: WeightBucketReservation,
+        *,
+        transport_bytes: int,
+        staging_bytes: int,
+        consumer_objects: int,
+    ) -> None:
+        """Record resources retained after a bucket has been submitted.
+
+        These counters are evidence only: admission remains governed by logical
+        bucket count and bytes. They make explicit when staging memory exceeds
+        the logical byte credit instead of silently treating the two as equal.
+        """
+        self._require_inflight(reservation)
+        if reservation in self._bucket_lifecycles:
+            raise RuntimeError(f"weight bucket {reservation.bucket_id} was already launched")
+        for name, value in (
+            ("transport_bytes", transport_bytes),
+            ("staging_bytes", staging_bytes),
+            ("consumer_objects", consumer_objects),
+        ):
+            if value < 0:
+                raise ValueError(f"{name} must be non-negative")
+
+        self._bucket_lifecycles[reservation] = _BucketLifecycle(
+            transport_bytes=transport_bytes,
+            staging_bytes=staging_bytes,
+            consumer_objects=consumer_objects,
+        )
+        self._transport_outstanding_bytes += transport_bytes
+        self._staging_resident_bytes += staging_bytes
+        self._pending_consumer_objects += consumer_objects
+        self._peak_transport_outstanding_bytes = max(
+            self._peak_transport_outstanding_bytes, self._transport_outstanding_bytes
+        )
+        self._peak_staging_resident_bytes = max(self._peak_staging_resident_bytes, self._staging_resident_bytes)
+        self._peak_pending_consumer_objects = max(self._peak_pending_consumer_objects, self._pending_consumer_objects)
+
+    def mark_transport_complete(self, reservation: WeightBucketReservation) -> None:
+        """Release transport accounting exactly once after its wait boundary."""
+        lifecycle = self._require_lifecycle(reservation)
+        if lifecycle.transport_bytes:
+            self._transport_outstanding_bytes -= lifecycle.transport_bytes
+            lifecycle.transport_bytes = 0
+
+    def mark_consumers_complete(self, reservation: WeightBucketReservation) -> None:
+        """Release consumer-object accounting exactly once after acknowledgement."""
+        lifecycle = self._require_lifecycle(reservation)
+        if lifecycle.consumer_objects:
+            self._pending_consumer_objects -= lifecycle.consumer_objects
+            lifecycle.consumer_objects = 0
+
+    def mark_staging_released(self, reservation: WeightBucketReservation) -> None:
+        """Release staging accounting exactly once after producer references are dropped."""
+        lifecycle = self._require_lifecycle(reservation)
+        if lifecycle.staging_bytes:
+            self._staging_resident_bytes -= lifecycle.staging_bytes
+            lifecycle.staging_bytes = 0
+
+    def set_persistent_staging_bytes(self, staging_bytes: int) -> None:
+        """Observe reusable staging that lives outside individual bucket objects."""
+        if staging_bytes < 0:
+            raise ValueError("staging_bytes must be non-negative")
+        self._staging_resident_bytes += staging_bytes - self._persistent_staging_bytes
+        self._persistent_staging_bytes = staging_bytes
+        self._peak_staging_resident_bytes = max(self._peak_staging_resident_bytes, self._staging_resident_bytes)
+
+    def fail_version(self, weight_version: int, error: BaseException | str) -> None:
+        """Poison a partially applied version so it can never be committed or reused."""
+        if weight_version != self._active_version:
+            raise RuntimeError(f"cannot fail inactive weight version {weight_version}")
+        if self._failed_reason is None:
+            self._failed_reason = str(error) if isinstance(error, str) else f"{type(error).__name__}: {error}"
 
     def release(self, reservation: WeightBucketReservation) -> None:
         """Release the oldest bucket, preserving engine load order."""
@@ -104,16 +253,47 @@ class WeightSyncCreditController:
                 f"got bucket {reservation.bucket_id}"
             )
 
+        lifecycle = self._bucket_lifecycles.get(reservation)
+        if lifecycle is not None:
+            if lifecycle.transport_bytes or lifecycle.staging_bytes or lifecycle.consumer_objects:
+                raise RuntimeError(
+                    f"cannot release weight bucket {reservation.bucket_id} before transport, "
+                    "consumers, and staging resources are complete"
+                )
+            del self._bucket_lifecycles[reservation]
+
         self._inflight.popleft()
         self._inflight_bytes -= reservation.bucket_bytes
 
     def commit_version(self, weight_version: int) -> None:
         if weight_version != self._active_version:
             raise RuntimeError(f"cannot commit inactive weight version {weight_version}")
+        if self._failed_reason is not None:
+            raise RuntimeError(f"cannot commit failed weight version {weight_version}: {self._failed_reason}")
         if self._inflight:
             raise RuntimeError(
                 f"cannot commit weight version {weight_version} with {len(self._inflight)} bucket(s) in flight"
             )
+        if (
+            self._bucket_lifecycles
+            or self._transport_outstanding_bytes
+            or self._staging_resident_bytes
+            or self._pending_consumer_objects
+        ):
+            raise RuntimeError(
+                f"cannot commit weight version {weight_version} with lifecycle resources still resident"
+            )
 
         self._last_committed_version = weight_version
         self._active_version = None
+
+    def _require_inflight(self, reservation: WeightBucketReservation) -> None:
+        if reservation not in self._inflight:
+            raise RuntimeError(f"weight bucket {reservation.bucket_id} is not in flight")
+
+    def _require_lifecycle(self, reservation: WeightBucketReservation) -> _BucketLifecycle:
+        self._require_inflight(reservation)
+        lifecycle = self._bucket_lifecycles.get(reservation)
+        if lifecycle is None:
+            raise RuntimeError(f"weight bucket {reservation.bucket_id} was not launched")
+        return lifecycle

--- a/slime/utils/arguments.py
+++ b/slime/utils/arguments.py
@@ -546,6 +546,26 @@ def get_slime_extra_args_provider(add_custom_arguments=None):
                 ),
             )
             parser.add_argument(
+                "--update-weight-max-inflight-buckets",
+                type=int,
+                default=0,
+                help=(
+                    "Maximum number of logical weight buckets launched before waiting for completion. "
+                    "0 disables the bucket-count credit. When both in-flight limits are 0, weight sync "
+                    "keeps the existing one-bucket-at-a-time behavior."
+                ),
+            )
+            parser.add_argument(
+                "--update-weight-max-inflight-bytes",
+                type=int,
+                default=0,
+                help=(
+                    "Maximum bytes across logical weight buckets launched before waiting for completion. "
+                    "Bytes are counted once per bucket, independent of rollout-engine fan-out; 0 disables "
+                    "the byte credit."
+                ),
+            )
+            parser.add_argument(
                 "--update-weights-interval",
                 type=int,
                 default=1,
@@ -2048,6 +2068,16 @@ def slime_validate_args(args):
         raise ValueError(
             "--update-weight-transport=disk requires --update-weight-disk-dir to point at "
             "a filesystem shared between the trainer and the rollout engines."
+        )
+    if args.update_weight_max_inflight_buckets < 0:
+        raise ValueError("--update-weight-max-inflight-buckets must be non-negative")
+    if args.update_weight_max_inflight_bytes < 0:
+        raise ValueError("--update-weight-max-inflight-bytes must be non-negative")
+    if (args.update_weight_max_inflight_buckets or args.update_weight_max_inflight_bytes) and (
+        args.update_weight_mode != "full" or args.update_weight_transport != "nccl"
+    ):
+        raise ValueError(
+            "weight bucket in-flight credits require --update-weight-mode=full " "and --update-weight-transport=nccl"
         )
     if args.release_train:
         if args.use_critic:

--- a/tests/test_empty_colocated_weight_bucket.py
+++ b/tests/test_empty_colocated_weight_bucket.py
@@ -55,7 +55,13 @@ class _FakeEngine:
 
 
 def _install_fake_deps(monkeypatch):
-    dist_state = types.SimpleNamespace(rank=0, world_size=2, gathered=None, local_object=None)
+    dist_state = types.SimpleNamespace(
+        rank=0,
+        world_size=2,
+        gathered=None,
+        local_object=None,
+        broadcast_value=None,
+    )
 
     slime_pkg = types.ModuleType("slime")
     slime_pkg.__path__ = [str(REPO_ROOT / "slime")]
@@ -80,9 +86,17 @@ def _install_fake_deps(monkeypatch):
         if object_gather_list is not None:
             object_gather_list[:] = dist_state.gathered(obj)
 
+    def broadcast_object_list(status, src, group):
+        assert group is not None
+        if dist_state.rank == src:
+            dist_state.broadcast_value = status[0]
+        else:
+            status[0] = dist_state.broadcast_value
+
     dist_mod.get_rank = lambda: dist_state.rank
     dist_mod.get_world_size = lambda group=None: dist_state.world_size
     dist_mod.gather_object = gather_object
+    dist_mod.broadcast_object_list = broadcast_object_list
 
     torch_mod = types.ModuleType("torch")
     torch_mod.Tensor = object
@@ -258,6 +272,9 @@ def test_tensor_credit_window_launches_all_admitted_buckets_before_waiting(monke
     )
     updater._weight_sync_credit.begin_version(4)
     updater._weight_bucket_bytes = lambda bucket: sum(tensor.numel() for _, tensor in bucket)
+    updater._ipc_gather_group = None
+    updater._ipc_gather_src = None
+    updater.rank = 0
 
     def send_hf_params(bucket):
         name = bucket[0][0]
@@ -316,6 +333,141 @@ def test_tensor_byte_credit_uses_the_largest_trainer_rank_bucket(monkeypatch):
     monkeypatch.setattr(module.dist, "all_reduce", all_reduce, raising=False)
 
     assert updater._weight_bucket_bytes([("local", _Tensor())]) == 12
+
+
+def test_colocated_source_broadcasts_load_failure_before_credit_release(monkeypatch):
+    module, dist_state = _load_update_weight_module(monkeypatch)
+    error = RuntimeError("engine load failed")
+    updater = object.__new__(module.UpdateWeightFromTensor)
+    updater.rank = 0
+    updater._ipc_gather_src = 0
+    updater._ipc_gather_group = object()
+    updater._weight_sync_credit = module.WeightSyncCreditController(max_inflight_buckets=1)
+    updater._weight_sync_credit.begin_version(6)
+    reservation = updater._weight_sync_credit.reserve(8)
+    assert reservation is not None
+    updater._weight_sync_credit.mark_launched(
+        reservation,
+        transport_bytes=8,
+        staging_bytes=16,
+        consumer_objects=1,
+    )
+    module.ray.get = lambda _refs: (_ for _ in ()).throw(error)
+
+    with pytest.raises(RuntimeError, match="engine load failed") as raised:
+        updater._wait_for_bucket_completion(reservation, [], ["engine-ref"])
+    assert raised.value is error
+    assert dist_state.broadcast_value == "RuntimeError: engine load failed"
+    assert updater._weight_sync_credit.snapshot.inflight_buckets == 1
+    assert updater._weight_sync_credit.snapshot.pending_consumer_objects == 1
+
+    updater._weight_sync_credit.fail_version(6, error)
+    with pytest.raises(RuntimeError, match="cannot commit failed weight version"):
+        updater._weight_sync_credit.commit_version(6)
+
+
+def test_colocated_non_source_observes_source_failure(monkeypatch):
+    module, dist_state = _load_update_weight_module(monkeypatch)
+    dist_state.rank = 1
+    dist_state.broadcast_value = "RuntimeError: engine load failed"
+    updater = object.__new__(module.UpdateWeightFromTensor)
+    updater.rank = 1
+    updater._ipc_gather_src = 0
+    updater._ipc_gather_group = object()
+    updater._weight_sync_credit = module.WeightSyncCreditController(max_inflight_buckets=1)
+    updater._weight_sync_credit.begin_version(6)
+    reservation = updater._weight_sync_credit.reserve(8)
+    assert reservation is not None
+    updater._weight_sync_credit.mark_launched(
+        reservation,
+        transport_bytes=8,
+        staging_bytes=16,
+        consumer_objects=0,
+    )
+
+    with pytest.raises(RuntimeError, match="consumer failed on engine source rank"):
+        updater._wait_for_bucket_completion(reservation, [], [])
+    assert updater._weight_sync_credit.snapshot.inflight_buckets == 1
+    assert updater._weight_sync_credit.snapshot.transport_outstanding_bytes == 8
+
+
+def _make_empty_update_updater(module, events, continue_result="continue-ref"):
+    class _EventRemote:
+        def __init__(self, name, result):
+            self.name = name
+            self.result = result
+
+        def remote(self):
+            events.append(self.name)
+            return self.result
+
+    colocated_engine = types.SimpleNamespace(
+        pause_generation=_EventRemote("pause", "pause-ref"),
+        flush_cache=_EventRemote("flush", "flush-ref"),
+        continue_generation=_EventRemote("continue", continue_result),
+    )
+    distributed_engine = types.SimpleNamespace(
+        pause_generation=_EventRemote("pause-distributed", "pause-distributed-ref"),
+        flush_cache=_EventRemote("flush-distributed", "flush-distributed-ref"),
+        continue_generation=_EventRemote("continue-distributed", "continue-distributed-ref"),
+    )
+    updater = object.__new__(module.UpdateWeightFromTensor)
+    updater.rank = 0
+    updater.weight_version = 0
+    updater.rollout_engines = [colocated_engine]
+    updater._all_rollout_engines = [colocated_engine, distributed_engine]
+    updater.quantization_config = None
+    updater._weight_sync_credit = module.WeightSyncCreditController(max_inflight_buckets=1)
+    updater.weights_getter = lambda: {}
+    updater._expert_transfer_plan = []
+    updater._non_expert_param_info_buckets = None
+    updater._full_param_info_buckets = ()
+    updater._hf_weight_iterator = types.SimpleNamespace(get_hf_weight_chunks=lambda *args, **kwargs: iter(()))
+    updater.update_weight_metrics = {}
+    return updater
+
+
+def test_tensor_version_commits_only_after_consumers_resume(monkeypatch):
+    module, _ = _load_update_weight_module(monkeypatch)
+    events = []
+    updater = _make_empty_update_updater(module, events)
+    module.dist.barrier = lambda **_: events.append("barrier")
+    original_commit = updater._weight_sync_credit.commit_version
+
+    def commit_version(version):
+        assert "continue" in events
+        events.append("commit")
+        original_commit(version)
+
+    updater._weight_sync_credit.commit_version = commit_version
+    updater.update_weights()
+
+    assert events[-1] == "commit"
+    assert "continue-distributed" in events
+    assert updater._weight_sync_credit.snapshot.active_version is None
+    assert updater.update_weight_metrics["perf/update_weights_sync_seconds"] >= 0
+
+
+def test_tensor_resume_failure_poisons_version(monkeypatch):
+    module, _ = _load_update_weight_module(monkeypatch)
+    events = []
+    updater = _make_empty_update_updater(module, events, continue_result="failed-ref")
+    module.dist.barrier = lambda **_: events.append("barrier")
+    error = RuntimeError("resume failed")
+
+    def ray_get(refs):
+        if "failed-ref" in refs:
+            raise error
+        return refs
+
+    module.ray.get = ray_get
+    with pytest.raises(RuntimeError, match="resume failed") as raised:
+        updater.update_weights()
+    assert raised.value is error
+    assert updater._weight_sync_credit.snapshot.active_version == 1
+    assert updater._weight_sync_credit.snapshot.failed_reason == "RuntimeError: resume failed"
+    with pytest.raises(RuntimeError, match="cannot commit failed weight version"):
+        updater._weight_sync_credit.commit_version(1)
 
 
 if __name__ == "__main__":

--- a/tests/test_empty_colocated_weight_bucket.py
+++ b/tests/test_empty_colocated_weight_bucket.py
@@ -71,6 +71,7 @@ def _install_fake_deps(monkeypatch):
     accelerator_mod.device = lambda: "cuda:0"
     accelerator_mod.current_device = lambda: "cuda:0"
     accelerator_mod.ipc_collect = lambda: None
+    accelerator_mod.empty_cache = lambda: None
 
     dist_mod = types.ModuleType("torch.distributed")
 
@@ -95,6 +96,7 @@ def _install_fake_deps(monkeypatch):
 
     ray_mod = types.ModuleType("ray")
     ray_mod.ObjectRef = object
+    ray_mod.get = lambda refs: refs
     ray_actor_mod = types.ModuleType("ray.actor")
     ray_actor_mod.ActorHandle = object
 
@@ -129,8 +131,8 @@ def _install_fake_deps(monkeypatch):
     )
     update_from_distributed_mod.connect_rollout_engines_from_distributed = lambda *args, **kwargs: None
     update_from_distributed_mod.disconnect_rollout_engines_from_distributed = lambda *args, **kwargs: None
+    update_from_distributed_mod.launch_weights_from_distributed = lambda *args, **kwargs: ([], [])
     update_from_distributed_mod.post_process_weights = lambda *args, **kwargs: None
-    update_from_distributed_mod.update_weights_from_distributed = lambda *args, **kwargs: []
 
     monkeypatch.setitem(sys.modules, "slime", slime_pkg)
     monkeypatch.setitem(sys.modules, "slime.backends", slime_backends_pkg)
@@ -226,6 +228,94 @@ def test_source_rank_pads_empty_colocated_bucket_entries(monkeypatch):
             "weight_version": "7",
         }
     ]
+
+
+def test_tensor_credit_window_launches_all_admitted_buckets_before_waiting(monkeypatch):
+    module, _ = _load_update_weight_module(monkeypatch)
+    events = []
+
+    class _Tensor:
+        def __init__(self, size):
+            self.size = size
+
+        def numel(self):
+            return self.size
+
+        def element_size(self):
+            return 1
+
+    class _Handle:
+        def __init__(self, name):
+            self.name = name
+
+        def wait(self):
+            events.append(("wait", self.name))
+
+    updater = object.__new__(module.UpdateWeightFromTensor)
+    updater._weight_sync_credit = module.WeightSyncCreditController(
+        max_inflight_buckets=2,
+        max_inflight_bytes=10,
+    )
+    updater._weight_sync_credit.begin_version(4)
+    updater._weight_bucket_bytes = lambda bucket: sum(tensor.numel() for _, tensor in bucket)
+
+    def send_hf_params(bucket):
+        name = bucket[0][0]
+        events.append(("launch", name))
+        return [f"ref-{name}"], [_Handle(name)], object()
+
+    updater._send_hf_params = send_hf_params
+    module.ray.get = lambda refs: events.append(("get", refs[0]))
+    buckets = [[("b0", _Tensor(6))], [("b1", _Tensor(4))], [("b2", _Tensor(5))]]
+
+    updater._send_weight_bucket_windows(iter(buckets))
+    updater._weight_sync_credit.commit_version(4)
+
+    assert events == [
+        ("launch", "b0"),
+        ("launch", "b1"),
+        ("wait", "b0"),
+        ("get", "ref-b0"),
+        ("wait", "b1"),
+        ("get", "ref-b1"),
+        ("launch", "b2"),
+        ("wait", "b2"),
+        ("get", "ref-b2"),
+    ]
+    assert buckets == [[], [], []]
+
+
+def test_tensor_byte_credit_uses_the_largest_trainer_rank_bucket(monkeypatch):
+    module, _ = _load_update_weight_module(monkeypatch)
+
+    class _Tensor:
+        def numel(self):
+            return 5
+
+        def element_size(self):
+            return 1
+
+    class _Scalar:
+        def __init__(self, value):
+            self.value = value
+
+        def item(self):
+            return self.value
+
+    updater = object.__new__(module.UpdateWeightFromTensor)
+    updater._weight_sync_credit = module.WeightSyncCreditController(max_inflight_bytes=16)
+    monkeypatch.setattr(module.torch, "int64", "int64", raising=False)
+    monkeypatch.setattr(module.torch, "tensor", lambda value, **_: _Scalar(value), raising=False)
+    monkeypatch.setattr(module.dist, "ReduceOp", types.SimpleNamespace(MAX="max"), raising=False)
+
+    def all_reduce(value, *, op, group):
+        assert op == "max"
+        assert group is not None
+        value.value = 12
+
+    monkeypatch.setattr(module.dist, "all_reduce", all_reduce, raising=False)
+
+    assert updater._weight_bucket_bytes([("local", _Tensor())]) == 12
 
 
 if __name__ == "__main__":

--- a/tests/test_megatron_argument_validation.py
+++ b/tests/test_megatron_argument_validation.py
@@ -256,6 +256,8 @@ def make_slime_validate_args(**overrides):
         update_weight_disk_dir=None,
         update_weight_local_checkpoint_dir=None,
         update_weight_mode="full",
+        update_weight_max_inflight_buckets=0,
+        update_weight_max_inflight_bytes=0,
         rollout_temperature=1.0,
     )
     values.update(overrides)
@@ -388,6 +390,59 @@ def test_update_weight_delta_requires_local_checkpoint_dir(monkeypatch):
 
     with pytest.raises(ValueError, match="requires --update-weight-local-checkpoint-dir"):
         module.slime_validate_args(args)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("field", "option"),
+    [
+        ("update_weight_max_inflight_buckets", "--update-weight-max-inflight-buckets"),
+        ("update_weight_max_inflight_bytes", "--update-weight-max-inflight-bytes"),
+    ],
+)
+def test_weight_bucket_credit_rejects_negative_limits(monkeypatch, field, option):
+    module = load_slime_arguments_module(monkeypatch)
+    args = make_slime_validate_args(**{field: -1})
+
+    with pytest.raises(ValueError, match=option):
+        module.slime_validate_args(args)
+
+
+@pytest.mark.unit
+def test_weight_bucket_credit_requires_full_nccl_sync(monkeypatch):
+    module = load_slime_arguments_module(monkeypatch)
+    args = make_slime_validate_args(
+        update_weight_transport="disk",
+        update_weight_disk_dir="/shared/weights",
+        update_weight_max_inflight_buckets=2,
+    )
+
+    with pytest.raises(ValueError, match="require --update-weight-mode=full"):
+        module.slime_validate_args(args)
+
+
+@pytest.mark.unit
+def test_weight_bucket_credit_argument_defaults_preserve_synchronous_sync(monkeypatch):
+    module = load_slime_arguments_module(monkeypatch)
+    parser = argparse.ArgumentParser()
+    module.get_slime_extra_args_provider()(parser)
+
+    defaults = parser.parse_args(["--rollout-batch-size", "1"])
+    configured = parser.parse_args(
+        [
+            "--rollout-batch-size",
+            "1",
+            "--update-weight-max-inflight-buckets",
+            "3",
+            "--update-weight-max-inflight-bytes",
+            "1048576",
+        ]
+    )
+
+    assert defaults.update_weight_max_inflight_buckets == 0
+    assert defaults.update_weight_max_inflight_bytes == 0
+    assert configured.update_weight_max_inflight_buckets == 3
+    assert configured.update_weight_max_inflight_bytes == 1048576
 
 
 @pytest.mark.unit

--- a/tests/test_weight_sync_credit.py
+++ b/tests/test_weight_sync_credit.py
@@ -95,6 +95,80 @@ def test_release_is_fifo_and_commit_requires_a_drained_version() -> None:
         controller.begin_version(3)
 
 
+def test_lifecycle_accounting_tracks_distinct_resources_and_duplicate_completion() -> None:
+    controller = WeightSyncCreditController(max_inflight_buckets=2, max_inflight_bytes=10)
+    controller.begin_version(5)
+    first = controller.reserve(6)
+    second = controller.reserve(4)
+    assert first is not None
+    assert second is not None
+
+    controller.mark_launched(first, transport_bytes=6, staging_bytes=12, consumer_objects=2)
+    controller.mark_launched(second, transport_bytes=4, staging_bytes=8, consumer_objects=1)
+    snapshot = controller.snapshot
+    assert snapshot.inflight_bytes == 10
+    assert snapshot.transport_outstanding_bytes == 10
+    assert snapshot.staging_resident_bytes == 20
+    assert snapshot.pending_consumer_objects == 3
+    assert snapshot.peak_staging_resident_bytes > snapshot.peak_inflight_bytes
+
+    controller.mark_transport_complete(first)
+    controller.mark_transport_complete(first)
+    controller.mark_consumers_complete(first)
+    controller.mark_consumers_complete(first)
+    with pytest.raises(RuntimeError, match="before transport, consumers, and staging"):
+        controller.release(first)
+    controller.mark_staging_released(first)
+    controller.mark_staging_released(first)
+    controller.release(first)
+
+    controller.mark_transport_complete(second)
+    controller.mark_consumers_complete(second)
+    controller.mark_staging_released(second)
+    controller.release(second)
+    controller.commit_version(5)
+
+    metrics = controller.metrics()
+    assert metrics["perf/update_weights_peak_inflight_buckets"] == 2
+    assert metrics["perf/update_weights_peak_logical_inflight_bytes"] == 10
+    assert metrics["perf/update_weights_peak_transport_outstanding_bytes"] == 10
+    assert metrics["perf/update_weights_peak_staging_resident_bytes"] == 20
+    assert metrics["perf/update_weights_peak_pending_consumer_objects"] == 3
+
+
+def test_failed_version_is_poisoned_and_preserves_outstanding_evidence() -> None:
+    controller = WeightSyncCreditController(max_inflight_buckets=1)
+    controller.begin_version(8)
+    reservation = controller.reserve(7)
+    assert reservation is not None
+    controller.mark_launched(reservation, transport_bytes=7, staging_bytes=11, consumer_objects=1)
+
+    controller.fail_version(8, RuntimeError("consumer load failed"))
+    controller.fail_version(8, RuntimeError("later wrapper error"))
+    snapshot = controller.snapshot
+    assert snapshot.failed_reason == "RuntimeError: consumer load failed"
+    assert snapshot.transport_outstanding_bytes == 7
+    assert snapshot.staging_resident_bytes == 11
+    assert snapshot.pending_consumer_objects == 1
+    with pytest.raises(RuntimeError, match="cannot commit failed weight version 8"):
+        controller.commit_version(8)
+    with pytest.raises(RuntimeError, match="weight version 8 is still active"):
+        controller.begin_version(9)
+
+
+def test_persistent_staging_must_be_released_before_version_commit() -> None:
+    controller = WeightSyncCreditController()
+    controller.begin_version(2)
+    controller.set_persistent_staging_bytes(32)
+    controller.set_persistent_staging_bytes(48)
+    assert controller.snapshot.staging_resident_bytes == 48
+    assert controller.snapshot.peak_staging_resident_bytes == 48
+    with pytest.raises(RuntimeError, match="lifecycle resources still resident"):
+        controller.commit_version(2)
+    controller.set_persistent_staging_bytes(0)
+    controller.commit_version(2)
+
+
 def _load_distributed_update_module(monkeypatch):
     ray_mod = types.ModuleType("ray")
     ray_mod.ObjectRef = object

--- a/tests/test_weight_sync_credit.py
+++ b/tests/test_weight_sync_credit.py
@@ -1,0 +1,308 @@
+from __future__ import annotations
+
+import importlib.util
+import os
+import socket
+import sys
+import types
+from pathlib import Path
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+from slime.backends.megatron_utils.update_weight.weight_sync_credit import WeightSyncCreditController
+
+NUM_GPUS = 0
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _free_port() -> int:
+    with socket.socket() as sock:
+        sock.bind(("", 0))
+        return sock.getsockname()[1]
+
+
+def test_bucket_and_byte_credits_are_independent() -> None:
+    controller = WeightSyncCreditController(max_inflight_buckets=2, max_inflight_bytes=10)
+    controller.begin_version(7)
+
+    first = controller.reserve(6)
+    second = controller.reserve(4)
+    assert first is not None
+    assert second is not None
+    assert controller.inflight_buckets == 2
+    assert controller.inflight_bytes == 10
+    assert controller.full
+    assert controller.reserve(0) is None
+
+    controller.release(first)
+    third = controller.reserve(5)
+    assert third is not None
+    assert third.bucket_id == 2
+    assert controller.inflight_buckets == 2
+    assert controller.inflight_bytes == 9
+
+    controller.release(second)
+    controller.release(third)
+    controller.commit_version(7)
+
+
+@pytest.mark.parametrize(
+    ("max_buckets", "max_bytes", "third_admitted"),
+    [
+        (2, 0, False),
+        (0, 8, False),
+        (0, 0, True),
+    ],
+)
+def test_zero_disables_only_its_credit_dimension(max_buckets: int, max_bytes: int, third_admitted: bool) -> None:
+    controller = WeightSyncCreditController(max_buckets, max_bytes)
+    controller.begin_version(1)
+
+    assert controller.reserve(4) is not None
+    assert controller.reserve(4) is not None
+    assert (controller.reserve(4) is not None) is third_admitted
+
+
+def test_one_bucket_must_fit_the_byte_credit() -> None:
+    controller = WeightSyncCreditController(max_inflight_bytes=8)
+    controller.begin_version(1)
+
+    with pytest.raises(ValueError, match="requires 9 bytes"):
+        controller.reserve(9)
+
+
+def test_release_is_fifo_and_commit_requires_a_drained_version() -> None:
+    controller = WeightSyncCreditController(max_inflight_buckets=2)
+    controller.begin_version(3)
+    first = controller.reserve(4)
+    second = controller.reserve(4)
+    assert first is not None
+    assert second is not None
+
+    with pytest.raises(RuntimeError, match="must complete in order"):
+        controller.release(second)
+    with pytest.raises(RuntimeError, match=r"bucket\(s\) in flight"):
+        controller.commit_version(3)
+
+    controller.release(first)
+    controller.release(second)
+    controller.commit_version(3)
+
+    with pytest.raises(ValueError, match="must be newer"):
+        controller.begin_version(3)
+
+
+def _load_distributed_update_module(monkeypatch):
+    ray_mod = types.ModuleType("ray")
+    ray_mod.ObjectRef = object
+    ray_actor_mod = types.ModuleType("ray.actor")
+    ray_actor_mod.ActorHandle = object
+
+    mpu_mod = types.ModuleType("megatron.core.mpu")
+    megatron_mod = types.ModuleType("megatron")
+    megatron_core_mod = types.ModuleType("megatron.core")
+    megatron_core_mod.mpu = mpu_mod
+
+    accelerator_mod = types.ModuleType("slime.utils.accelerator")
+    accelerator_mod.current_device = lambda: "cpu"
+    accelerator_mod.weight_update_backend = lambda: "gloo"
+    distributed_utils_mod = types.ModuleType("slime.utils.distributed_utils")
+    distributed_utils_mod.get_gloo_group = lambda: object()
+    distributed_utils_mod.init_process_group = lambda **_: object()
+    http_utils_mod = types.ModuleType("slime.utils.http_utils")
+    http_utils_mod._wrap_ipv6 = lambda address: address
+    converter_mod = types.ModuleType("slime.backends.megatron_utils.megatron_to_hf")
+    converter_mod.convert_to_hf = lambda *args, **kwargs: []
+    common_mod = types.ModuleType("slime.backends.megatron_utils.update_weight.common")
+    common_mod.all_gather_param = lambda _name, param: param
+    common_mod.named_params_and_buffers = lambda *_: []
+
+    monkeypatch.setitem(sys.modules, "ray", ray_mod)
+    monkeypatch.setitem(sys.modules, "ray.actor", ray_actor_mod)
+    monkeypatch.setitem(sys.modules, "megatron", megatron_mod)
+    monkeypatch.setitem(sys.modules, "megatron.core", megatron_core_mod)
+    monkeypatch.setitem(sys.modules, "megatron.core.mpu", mpu_mod)
+    monkeypatch.setitem(sys.modules, "slime.utils.accelerator", accelerator_mod)
+    monkeypatch.setitem(sys.modules, "slime.utils.distributed_utils", distributed_utils_mod)
+    monkeypatch.setitem(sys.modules, "slime.utils.http_utils", http_utils_mod)
+    monkeypatch.setitem(sys.modules, "slime.backends.megatron_utils.megatron_to_hf", converter_mod)
+    monkeypatch.setitem(sys.modules, "slime.backends.megatron_utils.update_weight.common", common_mod)
+
+    module_name = "slime.backends.megatron_utils.update_weight.update_weight_from_distributed"
+    monkeypatch.delitem(sys.modules, module_name, raising=False)
+    module_path = (
+        REPO_ROOT / "slime" / "backends" / "megatron_utils" / "update_weight" / "update_weight_from_distributed.py"
+    )
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, module_name, module)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_distributed_bucket_launch_returns_before_collective_wait(monkeypatch) -> None:
+    module = _load_distributed_update_module(monkeypatch)
+    events = []
+
+    class _Tensor:
+        dtype = "float32"
+        shape = (4,)
+        data = "payload"
+
+    class _Handle:
+        def wait(self):
+            events.append("wait")
+
+    class _RemoteMethod:
+        def remote(self, **kwargs):
+            events.append(("metadata", kwargs))
+            return "engine-ref"
+
+    engine = types.SimpleNamespace(update_weights_from_distributed=_RemoteMethod())
+    monkeypatch.setattr(
+        module.dist,
+        "broadcast",
+        lambda tensor, src, group, async_op: events.append(("broadcast", tensor, src, group, async_op)) or _Handle(),
+    )
+
+    refs, handles = module.launch_weights_from_distributed(
+        "weights",
+        "group",
+        9,
+        [engine],
+        [("layer.weight", _Tensor())],
+    )
+
+    assert refs == ["engine-ref"]
+    assert len(handles) == 1
+    assert [event[0] for event in events] == ["metadata", "broadcast"]
+    assert events[0][1]["weight_version"] == "9"
+    handles[0].wait()
+    assert events[-1] == "wait"
+
+
+def test_distributed_credit_window_holds_one_lock_and_waits_fifo(monkeypatch) -> None:
+    module = _load_distributed_update_module(monkeypatch)
+    events = []
+
+    class _Handle:
+        def __init__(self, name):
+            self.name = name
+
+        def wait(self):
+            events.append(("wait", self.name))
+
+    class _RemoteMethod:
+        def __init__(self, name, result):
+            self.name = name
+            self.result = result
+
+        def remote(self):
+            events.append((self.name,))
+            return self.result
+
+    updater = object.__new__(module.UpdateWeightFromDistributed)
+    updater._group_name = "weights"
+    updater._model_update_groups = "group"
+    updater.weight_version = 13
+    updater.rollout_engines = [object()]
+    updater.rollout_engine_lock = types.SimpleNamespace(
+        acquire=_RemoteMethod("acquire", True),
+        release=_RemoteMethod("release", None),
+    )
+    updater._weight_sync_credit = WeightSyncCreditController(max_inflight_buckets=2)
+    updater._weight_sync_credit.begin_version(13)
+    first = updater._weight_sync_credit.reserve(4)
+    second = updater._weight_sync_credit.reserve(4)
+    assert first is not None
+    assert second is not None
+    first_bucket = [("b0", object())]
+    second_bucket = [("b1", object())]
+
+    def launch(_group_name, _group, _version, _engines, bucket):
+        name = bucket[0][0]
+        events.append(("launch", name))
+        return [f"ref-{name}"], [_Handle(name)]
+
+    def ray_get(value):
+        if isinstance(value, list):
+            events.append(("ray_get", value[0]))
+        return value
+
+    monkeypatch.setattr(module, "launch_weights_from_distributed", launch)
+    module.ray.get = ray_get
+
+    updater._flush_weight_bucket_window(
+        [(first, first_bucket), (second, second_bucket)],
+        pbar=None,
+    )
+    updater._weight_sync_credit.commit_version(13)
+
+    assert events == [
+        ("acquire",),
+        ("launch", "b0"),
+        ("launch", "b1"),
+        ("wait", "b0"),
+        ("ray_get", "ref-b0"),
+        ("wait", "b1"),
+        ("ray_get", "ref-b1"),
+        ("release",),
+    ]
+    assert first_bucket == []
+    assert second_bucket == []
+
+
+def _gloo_credit_worker(rank: int, world_size: int, port: int) -> None:
+    os.environ["MASTER_ADDR"] = "127.0.0.1"
+    os.environ["MASTER_PORT"] = str(port)
+    dist.init_process_group("gloo", rank=rank, world_size=world_size)
+    try:
+        controller = WeightSyncCreditController(max_inflight_buckets=2, max_inflight_bytes=40)
+        controller.begin_version(11)
+        pending = []
+        received = []
+        peak_buckets = 0
+        peak_bytes = 0
+
+        for bucket_id, elements in enumerate((4, 6, 2, 8)):
+            bucket_bytes = elements * torch.tensor([], dtype=torch.float32).element_size()
+            reservation = controller.reserve(bucket_bytes)
+            if reservation is None:
+                oldest_reservation, oldest_handle = pending.pop(0)
+                oldest_handle.wait()
+                controller.release(oldest_reservation)
+                reservation = controller.reserve(bucket_bytes)
+            assert reservation is not None
+
+            tensor = torch.full((elements,), float(bucket_id + 1)) if rank == 0 else torch.zeros(elements)
+            handle = dist.broadcast(tensor, src=0, async_op=True)
+            pending.append((reservation, handle))
+            received.append(tensor)
+            peak_buckets = max(peak_buckets, controller.inflight_buckets)
+            peak_bytes = max(peak_bytes, controller.inflight_bytes)
+
+        while pending:
+            reservation, handle = pending.pop(0)
+            handle.wait()
+            controller.release(reservation)
+        controller.commit_version(11)
+
+        assert peak_buckets == 2
+        assert peak_bytes == 40
+        for bucket_id, tensor in enumerate(received):
+            torch.testing.assert_close(tensor, torch.full_like(tensor, float(bucket_id + 1)))
+    finally:
+        dist.destroy_process_group()
+
+
+@pytest.mark.unit
+def test_credit_window_drives_real_async_gloo_broadcasts() -> None:
+    mp.spawn(_gloo_credit_worker, args=(2, _free_port()), nprocs=2, join=True)
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__]))

--- a/tests/test_weight_sync_lifecycle_cuda.py
+++ b/tests/test_weight_sync_lifecycle_cuda.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import json
+import os
+import resource
+import time
+from pathlib import Path
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+from slime.backends.megatron_utils.update_weight.weight_sync_credit import WeightSyncCreditController
+
+NUM_GPUS = 0
+
+
+def _nccl_lifecycle_worker(rank: int, world_size: int, init_method: str, artifact_dir: str) -> None:
+    torch.cuda.set_device(rank)
+    dist.init_process_group("nccl", init_method=init_method, rank=rank, world_size=world_size)
+    control_group = dist.new_group(ranks=list(range(world_size)), backend="gloo")
+    bucket_elements = (257, 1024)
+    element_size = torch.empty((), dtype=torch.float32).element_size()
+    controller = WeightSyncCreditController(
+        max_inflight_buckets=2,
+        max_inflight_bytes=sum(bucket_elements) * element_size,
+    )
+    try:
+        device = torch.device("cuda", rank)
+        torch.cuda.reset_peak_memory_stats(device)
+        sync_started = time.perf_counter()
+        tensors = [
+            (
+                torch.full((elements,), float(bucket_id + 1), device=device)
+                if rank == 0
+                else torch.zeros(elements, device=device)
+            )
+            for bucket_id, elements in enumerate(bucket_elements)
+        ]
+        works = []
+        reservations = []
+        if rank == 0:
+            controller.begin_version(17)
+
+        for tensor in tensors:
+            bucket_bytes = tensor.numel() * tensor.element_size()
+            if rank == 0:
+                reservation = controller.reserve(bucket_bytes)
+                assert reservation is not None
+                controller.mark_launched(
+                    reservation,
+                    transport_bytes=bucket_bytes,
+                    staging_bytes=bucket_bytes,
+                    consumer_objects=world_size - 1,
+                )
+                reservations.append(reservation)
+            works.append(dist.broadcast(tensor, src=0, async_op=True))
+
+        if rank == 0:
+            launched = controller.snapshot
+            assert launched.inflight_buckets == 2
+            assert launched.transport_outstanding_bytes == sum(bucket_elements) * element_size
+            assert launched.pending_consumer_objects == world_size - 1 + world_size - 1
+
+        for bucket_id, (tensor, work) in enumerate(zip(tensors, works, strict=True)):
+            work.wait()
+            if rank == 0:
+                reservation = reservations[bucket_id]
+                controller.mark_transport_complete(reservation)
+                # The consumer cannot acknowledge until the source has observed
+                # that transport is still distinct from consumer completion.
+                assert controller.snapshot.pending_consumer_objects > 0
+                ready = [bucket_id]
+                dist.broadcast_object_list(ready, src=0, group=control_group)
+                acknowledgements = [None] * world_size
+                dist.all_gather_object(acknowledgements, f"rank-{rank}-loaded-{bucket_id}", group=control_group)
+                assert acknowledgements == [f"rank-{member}-loaded-{bucket_id}" for member in range(world_size)]
+                controller.mark_consumers_complete(reservation)
+                controller.mark_staging_released(reservation)
+                controller.release(reservation)
+            else:
+                ready = [None]
+                dist.broadcast_object_list(ready, src=0, group=control_group)
+                assert ready[0] == bucket_id
+                torch.testing.assert_close(tensor, torch.full_like(tensor, float(bucket_id + 1)))
+                acknowledgements = [None] * world_size
+                dist.all_gather_object(acknowledgements, f"rank-{rank}-loaded-{bucket_id}", group=control_group)
+
+        if rank == 0:
+            controller.commit_version(17)
+            snapshot = controller.snapshot
+            assert snapshot.active_version is None
+            assert snapshot.inflight_buckets == 0
+            assert snapshot.transport_outstanding_bytes == 0
+            assert snapshot.staging_resident_bytes == 0
+            assert snapshot.pending_consumer_objects == 0
+            metrics = controller.metrics()
+        else:
+            metrics = {}
+
+        torch.cuda.synchronize(device)
+        sync_seconds = time.perf_counter() - sync_started
+
+        report = {
+            "backend": dist.get_backend(),
+            "bucket_bytes": [elements * element_size for elements in bucket_elements],
+            "committed_version": 17 if rank == 0 else None,
+            "control_backend": dist.get_backend(control_group),
+            "host_max_rss_bytes": resource.getrusage(resource.RUSAGE_SELF).ru_maxrss * 1024,
+            "metrics": metrics,
+            "peak_cuda_memory_allocated_bytes": torch.cuda.max_memory_allocated(device),
+            "peak_cuda_memory_reserved_bytes": torch.cuda.max_memory_reserved(device),
+            "physical_gpu_uuids": os.environ.get("PHYSICAL_GPU_UUIDS", "unknown"),
+            "process_group_membership": list(range(world_size)),
+            "rank": rank,
+            "sync_seconds": sync_seconds,
+            "torch_version": torch.__version__,
+            "world_size": world_size,
+        }
+        output = Path(artifact_dir) / f"weight-sync-lifecycle-nccl-rank-{rank}.json"
+        output.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    finally:
+        dist.destroy_process_group(control_group)
+        dist.destroy_process_group()
+
+
+@pytest.mark.skipif(
+    os.environ.get("SLIME_RUN_WEIGHT_SYNC_LIFECYCLE_NCCL_TEST") != "1",
+    reason="set SLIME_RUN_WEIGHT_SYNC_LIFECYCLE_NCCL_TEST=1 for the opt-in NCCL check",
+)
+def test_weight_sync_lifecycle_with_nccl_transport(tmp_path: Path) -> None:
+    world_size = int(os.environ.get("SLIME_WEIGHT_SYNC_LIFECYCLE_WORLD_SIZE", "2"))
+    if world_size not in (2, 4):
+        pytest.fail("SLIME_WEIGHT_SYNC_LIFECYCLE_WORLD_SIZE must be 2 or 4")
+    if not torch.cuda.is_available() or torch.cuda.device_count() < world_size:
+        pytest.skip(f"the NCCL check requires {world_size} visible CUDA devices")
+    artifact_dir = os.environ.get("SLIME_WEIGHT_SYNC_LIFECYCLE_ARTIFACT_DIR", str(tmp_path))
+    Path(artifact_dir).mkdir(parents=True, exist_ok=True)
+    mp.spawn(
+        _nccl_lifecycle_worker,
+        args=(world_size, f"file://{tmp_path / 'nccl_init'}", artifact_dir),
+        nprocs=world_size,
+        join=True,
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__]))


### PR DESCRIPTION
## Draft update — 2026-09-05

Separates logical admission, transport completion, staging and consumer acknowledgements; failed versions remain unpublished and resources remain held until the appropriate lifecycle boundary. Real two-rank Gloo tests passed. Full-model NCCL and Ray/SGLang confirmation remain pending.

AI assistance: OpenAI Codex. Remains Draft; implementation, CPU/Gloo checks and production GPU validation are separate acceptance gates. No new GPU results were generated during publication.

The original submission description and validation history follow.

---

## Summary

- add a reusable weight-sync credit controller with independent bucket-count and byte limits
- pipeline ordinary full-weight NCCL and colocated tensor buckets while releasing credit in FIFO completion order
- preserve weight-version fences, reject impossible oversized buckets, and add focused CPU/Gloo tests plus English/Chinese documentation

## Motivation

The existing full-weight path waits after each converted bucket. That is safe but prevents conversion/communication overlap. This change makes overlap opt-in and bounded, so operators can choose a memory/concurrency budget rather than relying on a rank-count-specific schedule.

## Semantics and compatibility

The two independent controls are:

- `--update-weight-max-inflight-buckets`: maximum logical buckets in flight (`0` disables this dimension)
- `--update-weight-max-inflight-bytes`: maximum total logical bucket bytes in flight (`0` disables this dimension)

Both default to `0`. When both are zero, slime keeps the legacy one-bucket blocking path. Bucket bytes are counted once regardless of rollout-engine fan-out. Colocated trainers use the maximum per-rank bucket size through their Gloo control group so every rank chooses identical flush boundaries. Reservations complete and release FIFO, and all reservations drain before the weight version commits. A bucket larger than a configured byte limit fails immediately instead of deadlocking.

The window applies only to ordinary full-weight NCCL/tensor transfers. Explicit expert-routed transfers remain serial because they reuse staging buffers, while still enforcing the byte ceiling. Disk and delta transports reject nonzero credit settings because they do not use this in-memory bucket data plane. There are no world-size or rank-count special cases.

## Validation

Correctness validation completed before publication:

- 47 relevant CPU tests passed, including controller invariants, CLI/default compatibility, distributed launch ordering, colocated admission, expert-path constraints, and documentation checks
- a real two-rank asynchronous Gloo test reached the configured bucket/byte ceiling and verified received tensor contents
- repository pre-commit hooks, Python compilation checks, and `git diff --check` passed
- a single-card CUDA/NCCL smoke was limited to physical GPU 6 and observed peak credits of 2 buckets / 3072 bytes with checksum 6144; no other GPU was used

Performance validation is limited to proving that multiple asynchronous buckets can be admitted up to the configured credits. No production throughput or latency improvement is claimed from that smoke. A real Ray/SGLang end-to-end run was **not** performed. Before merge, this draft needs a deployment benchmark covering peak memory, weight-sync duration, and rollout latency at several bucket/byte windows versus the all-zero default.

## Duplicate check

I searched current open issues and PRs for weight-bucket credits, in-flight bytes/buckets, backpressure, pipelined/asynchronous weight sync, and both exact option names. I found no substantive duplicate. Existing transport proposals such as #2146 and #2159 change how weights move; they do not provide this admission/credit controller.

## AI assistance and required review

This implementation, tests, documentation, and PR text were prepared with OpenAI Codex assistance. A human contributor/maintainer must review **every changed line**, validate the credit and collective-ordering assumptions, and reproduce the relevant tests and deployment benchmark before this draft is considered ready to merge.
