### PR TITLE
[profiling] Add trainer communication timeline

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -643,6 +643,10 @@ jobs:
             },
             {
               "num_gpus": 0,
+              "test_file": "observability/test_communication_timeline.py"
+            },
+            {
+              "num_gpus": 0,
               "test_file": "observability/test_trace_utils.py"
             },
             {

--- a/.github/workflows/pr-test.yml.j2
+++ b/.github/workflows/pr-test.yml.j2
@@ -86,6 +86,7 @@
         {'test_file': 'test_loss_cp_invariance.py', 'num_gpus': 0},
         {'test_file': 'test_advantage_whiten_cp.py', 'num_gpus': 0},
         {'test_file': 'test_logprob_response_spans.py', 'num_gpus': 0},
+        {'test_file': 'observability/test_communication_timeline.py', 'num_gpus': 0},
         {'test_file': 'observability/test_trace_utils.py', 'num_gpus': 0},
         {'test_file': 'test_value_temperature.py', 'num_gpus': 0},
         {'test_file': 'test_ppo_kl_metric.py', 'num_gpus': 0},

--- a/docs/en/developer_guide/communication_timeline.md
+++ b/docs/en/developer_guide/communication_timeline.md
@@ -33,6 +33,8 @@ CUDA spans use events on the current framework stream. Events are queried withou
 
 Do not use these event-bracket timestamps to select or apply an automatic communication policy. Such a consumer must fail closed until an adapter supplies kernel-observed timestamps and a measured clock-synchronization error bound for every participating rank. The built-in timeline remains useful for lifecycle diagnostics and for correlating its NVTX ranges with an exact profiler trace.
 
+When the timeline is not configured, the public helpers use one shared no-op phase. They do not read clocks, import torch, allocate CUDA events, push NVTX, scan bucket tensor sizes, update context variables, serialize JSON, open files, or synchronize. Host-only, CUDA-event, and external-profiler overhead must be measured as separate modes; profiler runs must not be mixed into non-profiler throughput samples.
+
 ## Add semantic phases from custom code
 
 slime deliberately does not patch Megatron's internal MoE implementation. A custom Megatron hook or plugin can add `ep_dispatch` and `ep_combine` without changing the schema:

--- a/docs/en/developer_guide/communication_timeline.md
+++ b/docs/en/developer_guide/communication_timeline.md
@@ -29,7 +29,9 @@ The trainer records:
 
 Every record carries the common fields `global_step`, `rollout_id`, `weight_version`, `bucket_id`, `trainer_rank`, `engine_id`, `message_bytes`, and `transport`. Fields that do not apply at a boundary are `null`. `sequence_id` is process-local and monotonic, while `logical_operation_id` combines the available lifecycle identifiers with the operation name.
 
-CUDA spans use events on the current framework stream. Events are queried without blocking during normal execution and drained at process shutdown. These timestamps bracket framework eligibility and observed completion; they do not claim to be the exact start of an NCCL kernel on an internal ProcessGroupNCCL stream. Each span also emits an NVTX range named `slime.comm/<operation>` so Nsight Systems can provide exact kernel correlation.
+CUDA spans use events on the current framework stream. Events are queried without blocking during normal execution and drained at process shutdown. Schema v2 labels this provenance explicitly with `gpu_timestamp_semantics="event-bracket"`, `timestamp_domain="process-realtime-projected-cuda-event"`, and `clock_sync_error_bound_us=null`. The projected GPU interval brackets framework eligibility and observed completion; it does not claim to be the exact start of an NCCL kernel on an internal ProcessGroupNCCL stream, and the process realtime clocks have no measured cross-rank error bound. Each span also emits an NVTX range named `slime.comm/<operation>` so Nsight Systems can provide exact kernel correlation.
+
+Do not use these event-bracket timestamps to select or apply an automatic communication policy. Such a consumer must fail closed until an adapter supplies kernel-observed timestamps and a measured clock-synchronization error bound for every participating rank. The built-in timeline remains useful for lifecycle diagnostics and for correlating its NVTX ranges with an exact profiler trace.
 
 ## Add semantic phases from custom code
 

--- a/docs/en/developer_guide/communication_timeline.md
+++ b/docs/en/developer_guide/communication_timeline.md
@@ -1,0 +1,53 @@
+# Trainer Communication Timeline
+
+slime can write a low-overhead JSONL timeline for training and weight synchronization. It is disabled by default and does not change collective ordering or add synchronization to the training path.
+
+Enable it with a per-rank path:
+
+```bash
+python train.py \
+  ... \
+  --communication-timeline /path/to/traces/slime-{role}-{rank}.jsonl
+```
+
+The equivalent environment variable is `SLIME_COMMUNICATION_TIMELINE`. Paths support `{rank}`, `{trainer_rank}`, `{local_rank}`, `{pid}`, `{hostname}`, `{role}`, and `{world_size}`. If a multi-rank path has no rank placeholder, slime adds a `.rank-N` suffix. Actor, critic, and disk-orchestrator roles also get separate suffixes when `{role}` is omitted. This works for any world size; there is no topology-specific rank layout. slime generates one shared `run_id` for the actor group; use `--communication-timeline-run-id` or `SLIME_COMMUNICATION_TIMELINE_RUN_ID` to supply one explicitly.
+
+## Built-in phases
+
+The trainer records:
+
+- `train_forward_backward`: the Megatron forward/backward schedule;
+- `grad_sync`: Megatron's final gradient synchronization callback;
+- `optimizer_step`;
+- `weight_convert`: work performed while producing each HF weight bucket;
+- `weight_bucket_ready` and `weight_bucket_send`;
+- `engine_bucket_receive`: the trainer's observation that transfer has completed;
+- `engine_load_weights`: time until the engine update request returns;
+- `weight_sync_complete`.
+
+`engine_bucket_receive` is a trainer-side observation, not an engine-side timestamp. The `observation` metadata says which boundary produced it.
+
+Every record carries the common fields `global_step`, `rollout_id`, `weight_version`, `bucket_id`, `trainer_rank`, `engine_id`, `message_bytes`, and `transport`. Fields that do not apply at a boundary are `null`. `sequence_id` is process-local and monotonic, while `logical_operation_id` combines the available lifecycle identifiers with the operation name.
+
+CUDA spans use events on the current framework stream. Events are queried without blocking during normal execution and drained at process shutdown. These timestamps bracket framework eligibility and observed completion; they do not claim to be the exact start of an NCCL kernel on an internal ProcessGroupNCCL stream. Each span also emits an NVTX range named `slime.comm/<operation>` so Nsight Systems can provide exact kernel correlation.
+
+## Add semantic phases from custom code
+
+slime deliberately does not patch Megatron's internal MoE implementation. A custom Megatron hook or plugin can add `ep_dispatch` and `ep_combine` without changing the schema:
+
+```python
+from slime.observability.communication_timeline import communication_context, communication_phase
+
+with communication_context(global_step=step, rollout_id=rollout_id):
+    with communication_phase(
+        "ep_dispatch",
+        message_bytes=dispatch_bytes,
+        transport="nccl",
+        layer=layer_id,
+    ):
+        dispatch_tokens()
+```
+
+Use `communication_event(...)` for an instantaneous boundary and call `mark_consumer()` on the object yielded by `communication_phase(...)` when the first consumer is observed.
+
+This timeline is process-oriented and complements the per-sample [Trace Viewer](./trace.md). For kernel-level analysis, correlate its NVTX ranges with [Profiling](./profiling.md).

--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -42,7 +42,7 @@ Start by Use Case
 - Use PD disaggregation: :doc:`advanced/pd-disaggregation`
 - Use BF16 training with FP8 rollout or FP8 KV cache: :doc:`advanced/low-precision`
 - Understand CI and reliability coverage: :doc:`developer_guide/ci`
-- Debug, trace, and profile long-running jobs: :doc:`developer_guide/debug`, :doc:`developer_guide/trace`, :doc:`developer_guide/profiling`
+- Debug, trace, and profile long-running jobs: :doc:`developer_guide/debug`, :doc:`developer_guide/trace`, :doc:`developer_guide/communication_timeline`, :doc:`developer_guide/profiling`
 
 .. toctree::
    :maxdepth: 1
@@ -106,6 +106,7 @@ Start by Use Case
    developer_guide/ci.md
    developer_guide/debug.md
    developer_guide/trace.md
+   developer_guide/communication_timeline.md
    developer_guide/profiling.md
 
 .. toctree::

--- a/docs/zh/developer_guide/communication_timeline.md
+++ b/docs/zh/developer_guide/communication_timeline.md
@@ -33,6 +33,8 @@ CUDA span 在框架当前 stream 上记录 event。正常运行中只做非阻�
 
 自动通信策略不得直接使用这些 event-bracket 时间戳进行选择或执行；在 adapter 为每个参与 rank 提供 kernel-observed 时间戳和实测时钟同步误差上界之前，策略消费者必须 fail closed。内置时间线仍可用于生命周期诊断，以及通过 NVTX range 与精确 profiler trace 做关联。
 
+未配置 timeline 时，公开 helper 会复用同一个 no-op phase，不读取时钟、不导入 torch、不分配 CUDA event、不 push NVTX、不扫描 bucket tensor 大小、不更新 context variable、不序列化 JSON、不打开文件，也不做同步。host-only、CUDA-event 和外部 profiler 三种开销必须分别测量；带 profiler 的样本不得混入不带 profiler 的吞吐对比。
+
 ## 从自定义代码补充语义阶段
 
 slime 不会修改 Megatron 内部 MoE 实现。自定义 Megatron hook 或 plugin 可以直接按同一 schema 补充 `ep_dispatch` 与 `ep_combine`：

--- a/docs/zh/developer_guide/communication_timeline.md
+++ b/docs/zh/developer_guide/communication_timeline.md
@@ -29,7 +29,9 @@ trainer 会记录：
 
 每条记录都有 `global_step`、`rollout_id`、`weight_version`、`bucket_id`、`trainer_rank`、`engine_id`、`message_bytes` 和 `transport` 等共享字段。不适用的字段为 `null`。`sequence_id` 在进程内单调递增，`logical_operation_id` 则由当前可用的生命周期 ID 与操作名组合而成。
 
-CUDA span 在框架当前 stream 上记录 event。正常运行中只做非阻塞查询，在进程退出时才排空尚未完成的 event。这些时间戳表示框架操作可执行到观测完成的区间，并不宣称等于 ProcessGroupNCCL 内部 stream 上 NCCL kernel 的精确起点。每个 span 同时生成名为 `slime.comm/<operation>` 的 NVTX range，可在 Nsight Systems 中精确关联 kernel。
+CUDA span 在框架当前 stream 上记录 event。正常运行中只做非阻塞查询，在进程退出时才排空尚未完成的 event。schema v2 用 `gpu_timestamp_semantics="event-bracket"`、`timestamp_domain="process-realtime-projected-cuda-event"` 和 `clock_sync_error_bound_us=null` 显式标注时间来源。投影后的 GPU 区间表示框架操作可执行到观测完成的边界，并不宣称等于 ProcessGroupNCCL 内部 stream 上 NCCL kernel 的精确起点；各进程 realtime clock 也没有经过测量的跨 rank 误差上界。每个 span 同时生成名为 `slime.comm/<operation>` 的 NVTX range，可在 Nsight Systems 中精确关联 kernel。
+
+自动通信策略不得直接使用这些 event-bracket 时间戳进行选择或执行；在 adapter 为每个参与 rank 提供 kernel-observed 时间戳和实测时钟同步误差上界之前，策略消费者必须 fail closed。内置时间线仍可用于生命周期诊断，以及通过 NVTX range 与精确 profiler trace 做关联。
 
 ## 从自定义代码补充语义阶段
 

--- a/docs/zh/developer_guide/communication_timeline.md
+++ b/docs/zh/developer_guide/communication_timeline.md
@@ -1,0 +1,53 @@
+# Trainer 通信时间线
+
+slime 可以把训练与权重同步阶段写成低开销 JSONL 时间线。该功能默认关闭，不会改变 collective 顺序，也不会在训练路径中增加同步。
+
+使用每 rank 独立路径启用：
+
+```bash
+python train.py \
+  ... \
+  --communication-timeline /path/to/traces/slime-{role}-{rank}.jsonl
+```
+
+也可以设置等价环境变量 `SLIME_COMMUNICATION_TIMELINE`。路径支持 `{rank}`、`{trainer_rank}`、`{local_rank}`、`{pid}`、`{hostname}`、`{role}` 和 `{world_size}`。多 rank 运行若没有 rank 占位符，slime 会自动追加 `.rank-N`；省略 `{role}` 时，actor、critic 与磁盘同步 orchestrator 也会自动使用独立后缀。该机制适用于任意 world size，不依赖特定 rank 拓扑。slime 会为同一 actor group 生成共享 `run_id`；也可通过 `--communication-timeline-run-id` 或 `SLIME_COMMUNICATION_TIMELINE_RUN_ID` 显式指定。
+
+## 内置阶段
+
+trainer 会记录：
+
+- `train_forward_backward`：Megatron forward/backward schedule；
+- `grad_sync`：Megatron 最终梯度同步回调；
+- `optimizer_step`；
+- `weight_convert`：生成每个 HF 权重 bucket 的工作；
+- `weight_bucket_ready` 与 `weight_bucket_send`；
+- `engine_bucket_receive`：trainer 侧观察到传输完成的边界；
+- `engine_load_weights`：等待 engine 更新请求返回的时间；
+- `weight_sync_complete`。
+
+`engine_bucket_receive` 是 trainer 侧观测，不是 engine 内部时间戳；记录中的 `observation` metadata 会说明它对应的具体边界。
+
+每条记录都有 `global_step`、`rollout_id`、`weight_version`、`bucket_id`、`trainer_rank`、`engine_id`、`message_bytes` 和 `transport` 等共享字段。不适用的字段为 `null`。`sequence_id` 在进程内单调递增，`logical_operation_id` 则由当前可用的生命周期 ID 与操作名组合而成。
+
+CUDA span 在框架当前 stream 上记录 event。正常运行中只做非阻塞查询，在进程退出时才排空尚未完成的 event。这些时间戳表示框架操作可执行到观测完成的区间，并不宣称等于 ProcessGroupNCCL 内部 stream 上 NCCL kernel 的精确起点。每个 span 同时生成名为 `slime.comm/<operation>` 的 NVTX range，可在 Nsight Systems 中精确关联 kernel。
+
+## 从自定义代码补充语义阶段
+
+slime 不会修改 Megatron 内部 MoE 实现。自定义 Megatron hook 或 plugin 可以直接按同一 schema 补充 `ep_dispatch` 与 `ep_combine`：
+
+```python
+from slime.observability.communication_timeline import communication_context, communication_phase
+
+with communication_context(global_step=step, rollout_id=rollout_id):
+    with communication_phase(
+        "ep_dispatch",
+        message_bytes=dispatch_bytes,
+        transport="nccl",
+        layer=layer_id,
+    ):
+        dispatch_tokens()
+```
+
+瞬时边界使用 `communication_event(...)`；观察到第一个 consumer 时，可对 `communication_phase(...)` 返回的对象调用 `mark_consumer()`。
+
+这条时间线面向进程级训练/通信阶段，与按 sample 展示的 [Trace Viewer](./trace.md) 互补。kernel 级分析请把 NVTX range 与[性能分析](./profiling.md)结合使用。

--- a/docs/zh/index.rst
+++ b/docs/zh/index.rst
@@ -42,7 +42,7 @@ slime 的设计目标，是让这两大能力彼此强化，同时避免把系�
 - 使用 PD disaggregation：:doc:`advanced/pd-disaggregation`
 - 使用 BF16 训练 + FP8 rollout 或 FP8 KV cache：:doc:`advanced/low-precision`
 - 了解 CI 和可靠性覆盖：:doc:`developer_guide/ci`
-- 调试、trace 和 profiling 长时间任务：:doc:`developer_guide/debug`、:doc:`developer_guide/trace`、:doc:`developer_guide/profiling`
+- 调试、trace 和 profiling 长时间任务：:doc:`developer_guide/debug`、:doc:`developer_guide/trace`、:doc:`developer_guide/communication_timeline`、:doc:`developer_guide/profiling`
 
 .. toctree::
    :maxdepth: 1
@@ -106,6 +106,7 @@ slime 的设计目标，是让这两大能力彼此强化，同时避免把系�
    developer_guide/ci.md
    developer_guide/debug.md
    developer_guide/trace.md
+   developer_guide/communication_timeline.md
    developer_guide/profiling.md
 
 .. toctree::

--- a/slime/backends/megatron_utils/actor.py
+++ b/slime/backends/megatron_utils/actor.py
@@ -13,6 +13,7 @@ from torch_memory_saver import torch_memory_saver
 from transformers import AutoConfig, AutoTokenizer
 
 from slime.observability import train_data_utils, train_metric_utils
+from slime.observability.communication_timeline import communication_context, flush_communication_timeline
 from slime.observability.logging_utils import init_tracking
 from slime.observability.profile_utils import TrainProfiler
 from slime.observability.timer import Timer, inverse_timer, timer, with_defer
@@ -604,7 +605,8 @@ class MegatronTrainRayActor(TrainRayActor):
 
         with torch_memory_saver.disable() if self.args.offload_train else nullcontext():
             print_memory("before update_weights")
-            self.weight_updater.update_weights()
+            with communication_context(rollout_id=self._communication_rollout_id):
+                self.weight_updater.update_weights()
             print_memory("after update_weights")
 
             if getattr(self.args, "keep_old_actor", False):
@@ -622,6 +624,7 @@ class MegatronTrainRayActor(TrainRayActor):
             self.sleep()
         elif self.args.offload_train:
             destroy_process_groups()
+        flush_communication_timeline(block=getattr(self.args, "release_train", False))
 
     def load_other_checkpoint(self, model_tag: str, path: str) -> None:
         old_args = (

--- a/slime/backends/megatron_utils/model.py
+++ b/slime/backends/megatron_utils/model.py
@@ -29,6 +29,11 @@ try:
 except ImportError:
     from megatron.core.utils import unwrap_model
 from slime.observability import logging_utils, train_metric_utils
+from slime.observability.communication_timeline import (
+    communication_context,
+    communication_phase,
+    flush_communication_timeline,
+)
 from slime.utils.memory_utils import clear_memory
 
 from .checkpoint import load_checkpoint, save_checkpoint
@@ -38,6 +43,11 @@ from .model_provider import get_model_provider_func
 from .stateless_adam import StatelessAdam
 
 logger = logging.getLogger(__name__)
+
+
+def _finalize_model_grads_with_trace(*args, **kwargs):
+    with communication_phase("grad_sync"):
+        return finalize_model_grads(*args, **kwargs)
 
 
 def _disable_tqdm_for_non_main_rank() -> bool:
@@ -519,6 +529,7 @@ def train_one_step(
     opt_param_scheduler: OptimizerParamScheduler,
     num_microbatches: int,
     step_global_batch_size: int,
+    global_step: int,
     microbatch_pbar=None,
 ) -> tuple[dict[str, float], float]:
     """Execute a single pipeline-parallel training step.
@@ -542,6 +553,8 @@ def train_one_step(
             normalizer inside the closure and as the LR scheduler
             ``increment``. In the common case (1 rollout = 1 sample) this
             equals the per-step sample count, so behavior is unchanged.
+        global_step (int): Monotonic train-step identifier used by the
+            communication timeline.
 
     Returns:
         tuple[dict[str, float], float]: Reduced loss dictionary (last stage only)
@@ -645,16 +658,23 @@ def train_one_step(
 
     # Forward pass.
     forward_backward_func = get_forward_backward_func()
-    losses_reduced = forward_backward_func(
-        forward_step_func=_wrap_forward_step_with_microbatch_pbar(forward_step, microbatch_pbar),
-        data_iterator=data_iterator,
-        model=model,
-        num_microbatches=num_microbatches,
-        seq_length=args.seq_length,
-        micro_batch_size=args.micro_batch_size,
-        decoder_seq_length=args.decoder_seq_length,
-        forward_only=False,
-    )
+    trace_context = {
+        "global_step": global_step,
+        "rollout_id": rollout_id,
+        "trainer_rank": getattr(args, "rank", None),
+    }
+    with communication_context(**trace_context):
+        with communication_phase("train_forward_backward", microbatch_count=num_microbatches):
+            losses_reduced = forward_backward_func(
+                forward_step_func=_wrap_forward_step_with_microbatch_pbar(forward_step, microbatch_pbar),
+                data_iterator=data_iterator,
+                model=model,
+                num_microbatches=num_microbatches,
+                seq_length=args.seq_length,
+                micro_batch_size=args.micro_batch_size,
+                decoder_seq_length=args.decoder_seq_length,
+                forward_only=False,
+            )
 
     valid_step = True
     grad_norm = float("nan")
@@ -678,7 +698,9 @@ def train_one_step(
 
     if valid_step:
         # Update parameters.
-        update_successful, grad_norm, num_zeros_in_grad = optimizer.step()
+        with communication_context(**trace_context):
+            with communication_phase("optimizer_step"):
+                update_successful, grad_norm, num_zeros_in_grad = optimizer.step()
 
         # Update learning rate. Use the per-step global_batch_size when dynamic
         # batching is on so the scheduler's samples-seen counter tracks reality.
@@ -690,6 +712,7 @@ def train_one_step(
         model_chunk.zero_grad_buffer()
     optimizer.zero_grad()
 
+    flush_communication_timeline(block=False)
     if mpu.is_pipeline_last_stage(ignore_virtual=True):
         loss_reduced = train_metric_utils.reduce_train_step_metrics(
             losses_reduced,
@@ -769,7 +792,7 @@ def train(
         config.param_sync_func = [model_chunk.start_param_sync for model_chunk in model]
         if len(model) == 1:
             config.param_sync_func = config.param_sync_func[0]
-    config.finalize_model_grads_func = finalize_model_grads
+    config.finalize_model_grads_func = _finalize_model_grads_with_trace
 
     pre_hook_enabled = False
 
@@ -825,6 +848,7 @@ def train(
 
     # Run training iterations till done.
     for step_id in range(num_steps_per_rollout):
+        global_step = rollout_id * num_steps_per_rollout + step_id
 
         # Run training step.
         loss_dict, grad_norm = train_one_step(
@@ -837,6 +861,7 @@ def train(
             opt_param_scheduler,
             num_microbatches[step_id],
             global_batch_sizes[step_id],
+            global_step,
             microbatch_pbar=microbatch_pbar,
         )
 
@@ -876,7 +901,7 @@ def train(
             and mpu.get_tensor_model_parallel_rank() == 0
             and mpu.get_pipeline_model_parallel_rank() == mpu.get_pipeline_model_parallel_world_size() - 1
         ):
-            accumulated_step_id = rollout_id * num_steps_per_rollout + step_id
+            accumulated_step_id = global_step
             role = getattr(model[0], "role", "actor")
             role_tag = "" if role == "actor" else f"{role}-"
             log_dict = {

--- a/slime/backends/megatron_utils/update_weight/update_weight_from_disk.py
+++ b/slime/backends/megatron_utils/update_weight/update_weight_from_disk.py
@@ -9,6 +9,12 @@ import torch
 import torch.distributed as dist
 from ray.actor import ActorHandle
 
+from slime.observability.communication_timeline import (
+    communication_context,
+    communication_event,
+    communication_phase,
+    flush_communication_timeline,
+)
 from slime.utils.distributed_utils import get_gloo_group
 
 from ..hf_checkpoint_saver import save_hf_model_to_path
@@ -71,24 +77,29 @@ class UpdateWeightFromDisk:
             shutil.rmtree(version_dir, ignore_errors=True)
         dist.barrier(group=get_gloo_group())
 
-        # every writing rank creates the dir itself: a non-POSIX shared filesystem may not surface
-        # one rank's mkdir to another until commit
-        version_dir.mkdir(parents=True, exist_ok=True)
-        save_hf_model_to_path(
-            self.args,
-            version_dir,
-            self.model,
-            model_name=self.model_name,
-            quantization_config=self.quantization_config,
-            progress_desc="Save HF  weights for update from disk",
-        )
-        dist.barrier(group=get_gloo_group())
+        with communication_context(weight_version=self.weight_version, transport="disk"):
+            # every writing rank creates the dir itself: a non-POSIX shared filesystem may not surface
+            # one rank's mkdir to another until commit
+            version_dir.mkdir(parents=True, exist_ok=True)
+            with communication_phase("weight_convert", bucket_id=0):
+                save_hf_model_to_path(
+                    self.args,
+                    version_dir,
+                    self.model,
+                    model_name=self.model_name,
+                    quantization_config=self.quantization_config,
+                    progress_desc="Save HF  weights for update from disk",
+                )
+            dist.barrier(group=get_gloo_group())
+            communication_event("weight_bucket_ready", bucket_id=0)
 
-        # every rank runs the hook (it gates itself): each container must publish
-        # its own writes
-        if self._post_write_hook is not None:
-            self._post_write_hook(self.args, str(version_dir), list(self.rollout_engines))
-        dist.barrier(group=get_gloo_group())
+            # every rank runs the hook (it gates itself): each container must publish
+            # its own writes
+            with communication_phase("weight_bucket_send", bucket_id=0):
+                if self._post_write_hook is not None:
+                    self._post_write_hook(self.args, str(version_dir), list(self.rollout_engines))
+                dist.barrier(group=get_gloo_group())
+            flush_communication_timeline(block=False)
 
         # SGLang reload is orchestrated by RayTrainGroup after the checkpoint
         # is fully written, so training-side lifecycle can decide whether

--- a/slime/backends/megatron_utils/update_weight/update_weight_from_disk_delta.py
+++ b/slime/backends/megatron_utils/update_weight/update_weight_from_disk_delta.py
@@ -19,6 +19,12 @@ import zstandard
 from megatron.core import mpu
 from ray.actor import ActorHandle
 
+from slime.observability.communication_timeline import (
+    communication_context,
+    communication_event,
+    communication_phase,
+    flush_communication_timeline,
+)
 from slime.utils import accelerator
 from slime.utils.disk_delta import NUM_WORKERS, checksum, make_tensor_reader, overwrite_encode
 from slime.utils.distributed_utils import get_gloo_group
@@ -84,14 +90,20 @@ class UpdateWeightFromDiskDelta(UpdateWeightFromDistributed):
     def update_weights(self) -> None:
         # The first call only captures the baseline snapshot the next sync diffs against.
         if not self._baseline_captured:
-            self._capture_baseline()
+            with communication_context(weight_version=0, transport="disk_delta"):
+                with communication_phase("weight_convert", bucket_id=0, baseline_snapshot=True):
+                    self._capture_baseline()
+                flush_communication_timeline(block=False)
             self._baseline_captured = True
             return
 
         self.weight_version += 1
-        self._publish()
-        self._reload_engines()
-        self._record_metrics()
+        with communication_context(weight_version=self.weight_version, transport="disk_delta"):
+            self._publish()
+            self._reload_engines()
+            self._record_metrics()
+            communication_event("weight_sync_complete")
+            flush_communication_timeline(block=False)
 
     def _capture_baseline(self) -> None:
         """Capture the baseline snapshot the first delta diffs against (no publish), and clear any
@@ -127,9 +139,14 @@ class UpdateWeightFromDiskDelta(UpdateWeightFromDistributed):
 
     def _publish(self) -> None:
         """Encode this version's changed tensors (PP-src ranks), then write it as a canonical HF dir."""
-        self._encode_delta()
-        dist.barrier(group=get_gloo_group())
-        self._write_delta_files()
+        with communication_phase("weight_convert", bucket_id=0) as phase:
+            self._encode_delta()
+            phase.update(message_bytes=self.total_bytes, changed_bytes=self.changed_bytes)
+        communication_event("weight_bucket_ready", bucket_id=0, message_bytes=self.changed_bytes)
+        with communication_phase("weight_bucket_send", bucket_id=0, message_bytes=self.changed_bytes) as phase:
+            dist.barrier(group=get_gloo_group())
+            self._write_delta_files()
+            phase.update(wire_bytes=self.wire_bytes)
 
     def _write_delta_files(self) -> None:
         """Write this rank's changed tensors as one canonical model-NNNNN.safetensors, and on rank
@@ -175,18 +192,31 @@ class UpdateWeightFromDiskDelta(UpdateWeightFromDistributed):
             self._post_write_hook(self.args, self._version_dir, list(self.rollout_engines))
         dist.barrier(group=get_gloo_group())
         if dist.get_rank() == 0:
-            ray.get([engine.pull_weights.remote(self.weight_version) for engine in self.rollout_engines])
+            shared_fields = {
+                "bucket_id": 0,
+                "message_bytes": self.wire_bytes,
+                "engine_count": len(self.rollout_engines),
+            }
+            with communication_phase(
+                "engine_bucket_receive",
+                observation="trainer_pull_request_complete",
+                **shared_fields,
+            ) as phase:
+                ray.get([engine.pull_weights.remote(self.weight_version) for engine in self.rollout_engines])
+                phase.mark_consumer()
             ray.get([engine.pause_generation.remote() for engine in self.rollout_engines])
             ray.get([engine.flush_cache.remote() for engine in self.rollout_engines])
-            ray.get(
-                [
-                    engine.update_weights_from_disk.remote(
-                        model_path=self.args.update_weight_local_checkpoint_dir,
-                        weight_version=str(self.weight_version),
-                    )
-                    for engine in self.rollout_engines
-                ]
-            )
+            with communication_phase("engine_load_weights", **shared_fields) as phase:
+                ray.get(
+                    [
+                        engine.update_weights_from_disk.remote(
+                            model_path=self.args.update_weight_local_checkpoint_dir,
+                            weight_version=str(self.weight_version),
+                        )
+                        for engine in self.rollout_engines
+                    ]
+                )
+                phase.mark_consumer()
             ray.get([engine.continue_generation.remote() for engine in self.rollout_engines])
         dist.barrier(group=get_gloo_group())
 

--- a/slime/backends/megatron_utils/update_weight/update_weight_from_distributed.py
+++ b/slime/backends/megatron_utils/update_weight/update_weight_from_distributed.py
@@ -13,6 +13,13 @@ from ray import ObjectRef
 from ray.actor import ActorHandle
 from tqdm import tqdm
 
+from slime.observability.communication_timeline import (
+    communication_context,
+    communication_event,
+    communication_phase,
+    flush_communication_timeline,
+    iter_communication_buckets,
+)
 from slime.utils import accelerator
 from slime.utils.distributed_utils import get_gloo_group, init_process_group
 from slime.utils.http_utils import _wrap_ipv6
@@ -105,32 +112,35 @@ class UpdateWeightFromDistributed:
         """
         self.weight_version += 1
 
-        if dist.get_rank() == 0:
-            ray.get([engine.pause_generation.remote() for engine in self.rollout_engines])
-            ray.get([engine.flush_cache.remote() for engine in self.rollout_engines])
+        with communication_context(weight_version=self.weight_version, transport="nccl"):
+            if dist.get_rank() == 0:
+                ray.get([engine.pause_generation.remote() for engine in self.rollout_engines])
+                ray.get([engine.flush_cache.remote() for engine in self.rollout_engines])
 
-            # int4/fp4 pre_process
-            if self.quantization_config and self.quantization_config["quant_method"] in ["compressed-tensors"]:
-                post_process_weights(
-                    restore_weights_before_load=True,
-                    post_process_quantization=False,
-                    rollout_engines=self.rollout_engines,
-                )
-        dist.barrier(group=get_gloo_group())
+                # int4/fp4 pre_process
+                if self.quantization_config and self.quantization_config["quant_method"] in ["compressed-tensors"]:
+                    post_process_weights(
+                        restore_weights_before_load=True,
+                        post_process_quantization=False,
+                        rollout_engines=self.rollout_engines,
+                    )
+            dist.barrier(group=get_gloo_group())
 
-        pbar = tqdm(desc=f"[{self._group_name}] Update weights", total=0) if self._is_pp_src_rank else None
-        self._send_weights(pbar)
+            pbar = tqdm(desc=f"[{self._group_name}] Update weights", total=0) if self._is_pp_src_rank else None
+            self._send_weights(pbar)
 
-        if dist.get_rank() == 0:
-            # int4/fp4 post_process
-            if self.quantization_config and self.quantization_config["quant_method"] in ["compressed-tensors"]:
-                post_process_weights(
-                    restore_weights_before_load=False,
-                    post_process_quantization=True,
-                    rollout_engines=self.rollout_engines,
-                )
-            ray.get([engine.continue_generation.remote() for engine in self.rollout_engines])
-        dist.barrier(group=get_gloo_group())
+            if dist.get_rank() == 0:
+                # int4/fp4 post_process
+                if self.quantization_config and self.quantization_config["quant_method"] in ["compressed-tensors"]:
+                    post_process_weights(
+                        restore_weights_before_load=False,
+                        post_process_quantization=True,
+                        rollout_engines=self.rollout_engines,
+                    )
+                ray.get([engine.continue_generation.remote() for engine in self.rollout_engines])
+            dist.barrier(group=get_gloo_group())
+            communication_event("weight_sync_complete")
+            flush_communication_timeline(block=False)
 
     def _send_weights(self, pbar: tqdm | None) -> None:
         """
@@ -138,10 +148,30 @@ class UpdateWeightFromDistributed:
         yields broadcast-ready chunks (bucketing happens internally); subclasses
         override ``_on_chunk`` to inject per-chunk behaviour.
         """
-        for chunk_iter in (self._iter_non_expert_chunks(), self._iter_expert_chunks()):
-            for hf_chunk in chunk_iter:
+        bucket_id = 0
+        chunk_iters = (
+            ("non_expert", self._iter_non_expert_chunks()),
+            ("expert", self._iter_expert_chunks()),
+        )
+        for bucket_kind, chunk_iter in chunk_iters:
+            for current_bucket_id, hf_chunk in iter_communication_buckets(
+                chunk_iter,
+                start_bucket_id=bucket_id,
+            ):
+                message_bytes = sum(tensor.numel() * tensor.element_size() for _, tensor in hf_chunk)
+                communication_event(
+                    "weight_bucket_ready",
+                    bucket_id=current_bucket_id,
+                    message_bytes=message_bytes,
+                    bucket_kind=bucket_kind,
+                )
                 self._on_chunk(hf_chunk)
-                self._update_bucket_weights_from_distributed(hf_chunk, pbar=pbar)
+                self._update_bucket_weights_from_distributed(
+                    hf_chunk,
+                    bucket_id=current_bucket_id,
+                    pbar=pbar,
+                )
+                bucket_id = current_bucket_id + 1
             dist.barrier(group=get_gloo_group())
 
     def _on_chunk(self, hf_chunk: list[tuple[str, torch.Tensor]]) -> None:
@@ -239,6 +269,7 @@ class UpdateWeightFromDistributed:
     def _update_bucket_weights_from_distributed(
         self,
         converted_named_tensors: list[tuple[str, torch.Tensor]],
+        bucket_id: int,
         pbar: tqdm | None = None,
         load_format: str | None = None,
     ) -> None:
@@ -249,16 +280,26 @@ class UpdateWeightFromDistributed:
         while not ray.get(self.rollout_engine_lock.acquire.remote()):
             time.sleep(0.1)
 
-        refs = update_weights_from_distributed(
-            self._group_name,
-            self._model_update_groups,
-            self.weight_version,
-            self.rollout_engines,
-            converted_named_tensors,
-            load_format=load_format,
-        )
+        message_bytes = sum(tensor.numel() * tensor.element_size() for _, tensor in converted_named_tensors)
+        shared_fields = {
+            "bucket_id": bucket_id,
+            "message_bytes": message_bytes,
+            "engine_count": len(self.rollout_engines),
+        }
+        with communication_phase("weight_bucket_send", **shared_fields):
+            refs = update_weights_from_distributed(
+                self._group_name,
+                self._model_update_groups,
+                self.weight_version,
+                self.rollout_engines,
+                converted_named_tensors,
+                load_format=load_format,
+            )
 
-        ray.get(refs)
+        communication_event("engine_bucket_receive", observation="trainer_broadcast_complete", **shared_fields)
+        with communication_phase("engine_load_weights", **shared_fields) as phase:
+            ray.get(refs)
+            phase.mark_consumer()
         converted_named_tensors.clear()
         ray.get(self.rollout_engine_lock.release.remote())
         pbar.update(1)

--- a/slime/backends/megatron_utils/update_weight/update_weight_from_tensor.py
+++ b/slime/backends/megatron_utils/update_weight/update_weight_from_tensor.py
@@ -11,6 +11,13 @@ from ray import ObjectRef
 from ray.actor import ActorHandle
 from tqdm import tqdm
 
+from slime.observability.communication_timeline import (
+    communication_context,
+    communication_event,
+    communication_phase,
+    flush_communication_timeline,
+    iter_communication_buckets,
+)
 from slime.utils import accelerator
 from slime.utils.distributed_utils import get_gloo_group
 from slime.utils.types import ParamInfo
@@ -259,13 +266,19 @@ class UpdateWeightFromTensor:
             desc="Update expert weights",
         ):
             for transfer_batch in transfer_group:
-                hf_named_tensors = self._prepare_expert_weight_batch(
-                    transfer_batch,
-                    megatron_local_weights,
-                    staging_buffers,
+                bucket_id = self._communication_bucket_id
+                with communication_phase("weight_convert", bucket_id=bucket_id) as phase:
+                    hf_named_tensors = self._prepare_expert_weight_batch(
+                        transfer_batch,
+                        megatron_local_weights,
+                        staging_buffers,
+                    )
+                    phase.update(message_bytes=self._weight_bytes(hf_named_tensors), bucket_kind="expert")
+                refs, long_lived_tensors = self._send_weight_bucket(
+                    hf_named_tensors,
+                    bucket_id=bucket_id,
+                    bucket_kind="expert",
                 )
-                refs, long_lived_tensors = self._send_hf_params(hf_named_tensors)
-                ray.get(refs)
                 dist.barrier(group=get_gloo_group())
                 accelerator.synchronize()
                 del refs, long_lived_tensors, hf_named_tensors
@@ -280,56 +293,93 @@ class UpdateWeightFromTensor:
         version++, flush caches, process buckets. Progress on rank 0.
         """
         self.weight_version += 1
+        self._communication_bucket_id = 0
 
-        if self.rank == 0:
-            ray.get([engine.pause_generation.remote() for engine in self.rollout_engines])
-            ray.get([engine.flush_cache.remote() for engine in self.rollout_engines])
-            if self.quantization_config and self.quantization_config["quant_method"] in ["compressed-tensors"]:
-                post_process_weights(
-                    restore_weights_before_load=True,
-                    post_process_quantization=False,
-                    rollout_engines=self.rollout_engines,
+        with communication_context(weight_version=self.weight_version, transport="nccl_or_cuda_ipc"):
+            if self.rank == 0:
+                ray.get([engine.pause_generation.remote() for engine in self.rollout_engines])
+                ray.get([engine.flush_cache.remote() for engine in self.rollout_engines])
+                if self.quantization_config and self.quantization_config["quant_method"] in ["compressed-tensors"]:
+                    post_process_weights(
+                        restore_weights_before_load=True,
+                        post_process_quantization=False,
+                        rollout_engines=self.rollout_engines,
+                    )
+            dist.barrier(group=get_gloo_group())
+
+            megatron_local_weights = self.weights_getter()
+
+            param_info_buckets = (
+                self._non_expert_param_info_buckets if self._expert_transfer_plan else self._full_param_info_buckets
+            )
+            chunks = self._hf_weight_iterator.get_hf_weight_chunks(
+                megatron_local_weights,
+                param_info_buckets=param_info_buckets,
+            )
+            for bucket_id, hf_named_tensors in iter_communication_buckets(
+                chunks,
+                start_bucket_id=self._communication_bucket_id,
+            ):
+                refs, long_lived_tensors = self._send_weight_bucket(
+                    hf_named_tensors,
+                    bucket_id=bucket_id,
+                    bucket_kind="non_expert",
                 )
-        dist.barrier(group=get_gloo_group())
+                # Free GPU tensors so the caching allocator can reuse the blocks,
+                # then release CUDA IPC cache entries whose consumers (sglang engines)
+                # have already closed their IPC handles.
+                del refs, long_lived_tensors, hf_named_tensors
+                accelerator.ipc_collect()
+                accelerator.empty_cache()
 
-        megatron_local_weights = self.weights_getter()
+            if self._expert_transfer_plan:
+                self._update_expert_weights(megatron_local_weights)
 
-        param_info_buckets = (
-            self._non_expert_param_info_buckets if self._expert_transfer_plan else self._full_param_info_buckets
-        )
-        for hf_named_tensors in self._hf_weight_iterator.get_hf_weight_chunks(
-            megatron_local_weights,
-            param_info_buckets=param_info_buckets,
-        ):
-            refs, long_lived_tensors = self._send_hf_params(hf_named_tensors)
-            ray.get(refs)
-            # Free GPU tensors so the caching allocator can reuse the blocks,
-            # then release CUDA IPC cache entries whose consumers (sglang engines)
-            # have already closed their IPC handles.
-            del refs, long_lived_tensors, hf_named_tensors
+            del megatron_local_weights
+            dist.barrier(group=get_gloo_group())
+            # After the barrier all engines have returned, so every rank's last-chunk
+            # IPC handles are now released by the consumers.  Clean them up.
             accelerator.ipc_collect()
             accelerator.empty_cache()
 
-        if self._expert_transfer_plan:
-            self._update_expert_weights(megatron_local_weights)
+            # int4/fp4 post_process
+            if self.rank == 0:
+                if self.quantization_config and self.quantization_config["quant_method"] in ["compressed-tensors"]:
+                    post_process_weights(
+                        restore_weights_before_load=False,
+                        post_process_quantization=True,
+                        rollout_engines=self.rollout_engines,
+                    )
+                ray.get([engine.continue_generation.remote() for engine in self.rollout_engines])
+            dist.barrier(group=get_gloo_group())
+            communication_event("weight_sync_complete")
+            flush_communication_timeline(block=False)
 
-        del megatron_local_weights
-        dist.barrier(group=get_gloo_group())
-        # After the barrier all engines have returned, so every rank's last-chunk
-        # IPC handles are now released by the consumers.  Clean them up.
-        accelerator.ipc_collect()
-        accelerator.empty_cache()
+    @staticmethod
+    def _weight_bytes(hf_named_tensors) -> int:
+        return sum(tensor.numel() * tensor.element_size() for _, tensor in hf_named_tensors)
 
-        # int4/fp4 post_process
-        if self.rank == 0:
-            if self.quantization_config and self.quantization_config["quant_method"] in ["compressed-tensors"]:
-                post_process_weights(
-                    restore_weights_before_load=False,
-                    post_process_quantization=True,
-                    rollout_engines=self.rollout_engines,
-                )
-            ray.get([engine.continue_generation.remote() for engine in self.rollout_engines])
-        dist.barrier(group=get_gloo_group())
+    def _send_weight_bucket(self, hf_named_tensors, *, bucket_id: int, bucket_kind: str):
+        message_bytes = self._weight_bytes(hf_named_tensors)
+        engine_count = len(self.rollout_engines) + (
+            len(self.distributed_rollout_engines) if getattr(self, "use_distribute", False) else 0
+        )
+        shared_fields = {
+            "bucket_id": bucket_id,
+            "message_bytes": message_bytes,
+            "bucket_kind": bucket_kind,
+            "engine_count": engine_count,
+        }
+        communication_event("weight_bucket_ready", **shared_fields)
+        with communication_phase("weight_bucket_send", **shared_fields):
+            refs, long_lived_tensors = self._send_hf_params(hf_named_tensors)
+        if refs:
+            communication_event("engine_bucket_receive", observation="trainer_transfer_complete", **shared_fields)
+            with communication_phase("engine_load_weights", **shared_fields) as phase:
+                ray.get(refs)
+                phase.mark_consumer()
+        self._communication_bucket_id = bucket_id + 1
+        return refs, long_lived_tensors
 
     def _send_hf_params(self, hf_named_tensors) -> tuple[list[ObjectRef], Any]:
         all_refs = []

--- a/slime/observability/communication_timeline.py
+++ b/slime/observability/communication_timeline.py
@@ -1,0 +1,485 @@
+from __future__ import annotations
+
+import atexit
+import contextvars
+import json
+import logging
+import os
+import socket
+import threading
+import time
+import uuid
+from collections.abc import Iterator, Mapping
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+COMMUNICATION_TIMELINE_VERSION = 1
+COMMUNICATION_TIMELINE_ENV = "SLIME_COMMUNICATION_TIMELINE"
+COMMUNICATION_TIMELINE_RUN_ID_ENV = "SLIME_COMMUNICATION_TIMELINE_RUN_ID"
+
+_STANDARD_FIELDS = (
+    "global_step",
+    "rollout_id",
+    "weight_version",
+    "bucket_id",
+    "trainer_rank",
+    "engine_id",
+    "message_bytes",
+    "transport",
+)
+_CONTEXT: contextvars.ContextVar[dict[str, Any] | None] = contextvars.ContextVar(
+    "slime_communication_timeline_context",
+    default=None,
+)
+_GLOBAL_LOCK = threading.RLock()
+_GLOBAL_TIMELINE: CommunicationTimeline | None = None
+_GLOBAL_CONFIGURED = False
+
+
+def _optional_torch():
+    try:
+        import torch
+
+        return torch
+    except ImportError:
+        return None
+
+
+def _detect_rank() -> int:
+    torch = _optional_torch()
+    if torch is not None and torch.distributed.is_available() and torch.distributed.is_initialized():
+        return torch.distributed.get_rank()
+    return int(os.environ.get("RANK", 0))
+
+
+def _detect_local_rank() -> int:
+    return int(os.environ.get("LOCAL_RANK", 0))
+
+
+def _detect_world_size() -> int:
+    torch = _optional_torch()
+    if torch is not None and torch.distributed.is_available() and torch.distributed.is_initialized():
+        return torch.distributed.get_world_size()
+    return int(os.environ.get("WORLD_SIZE", 1))
+
+
+def _resolve_path(template: str, *, rank: int, local_rank: int, role: str, world_size: int) -> Path:
+    values = {
+        "rank": rank,
+        "trainer_rank": rank,
+        "local_rank": local_rank,
+        "pid": os.getpid(),
+        "hostname": socket.gethostname(),
+        "role": role,
+        "world_size": world_size,
+    }
+    try:
+        resolved = template.format_map(values)
+    except (KeyError, ValueError) as exc:
+        raise ValueError(
+            "communication timeline path supports only {rank}, {trainer_rank}, {local_rank}, "
+            "{pid}, {hostname}, {role}, and {world_size} placeholders"
+        ) from exc
+    path = Path(resolved).expanduser()
+    if role != "trainer" and "{role}" not in template and "{pid}" not in template:
+        suffix = path.suffix
+        stem = path.name[: -len(suffix)] if suffix else path.name
+        path = path.with_name(f"{stem}.role-{role}{suffix}")
+    if world_size > 1 and not any(f"{{{name}}}" in template for name in ("rank", "trainer_rank", "pid")):
+        suffix = path.suffix
+        stem = path.name[: -len(suffix)] if suffix else path.name
+        path = path.with_name(f"{stem}.rank-{rank}{suffix}")
+    return path
+
+
+def _message_bytes(named_tensors) -> int:
+    total = 0
+    for item in named_tensors:
+        tensor = item[1] if isinstance(item, tuple) else item
+        total += int(tensor.numel()) * int(tensor.element_size())
+    return total
+
+
+@dataclass
+class _PendingRecord:
+    record: dict[str, Any] | None
+    gpu_start: Any = None
+    gpu_end: Any = None
+
+
+class CommunicationTimeline:
+    """Append-only trainer communication timeline.
+
+    CUDA events are queried without synchronizing the training stream during normal
+    operation. ``close()`` waits only for the outstanding end events so the final
+    records are not lost at process shutdown.
+    """
+
+    def __init__(
+        self,
+        path: str,
+        *,
+        rank: int | None = None,
+        local_rank: int | None = None,
+        world_size: int | None = None,
+        role: str = "trainer",
+        run_id: str | None = None,
+    ) -> None:
+        self.rank = _detect_rank() if rank is None else rank
+        self.local_rank = _detect_local_rank() if local_rank is None else local_rank
+        self.world_size = _detect_world_size() if world_size is None else world_size
+        self.role = role
+        self.run_id = run_id or os.environ.get(COMMUNICATION_TIMELINE_RUN_ID_ENV) or uuid.uuid4().hex
+        self.path = _resolve_path(
+            path,
+            rank=self.rank,
+            local_rank=self.local_rank,
+            role=role,
+            world_size=self.world_size,
+        )
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._file = self.path.open("a", encoding="utf-8", buffering=1)
+        self._lock = threading.RLock()
+        self._pending: dict[int, _PendingRecord] = {}
+        self._sequence_id = 0
+        self._next_write_sequence_id = 0
+        self._closed = False
+        self._write_failed = False
+
+    def next_sequence_id(self) -> int:
+        with self._lock:
+            sequence_id = self._sequence_id
+            self._sequence_id += 1
+            return sequence_id
+
+    def new_span(self, operation: str, fields: Mapping[str, Any]) -> CommunicationPhase:
+        return CommunicationPhase(self, operation, dict(fields))
+
+    def emit_event(self, operation: str, fields: Mapping[str, Any]) -> None:
+        now_wall = time.time_ns()
+        now_monotonic = time.perf_counter_ns()
+        record = self._base_record(operation, fields)
+        record.update(
+            {
+                "record_type": "event",
+                "api_launch_timestamp_ns": now_wall,
+                "api_return_timestamp_ns": now_wall,
+                "completion_timestamp_ns": now_wall,
+                "consumer_timestamp_ns": fields.get("consumer_timestamp_ns"),
+                "api_launch_monotonic_ns": now_monotonic,
+                "completion_monotonic_ns": now_monotonic,
+                "duration_ns": 0,
+                "gpu_start_timestamp_ns": None,
+                "gpu_end_timestamp_ns": None,
+                "gpu_elapsed_ns": None,
+                "status": "ok",
+            }
+        )
+        self._queue(_PendingRecord(record=record))
+        self.flush(block=False)
+
+    def _base_record(self, operation: str, fields: Mapping[str, Any]) -> dict[str, Any]:
+        context = dict(_CONTEXT.get() or {})
+        context.update(fields)
+        standard = {name: context.pop(name, None) for name in _STANDARD_FIELDS}
+        if standard["trainer_rank"] is None:
+            standard["trainer_rank"] = self.rank
+        sequence_id = self.next_sequence_id()
+        logical_parts = (
+            standard["global_step"],
+            standard["rollout_id"],
+            standard["weight_version"],
+            standard["bucket_id"],
+            operation,
+        )
+        logical_operation_id = "/".join("-" if value is None else str(value) for value in logical_parts)
+        return {
+            "schema_version": COMMUNICATION_TIMELINE_VERSION,
+            "framework": "slime",
+            "run_id": self.run_id,
+            "role": self.role,
+            "rank": self.rank,
+            "local_rank": self.local_rank,
+            "world_size": self.world_size,
+            "hostname": socket.gethostname(),
+            "pid": os.getpid(),
+            "sequence_id": sequence_id,
+            "logical_operation_id": logical_operation_id,
+            "operation": operation,
+            **standard,
+            "metadata": context,
+        }
+
+    def finish_span(self, span: CommunicationPhase, error: BaseException | None) -> None:
+        if span.cancelled:
+            self._queue(_PendingRecord(record=None), sequence_id=span.record["sequence_id"])
+            self.flush(block=False)
+            return
+        end_wall = time.time_ns()
+        end_monotonic = time.perf_counter_ns()
+        if span.gpu_end is not None:
+            try:
+                span.gpu_end.record()
+            except Exception as exc:
+                span.record["metadata"]["gpu_event_error"] = str(exc)
+                span.gpu_start = span.gpu_end = None
+        record = span.record
+        record.update(
+            {
+                "api_return_timestamp_ns": end_wall,
+                "completion_timestamp_ns": end_wall,
+                "consumer_timestamp_ns": span.consumer_timestamp_ns,
+                "completion_monotonic_ns": end_monotonic,
+                "duration_ns": end_monotonic - span.start_monotonic_ns,
+                "gpu_start_timestamp_ns": None,
+                "gpu_end_timestamp_ns": None,
+                "gpu_elapsed_ns": None,
+                "status": "error" if error is not None else "ok",
+            }
+        )
+        if error is not None:
+            record["metadata"]["error_type"] = type(error).__name__
+            record["metadata"]["error_message"] = str(error)
+        pending = _PendingRecord(record=record, gpu_start=span.gpu_start, gpu_end=span.gpu_end)
+        self._queue(pending)
+        self.flush(block=False)
+
+    def _queue(self, pending: _PendingRecord, *, sequence_id: int | None = None) -> None:
+        if sequence_id is None:
+            assert pending.record is not None
+            sequence_id = pending.record["sequence_id"]
+        with self._lock:
+            self._pending[sequence_id] = pending
+
+    def flush(self, *, block: bool = False) -> None:
+        with self._lock:
+            while self._next_write_sequence_id in self._pending:
+                pending = self._pending[self._next_write_sequence_id]
+                if pending.record is None:
+                    del self._pending[self._next_write_sequence_id]
+                    self._next_write_sequence_id += 1
+                    continue
+                if pending.gpu_end is not None:
+                    try:
+                        if block:
+                            pending.gpu_end.synchronize()
+                        elif not pending.gpu_end.query():
+                            break
+                        elapsed_ns = int(round(pending.gpu_start.elapsed_time(pending.gpu_end) * 1_000_000))
+                        gpu_start_ns = pending.record["api_launch_timestamp_ns"]
+                        pending.record["gpu_start_timestamp_ns"] = gpu_start_ns
+                        pending.record["gpu_end_timestamp_ns"] = gpu_start_ns + elapsed_ns
+                        pending.record["gpu_elapsed_ns"] = elapsed_ns
+                    except Exception as exc:
+                        pending.record["metadata"]["gpu_timing_error"] = str(exc)
+                self._write_unlocked(pending.record)
+                del self._pending[self._next_write_sequence_id]
+                self._next_write_sequence_id += 1
+            try:
+                self._file.flush()
+            except OSError as exc:
+                self._mark_write_failed(exc)
+
+    def close(self) -> None:
+        with self._lock:
+            if self._closed:
+                return
+        try:
+            self.flush(block=True)
+        finally:
+            with self._lock:
+                if not self._closed:
+                    try:
+                        self._file.close()
+                    except OSError as exc:
+                        self._mark_write_failed(exc)
+                    self._closed = True
+
+    def _write_unlocked(self, record: Mapping[str, Any]) -> None:
+        if self._write_failed:
+            return
+        try:
+            self._file.write(json.dumps(record, sort_keys=True, separators=(",", ":"), default=str) + "\n")
+        except OSError as exc:
+            self._mark_write_failed(exc)
+
+    def _mark_write_failed(self, exc: OSError) -> None:
+        if not self._write_failed:
+            logger.warning("communication timeline disabled after write failure: %s", exc)
+            self._write_failed = True
+
+
+@dataclass
+class CommunicationPhase:
+    timeline: CommunicationTimeline | None
+    operation: str
+    fields: dict[str, Any] = field(default_factory=dict)
+    record: dict[str, Any] = field(default_factory=dict, init=False)
+    start_monotonic_ns: int = field(default=0, init=False)
+    consumer_timestamp_ns: int | None = field(default=None, init=False)
+    gpu_start: Any = field(default=None, init=False)
+    gpu_end: Any = field(default=None, init=False)
+    cancelled: bool = field(default=False, init=False)
+    _nvtx: bool = field(default=False, init=False)
+
+    def __enter__(self) -> CommunicationPhase:
+        if self.timeline is None:
+            return self
+        start_wall = time.time_ns()
+        self.start_monotonic_ns = time.perf_counter_ns()
+        self.record = self.timeline._base_record(self.operation, self.fields)
+        self.record.update(
+            {
+                "record_type": "span",
+                "api_launch_timestamp_ns": start_wall,
+                "api_launch_monotonic_ns": self.start_monotonic_ns,
+            }
+        )
+        torch = _optional_torch()
+        if torch is not None and torch.cuda.is_available():
+            try:
+                self.record["stream_id"] = int(torch.cuda.current_stream().cuda_stream)
+                self.gpu_start = torch.cuda.Event(enable_timing=True)
+                self.gpu_end = torch.cuda.Event(enable_timing=True)
+                self.gpu_start.record()
+                torch.cuda.nvtx.range_push(f"slime.comm/{self.operation}")
+                self._nvtx = True
+            except Exception as exc:
+                self.record["metadata"]["gpu_event_error"] = str(exc)
+                self.gpu_start = self.gpu_end = None
+        else:
+            self.record["stream_id"] = None
+        return self
+
+    def __exit__(self, exc_type, exc, traceback) -> bool:
+        if self.timeline is None:
+            return False
+        if self._nvtx:
+            torch = _optional_torch()
+            try:
+                torch.cuda.nvtx.range_pop()
+            except Exception as nvtx_exc:
+                self.record["metadata"]["nvtx_error"] = str(nvtx_exc)
+        try:
+            self.timeline.finish_span(self, exc)
+        except Exception as timeline_exc:
+            logger.warning("communication timeline phase %s could not be recorded: %s", self.operation, timeline_exc)
+        return False
+
+    def update(self, **fields: Any) -> CommunicationPhase:
+        if self.timeline is None:
+            return self
+        for name, value in fields.items():
+            if name in _STANDARD_FIELDS:
+                self.record[name] = value
+            else:
+                self.record.setdefault("metadata", {})[name] = value
+        return self
+
+    def mark_consumer(self) -> CommunicationPhase:
+        self.consumer_timestamp_ns = time.time_ns()
+        return self
+
+    def cancel(self) -> None:
+        self.cancelled = True
+
+
+def configure_communication_timeline(
+    path: str | None = None,
+    *,
+    rank: int | None = None,
+    local_rank: int | None = None,
+    world_size: int | None = None,
+    role: str = "trainer",
+    run_id: str | None = None,
+) -> CommunicationTimeline | None:
+    """Configure the process-local timeline; ``None`` uses the environment."""
+
+    global _GLOBAL_CONFIGURED, _GLOBAL_TIMELINE
+    path = path or os.environ.get(COMMUNICATION_TIMELINE_ENV)
+    with _GLOBAL_LOCK:
+        if _GLOBAL_TIMELINE is not None:
+            _GLOBAL_TIMELINE.close()
+        _GLOBAL_TIMELINE = (
+            CommunicationTimeline(
+                path,
+                rank=rank,
+                local_rank=local_rank,
+                world_size=world_size,
+                role=role,
+                run_id=run_id,
+            )
+            if path
+            else None
+        )
+        _GLOBAL_CONFIGURED = True
+        return _GLOBAL_TIMELINE
+
+
+def get_communication_timeline() -> CommunicationTimeline | None:
+    global _GLOBAL_CONFIGURED
+    with _GLOBAL_LOCK:
+        if not _GLOBAL_CONFIGURED:
+            configure_communication_timeline()
+        return _GLOBAL_TIMELINE
+
+
+def communication_phase(operation: str, **fields: Any) -> CommunicationPhase:
+    timeline = get_communication_timeline()
+    return CommunicationPhase(timeline, operation, fields)
+
+
+def communication_event(operation: str, **fields: Any) -> None:
+    timeline = get_communication_timeline()
+    if timeline is not None:
+        timeline.emit_event(operation, fields)
+
+
+@contextmanager
+def communication_context(**fields: Any) -> Iterator[None]:
+    current = dict(_CONTEXT.get() or {})
+    current.update(fields)
+    token = _CONTEXT.set(current)
+    try:
+        yield
+    finally:
+        _CONTEXT.reset(token)
+
+
+def iter_communication_buckets(chunks, *, operation: str = "weight_convert", start_bucket_id: int = 0):
+    """Yield chunks while timing the generator work that produces each bucket."""
+
+    iterator = iter(chunks)
+    bucket_id = start_bucket_id
+    while True:
+        with communication_phase(operation, bucket_id=bucket_id) as phase:
+            try:
+                chunk = next(iterator)
+            except StopIteration:
+                phase.cancel()
+                break
+            phase.update(message_bytes=_message_bytes(chunk))
+        yield bucket_id, chunk
+        bucket_id += 1
+
+
+def flush_communication_timeline(*, block: bool = False) -> None:
+    timeline = get_communication_timeline()
+    if timeline is not None:
+        timeline.flush(block=block)
+
+
+def close_communication_timeline() -> None:
+    global _GLOBAL_CONFIGURED, _GLOBAL_TIMELINE
+    with _GLOBAL_LOCK:
+        timeline, _GLOBAL_TIMELINE = _GLOBAL_TIMELINE, None
+        _GLOBAL_CONFIGURED = True
+    if timeline is not None:
+        timeline.close()
+
+
+atexit.register(close_communication_timeline)

--- a/slime/observability/communication_timeline.py
+++ b/slime/observability/communication_timeline.py
@@ -13,7 +13,7 @@ from collections.abc import Iterator, Mapping
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import Any, ClassVar
 
 logger = logging.getLogger(__name__)
 
@@ -38,6 +38,30 @@ _CONTEXT: contextvars.ContextVar[dict[str, Any] | None] = contextvars.ContextVar
 _GLOBAL_LOCK = threading.RLock()
 _GLOBAL_TIMELINE: CommunicationTimeline | None = None
 _GLOBAL_CONFIGURED = False
+
+
+class _DisabledCommunicationPhase:
+    """Shared no-op phase used after tracing is configured off."""
+
+    enabled = False
+
+    def __enter__(self) -> _DisabledCommunicationPhase:
+        return self
+
+    def __exit__(self, exc_type, exc, traceback) -> bool:
+        return False
+
+    def update(self, **fields: Any) -> _DisabledCommunicationPhase:
+        return self
+
+    def mark_consumer(self) -> _DisabledCommunicationPhase:
+        return self
+
+    def cancel(self) -> None:
+        return None
+
+
+_DISABLED_PHASE = _DisabledCommunicationPhase()
 
 
 def _optional_torch():
@@ -318,6 +342,7 @@ class CommunicationTimeline:
 
 @dataclass
 class CommunicationPhase:
+    enabled: ClassVar[bool] = True
     timeline: CommunicationTimeline | None
     operation: str
     fields: dict[str, Any] = field(default_factory=dict)
@@ -431,19 +456,30 @@ def get_communication_timeline() -> CommunicationTimeline | None:
         return _GLOBAL_TIMELINE
 
 
-def communication_phase(operation: str, **fields: Any) -> CommunicationPhase:
-    timeline = get_communication_timeline()
+def _configured_timeline() -> CommunicationTimeline | None:
+    if _GLOBAL_CONFIGURED:
+        return _GLOBAL_TIMELINE
+    return get_communication_timeline()
+
+
+def communication_phase(operation: str, **fields: Any) -> CommunicationPhase | _DisabledCommunicationPhase:
+    timeline = _configured_timeline()
+    if timeline is None:
+        return _DISABLED_PHASE
     return CommunicationPhase(timeline, operation, fields)
 
 
 def communication_event(operation: str, **fields: Any) -> None:
-    timeline = get_communication_timeline()
+    timeline = _configured_timeline()
     if timeline is not None:
         timeline.emit_event(operation, fields)
 
 
 @contextmanager
 def communication_context(**fields: Any) -> Iterator[None]:
+    if _configured_timeline() is None:
+        yield
+        return
     current = dict(_CONTEXT.get() or {})
     current.update(fields)
     token = _CONTEXT.set(current)
@@ -465,13 +501,14 @@ def iter_communication_buckets(chunks, *, operation: str = "weight_convert", sta
             except StopIteration:
                 phase.cancel()
                 break
-            phase.update(message_bytes=_message_bytes(chunk))
+            if phase.enabled:
+                phase.update(message_bytes=_message_bytes(chunk))
         yield bucket_id, chunk
         bucket_id += 1
 
 
 def flush_communication_timeline(*, block: bool = False) -> None:
-    timeline = get_communication_timeline()
+    timeline = _configured_timeline()
     if timeline is not None:
         timeline.flush(block=block)
 

--- a/slime/observability/communication_timeline.py
+++ b/slime/observability/communication_timeline.py
@@ -17,7 +17,7 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
-COMMUNICATION_TIMELINE_VERSION = 1
+COMMUNICATION_TIMELINE_VERSION = 2
 COMMUNICATION_TIMELINE_ENV = "SLIME_COMMUNICATION_TIMELINE"
 COMMUNICATION_TIMELINE_RUN_ID_ENV = "SLIME_COMMUNICATION_TIMELINE_RUN_ID"
 
@@ -200,6 +200,9 @@ class CommunicationTimeline:
         return {
             "schema_version": COMMUNICATION_TIMELINE_VERSION,
             "framework": "slime",
+            "gpu_timestamp_semantics": "event-bracket",
+            "timestamp_domain": "process-realtime-projected-cuda-event",
+            "clock_sync_error_bound_us": None,
             "run_id": self.run_id,
             "role": self.role,
             "rank": self.rank,

--- a/slime/ray/actor_group.py
+++ b/slime/ray/actor_group.py
@@ -1,12 +1,19 @@
+import atexit
 import os
 import shutil
 import time
+import uuid
 from pathlib import Path
 
 import ray
 from ray.util.placement_group import PlacementGroup
 from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 
+from slime.observability.communication_timeline import (
+    COMMUNICATION_TIMELINE_ENV,
+    COMMUNICATION_TIMELINE_RUN_ID_ENV,
+    CommunicationTimeline,
+)
 from slime.ray.utils import NOSET_VISIBLE_DEVICES_ENV_VARS_LIST, add_default_ray_env_vars
 
 
@@ -53,6 +60,25 @@ class RayTrainGroup:
         self._rollout_manager = None
         self._disk_weight_version = getattr(args, "update_weight_start_version", 0)
         self._actor_handlers = []
+        timeline_path = getattr(args, "communication_timeline", None) or os.environ.get(COMMUNICATION_TIMELINE_ENV)
+        self._communication_timeline_enabled = bool(timeline_path)
+        self._communication_timeline = None
+        timeline_run_id = getattr(args, "communication_timeline_run_id", None) or os.environ.get(
+            COMMUNICATION_TIMELINE_RUN_ID_ENV
+        )
+        if timeline_path and timeline_run_id is None:
+            timeline_run_id = uuid.uuid4().hex
+            args.communication_timeline_run_id = timeline_run_id
+        if timeline_path and self._full_disk_weight_update_enabled():
+            self._communication_timeline = CommunicationTimeline(
+                timeline_path,
+                rank=-1,
+                local_rank=-1,
+                world_size=1,
+                role=f"{role}-orchestrator",
+                run_id=timeline_run_id,
+            )
+            atexit.register(self._communication_timeline.close)
 
     def _allocate_gpus_for_actor(self, pg, num_gpus_per_actor):
         world_size = self._num_nodes * self._num_gpus_per_node
@@ -159,8 +185,10 @@ class RayTrainGroup:
             self.args.no_load_rng = False
         return ret
 
-    def update_weights(self):
+    def update_weights(self, rollout_id=None):
         """Broadcast weights from rank 0 to all other ranks."""
+        if self._communication_timeline_enabled:
+            ray.get([actor.set_communication_rollout_id.remote(rollout_id) for actor in self._actor_handlers])
         if not self._full_disk_weight_update_enabled():
             return ray.get([actor.update_weights.remote() for actor in self._actor_handlers])
 
@@ -170,7 +198,7 @@ class RayTrainGroup:
         self._disk_weight_version = weight_version
         if self._release_train_enabled():
             self.release()
-        self._reload_rollout_weights_from_disk(disk_weight_dir, str(weight_version))
+        self._reload_rollout_weights_from_disk(disk_weight_dir, str(weight_version), rollout_id=rollout_id)
 
     def onload(self):
         return ray.get([actor.wake_up.remote() for actor in self._actor_handlers])
@@ -224,7 +252,7 @@ class RayTrainGroup:
             and self.args.update_weight_transport == "disk"
         )
 
-    def _reload_rollout_weights_from_disk(self, disk_weight_dir, weight_version):
+    def _reload_rollout_weights_from_disk(self, disk_weight_dir, weight_version, *, rollout_id=None):
         assert self._rollout_manager is not None, "disk weight update requires a rollout manager."
         if self.args.offload_rollout:
             ray.get(self._rollout_manager.onload_weights.remote())
@@ -237,21 +265,50 @@ class RayTrainGroup:
             # each host pulls the published checkpoint onto local disk (e.g. NVMe) and
             # the engines reload from there; the pull is disk-only, so it runs before
             # pause and overlaps generation
-            ray.get([engine.pull_weights.remote(int(weight_version)) for engine in engines])
+            pull_refs = [engine.pull_weights.remote(int(weight_version)) for engine in engines]
+            if self._communication_timeline is None:
+                ray.get(pull_refs)
+            else:
+                with self._communication_timeline.new_span(
+                    "engine_bucket_receive",
+                    {
+                        "weight_version": weight_version,
+                        "rollout_id": rollout_id,
+                        "bucket_id": 0,
+                        "transport": "disk",
+                        "engine_count": len(engines),
+                        "observation": "trainer_pull_request_complete",
+                    },
+                ) as phase:
+                    ray.get(pull_refs)
+                    phase.mark_consumer()
             model_path = self.args.update_weight_local_checkpoint_dir
         else:
             model_path = str(disk_weight_dir)
         ray.get([engine.pause_generation.remote() for engine in engines])
         ray.get([engine.flush_cache.remote() for engine in engines])
-        ray.get(
-            [
-                engine.update_weights_from_disk.remote(
-                    model_path=model_path,
-                    weight_version=weight_version,
-                )
-                for engine in engines
-            ]
-        )
+        load_refs = [
+            engine.update_weights_from_disk.remote(
+                model_path=model_path,
+                weight_version=weight_version,
+            )
+            for engine in engines
+        ]
+        if self._communication_timeline is None:
+            ray.get(load_refs)
+        else:
+            with self._communication_timeline.new_span(
+                "engine_load_weights",
+                {
+                    "weight_version": weight_version,
+                    "rollout_id": rollout_id,
+                    "bucket_id": 0,
+                    "transport": "disk",
+                    "engine_count": len(engines),
+                },
+            ) as phase:
+                ray.get(load_refs)
+                phase.mark_consumer()
         if self.args.ci_test:
             engine_versions = ray.get([engine.get_weight_version.remote() for engine in engines])
             mismatches = [
@@ -267,3 +324,14 @@ class RayTrainGroup:
         if not self.args.update_weight_disk_keep_files:
             shutil.rmtree(disk_weight_dir, ignore_errors=True)
         ray.get([engine.continue_generation.remote() for engine in engines])
+        if self._communication_timeline is not None:
+            self._communication_timeline.emit_event(
+                "weight_sync_complete",
+                {
+                    "weight_version": weight_version,
+                    "rollout_id": rollout_id,
+                    "transport": "disk",
+                    "engine_count": len(engines),
+                },
+            )
+            self._communication_timeline.flush(block=False)

--- a/slime/ray/train_actor.py
+++ b/slime/ray/train_actor.py
@@ -9,6 +9,7 @@ import torch
 import torch.distributed as dist
 
 import slime.utils.eval_config
+from slime.observability.communication_timeline import configure_communication_timeline
 from slime.observability.logging_utils import configure_logger
 from slime.ray.ray_actor import RayActor
 from slime.utils import accelerator
@@ -70,6 +71,15 @@ class TrainRayActor(RayActor):
 
         args.rank = dist.get_rank()
         args.world_size = dist.get_world_size()
+        configure_communication_timeline(
+            getattr(args, "communication_timeline", None),
+            rank=args.rank,
+            local_rank=local_rank,
+            world_size=args.world_size,
+            role=role,
+            run_id=getattr(args, "communication_timeline_run_id", None),
+        )
+        self._communication_rollout_id = None
 
         try:
             if torch.version.hip is not None:
@@ -119,6 +129,9 @@ class TrainRayActor(RayActor):
     @abc.abstractmethod
     def update_weights(self):
         raise NotImplementedError
+
+    def set_communication_rollout_id(self, rollout_id):
+        self._communication_rollout_id = rollout_id
 
     def set_rollout_manager(self, rollout_manager):
         self.rollout_manager = rollout_manager

--- a/slime/utils/arguments.py
+++ b/slime/utils/arguments.py
@@ -1318,6 +1318,22 @@ def get_slime_extra_args_provider(add_custom_arguments=None):
                 default=None,
             )
             parser.add_argument(
+                "--communication-timeline",
+                type=str,
+                default=None,
+                help=(
+                    "Optional JSONL path for trainer communication phases. Supports {rank}, {trainer_rank}, "
+                    "{local_rank}, {pid}, {hostname}, {role}, and {world_size}; a rank suffix is added "
+                    "automatically for a shared multi-rank path."
+                ),
+            )
+            parser.add_argument(
+                "--communication-timeline-run-id",
+                type=str,
+                default=None,
+                help="Optional run identifier shared by all trainer communication timeline records.",
+            )
+            parser.add_argument(
                 "--memory-recorder",
                 type=str,
                 choices=["torch", "memray"],

--- a/tests/observability/test_communication_timeline.py
+++ b/tests/observability/test_communication_timeline.py
@@ -41,6 +41,43 @@ def test_disabled_timeline_does_not_create_a_file(tmp_path):
     assert list(tmp_path.iterdir()) == []
 
 
+def test_disabled_timeline_skips_clocks_torch_events_context_and_serialization(monkeypatch):
+    timeline.configure_communication_timeline(None)
+    monkeypatch.setattr(timeline.time, "time_ns", lambda: pytest.fail("disabled timeline read the wall clock"))
+    monkeypatch.setattr(
+        timeline.time,
+        "perf_counter_ns",
+        lambda: pytest.fail("disabled timeline read the monotonic clock"),
+    )
+    monkeypatch.setattr(timeline, "_optional_torch", lambda: pytest.fail("disabled timeline imported torch"))
+    monkeypatch.setattr(timeline.json, "dumps", lambda *_args, **_kwargs: pytest.fail("disabled timeline serialized"))
+
+    first = timeline.communication_phase("weight_bucket_send", message_bytes=8)
+    second = timeline.communication_phase("grad_sync")
+    assert first is second
+    assert not first.enabled
+    with first as phase:
+        phase.update(bucket_id=3)
+        phase.mark_consumer()
+    timeline.communication_event("weight_sync_complete", weight_version=4)
+    with timeline.communication_context(global_step=2):
+        assert timeline._CONTEXT.get() is None
+    timeline.flush_communication_timeline(block=True)
+
+
+def test_disabled_bucket_iterator_does_not_scan_tensor_sizes():
+    class SizeMustNotBeRead:
+        def numel(self):
+            pytest.fail("disabled timeline scanned tensor elements")
+
+        def element_size(self):
+            pytest.fail("disabled timeline scanned tensor element size")
+
+    timeline.configure_communication_timeline(None)
+    bucket = [("weight", SizeMustNotBeRead())]
+    assert list(timeline.iter_communication_buckets([bucket])) == [(0, bucket)]
+
+
 def test_span_and_event_emit_stable_shared_schema(tmp_path):
     path_template = str(tmp_path / "trainer-{rank}.jsonl")
     resolved = tmp_path / "trainer-2.jsonl"

--- a/tests/observability/test_communication_timeline.py
+++ b/tests/observability/test_communication_timeline.py
@@ -62,6 +62,9 @@ def test_span_and_event_emit_stable_shared_schema(tmp_path):
     span, event = _read_jsonl(resolved)
     assert span["schema_version"] == timeline.COMMUNICATION_TIMELINE_VERSION
     assert span["framework"] == "slime"
+    assert span["gpu_timestamp_semantics"] == "event-bracket"
+    assert span["timestamp_domain"] == "process-realtime-projected-cuda-event"
+    assert span["clock_sync_error_bound_us"] is None
     assert span["run_id"] == "run-1"
     assert span["operation"] == "weight_bucket_send"
     assert span["logical_operation_id"] == "7/3/5/1/weight_bucket_send"
@@ -75,6 +78,8 @@ def test_span_and_event_emit_stable_shared_schema(tmp_path):
     assert span["duration_ns"] >= 0
     assert event["record_type"] == "event"
     assert event["operation"] == "weight_sync_complete"
+    assert event["gpu_timestamp_semantics"] == "event-bracket"
+    assert event["clock_sync_error_bound_us"] is None
     assert event["sequence_id"] == span["sequence_id"] + 1
 
 
@@ -83,7 +88,7 @@ def test_world_size_uses_rank_suffix_when_template_is_shared(tmp_path):
         str(tmp_path / "timeline.jsonl"),
         rank=3,
         local_rank=1,
-        world_size=8,
+        world_size=4,
     )
 
     assert configured.path == tmp_path / "timeline.rank-3.jsonl"

--- a/tests/observability/test_communication_timeline.py
+++ b/tests/observability/test_communication_timeline.py
@@ -1,0 +1,203 @@
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from slime.observability import communication_timeline as timeline
+
+
+class _Tensor:
+    def __init__(self, elements, element_size):
+        self._elements = elements
+        self._element_size = element_size
+
+    def numel(self):
+        return self._elements
+
+    def element_size(self):
+        return self._element_size
+
+
+@pytest.fixture(autouse=True)
+def _reset_timeline(monkeypatch):
+    timeline.close_communication_timeline()
+    monkeypatch.delenv(timeline.COMMUNICATION_TIMELINE_ENV, raising=False)
+    yield
+    timeline.close_communication_timeline()
+
+
+def _read_jsonl(path):
+    return [json.loads(line) for line in path.read_text().splitlines()]
+
+
+def test_disabled_timeline_does_not_create_a_file(tmp_path):
+    timeline.configure_communication_timeline(None)
+
+    with timeline.communication_phase("train_forward_backward") as phase:
+        phase.update(global_step=2)
+        phase.mark_consumer()
+    timeline.communication_event("weight_sync_complete", weight_version=1)
+
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_span_and_event_emit_stable_shared_schema(tmp_path):
+    path_template = str(tmp_path / "trainer-{rank}.jsonl")
+    resolved = tmp_path / "trainer-2.jsonl"
+    timeline.configure_communication_timeline(
+        path_template,
+        rank=2,
+        local_rank=0,
+        world_size=4,
+        run_id="run-1",
+    )
+
+    with timeline.communication_context(global_step=7, rollout_id=3, trainer_rank=2):
+        with timeline.communication_phase("weight_bucket_send", weight_version=5, bucket_id=1) as phase:
+            phase.update(message_bytes=4096, engine_count=2)
+            phase.mark_consumer()
+        timeline.communication_event("weight_sync_complete", weight_version=5)
+    timeline.close_communication_timeline()
+
+    span, event = _read_jsonl(resolved)
+    assert span["schema_version"] == timeline.COMMUNICATION_TIMELINE_VERSION
+    assert span["framework"] == "slime"
+    assert span["run_id"] == "run-1"
+    assert span["operation"] == "weight_bucket_send"
+    assert span["logical_operation_id"] == "7/3/5/1/weight_bucket_send"
+    assert span["global_step"] == 7
+    assert span["rollout_id"] == 3
+    assert span["trainer_rank"] == 2
+    assert span["message_bytes"] == 4096
+    assert span["metadata"]["engine_count"] == 2
+    assert span["consumer_timestamp_ns"] is not None
+    assert span["completion_timestamp_ns"] >= span["api_launch_timestamp_ns"]
+    assert span["duration_ns"] >= 0
+    assert event["record_type"] == "event"
+    assert event["operation"] == "weight_sync_complete"
+    assert event["sequence_id"] == span["sequence_id"] + 1
+
+
+def test_world_size_uses_rank_suffix_when_template_is_shared(tmp_path):
+    configured = timeline.configure_communication_timeline(
+        str(tmp_path / "timeline.jsonl"),
+        rank=3,
+        local_rank=1,
+        world_size=8,
+    )
+
+    assert configured.path == tmp_path / "timeline.rank-3.jsonl"
+
+
+def test_non_trainer_roles_get_separate_files_without_role_placeholder(tmp_path):
+    configured = timeline.configure_communication_timeline(
+        str(tmp_path / "timeline-{rank}.jsonl"),
+        rank=0,
+        world_size=2,
+        role="critic",
+    )
+
+    assert configured.path == tmp_path / "timeline-0.role-critic.jsonl"
+
+
+def test_failed_span_is_recorded_and_reraised(tmp_path):
+    path = tmp_path / "failure.jsonl"
+    timeline.configure_communication_timeline(str(path), rank=0, world_size=1)
+
+    with pytest.raises(RuntimeError, match="boom"):
+        with timeline.communication_phase("optimizer_step"):
+            raise RuntimeError("boom")
+    timeline.close_communication_timeline()
+
+    record = _read_jsonl(path)[0]
+    assert record["status"] == "error"
+    assert record["metadata"]["error_type"] == "RuntimeError"
+    assert record["metadata"]["error_message"] == "boom"
+
+
+def test_iter_communication_buckets_times_only_produced_buckets(tmp_path):
+    path = tmp_path / "buckets.jsonl"
+    timeline.configure_communication_timeline(str(path), rank=0, world_size=1)
+    chunks = [
+        [("a", _Tensor(4, 2))],
+        [("b", _Tensor(3, 4)), ("c", _Tensor(1, 1))],
+    ]
+
+    yielded = list(timeline.iter_communication_buckets(chunks))
+    timeline.close_communication_timeline()
+
+    assert [bucket_id for bucket_id, _ in yielded] == [0, 1]
+    records = _read_jsonl(path)
+    assert [record["bucket_id"] for record in records] == [0, 1]
+    assert [record["message_bytes"] for record in records] == [8, 13]
+
+
+def test_nested_spans_are_written_in_launch_sequence_order(tmp_path):
+    path = tmp_path / "nested.jsonl"
+    timeline.configure_communication_timeline(str(path), rank=0, world_size=1)
+
+    with timeline.communication_phase("train_forward_backward"):
+        timeline.communication_event("weight_bucket_ready")
+        with timeline.communication_phase("grad_sync"):
+            pass
+    timeline.close_communication_timeline()
+
+    records = _read_jsonl(path)
+    assert [record["sequence_id"] for record in records] == [0, 1, 2]
+    assert [record["operation"] for record in records] == [
+        "train_forward_backward",
+        "weight_bucket_ready",
+        "grad_sync",
+    ]
+
+
+def test_cuda_events_are_resolved_without_changing_schema(tmp_path, monkeypatch):
+    class FakeEvent:
+        def __init__(self, enable_timing):
+            assert enable_timing
+
+        def record(self):
+            return None
+
+        def query(self):
+            return True
+
+        def synchronize(self):
+            return None
+
+        def elapsed_time(self, other):
+            assert isinstance(other, FakeEvent)
+            return 2.5
+
+    class FakeNvtx:
+        pushes = []
+        pops = 0
+
+        @classmethod
+        def range_push(cls, name):
+            cls.pushes.append(name)
+
+        @classmethod
+        def range_pop(cls):
+            cls.pops += 1
+
+    fake_cuda = SimpleNamespace(
+        is_available=lambda: True,
+        current_stream=lambda: SimpleNamespace(cuda_stream=123),
+        Event=FakeEvent,
+        nvtx=FakeNvtx,
+    )
+    monkeypatch.setattr(timeline, "_optional_torch", lambda: SimpleNamespace(cuda=fake_cuda))
+    path = tmp_path / "cuda.jsonl"
+    timeline.configure_communication_timeline(str(path), rank=0, local_rank=0, world_size=1)
+
+    with timeline.communication_phase("grad_sync"):
+        pass
+    timeline.close_communication_timeline()
+
+    record = _read_jsonl(path)[0]
+    assert record["stream_id"] == 123
+    assert record["gpu_elapsed_ns"] == 2_500_000
+    assert record["gpu_end_timestamp_ns"] - record["gpu_start_timestamp_ns"] == 2_500_000
+    assert FakeNvtx.pushes == ["slime.comm/grad_sync"]
+    assert FakeNvtx.pops == 1

--- a/tests/test_empty_colocated_weight_bucket.py
+++ b/tests/test_empty_colocated_weight_bucket.py
@@ -1,4 +1,5 @@
 import importlib.util
+import json
 import sys
 import types
 from pathlib import Path
@@ -54,6 +55,18 @@ class _FakeEngine:
         self.update_weights_from_tensor = _FakeRemoteMethod()
 
 
+class _FakeTensor:
+    def __init__(self, numel, element_size):
+        self._numel = numel
+        self._element_size = element_size
+
+    def numel(self):
+        return self._numel
+
+    def element_size(self):
+        return self._element_size
+
+
 def _install_fake_deps(monkeypatch):
     dist_state = types.SimpleNamespace(rank=0, world_size=2, gathered=None, local_object=None)
 
@@ -90,11 +103,22 @@ def _install_fake_deps(monkeypatch):
     torch_mod.distributed = dist_mod
     torch_mod.empty = lambda size, dtype, device: {"size": size, "dtype": dtype, "device": device}
     torch_mod.no_grad = lambda: (lambda fn: fn)
-    torch_mod.cuda = types.SimpleNamespace(current_device=lambda: "cuda:0", ipc_collect=lambda: None)
+    torch_mod.cuda = types.SimpleNamespace(
+        current_device=lambda: "cuda:0",
+        ipc_collect=lambda: None,
+        is_available=lambda: False,
+    )
     torch_mod.nn = types.SimpleNamespace(Module=object)
 
     ray_mod = types.ModuleType("ray")
     ray_mod.ObjectRef = object
+    ray_mod.get_calls = []
+
+    def ray_get(refs):
+        ray_mod.get_calls.append(refs)
+        return None
+
+    ray_mod.get = ray_get
     ray_actor_mod = types.ModuleType("ray.actor")
     ray_actor_mod.ActorHandle = object
 
@@ -226,6 +250,38 @@ def test_source_rank_pads_empty_colocated_bucket_entries(monkeypatch):
             "weight_version": "7",
         }
     ]
+
+
+def test_send_weight_bucket_records_transfer_and_consumer_wait(monkeypatch, tmp_path):
+    module, _ = _load_update_weight_module(monkeypatch)
+    timeline = importlib.import_module("slime.observability.communication_timeline")
+    trace_path = tmp_path / "weight-bucket.jsonl"
+    timeline.configure_communication_timeline(str(trace_path), rank=0, world_size=1, run_id="test")
+    updater = module.UpdateWeightFromTensor.__new__(module.UpdateWeightFromTensor)
+    updater.rollout_engines = [object()]
+    updater.use_distribute = False
+    updater.weight_version = 4
+    updater._send_hf_params = lambda tensors: (["engine-ref"], "keepalive")
+    tensors = [("weight", _FakeTensor(8, 2))]
+
+    with module.communication_context(weight_version=4, transport="cuda_ipc"):
+        refs, keepalive = updater._send_weight_bucket(tensors, bucket_id=2, bucket_kind="non_expert")
+    timeline.close_communication_timeline()
+
+    assert refs == ["engine-ref"]
+    assert keepalive == "keepalive"
+    assert sys.modules["ray"].get_calls == [["engine-ref"]]
+    records = [json.loads(line) for line in trace_path.read_text().splitlines()]
+    assert [record["operation"] for record in records] == [
+        "weight_bucket_ready",
+        "weight_bucket_send",
+        "engine_bucket_receive",
+        "engine_load_weights",
+    ]
+    assert all(record["weight_version"] == 4 for record in records)
+    assert all(record["bucket_id"] == 2 for record in records)
+    assert all(record["message_bytes"] == 16 for record in records)
+    assert records[-1]["consumer_timestamp_ns"] is not None
 
 
 if __name__ == "__main__":

--- a/train.py
+++ b/train.py
@@ -82,7 +82,7 @@ def train(args):
         offload_train(actor_trains)
         if args.offload_rollout and not release_train:
             ray.get(rollout_manager.onload_weights.remote())
-        actor_model.update_weights()
+        actor_model.update_weights(rollout_id=rollout_id)
 
         if args.offload_rollout:
             ray.get(rollout_manager.onload_kv.remote())

--- a/train_async.py
+++ b/train_async.py
@@ -67,7 +67,7 @@ def train(args):
             # sync generate before update weights to prevent update weight in the middle of generation
             rollout_data_curr_ref = ray.get(x) if (x := rollout_data_next_future) is not None else None
             rollout_data_next_future = None
-            actor_model.update_weights()
+            actor_model.update_weights(rollout_id=rollout_id)
 
         if should_run_periodic_action(rollout_id, args.eval_interval, num_rollout_per_epoch):
             ray.get(rollout_manager.eval.remote(rollout_id))


### PR DESCRIPTION
## Draft update — 2026-09-05

Labels CUDA-event timing as event brackets rather than kernel-observed timestamps, and removes disabled-timeline hot-path work. The targeted timeline follow-up passed 10 tests. No new full Ray/SGLang GPU run or cross-rank clock-calibration claim is made.

AI assistance: OpenAI Codex. Remains Draft; implementation, CPU/Gloo checks and production GPU validation are separate acceptance gates. No new GPU results were generated during publication.

The original submission description and validation history follow.

---

## Summary

- add a default-off trainer-side communication timeline under `slime.observability`, with semantic JSONL records, CUDA-event timing, and optional NVTX ranges
- propagate one run identity and the active rollout identity across training and weight synchronization
- instrument forward/backward, gradient synchronization, optimizer, weight conversion, bucket readiness/send, engine receive/load, and synchronization completion
- cover distributed NCCL, colocated CUDA IPC/tensor, full-disk, and delta-disk weight update paths
- expose a custom expert-parallel hook API without assuming a fixed world size or rank count
- register the timeline regression test in the generated CPU PR workflow

## Rebase and duplicate audit

This draft is rebased onto `main` at `4c193f1f`. Conflict resolution preserves the current accelerator abstraction, weight-updater factory, and observability refactor.

The newer `slime.observability.trace_utils` implementation records rollout/sample spans for offline trajectory inspection. This draft records trainer-process and weight-sync phases with CUDA events and a shared run/rollout identity, so the two facilities are complementary rather than duplicate implementations. A fresh open issue/PR search found no equivalent trainer communication timeline.

## Compatibility and scope

- tracing remains disabled unless `--communication-timeline` or its environment-variable equivalent is explicitly configured
- the disabled path does not create timeline files or issue rollout-ID RPCs
- this is observability only: it does not change collective ordering or introduce a runtime scheduling policy
- no 5-rank or 6-rank special case is present

## Validation

- targeted CPU/regression tests: 31 passed (`tests/observability/test_communication_timeline.py`, `tests/test_empty_colocated_weight_bucket.py`, and `tests/test_megatron_argument_validation.py`)
- full repository pre-commit suite passed: YAML/case/private-key/large-file/requirements checks, Ruff, autoflake, isort, and Black
- changed Python files passed `py_compile`; the rebased diff passed `git diff --check`
- an earlier single-GPU CUDA smoke for this implementation emitted 7 timeline records, each with a real CUDA-event duration; the conflict-only rebase was validated with CPU tests and static checks

## Limitations

- no end-to-end multi-node Ray/SGLang run or performance claim is made in this draft
- PyTorch-dependent upstream factory/trace tests were not runnable in the local macOS test environment; repository CI remains the source of truth for those jobs

## AI assistance disclosure

This draft was developed with OpenAI Codex assistance. The human submitter must review and understand every changed line and be prepared to defend the design and test coverage before marking it ready for review.
