### PR TITLE
docs: fix flag help and fault-tolerance default values

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,8 +10,8 @@ slime is the RL training infrastructure behind [GLM-4.5 through GLM-5.3](https:/
 
 Our goal for open-source collaboration is focused on **bug fixes** and **general-purpose large-scale RL optimizations**. We have had several successful collaborations with the community in this area, including:
 
-- Speculative decoding in RL ([docs](https://thudm.github.io/slime/en/advanced/speculative_decoding.html))
-- Low-precision training: fp8 rollout + bf16/fp8 training, int4 rollout + int4 QAT training ([docs](https://thudm.github.io/slime/en/advanced/low_precision_training.html))
+- Speculative decoding in RL ([docs](https://thudm.github.io/slime/en/advanced/speculative-decoding.html))
+- Low-precision training: fp8 rollout + bf16/fp8 training, int4 rollout + int4 QAT training ([docs](https://thudm.github.io/slime/en/advanced/low-precision.html))
 - Deterministic training ([docs](https://thudm.github.io/slime/en/advanced/reproducibility.html))
 
 ### What We Welcome
@@ -56,8 +56,8 @@ slime 承担了智谱内部的大量实验，包括 GLM 4.5 至 5.3 的全部 RL
 
 我们将开源协作的范围限制在 **bug fix** 和一些**通用的大规模 RL 优化**上。在这方面我们也和社区达成了多次成功的合作，例如：
 
-- RL 中的投机采样（[文档](https://thudm.github.io/slime/en/advanced/speculative_decoding.html)）
-- 低精度训练：fp8 rollout + bf16/fp8 training，int4 rollout + int4 QAT training（[文档](https://thudm.github.io/slime/en/advanced/low_precision_training.html)）
+- RL 中的投机采样（[文档](https://thudm.github.io/slime/en/advanced/speculative-decoding.html)）
+- 低精度训练：fp8 rollout + bf16/fp8 training，int4 rollout + int4 QAT training（[文档](https://thudm.github.io/slime/en/advanced/low-precision.html)）
 - 确定性训练（[文档](https://thudm.github.io/slime/en/advanced/reproducibility.html)）
 
 ### 我们欢迎的

--- a/docs/en/advanced/fault-tolerance.md
+++ b/docs/en/advanced/fault-tolerance.md
@@ -26,17 +26,17 @@ During rollout, slime periodically sends heartbeat requests (`/health_generate`)
 
 The main arguments are:
 
-- `--rollout-health-check-first-wait`: wait before starting heartbeat checks for the first rollout. Large MoE models may compile kernels on first run. Default: `300` seconds.
-- `--rollout-health-check-interval`: interval between heartbeat checks. Default: `10` seconds.
-- `--rollout-health-check-timeout`: timeout for one heartbeat request. Default: `5` seconds.
+- `--rollout-health-check-first-wait`: wait before starting heartbeat checks for the first rollout. Large MoE models may compile kernels on first run. Default: `0` seconds.
+- `--rollout-health-check-interval`: interval between heartbeat checks. Default: `30` seconds.
+- `--rollout-health-check-timeout`: timeout for one heartbeat request. Default: `30` seconds.
 
-Example:
+Example (increase first-wait for large models that compile kernels on first run):
 
 ```bash
 --use-fault-tolerance \
 --rollout-health-check-first-wait 600 \
---rollout-health-check-interval 10 \
---rollout-health-check-timeout 5
+--rollout-health-check-interval 30 \
+--rollout-health-check-timeout 30
 ```
 
 ## Debug and Replay Path

--- a/docs/zh/advanced/fault-tolerance.md
+++ b/docs/zh/advanced/fault-tolerance.md
@@ -26,17 +26,17 @@ rollout 过程中，slime 会定期向所有 SGLang server 发送 heartbeat 请�
 
 主要参数：
 
-- `--rollout-health-check-first-wait`：第一次 rollout 前等待多久再开始 heartbeat。大 MoE 模型首次运行可能需要 kernel compilation。默认 `300` 秒。
-- `--rollout-health-check-interval`：heartbeat 间隔。默认 `10` 秒。
-- `--rollout-health-check-timeout`：单次 heartbeat timeout。默认 `5` 秒。
+- `--rollout-health-check-first-wait`：第一次 rollout 前等待多久再开始 heartbeat。大 MoE 模型首次运行可能需要 kernel compilation。默认 `0` 秒。
+- `--rollout-health-check-interval`：heartbeat 间隔。默认 `30` 秒。
+- `--rollout-health-check-timeout`：单次 heartbeat timeout。默认 `30` 秒。
 
-示例：
+示例（大模型首次运行需要 kernel compilation 时可增大 first-wait）：
 
 ```bash
 --use-fault-tolerance \
 --rollout-health-check-first-wait 600 \
---rollout-health-check-interval 10 \
---rollout-health-check-timeout 5
+--rollout-health-check-interval 30 \
+--rollout-health-check-timeout 30
 ```
 
 ## Debug 与 Replay 路径

--- a/slime/utils/arguments.py
+++ b/slime/utils/arguments.py
@@ -640,10 +640,10 @@ def get_slime_extra_args_provider(add_custom_arguments=None):
                 action="store_false",
                 dest="rollout_global_dataset",
                 help=(
-                    "Whether to use a global dataset for rollout. "
-                    "If set, the rollout will use the `--prompt-data` as the prompt dataset, "
-                    "and the prompts for rollout will be sampled from the dataset. "
-                    "If not set, you need to manage the data by your self."
+                    "Disable the global prompt dataset for rollout. "
+                    "By default, rollout uses `--prompt-data` as a global prompt dataset "
+                    "and samples prompts from it. "
+                    "If this flag is set, you need to manage the data yourself."
                 ),
             )
 
@@ -948,7 +948,7 @@ def get_slime_extra_args_provider(add_custom_arguments=None):
                 type=str,
                 choices=["k1", "k2", "k3", "low_var_kl"],
                 default="k1",
-                help="Choose KL loss type: kl, k2, k3, low_var_kl",
+                help="Choose KL loss type: k1, k2, k3, low_var_kl. Default: k1.",
             )
             parser.add_argument(
                 "--advantage-estimator",


### PR DESCRIPTION
Align help strings and published docs with the current code. No runtime behavior changes.

### Fault-tolerance docs disagree with code defaults
`docs/en/advanced/fault-tolerance.md` and `docs/zh/advanced/fault-tolerance.md` listed stale health-check defaults.

| Flag | Before (docs) | After (matches `slime/utils/arguments.py`) |
| --- | --- | --- |
| `--rollout-health-check-first-wait` | 300 | **0** |
| `--rollout-health-check-interval` | 10 | **30** |
| `--rollout-health-check-timeout` | 5 | **30** |

The example still sets `--rollout-health-check-first-wait 600` as an override for large-model kernel compilation, not as the default.

### `--disable-rollout-global-dataset` help is inverted
`action="store_false"` / `dest="rollout_global_dataset"` means passing the flag **disables** the global dataset.

- **Before:** "If set, the rollout will use `--prompt-data`... If not set, you need to manage the data by your self."
- **After:** Default uses `--prompt-data` as a global prompt dataset. If this flag is set, you manage data yourself (no global dataset).

### `--kl-loss-type` help advertises invalid `kl`
- **Before:** `kl, k2, k3, low_var_kl`
- **After:** `k1, k2, k3, low_var_kl` (default `k1`), matching `choices`.

### CONTRIBUTING.md published doc URLs 404
Fixed both EN and ZH sections:

- `speculative_decoding.html` → https://thudm.github.io/slime/en/advanced/speculative-decoding.html
- `low_precision_training.html` → https://thudm.github.io/slime/en/advanced/low-precision.html
- `reproducibility.html` was already correct