### PR TITLE
fix(whiten): scale-only path when shift_mean is false

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -639,6 +639,10 @@ jobs:
             },
             {
               "num_gpus": 0,
+              "test_file": "test_distributed_masked_whiten.py"
+            },
+            {
+              "num_gpus": 0,
               "test_file": "test_logprob_response_spans.py"
             },
             {

--- a/.github/workflows/pr-test.yml.j2
+++ b/.github/workflows/pr-test.yml.j2
@@ -85,6 +85,7 @@
         {'test_file': 'test_metric_report_dist.py', 'num_gpus': 0},
         {'test_file': 'test_loss_cp_invariance.py', 'num_gpus': 0},
         {'test_file': 'test_advantage_whiten_cp.py', 'num_gpus': 0},
+        {'test_file': 'test_distributed_masked_whiten.py', 'num_gpus': 0},
         {'test_file': 'test_logprob_response_spans.py', 'num_gpus': 0},
         {'test_file': 'observability/test_trace_utils.py', 'num_gpus': 0},
         {'test_file': 'test_value_temperature.py', 'num_gpus': 0},

--- a/slime/utils/distributed_utils.py
+++ b/slime/utils/distributed_utils.py
@@ -118,16 +118,19 @@ def distributed_masked_whiten(
     """
     Performs whitening on a tensor using global statistics from all participating GPUs.
 
-    It calculates the global mean and variance across all ranks in the default
-    process group (the WORLD) and uses these global statistics to normalize the
-    local data on each rank.
+    It calculates the global mean and variance across all ranks in the given
+    process group and uses these global statistics to normalize the local data
+    on each rank.
 
     Args:
         values (torch.Tensor): The local tensor of values to whiten.
         mask (torch.Tensor): The local mask corresponding to the values.
         process_group: The process group for all_reduce.
                       If None, uses the default world group.
-        shift_mean (bool): If True, the output is zero-mean. Defaults to True.
+        shift_mean (bool): If True (default), center then scale:
+            ``(values - mean) * rsqrt(var + epsilon)`` (zero-mean, unit-variance).
+            If False, scale only: ``values * rsqrt(var + epsilon)``
+            (do not subtract the mean, and do not add it back).
         epsilon (float): A small value for numerical stability.
 
     Returns:
@@ -162,10 +165,8 @@ def distributed_masked_whiten(
         bessel_correction = global_mask_sum / (global_mask_sum - 1)
         global_var = global_var * bessel_correction
 
-    # Whiten local data using global stats
-    whitened_values = (values - global_mean) * torch.rsqrt(global_var + epsilon)
-
-    if not shift_mean:
-        whitened_values += global_mean
-
-    return whitened_values
+    # Both paths share the same global var (including Bessel correction).
+    inv_std = torch.rsqrt(global_var + epsilon)
+    if shift_mean:
+        return (values - global_mean) * inv_std
+    return values * inv_std

--- a/tests/test_distributed_masked_whiten.py
+++ b/tests/test_distributed_masked_whiten.py
@@ -1,0 +1,90 @@
+"""CPU tests for distributed_masked_whiten shift_mean paths."""
+
+import pytest
+import torch
+import torch.distributed as dist
+
+from slime.utils.distributed_utils import distributed_masked_whiten
+
+NUM_GPUS = 0
+EPSILON = 1e-8
+
+
+def _noop_all_reduce(tensor, group=None, op=None, **kwargs):
+    """Single-rank stand-in: leave the local stats tensor unchanged."""
+    return tensor
+
+
+def _masked_mean_var(values: torch.Tensor, mask: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    """Global mean / Bessel-corrected var matching distributed_masked_whiten."""
+    mask_sum = mask.sum()
+    global_mean = (values * mask).sum() / mask_sum
+    global_mean_sq = ((values**2) * mask).sum() / mask_sum
+    global_var = global_mean_sq - global_mean**2
+    if mask_sum.item() >= 2:
+        global_var = global_var * (mask_sum / (mask_sum - 1))
+    return global_mean, global_var
+
+
+@pytest.fixture
+def values_and_mask():
+    # Non-zero mean so the two shift_mean paths are distinguishable.
+    values = torch.tensor([1.0, 2.0, 3.0, 4.0, 10.0, -1.0], dtype=torch.float32)
+    mask = torch.tensor([1.0, 1.0, 1.0, 1.0, 0.0, 1.0], dtype=torch.float32)
+    return values, mask
+
+
+def test_shift_mean_true_is_zero_mean_and_matches_current_formula(monkeypatch, values_and_mask):
+    monkeypatch.setattr(dist, "all_reduce", _noop_all_reduce)
+    values, mask = values_and_mask
+    mean, var = _masked_mean_var(values, mask)
+
+    out = distributed_masked_whiten(values, mask, shift_mean=True, epsilon=EPSILON)
+
+    expected = (values - mean) * torch.rsqrt(var + EPSILON)
+    torch.testing.assert_close(out, expected)
+    masked_out_mean = (out * mask).sum() / mask.sum()
+    assert masked_out_mean.abs().item() < 1e-5
+
+
+def test_shift_mean_false_scales_only_without_mean_add_back(monkeypatch, values_and_mask):
+    monkeypatch.setattr(dist, "all_reduce", _noop_all_reduce)
+    values, mask = values_and_mask
+    mean, var = _masked_mean_var(values, mask)
+
+    out = distributed_masked_whiten(values, mask, shift_mean=False, epsilon=EPSILON)
+
+    expected = values * torch.rsqrt(var + EPSILON)
+    torch.testing.assert_close(out, expected)
+
+    old_add_back = (values - mean) * torch.rsqrt(var + EPSILON) + mean
+    assert not torch.allclose(out, old_add_back)
+
+    orig_mean = (values * mask).sum() / mask.sum()
+    out_mean = (out * mask).sum() / mask.sum()
+    assert not torch.allclose(out_mean, orig_mean)
+
+
+def test_both_paths_share_bessel_corrected_var(monkeypatch, values_and_mask):
+    monkeypatch.setattr(dist, "all_reduce", _noop_all_reduce)
+    values, mask = values_and_mask
+    mean, var = _masked_mean_var(values, mask)
+
+    pop_var = ((values**2) * mask).sum() / mask.sum() - mean**2
+    assert var > pop_var
+
+    scale = torch.rsqrt(var + EPSILON)
+    pop_scale = torch.rsqrt(pop_var + EPSILON)
+    assert not torch.allclose(scale, pop_scale)
+
+    out_shift = distributed_masked_whiten(values, mask, shift_mean=True, epsilon=EPSILON)
+    out_noshift = distributed_masked_whiten(values, mask, shift_mean=False, epsilon=EPSILON)
+
+    torch.testing.assert_close(out_shift, (values - mean) * scale)
+    torch.testing.assert_close(out_noshift, values * scale)
+    assert not torch.allclose(out_shift, (values - mean) * pop_scale)
+    assert not torch.allclose(out_noshift, values * pop_scale)
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__]))


### PR DESCRIPTION
Fixes #1369.

`distributed_masked_whiten(..., shift_mean=False)` used to center, scale, then add the mean back:

```
whitened_values = (values - global_mean) * rsqrt(var)
if not shift_mean:
    whitened_values += global_mean
```

That is not a scale-only path. This change makes `shift_mean` do what it says:

- `shift_mean=True` (default): `(values - global_mean) * rsqrt(global_var + epsilon)` — zero-mean, unit-variance
- `shift_mean=False`: `values * rsqrt(global_var + epsilon)` — scale only; do not subtract the mean, and do not add it back

Both paths still share the same Bessel-corrected global variance estimate.

The live GRPO caller in `slime/backends/megatron_utils/loss.py` already uses `shift_mean=True`, so the production whitening path is unchanged.

A CPU unit test (`NUM_GPUS = 0`) mocks `torch.distributed.all_reduce` as a no-op so it can run without a process group, and pins the two formulas plus the shared variance.