### PR TITLE
fix(rm): stop double-extracting boxed answers for boxed_math

### DIFF
--- a/slime/rollout/rm_hub/__init__.py
+++ b/slime/rollout/rm_hub/__init__.py
@@ -67,8 +67,12 @@ async def async_rm(args, sample: Sample, **kwargs):
     response = sample.response
     label = sample.label
     if rm_type.startswith("boxed_"):
-        response = extract_boxed_answer(response) or ""
         rm_type = rm_type[len("boxed_") :]
+        # math / dapo / deepscaler already extract \boxed{} themselves.
+        # Pre-stripping here makes grade_answer_verl / extract_answer miss
+        # the answer and score a correct boxed response as 0.
+        if rm_type not in ("math", "dapo", "deepscaler"):
+            response = extract_boxed_answer(response) or ""
 
     # This function is intended for remote or time-consuming reward model evaluation.
     # Implement the actual logic as needed.

--- a/tests/test_rm_boxed.py
+++ b/tests/test_rm_boxed.py
@@ -1,0 +1,59 @@
+"""CPU unit tests for boxed_ prefix handling in ``async_rm``.
+
+``rm_type="boxed_math"`` used to pre-strip ``\\boxed{}`` and then hand the
+bare string to ``grade_answer_verl``, which looks for ``\\boxed`` again and
+returns False. Types that extract boxed answers themselves (math / dapo /
+deepscaler) must skip that pre-extract; types that do not (f1, gpqa, ...)
+still get it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from slime.rollout.rm_hub import async_rm
+from slime.utils.types import Sample
+
+
+NUM_GPUS = 0
+
+
+def _args(rm_type: str):
+    return SimpleNamespace(custom_rm_path=None, rm_type=rm_type)
+
+
+def _sample(response: str, label: str) -> Sample:
+    return Sample(response=response, label=label, metadata={})
+
+
+def _reward(rm_type: str, response: str, label: str):
+    return asyncio.run(async_rm(_args(rm_type), _sample(response, label)))
+
+
+@pytest.mark.unit
+def test_boxed_math_scores_correct_boxed_answer():
+    assert _reward("boxed_math", r"Answer: \boxed{5}", "5") == 1
+
+
+@pytest.mark.unit
+def test_boxed_math_scores_wrong_boxed_answer_zero():
+    assert _reward("boxed_math", r"Answer: \boxed{5}", "6") == 0
+
+
+@pytest.mark.unit
+def test_math_still_requires_boxed_wrapper():
+    """Bare ``rm_type="math"`` must keep requiring ``\\boxed``; do not
+    loosen ``grade_answer_verl`` to accept unboxed strings."""
+    assert _reward("math", "5", "5") == 0
+
+
+@pytest.mark.unit
+def test_boxed_math_with_no_boxed_content_is_zero():
+    assert _reward("boxed_math", "just 5", "5") == 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__]))


### PR DESCRIPTION
## Problem

`rm_type="boxed_math"` pre-strips `\boxed{}` in `async_rm`, then `grade_answer_verl` looks for `\boxed{}` again. Extraction returns `None`, so a numerically correct answer is scored 0.

This is the same bug as #543. Prior PR #1246 was closed unmerged during the Dec 30 2025 review purge.

## Approach

Skip the generic `boxed_` pre-extract when the remaining type already extracts boxed answers itself: `math`, `dapo`, `deepscaler`.

Keep pre-extract for types that do **not** extract boxed (`f1`, `gpqa`, etc.).

`grade_answer_verl` is unchanged: unboxed strings still fail (`grade_answer_verl("just 42", "42") is False`).

## Test plan

CPU tests (`NUM_GPUS = 0`) in `tests/test_rm_boxed.py`:

- `async_rm` with `rm_type="boxed_math"`, response `Answer: \boxed{5}`, label `5` → reward 1
- same with wrong label → 0
- `rm_type="math"` still requires `\boxed` (unboxed `"5"` vs `"5"` → 0)
- `boxed_math` with no boxed content → 0

```
python -m pytest tests/test_rm_math.py tests/test_rm_boxed.py -q --tb=short
```

36 passed.

Fixes #543
