### PR TITLE
fix(args): reject --kl-coef for GRPO-style estimators

### DIFF
--- a/slime/utils/arguments.py
+++ b/slime/utils/arguments.py
@@ -1849,6 +1849,13 @@ def slime_validate_args(args):
     if args.save_interval is not None:
         assert args.save is not None, "'--save' is required when save_interval is set."
 
+    if args.kl_coef != 0 and args.advantage_estimator in ["grpo", "gspo", "cispo"]:
+        raise ValueError(
+            "--kl-coef is not supported with --advantage-estimator "
+            f"{args.advantage_estimator}. GRPO-style estimators do not apply KL to rewards; "
+            "use --use-kl-loss / --kl-loss-coef instead."
+        )
+
     assert not (args.kl_coef != 0 and args.kl_loss_coef != 0), "Only one of kl_coef and kl_loss_coef can be set"
 
     if args.advantage_estimator in ["reinforce_plus_plus", "reinforce_plus_plus_baseline"]:

--- a/tests/test_megatron_argument_validation.py
+++ b/tests/test_megatron_argument_validation.py
@@ -306,6 +306,24 @@ def test_slime_validate_args_rejects_non_positive_rollout_temperature(monkeypatc
 
 
 @pytest.mark.unit
+@pytest.mark.parametrize("estimator", ["grpo", "gspo", "cispo"])
+def test_slime_validate_args_rejects_kl_coef_for_grpo_style_estimators(monkeypatch, estimator):
+    module = load_slime_arguments_module(monkeypatch)
+    args = make_slime_validate_args(advantage_estimator=estimator, kl_coef=0.1, ref_load=".")
+
+    with pytest.raises(ValueError, match="kl-coef.*kl-loss"):
+        module.slime_validate_args(args)
+
+
+@pytest.mark.unit
+def test_slime_validate_args_allows_grpo_with_zero_kl_coef(monkeypatch):
+    module = load_slime_arguments_module(monkeypatch)
+    args = make_slime_validate_args(advantage_estimator="grpo", kl_coef=0)
+
+    module.slime_validate_args(args)
+
+
+@pytest.mark.unit
 def test_slime_validate_args_preserves_zero_rollout_gpus_under_colocate(monkeypatch):
     module = load_slime_arguments_module(monkeypatch)
     args = make_slime_validate_args(colocate=True, rollout_num_gpus=0)


### PR DESCRIPTION
## Summary

`--kl-coef` is reward-KL shaping. GRPO-style estimators (`grpo`, `gspo`, `cispo`) do not apply KL to rewards, so a non-zero `--kl-coef` is a silent no-op today.

This follows the maintainer decision on #399: we should not use KL in the GRPO reward, and should use `kl_loss` instead. #1247, which applied KL to GRPO rewards, was closed unmerged. This PR does **not** change `get_grpo_returns()` or invent reward-KL math.

`slime_validate_args` now raises a clear `ValueError` when `--kl-coef != 0` is combined with `--advantage-estimator {grpo,gspo,cispo}`, and points users at `--use-kl-loss` / `--kl-loss-coef`.

## Test plan

- [x] `python -m pytest tests/test_megatron_argument_validation.py -q --tb=short`
  - `grpo` / `gspo` / `cispo` + `--kl-coef 0.1` raise `ValueError` matching `kl-coef` / `kl-loss`
  - `grpo` + `--kl-coef 0` still passes
  - existing validate-args tests still pass

Fixes #397
