### PR TITLE
fix(agent): realign from divergence using previous response length

### DIFF
--- a/slime/agent/trajectory.py
+++ b/slime/agent/trajectory.py
@@ -129,7 +129,7 @@ def _common_prefix_len(a: list[int], b: list[int], chunk: int = 4096) -> int:
 
 class DriftKind(enum.Enum):
     CLEAN = "clean"  # drift == 0: prompt_ids exactly extends held tokens; append the tail beyond them
-    REALIGN = "realign"  # drift inside the most-recent response span and short incoming response; replace that span (loss_mask=0)
+    REALIGN = "realign"  # short prev-response + short incoming output; overwrite from the divergence (loss_mask=0)
     FORK = "fork"  # everything else: close this builder, open a fresh one as a fork
 
 
@@ -149,8 +149,10 @@ class _SampleBuilder:
     the prompt diverges from the held tokens (see :meth:`classify_token_drift`):
 
     * **CLEAN** -- no drift; append the prompt tail beyond what we hold.
-    * **REALIGN** -- a short divergence inside the most-recent response span;
-      overwrite that span from the prompt as loss_mask=0 and keep accumulating.
+    * **REALIGN** -- divergence inside the most-recent response span, and both
+      that previous response and this turn's ``output_ids`` are shorter than
+      ``fork_threshold``; overwrite from the divergence as loss_mask=0 and keep
+      accumulating. Tokens before the split keep their existing loss_mask.
     * **FORK** -- divergence too large or too early to absorb; this builder is
       rejected and the caller closes it and opens a fresh one. That boundary is
       the "fork".
@@ -172,10 +174,14 @@ class _SampleBuilder:
         The incoming turn's prompt is expected to match the tokens this builder
         already holds as an exact prefix. When token drift has occurred -- the
         prompt diverges from the held tokens -- we decide whether to REALIGN
-        (heal a short divergence inside the most-recent response span) or to FORK
-        (``len(turn.output_ids) >= fork_threshold``, or the divergence sits too
-        early to absorb). With no drift the turn is handled the CLEAN way -- a
-        plain prefix extension.
+        or to FORK. REALIGN rewrites the *previous* response from the
+        divergence, so both that sacrificed previous-response length *and*
+        ``len(turn.output_ids)`` must be ``< fork_threshold``. A long previous
+        response forks even when this turn is a short transition (otherwise a
+        61-token follow-up would zero a 28k-token trained span). Divergence
+        sitting before the most-recent response, or an empty builder, also
+        forks. With no drift the turn is handled the CLEAN way -- a plain
+        prefix extension.
         """
         realign_at = _common_prefix_len(self.tokens, turn.prompt_ids)
         drift = len(self.tokens) - realign_at
@@ -183,24 +189,34 @@ class _SampleBuilder:
         if drift == 0:
             return DriftKind.CLEAN
 
-        # REALIGN only heals drift that falls inside the most-recent response span
-        # (and is short); divergence anywhere earlier, or an empty builder, forks.
+        # REALIGN only heals drift inside the most-recent response, and only
+        # when *both* the previous response we would rewrite and this turn's
+        # new output are short. Divergence earlier, or either side at/over
+        # the threshold, forks.
         start = self.last_response_start_idx
-        if start is not None and realign_at >= start and len(turn.output_ids) < self._fork_threshold:
-            return DriftKind.REALIGN
+        if start is not None and realign_at >= start:
+            sacrificed_len = len(self.tokens) - start  # previous response length
+            both_short = (
+                len(turn.output_ids) < self._fork_threshold
+                and sacrificed_len < self._fork_threshold
+            )
+            return DriftKind.REALIGN if both_short else DriftKind.FORK
         return DriftKind.FORK
 
     def append_turn(self, turn: TurnRecord, kind: DriftKind, *, trained: bool = True) -> None:
         """Append one turn into this SampleBuilder, branching on ``kind``: for REALIGN
-        we overwrite the already-saved response span, for CLEAN we just append this
-        turn's prompt tail."""
+        we overwrite from the divergence with the prompt suffix, for CLEAN we just
+        append this turn's prompt tail."""
         assert kind is not DriftKind.FORK, "append_turn called on a builder that would fork"
 
         is_first_turn = self.last_response_start_idx is None
 
         # --- append this turn's prompt tail (loss_mask=0) ---
         if kind is DriftKind.REALIGN:
-            self._align_to_prompt(turn.prompt_ids)  # drop the drifted tail, re-append from prompt
+            # Same prefix cut classify_token_drift used to pick REALIGN; pass it
+            # through so _align_to_prompt zeros only from the divergence.
+            realign_at = _common_prefix_len(self.tokens, turn.prompt_ids)
+            self._align_to_prompt(turn.prompt_ids, realign_at)
         else:  # CLEAN: held tokens are an exact prefix of prompt_ids; append the tail beyond them
             self._append_tokens(turn.prompt_ids[len(self.tokens) :], loss_mask=0)
 
@@ -213,15 +229,19 @@ class _SampleBuilder:
         if is_first_turn:
             self.leading_prompt_len = len(turn.prompt_ids)
 
-    def _align_to_prompt(self, prompt_ids: list[int]) -> None:
-        """Heal REALIGN drift by overwriting the most-recent response span with
-        ``prompt_ids`` as loss_mask=0: the drifted tokens carry no signal, and re-appending
-        from the prompt keeps the builder contiguous. Earlier turns are untouched."""
-        response_start = self.last_response_start_idx
-        tail = prompt_ids[response_start:]
-        self.tokens[response_start:] = tail
-        self.loss_mask[response_start:] = [0] * len(tail)
-        self.logprobs[response_start:] = [0.0] * len(tail)
+    def _align_to_prompt(self, prompt_ids: list[int], realign_at: int) -> None:
+        """Heal REALIGN drift by overwriting from the divergence ``realign_at``.
+
+        Only the suffix from the BPE/template split is replaced with
+        ``prompt_ids[realign_at:]`` as loss_mask=0. Tokens before the split --
+        including already-trained tokens in the previous response -- keep their
+        existing loss_mask and logprobs. Zeroing from ``last_response_start_idx``
+        would also wipe that innocent prefix.
+        """
+        tail = prompt_ids[realign_at:]
+        self.tokens[realign_at:] = tail
+        self.loss_mask[realign_at:] = [0] * len(tail)
+        self.logprobs[realign_at:] = [0.0] * len(tail)
 
     def _append_tokens(self, ids: list[int], *, loss_mask: int, logprobs: list[float] | None = None) -> None:
         self.tokens.extend(ids)

--- a/tests/test_agent/test_trajectory_manager_branching.py
+++ b/tests/test_agent/test_trajectory_manager_branching.py
@@ -681,15 +681,15 @@ def test_2_4_drift_case_B1_short_replaces():
     s0 = samples[0]
     L = _common_prefix_len(p1 + r1, p2)
     assert L == drift_idx
-    # replace: the drifted r:call response is no longer a faithful echo of what the
-    # model generated (its tail diverged), so the WHOLE surviving span is masked and
-    # re-supplied as loss=0 prompt context (the <DRIFT> token marks the divergence);
-    # only the new r:done trains.
+    # replace from the divergence: the last token of r:call is the split, so that
+    # suffix (and the tool/gen tail) is re-supplied as loss=0 context. The
+    # innocent r:call prefix was already trained and keeps loss=1; only r:done
+    # is the new trained response.
     assert goldens(samples) == [
-        "<sys> system:S </sys> <usr> user:u </usr> <gen> r:call <DRIFT> "
+        "<sys> system:S </sys> <usr> user:u </usr> <gen> [r:call] <DRIFT> "
         "<tul> tool:t </tul> <gen> [r:done] [</ast>]",
     ]
-    assert s0.rollout_log_probs == [0.0] * (len(p2) - len(p1)) + [-0.4] * len(r2)
+    assert s0.rollout_log_probs == [-0.5] + [0.0] * (len(p2) - len(p1) - 1) + [-0.4] * len(r2)
     _check_invariants(samples)
     _record("2.4 drift case B1 (small) -> replace", mgr, sid, samples)
     print("PASS 2.4")
@@ -1216,19 +1216,21 @@ def test_4_5_mixed_logprobs_across_turns():
 
 
 def test_4_6_drift_B1_threshold_boundary():
-    """case-B1 threshold compares the incoming turn's full ``output_ids`` length
-    to ``fork_threshold`` (mirroring ``_try_merge_assistant_rewrite``): the gate
-    is exclusive, so ``len(r2) == threshold`` forks and ``len(r2) < threshold``
-    replaces. Drift-tail length is not part of the gate -- only its position
-    (inside the most-recent response span) keeps REALIGN physically applicable."""
+    """REALIGN only when BOTH the previous response length and this turn's
+    ``output_ids`` are ``< fork_threshold``. A long previous response forks
+    even if this turn is short (REALIGN rewrites that previous span, so its
+    length is what we would sacrifice). After REALIGN, tokens before
+    ``realign_at`` that were already trained keep ``loss_mask=1``; only the
+    suffix from the divergence is zeroed."""
 
-    def run(threshold, new_resp_len):
+    def run(threshold, new_resp_len, prev_resp_len=4):
         mgr = TrajectoryManager(fork_threshold_tokens=threshold)
-        sid = f"4.6-{threshold}-{new_resp_len}"
+        sid = f"4.6-{threshold}-{new_resp_len}-{prev_resp_len}"
         s, u = sys_msg("S"), usr_msg("u")
-        # 4-token response so the divergence can sit inside the response span.
+        # Default 4-token previous response so the divergence can sit inside
+        # the response span with an innocent prefix in front of it.
         p1 = render_prompt([s, u])
-        r1 = [9001, 9002, 9003, 9004]
+        r1 = [9001 + i for i in range(prev_resp_len)]
         mgr.record_turn(
             sid,
             turn=turn(p1, r1, finish_reason="tool_calls"),
@@ -1252,21 +1254,34 @@ def test_4_6_drift_B1_threshold_boundary():
         samples = get_traj(mgr, sid, base_sample=Sample(index=0, prompt=""), reward=1.0)
         return samples, p1, r1, p2, r2
 
-    # len(r2) == threshold -> fork: two single-turn segments, each trains its own resp.
-    forked, p1, r1, p2, r2 = run(threshold=2, new_resp_len=2)
-    assert len(forked) == 2, f"len(r2)==threshold must fork, got {len(forked)}"
+    # Previous response long (r1=4 >= 3) even though this turn is short (r2=2):
+    # must FORK. Old contract realigned here because it only looked at len(r2).
+    forked, p1, r1, p2, r2 = run(threshold=3, new_resp_len=2)
+    assert len(forked) == 2, f"long previous response must fork, got {len(forked)}"
     assert forked[0].tokens == p1 + r1
     assert forked[0].loss_mask == [1] * len(r1)
     assert forked[1].tokens == p2 + r2
     assert forked[1].loss_mask == [1] * len(r2)
-    # len(r2) < threshold -> replace: one coherent segment realigned to p2.
-    replaced, p1b, r1b, p2b, r2b = run(threshold=3, new_resp_len=2)
-    assert len(replaced) == 1, f"len(r2)<threshold must replace, got {len(replaced)}"
+
+    # This turn at the threshold, previous short -> still FORK (both must be short).
+    forked_new, p1c, r1c, p2c, r2c = run(threshold=3, new_resp_len=3, prev_resp_len=2)
+    assert len(forked_new) == 2, f"len(r2)==threshold must fork, got {len(forked_new)}"
+    assert forked_new[0].tokens == p1c + r1c
+    assert forked_new[1].tokens == p2c + r2c
+
+    # Both sides short -> REALIGN. Innocent r1 prefix (tokens before the last-
+    # token divergence) keeps loss_mask=1; only the suffix from realign_at is
+    # zeroed, then r2 trains.
+    replaced, p1b, r1b, p2b, r2b = run(threshold=5, new_resp_len=2)
+    assert len(replaced) == 1, f"both sides <threshold must realign, got {len(replaced)}"
     assert replaced[0].tokens == p2b + r2b
-    # the drifted r1 echo is not a faithful response anymore -> the WHOLE r1 span is
-    # masked (loss=0 prompt context), r2 trains.
-    assert replaced[0].loss_mask == [0] * (len(p2b) - len(p1b)) + [1] * len(r2b)
+    realign_at = len(p1b) + len(r1b) - 1
+    innocent = realign_at - len(p1b)
+    suffix = len(p2b) - realign_at
+    assert innocent == 3, "r1=4 with last-token drift leaves 3 trained tokens"
+    assert replaced[0].loss_mask == [1] * innocent + [0] * suffix + [1] * len(r2b)
     _check_invariants(forked)
+    _check_invariants(forked_new)
     _check_invariants(replaced)
     print("PASS 4.6")
 


### PR DESCRIPTION
## Background

`_SampleBuilder` heals TITO / chat-template token drift by either REALIGN (overwrite the drifted tail in-place) or FORK (close the builder and start a new Sample). REALIGN is supposed to be a cheap repair of a *short* previous response.

Fixes #2338.

## Problem

Two bugs in `slime/agent/trajectory.py`, both visible in the reporter's 3-turn example (default `fork_threshold=1024`): a 61-token transition turn REALIGN'd a 28k-token previous response, and 184–383 already-trained tokens *before* the BPE split were zeroed with it.

### 1. REALIGN gated on this turn's `output_ids`, not the previous response

`classify_token_drift` used `len(turn.output_ids)` to decide REALIGN vs FORK. REALIGN rewrites the **previous** response (it zeros that span and splices the new prompt suffix). A short follow-up therefore realigned — and discarded — a long trained span.

In the report: `new_resp_len=61 < 1024` → REALIGN, `zeroed_resp_tokens=28404`.

### 2. `_align_to_prompt` overwrote from `last_response_start_idx`, not the divergence

Even when REALIGN is correct, zeroing from the start of the previous response also wipes tokens that still match the new prompt (the "innocent prefix" before the BPE split). The reporter measured 184 / 237 / 332 / 383 trained tokens killed before `realign_at` across four REALIGNs, with `killed_masked_lm0 == 0` (the whole zeroed range was `loss_mask=1` model output, not tool/history).

## Solution

- `classify_token_drift`: REALIGN only when the divergence sits inside the most-recent response **and both** `sacrificed_len = len(tokens) - last_response_start_idx` (previous response) **and** `len(turn.output_ids)` are `< fork_threshold`. Otherwise FORK. `_try_merge_assistant_rewrite` is unchanged (different contract: merging a short abandoned assistant rewrite).
- `_align_to_prompt(prompt_ids, realign_at)`: overwrite `tokens` / `loss_mask` / `logprobs` from the divergence only. Tokens before `realign_at` keep their existing mask and logprobs.
- `append_turn` passes the same `_common_prefix_len` cut that classify already computed (recomputed at append time; tokens are unchanged between the two calls).

## Tests

`tests/test_agent/test_trajectory_manager_branching.py`:

- `test_4_6_drift_B1_threshold_boundary` now pins the new gate: REALIGN iff **both** sides are `< threshold`; a long previous response forks even if this turn is short (the old `threshold=3, r1=4, r2=2` case, which used to REALIGN). After REALIGN, the innocent prefix keeps `loss_mask=1` and only the suffix from `realign_at` is zeroed.
- `test_2_4_drift_case_B1_short_replaces` updated so the trained token before the last-token split stays `loss_mask=1`.

```
python -m pytest tests/test_agent/test_trajectory_manager_branching.py -q --tb=short
# 35 passed
```