### PR TITLE
fix(weight-sync): compose engine waves, credits and timeline

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -587,6 +587,18 @@ jobs:
             },
             {
               "num_gpus": 0,
+              "test_file": "test_engine_group_wave.py"
+            },
+            {
+              "num_gpus": 0,
+              "test_file": "test_engine_group_wave_distributed.py"
+            },
+            {
+              "num_gpus": 0,
+              "test_file": "test_weight_sync_callsite_benchmark.py"
+            },
+            {
+              "num_gpus": 0,
               "test_file": "utils/test_megatron_role_config.py"
             },
             {

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -655,6 +655,10 @@ jobs:
             },
             {
               "num_gpus": 0,
+              "test_file": "observability/test_communication_timeline.py"
+            },
+            {
+              "num_gpus": 0,
               "test_file": "observability/test_trace_utils.py"
             },
             {

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -767,6 +767,10 @@ jobs:
             },
             {
               "num_gpus": 0,
+              "test_file": "test_weight_sync_credit.py"
+            },
+            {
+              "num_gpus": 0,
               "test_file": "test_expert_routing.py"
             },
             {

--- a/.github/workflows/pr-test.yml.j2
+++ b/.github/workflows/pr-test.yml.j2
@@ -117,6 +117,7 @@
         {'test_file': 'test_external_sglang_engines.py', 'num_gpus': 0},
         {'test_file': 'test_streaming_rollout.py', 'num_gpus': 0},
         {'test_file': 'test_empty_colocated_weight_bucket.py', 'num_gpus': 0},
+        {'test_file': 'test_weight_sync_credit.py', 'num_gpus': 0},
         {'test_file': 'test_expert_routing.py', 'num_gpus': 0},
         {'test_file': 'test_glm5_indexer_short_context.py', 'num_gpus': 0},
         {'test_file': 'test_model_provider_freeze.py', 'num_gpus': 0},

--- a/.github/workflows/pr-test.yml.j2
+++ b/.github/workflows/pr-test.yml.j2
@@ -89,6 +89,7 @@
         {'test_file': 'test_loss_cp_invariance.py', 'num_gpus': 0},
         {'test_file': 'test_advantage_whiten_cp.py', 'num_gpus': 0},
         {'test_file': 'test_logprob_response_spans.py', 'num_gpus': 0},
+        {'test_file': 'observability/test_communication_timeline.py', 'num_gpus': 0},
         {'test_file': 'observability/test_trace_utils.py', 'num_gpus': 0},
         {'test_file': 'test_value_temperature.py', 'num_gpus': 0},
         {'test_file': 'test_ppo_kl_metric.py', 'num_gpus': 0},

--- a/.github/workflows/pr-test.yml.j2
+++ b/.github/workflows/pr-test.yml.j2
@@ -72,6 +72,9 @@
       'extra_pip_deps': 'transformers wandb',
       'tests': [
         {'test_file': 'test_megatron_argument_validation.py', 'num_gpus': 0},
+        {'test_file': 'test_engine_group_wave.py', 'num_gpus': 0},
+        {'test_file': 'test_engine_group_wave_distributed.py', 'num_gpus': 0},
+        {'test_file': 'test_weight_sync_callsite_benchmark.py', 'num_gpus': 0},
         {'test_file': 'utils/test_megatron_role_config.py', 'num_gpus': 0},
         {'test_file': 'test_deep_ep_tms_patch.py', 'num_gpus': 0},
         {'test_file': 'test_stateless_adam.py', 'num_gpus': 0},

--- a/docs/en/advanced/weight-sync-wave-scheduling.md
+++ b/docs/en/advanced/weight-sync-wave-scheduling.md
@@ -1,0 +1,128 @@
+# Weight-Sync Engine Waves
+
+Large rollout deployments can make every SGLang engine receive or load the same
+weight bucket at once. That maximizes fan-out, but can also create a short burst
+of GPU, PCIe, NVLink, network, or storage traffic. slime can bound this fan-out
+without adding a hardware-specific time delay:
+
+```bash
+--update-weight-max-inflight-engine-groups 2
+```
+
+An engine group here means one logical SGLang engine. Its tensor-, pipeline-, or
+multi-node workers remain one indivisible group. The scheduler walks the resolved
+engine list in stable order and admits at most the configured number at once.
+For four engines and a limit of three, the waves are therefore `(0, 1, 2)` and
+`(3)`; no particular world size or number of engines is assumed.
+
+The default is `0`, which keeps the existing all-at-once behavior. A value at
+least as large as the engine count is equivalent to the default. Negative values
+are rejected.
+
+## Supported transports
+
+- Non-colocated NCCL weight sync creates one process group per logical engine
+  only when a real bound is requested. Broadcasts for the engines in one wave
+  are launched asynchronously, and the next wave is not admitted until both the
+  NCCL work and engine-side load requests complete. The default continues to use
+  the original aggregate process group.
+- Colocated tensor/IPC sync coordinates the same deterministic waves across all
+  trainer ranks. A trainer control-group barrier closes each wave before source
+  buffers can be reused.
+- Full and delta disk sync apply the bound to checkpoint pulls and engine reload
+  requests.
+- Quantized post-load processing uses the same engine-group bound.
+
+The existing pause, flush, and weight-version boundaries are unchanged: an engine
+is not resumed early merely because its own wave completed. Disk-backed checkpoint
+pulls may run before the pause, but the serving weights are not changed by that
+prefetch. Consequently, wave admission does not introduce a new mixed-version
+serving interval.
+
+## Choosing a value
+
+Start with `0` as the throughput baseline, then compare small limits such as `1`,
+`2`, and `4` on the deployment topology that will run the job. Select the largest
+value that avoids the observed traffic or memory burst without increasing total
+weight-sync time or tail latency. This option limits concurrent engine groups;
+`--update-weight-buffer-size` independently controls the size of each weight
+bucket.
+
+## Production-callsite confirmation
+
+### Combining waves with bucket credits
+
+The integrated updater supports engine-group waves together with
+`--update-weight-max-inflight-buckets` and `--update-weight-max-inflight-bytes`.
+One logical bucket reservation spans all its engine waves. A wave must finish
+device transport, engine-load acknowledgement and staging release before the
+next wave is observed; the logical credit is returned only after the last wave.
+The final weight version is published after all consumers resume.
+
+When the engine population is split into multiple waves, buffered buckets are
+drained one at a time. The bucket window still bounds admitted logical bytes,
+but does not multiply the active engine-group cap or promise inter-bucket
+overlap. A single aggregate communicator retains the asynchronous bucket-window
+path. Logical bytes are not a physical CUDA-memory cap or measured wire bytes.
+Transport credit uses a host-visible stream fence after Work.wait; that wait
+alone is only a CUDA dependency. Failed loads poison the version, prevent the
+next wave/publication, and retain active-wave resources on the updater. Recover
+by recreating the failed updater/process; automatic partial-version retry is
+not supported.
+
+CPU integration tests exercise both production updater variants with 2/4
+logical engine groups, including load failure on a peer and staging retention.
+They are not a complete Ray/SGLang GPU training validation.
+
+`tools/benchmark_weight_sync_callsite.py` invokes the production
+`update_weights_in_engine_group_waves` function with real process groups and
+synthetic payloads. It is intentionally a callsite/module probe: it does not
+replace the scheduler, change defaults, or claim Ray/SGLang load performance.
+
+Use a four-process launch to retain three real two-rank
+`[trainer, engine]` groups. A/B are engine groups 0 and 1; the third group is
+the competing operation that distinguishes the all-at-once and window-2
+policies. Only use device counts permitted by the test environment.
+
+Each command below creates exactly one independent process-run artifact:
+
+```bash
+torchrun --standalone --nproc-per-node=4 \
+  tools/benchmark_weight_sync_callsite.py \
+  --backend gloo --policy candidate_windowed \
+  --evidence-role selection --run-id selection-windowed-00 \
+  --order ab --output-json /tmp/selection-windowed-00.json
+```
+
+In a minimal PyTorch container without slime's Ray/Megatron control-plane
+dependencies, set `SLIME_CALLSITE_SOURCE_LOAD=1`. That opt-in mode loads the
+exact production source file while stubbing only unused actor/conversion
+imports; the artifact records `source_with_control_plane_stubs` so it cannot be
+silently mixed with an installed-runtime campaign.
+When the checkout's `.git` metadata is not mounted into the container, pass the
+tested revision as `SLIME_BENCHMARK_SOURCE_COMMIT`.
+
+Run every policy in both `selection` and `confirmation` roles in separate
+process launches (five launches per policy/role by default), alternating
+`--order ab` and `--order ba`. Then validate and summarize the immutable raw
+artifacts:
+
+```bash
+python tools/benchmark_weight_sync_callsite.py \
+  --summarize /tmp/weight-sync-callsite/*.json \
+  --min-runs-per-role 5 \
+  --summary-json /tmp/weight-sync-callsite-summary.json
+```
+
+The summary fails closed on duplicate process/run identity, incomplete rank
+coverage, payload mismatch, mixed runtime/message/topology cells, or too few
+independent runs. It reports communication A/B, rank-local pair makespan,
+receiver consumer waits, callsite return, device readiness, and whole-stage
+sync readiness separately. NCCL intervals are labeled `event_bracket`, never
+`kernel_observed`. The tool records PyTorch/CUDA/NCCL versions, launch-order
+configuration, dtype, message geometry, graph state, hostname, device identity,
+and exact process-group membership.
+
+This evidence does not establish end-to-end training throughput, SGLang load
+latency, multi-node behavior, or a production policy winner. The summarizer
+does not automatically select or apply a policy.

--- a/docs/en/developer_guide/communication_timeline.md
+++ b/docs/en/developer_guide/communication_timeline.md
@@ -1,0 +1,75 @@
+# Trainer Communication Timeline
+
+slime can write a low-overhead JSONL timeline for training and weight synchronization. It is disabled by default and does not change collective ordering or add synchronization to the training path.
+
+Enable it with a per-rank path:
+
+```bash
+python train.py \
+  ... \
+  --communication-timeline /path/to/traces/slime-{role}-{rank}.jsonl
+```
+
+The equivalent environment variable is `SLIME_COMMUNICATION_TIMELINE`. Paths support `{rank}`, `{trainer_rank}`, `{local_rank}`, `{pid}`, `{hostname}`, `{role}`, and `{world_size}`. If a multi-rank path has no rank placeholder, slime adds a `.rank-N` suffix. Actor, critic, and disk-orchestrator roles also get separate suffixes when `{role}` is omitted. This works for any world size; there is no topology-specific rank layout. slime generates one shared `run_id` for the actor group; use `--communication-timeline-run-id` or `SLIME_COMMUNICATION_TIMELINE_RUN_ID` to supply one explicitly.
+
+## Built-in phases
+
+The trainer records:
+
+- `train_forward_backward`: the Megatron forward/backward schedule;
+- `grad_sync`: Megatron's final gradient synchronization callback;
+- `optimizer_step`;
+- `weight_convert`: work performed while producing each HF weight bucket;
+- `weight_bucket_ready` and `weight_bucket_send`;
+- `engine_bucket_receive`: the trainer's observation that transfer has completed;
+- `engine_load_weights`: time until the engine update request returns;
+- `weight_sync_complete`.
+
+`engine_bucket_receive` is a trainer-side observation, not an engine-side timestamp. The `observation` metadata says which boundary produced it.
+
+Every record carries the common fields `global_step`, `rollout_id`, `weight_version`, `bucket_id`, `trainer_rank`, `engine_id`, `message_bytes`, and `transport`. Fields that do not apply at a boundary are `null`. `sequence_id` is process-local and monotonic, while `logical_operation_id` combines the available lifecycle identifiers with the operation name.
+
+CUDA spans use events on the current framework stream. Events are queried without blocking during normal execution and drained at process shutdown. Schema v2 labels this provenance explicitly with `gpu_timestamp_semantics="event-bracket"`, `timestamp_domain="process-realtime-projected-cuda-event"`, and `clock_sync_error_bound_us=null`. The projected GPU interval brackets framework eligibility and observed completion; it does not claim to be the exact start of an NCCL kernel on an internal ProcessGroupNCCL stream, and the process realtime clocks have no measured cross-rank error bound. Each span also emits an NVTX range named `slime.comm/<operation>` so Nsight Systems can provide exact kernel correlation.
+
+Do not use these event-bracket timestamps to select or apply an automatic communication policy. Such a consumer must fail closed until an adapter supplies kernel-observed timestamps and a measured clock-synchronization error bound for every participating rank. The built-in timeline remains useful for lifecycle diagnostics and for correlating its NVTX ranges with an exact profiler trace.
+
+When the timeline is not configured, the public helpers use one shared no-op phase. They do not read clocks, import torch, allocate CUDA events, push NVTX, scan bucket tensor sizes, update context variables, serialize JSON, open files, or synchronize. Host-only, CUDA-event, and external-profiler overhead must be measured as separate modes; profiler runs must not be mixed into non-profiler throughput samples.
+
+## Add semantic phases from custom code
+
+### Integrated wave/credit updaters
+
+The integrated distributed and colocated updaters retain a bucket's send span
+across asynchronous API return until its transport completion boundary. An
+explicit `mark_api_return()` closes the API-side NVTX range without closing
+the pending GPU event bracket, so overlapping bucket submissions do not leave
+incorrectly nested NVTX ranges. Engine-load ACK wait is a separate trainer-side
+span; CUDA IPC completion is not inferred before that ACK. Wave IDs are kept in
+metadata and appended to the logical operation ID, not treated as new buckets.
+
+`weight_bucket_reusable` follows the actual credit/resource release boundary.
+`weight_sync_complete` follows the updater's version commit; failures instead
+emit `weight_sync_failed` and close incomplete spans with error status. The
+global trace sequence can have gaps from cancelled terminal conversion probes;
+it is not a communicator sequence ID. Trace-enabled and trace-disabled CPU
+composition tests cover 2/4 logical engine groups. They do not provide a full
+Ray/SGLang GPU or engine-internal kernel confirmation.
+
+slime deliberately does not patch Megatron's internal MoE implementation. A custom Megatron hook or plugin can add `ep_dispatch` and `ep_combine` without changing the schema:
+
+```python
+from slime.observability.communication_timeline import communication_context, communication_phase
+
+with communication_context(global_step=step, rollout_id=rollout_id):
+    with communication_phase(
+        "ep_dispatch",
+        message_bytes=dispatch_bytes,
+        transport="nccl",
+        layer=layer_id,
+    ):
+        dispatch_tokens()
+```
+
+Use `communication_event(...)` for an instantaneous boundary and call `mark_consumer()` on the object yielded by `communication_phase(...)` when the first consumer is observed.
+
+This timeline is process-oriented and complements the per-sample [Trace Viewer](./trace.md). For kernel-level analysis, correlate its NVTX ranges with [Profiling](./profiling.md).

--- a/docs/en/get_started/customization.md
+++ b/docs/en/get_started/customization.md
@@ -491,12 +491,29 @@ Both values default to `0`, which preserves the existing one-bucket-at-a-time pa
 or both to opt in. Bucket bytes are counted once, regardless of how many rollout engines consume
 the bucket. Colocated updates use the largest contribution across trainer ranks so every rank
 flushes at the same collective boundary. Completion and credit release remain FIFO, and every
-window is fully drained before its weight version is committed. If one bucket is larger than a
-configured byte limit, slime raises an error instead of waiting indefinitely.
+window is fully drained before its weight version is committed. A version is committed only after
+post-processing finishes and the rollout consumers resume. If one bucket is larger than a configured
+byte limit, slime raises an error instead of waiting indefinitely.
+
+The byte credit counts logical bucket payload, not allocator or transport duplication. Slime records
+rank-local peaks for logical in-flight bytes, transport-outstanding bytes, IPC staging-resident bytes,
+and pending consumer objects under `perf/update_weights_*`. These counters are kept separate because a
+colocated flattened IPC buffer can make staging residency larger than the logical byte credit. They are
+observability, not an additional admission budget. Staging residency counts explicit producer-owned
+staging tensor objects; it does not estimate allocator fragmentation or CUDA IPC limbo after references
+are dropped. `perf/update_weights_sync_seconds` measures, on one control clock, from synchronization
+start until all target consumers have completed loading,
+post-processing has finished, and generation has resumed.
+
+Within a colocated engine's existing Gloo TP group, the source rank propagates the Ray load
+acknowledgement before any member returns the corresponding credit. This does not add a global CUDA
+synchronize. A load failure poisons the active version: it cannot be committed or reused, and the actor
+group must follow its normal abort/restart path. A lost process is not treated as a successful consensus.
 
 The credit window applies to ordinary full-weight buckets in distributed and colocated updates.
 Explicitly routed expert transfers remain serial so they can safely reuse their staging buffers;
-their bucket size is still checked against the byte limit. Disk and delta transports do not have
+their bucket size is still checked against the byte limit, and the reusable staging pool is included in
+the staging-residency metric. Disk and delta transports do not have
 an in-memory bucket data plane and reject nonzero in-flight credit settings.
 
 ## Testing Custom Function Paths

--- a/docs/en/get_started/customization.md
+++ b/docs/en/get_started/customization.md
@@ -477,6 +477,28 @@ therefore an sglang server argument rather than a slime hook: pass
 published weights (e.g. refresh the mount's view). See
 [Delta Weight Sync](../advanced/delta-weight-sync.md) for the full mechanism.
 
+### 20. Weight-Sync In-Flight Credits
+
+Full tensor/NCCL weight sync can keep several converted buckets in flight instead of waiting
+after every bucket. The window is controlled by two independent limits:
+
+| Argument | Meaning |
+| --- | --- |
+| `--update-weight-max-inflight-buckets` | Maximum number of logical buckets in flight. `0` disables this dimension. |
+| `--update-weight-max-inflight-bytes` | Maximum bytes across logical buckets in flight. `0` disables this dimension. |
+
+Both values default to `0`, which preserves the existing one-bucket-at-a-time path. Set either
+or both to opt in. Bucket bytes are counted once, regardless of how many rollout engines consume
+the bucket. Colocated updates use the largest contribution across trainer ranks so every rank
+flushes at the same collective boundary. Completion and credit release remain FIFO, and every
+window is fully drained before its weight version is committed. If one bucket is larger than a
+configured byte limit, slime raises an error instead of waiting indefinitely.
+
+The credit window applies to ordinary full-weight buckets in distributed and colocated updates.
+Explicitly routed expert transfers remain serial so they can safely reuse their staging buffers;
+their bucket size is still checked against the byte limit. Disk and delta transports do not have
+an in-memory bucket data plane and reject nonzero in-flight credit settings.
+
 ## Testing Custom Function Paths
 
 slime also provides CPU-only contract tests for customization interfaces. These tests resolve components through import-path strings, so they can validate both built-in hooks and user-defined implementations passed through the same CLI arguments used by training.

--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -84,6 +84,7 @@ Start by Use Case
    advanced/pd-disaggregation.md
    advanced/external-rollout-engines.md
    advanced/delta-weight-sync.md
+   advanced/weight-sync-wave-scheduling.md
    advanced/sglang-config.md
    advanced/megatron-config.md
    advanced/arch-support-beyond-megatron.md

--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -42,7 +42,7 @@ Start by Use Case
 - Use PD disaggregation: :doc:`advanced/pd-disaggregation`
 - Use BF16 training with FP8 rollout or FP8 KV cache: :doc:`advanced/low-precision`
 - Understand CI and reliability coverage: :doc:`developer_guide/ci`
-- Debug, trace, and profile long-running jobs: :doc:`developer_guide/debug`, :doc:`developer_guide/trace`, :doc:`developer_guide/profiling`
+- Debug, trace, and profile long-running jobs: :doc:`developer_guide/debug`, :doc:`developer_guide/trace`, :doc:`developer_guide/communication_timeline`, :doc:`developer_guide/profiling`
 
 .. toctree::
    :maxdepth: 1
@@ -107,6 +107,7 @@ Start by Use Case
    developer_guide/ci.md
    developer_guide/debug.md
    developer_guide/trace.md
+   developer_guide/communication_timeline.md
    developer_guide/profiling.md
 
 .. toctree::

--- a/docs/zh/advanced/weight-sync-wave-scheduling.md
+++ b/docs/zh/advanced/weight-sync-wave-scheduling.md
@@ -1,0 +1,110 @@
+# 权重同步 Engine Wave 调度
+
+大规模 rollout 部署可能让所有 SGLang engine 同时接收或加载同一个权重
+bucket。这样可以最大化 fan-out，但也可能瞬间占满 GPU、PCIe、NVLink、网络
+或存储带宽。slime 可以在不引入硬件相关固定延迟的情况下限制这种 fan-out：
+
+```bash
+--update-weight-max-inflight-engine-groups 2
+```
+
+这里的 engine group 指一个逻辑 SGLang engine。它内部的 tensor parallel、
+pipeline parallel 或多节点 worker 始终作为不可拆分的整体。调度器按解析后的
+engine 列表稳定分波，每波最多放行配置数量。例如四个 engine、上限为三时，
+wave 依次为 `(0, 1, 2)` 和 `(3)`；实现不假设特定 world size 或 engine
+数量。
+
+默认值为 `0`，保持原有 all-at-once 行为。配置值大于等于 engine 数量时也
+等价于默认行为；负数会在启动参数校验阶段被拒绝。
+
+## 支持的传输路径
+
+- 非 colocate NCCL 权重同步只在确实要求并发上限时，为每个逻辑 engine
+  创建独立 process group。同一 wave 内的 broadcast 异步发起，NCCL work
+  与 engine 侧加载请求全部完成后才放行下一波；默认行为仍使用原来的聚合
+  process group。
+- Colocate tensor/IPC 同步在所有 trainer rank 间使用相同的确定性 wave；
+  每波结束用 trainer 控制组 barrier 封口，然后才允许复用源 buffer。
+- Full 和 delta disk 同步会对 checkpoint pull 与 engine reload 请求应用
+  同一并发上限。
+- 量化模型的 post-load 处理也遵守同一 engine-group 上限。
+
+现有的 pause、flush 与权重版本边界保持不变：某个 engine 不会仅仅因为自己的
+wave 先完成就提前恢复 generation。disk checkpoint pull 可以在 pause 前预取，
+但该过程不会修改 serving 权重。因此 wave 放行本身不会引入新的新旧权重混用
+窗口。
+
+## 如何选择上限
+
+先用 `0` 建立吞吐基线，再在实际部署拓扑上比较 `1`、`2`、`4` 等较小上限。
+应选择既能消除观测到的流量或显存峰值、又不会增加权重同步总时间或尾延迟的
+最大值。该参数只限制并发 engine group 数量；每个权重 bucket 的大小仍由
+`--update-weight-buffer-size` 独立控制。
+
+## 生产调用点确认
+
+### 同时启用 wave 与 bucket credit
+
+集成 updater 支持 wave 与 `--update-weight-max-inflight-buckets`、
+`--update-weight-max-inflight-bytes` 同时启用。一个逻辑 bucket 的 credit
+跨越该 bucket 的全部 engine wave；每波完成设备传输、engine load ACK 和
+staging 释放后才推进，最后一波结束后才返还逻辑 credit。所有消费者恢复后
+才发布最终版本。
+
+存在多个 wave 时，缓存窗口中的 bucket 逐个完成全部波次；逻辑字节窗口仍
+限制准入量，但不会将 engine 并发上限乘以 bucket 数量，也不承诺跨 bucket
+重叠。单个聚合 communicator 保留异步 bucket-window 路径。逻辑字节不是
+物理显存硬上限或实际网络线速字节。返还 transport credit 前，在 Work.wait
+插入的流依赖后执行主机可观察的流完成等待。load 失败会使版本不可提交、
+阻止下一波，并在 updater 上保留当前波的资源；恢复需要重建 updater/进程，
+不自动重试部分写入的版本。
+
+CPU 组合测试覆盖两种生产 updater、2/4 个逻辑 engine group、对端 load
+失败传播和 staging 保留，不等价于完整 Ray/SGLang GPU 训练验证。
+
+`tools/benchmark_weight_sync_callsite.py` 直接调用生产函数
+`update_weights_in_engine_group_waves`，使用真实 process group 和合成 payload。
+它是调用点/模块级探针：不会重写调度器、改变默认值，也不声称测到了
+Ray/SGLang 加载性能。
+
+四进程启动会保留三个真实的二 rank `[trainer, engine]` 通信组。A/B 是
+engine group 0 和 1；第三组是区分 all-at-once 与 window-2 的竞争操作。
+只使用当前测试环境允许的设备数量。
+
+下列每条命令只生成一个独立进程运行制品：
+
+```bash
+torchrun --standalone --nproc-per-node=4 \
+  tools/benchmark_weight_sync_callsite.py \
+  --backend gloo --policy candidate_windowed \
+  --evidence-role selection --run-id selection-windowed-00 \
+  --order ab --output-json /tmp/selection-windowed-00.json
+```
+
+若最小 PyTorch 容器缺少 slime 的 Ray/Megatron 控制面依赖，可显式设置
+`SLIME_CALLSITE_SOURCE_LOAD=1`。该模式加载完全相同的生产源文件，只替换本
+探针不会调用的 actor/conversion import；制品会记录
+`source_with_control_plane_stubs`，不能静默混入完整运行时 campaign。
+若容器内没有挂载 checkout 的 `.git` 元数据，请用
+`SLIME_BENCHMARK_SOURCE_COMMIT` 显式传入被测 revision。
+
+对每个 policy 分别以 `selection`、`confirmation` 角色启动独立进程（默认
+每个 policy/role 五次），并交替使用 `--order ab`、`--order ba`。随后校验、
+汇总不可变原始制品：
+
+```bash
+python tools/benchmark_weight_sync_callsite.py \
+  --summarize /tmp/weight-sync-callsite/*.json \
+  --min-runs-per-role 5 \
+  --summary-json /tmp/weight-sync-callsite-summary.json
+```
+
+遇到重复进程/运行身份、rank 覆盖不完整、payload 不一致、混用运行时/
+消息/拓扑 cell，或独立运行不足时，汇总器会 fail closed。它分别报告通信
+A/B、rank-local pair makespan、接收端 consumer wait、调用点返回、设备
+ready 和整个同步阶段 ready。NCCL 区间只标记为 `event_bracket`，绝不冒充
+`kernel_observed`。工具记录 PyTorch/CUDA/NCCL 版本、launch-order 配置、
+dtype、消息几何、graph 状态、主机/设备身份与精确 PG membership。
+
+这些证据不能证明端到端训练吞吐、SGLang 加载延迟、多机行为或某个生产
+策略必胜；汇总器不会自动选择或应用策略。

--- a/docs/zh/developer_guide/communication_timeline.md
+++ b/docs/zh/developer_guide/communication_timeline.md
@@ -1,0 +1,72 @@
+# Trainer 通信时间线
+
+slime 可以把训练与权重同步阶段写成低开销 JSONL 时间线。该功能默认关闭，不会改变 collective 顺序，也不会在训练路径中增加同步。
+
+使用每 rank 独立路径启用：
+
+```bash
+python train.py \
+  ... \
+  --communication-timeline /path/to/traces/slime-{role}-{rank}.jsonl
+```
+
+也可以设置等价环境变量 `SLIME_COMMUNICATION_TIMELINE`。路径支持 `{rank}`、`{trainer_rank}`、`{local_rank}`、`{pid}`、`{hostname}`、`{role}` 和 `{world_size}`。多 rank 运行若没有 rank 占位符，slime 会自动追加 `.rank-N`；省略 `{role}` 时，actor、critic 与磁盘同步 orchestrator 也会自动使用独立后缀。该机制适用于任意 world size，不依赖特定 rank 拓扑。slime 会为同一 actor group 生成共享 `run_id`；也可通过 `--communication-timeline-run-id` 或 `SLIME_COMMUNICATION_TIMELINE_RUN_ID` 显式指定。
+
+## 内置阶段
+
+trainer 会记录：
+
+- `train_forward_backward`：Megatron forward/backward schedule；
+- `grad_sync`：Megatron 最终梯度同步回调；
+- `optimizer_step`；
+- `weight_convert`：生成每个 HF 权重 bucket 的工作；
+- `weight_bucket_ready` 与 `weight_bucket_send`；
+- `engine_bucket_receive`：trainer 侧观察到传输完成的边界；
+- `engine_load_weights`：等待 engine 更新请求返回的时间；
+- `weight_sync_complete`。
+
+`engine_bucket_receive` 是 trainer 侧观测，不是 engine 内部时间戳；记录中的 `observation` metadata 会说明它对应的具体边界。
+
+每条记录都有 `global_step`、`rollout_id`、`weight_version`、`bucket_id`、`trainer_rank`、`engine_id`、`message_bytes` 和 `transport` 等共享字段。不适用的字段为 `null`。`sequence_id` 在进程内单调递增，`logical_operation_id` 则由当前可用的生命周期 ID 与操作名组合而成。
+
+CUDA span 在框架当前 stream 上记录 event。正常运行中只做非阻塞查询，在进程退出时才排空尚未完成的 event。schema v2 用 `gpu_timestamp_semantics="event-bracket"`、`timestamp_domain="process-realtime-projected-cuda-event"` 和 `clock_sync_error_bound_us=null` 显式标注时间来源。投影后的 GPU 区间表示框架操作可执行到观测完成的边界，并不宣称等于 ProcessGroupNCCL 内部 stream 上 NCCL kernel 的精确起点；各进程 realtime clock 也没有经过测量的跨 rank 误差上界。每个 span 同时生成名为 `slime.comm/<operation>` 的 NVTX range，可在 Nsight Systems 中精确关联 kernel。
+
+自动通信策略不得直接使用这些 event-bracket 时间戳进行选择或执行；在 adapter 为每个参与 rank 提供 kernel-observed 时间戳和实测时钟同步误差上界之前，策略消费者必须 fail closed。内置时间线仍可用于生命周期诊断，以及通过 NVTX range 与精确 profiler trace 做关联。
+
+未配置 timeline 时，公开 helper 会复用同一个 no-op phase，不读取时钟、不导入 torch、不分配 CUDA event、不 push NVTX、不扫描 bucket tensor 大小、不更新 context variable、不序列化 JSON、不打开文件，也不做同步。host-only、CUDA-event 和外部 profiler 三种开销必须分别测量；带 profiler 的样本不得混入不带 profiler 的吞吐对比。
+
+## 从自定义代码补充语义阶段
+
+### wave/credit 集成路径
+
+集成后的 distributed/colocated updater 会让发送 span 跨越异步 API 返回，
+持续到传输完成边界。`mark_api_return()` 仅关闭 API/NVTX range，保留待完成
+的 GPU event bracket，避免多个 bucket 的异步提交造成 NVTX 栈错误嵌套。
+engine load ACK 等待单独记录为 trainer-side span；CUDA IPC 在 ACK 前不
+臆造传输完成。wave ID 保留在 metadata，并加入 logical operation ID，不
+冒充新 bucket。
+
+`weight_bucket_reusable` 跟随实际 credit/资源释放，`weight_sync_complete`
+跟随最终版本 commit；失败则记录 `weight_sync_failed`，未完成 span 标记
+error。转换迭代器耗尽时取消的末尾 probe 会使全局 trace sequence 出现空洞，
+它不是 communicator sequence ID。启用/关闭 timeline 的 CPU 组合测试覆盖
+2/4 个逻辑 engine group，但不代表完整 Ray/SGLang GPU 或 engine 内核验证。
+
+slime 不会修改 Megatron 内部 MoE 实现。自定义 Megatron hook 或 plugin 可以直接按同一 schema 补充 `ep_dispatch` 与 `ep_combine`：
+
+```python
+from slime.observability.communication_timeline import communication_context, communication_phase
+
+with communication_context(global_step=step, rollout_id=rollout_id):
+    with communication_phase(
+        "ep_dispatch",
+        message_bytes=dispatch_bytes,
+        transport="nccl",
+        layer=layer_id,
+    ):
+        dispatch_tokens()
+```
+
+瞬时边界使用 `communication_event(...)`；观察到第一个 consumer 时，可对 `communication_phase(...)` 返回的对象调用 `mark_consumer()`。
+
+这条时间线面向进程级训练/通信阶段，与按 sample 展示的 [Trace Viewer](./trace.md) 互补。kernel 级分析请把 NVTX range 与[性能分析](./profiling.md)结合使用。

--- a/docs/zh/get_started/customization.md
+++ b/docs/zh/get_started/customization.md
@@ -489,11 +489,27 @@ full tensor/NCCL 权重同步可以同时推进多个已转换的 bucket，而�
 两个参数默认都是 `0`，因此默认仍走原有的逐 bucket 阻塞路径；设置任意一个即可启用窗口。
 逻辑 bucket 只统计一份字节，不会按 rollout engine fan-out 重复计数；colocated 更新会取所有
 trainer rank 中最大的本地 bucket 大小，确保每个 rank 在相同的 collective 边界 flush。bucket
-始终按 FIFO 顺序完成和归还 credit，并且一个 weight version 必须完全 drain 后才能 commit。
+始终按 FIFO 顺序完成和归还 credit，并且一个 weight version 只有在窗口完全 drain、后处理完成、
+rollout consumer 恢复之后才能 commit。
 如果单个 bucket 已经大于配置的字节上限，slime 会直接报错，而不是无限等待。
 
+byte credit 统计的是逻辑 bucket payload，不把 allocator 或 transport 产生的副本混为同一数值。
+slime 会在 `perf/update_weights_*` 下分别记录各 rank 的逻辑在飞字节、transport outstanding 字节、
+IPC staging resident 字节和待 consumer 对象数的峰值。colocated flattened IPC buffer 可能让 staging
+驻留量大于逻辑 byte credit，因此这些量必须分开解释；它们是观测指标，不是新增的 admission budget。
+staging residency 只统计 producer 明确持有的 staging tensor 对象，不估算 allocator fragmentation，
+也不把 producer 丢弃引用后的 CUDA IPC limbo 伪装成已测量值。`perf/update_weights_sync_seconds` 使用同一
+控制端时钟，测量从同步开始到所有目标 consumer 完成加载、
+后处理结束且 generation 恢复的时间。
+
+在 colocated engine 既有的 Gloo TP group 内，source rank 会先把 Ray load acknowledgement 传播给所有
+成员，然后各 rank 才归还对应 credit；这里不会增加全局 CUDA synchronize。加载失败会 poison 当前
+version，使其不能 commit 或复用，actor group 必须走框架原有的 abort/restart 路径；进程丢失不会被
+伪装成成功 consensus。
+
 credit 窗口覆盖 distributed 和 colocated 更新中的普通 full-weight bucket。显式路由的 expert
-传输为了安全复用 staging buffer，仍保持串行，但其 bucket 大小仍受 byte credit 检查。
+传输为了安全复用 staging buffer，仍保持串行，但其 bucket 大小仍受 byte credit 检查，且复用的
+staging pool 会计入 staging-residency 指标。
 disk 和 delta transport 没有内存在飞 bucket 数据面，因此非零 credit 配置会被拒绝。
 
 ## 自定义函数路径的测试

--- a/docs/zh/get_started/customization.md
+++ b/docs/zh/get_started/customization.md
@@ -476,6 +476,26 @@ engine 读取之前，在每个训练 rank 上调用。用于在非 POSIX 共享
 `hook(source_dir: str, target_version: int)`——在 `/pull_weights` 读取已发布权重之前调用
 （例如刷新挂载视图）。完整机制见 [Delta 权重同步](../advanced/delta-weight-sync.md)。
 
+### 20. 权重同步在飞 Credit
+
+full tensor/NCCL 权重同步可以同时推进多个已转换的 bucket，而不必在每个 bucket 后立即等待。
+窗口由两个相互独立的上限控制：
+
+| 参数 | 含义 |
+| --- | --- |
+| `--update-weight-max-inflight-buckets` | 在飞逻辑 bucket 数量上限；`0` 表示不限制这个维度。 |
+| `--update-weight-max-inflight-bytes` | 在飞逻辑 bucket 总字节数上限；`0` 表示不限制这个维度。 |
+
+两个参数默认都是 `0`，因此默认仍走原有的逐 bucket 阻塞路径；设置任意一个即可启用窗口。
+逻辑 bucket 只统计一份字节，不会按 rollout engine fan-out 重复计数；colocated 更新会取所有
+trainer rank 中最大的本地 bucket 大小，确保每个 rank 在相同的 collective 边界 flush。bucket
+始终按 FIFO 顺序完成和归还 credit，并且一个 weight version 必须完全 drain 后才能 commit。
+如果单个 bucket 已经大于配置的字节上限，slime 会直接报错，而不是无限等待。
+
+credit 窗口覆盖 distributed 和 colocated 更新中的普通 full-weight bucket。显式路由的 expert
+传输为了安全复用 staging buffer，仍保持串行，但其 bucket 大小仍受 byte credit 检查。
+disk 和 delta transport 没有内存在飞 bucket 数据面，因此非零 credit 配置会被拒绝。
+
 ## 自定义函数路径的测试
 
 slime 现在也提供了一组 CPU 契约测试，用于校验这些 customization 接口。测试会通过字符串形式的导入路径来动态加载组件，因此既能回归仓库内置 hook，也能验证用户通过和训练时完全相同的 CLI 参数传入的自定义实现。

--- a/docs/zh/index.rst
+++ b/docs/zh/index.rst
@@ -84,6 +84,7 @@ slime 的设计目标，是让这两大能力彼此强化，同时避免把系�
    advanced/pd-disaggregation.md
    advanced/external-rollout-engines.md
    advanced/delta-weight-sync.md
+   advanced/weight-sync-wave-scheduling.md
    advanced/sglang-config.md
    advanced/megatron-config.md
    advanced/arch-support-beyond-megatron.md

--- a/docs/zh/index.rst
+++ b/docs/zh/index.rst
@@ -42,7 +42,7 @@ slime 的设计目标，是让这两大能力彼此强化，同时避免把系�
 - 使用 PD disaggregation：:doc:`advanced/pd-disaggregation`
 - 使用 BF16 训练 + FP8 rollout 或 FP8 KV cache：:doc:`advanced/low-precision`
 - 了解 CI 和可靠性覆盖：:doc:`developer_guide/ci`
-- 调试、trace 和 profiling 长时间任务：:doc:`developer_guide/debug`、:doc:`developer_guide/trace`、:doc:`developer_guide/profiling`
+- 调试、trace 和 profiling 长时间任务：:doc:`developer_guide/debug`、:doc:`developer_guide/trace`、:doc:`developer_guide/communication_timeline`、:doc:`developer_guide/profiling`
 
 .. toctree::
    :maxdepth: 1
@@ -107,6 +107,7 @@ slime 的设计目标，是让这两大能力彼此强化，同时避免把系�
    developer_guide/ci.md
    developer_guide/debug.md
    developer_guide/trace.md
+   developer_guide/communication_timeline.md
    developer_guide/profiling.md
 
 .. toctree::

--- a/slime/backends/megatron_utils/actor.py
+++ b/slime/backends/megatron_utils/actor.py
@@ -13,6 +13,7 @@ from torch_memory_saver import torch_memory_saver
 from transformers import AutoConfig, AutoTokenizer
 
 from slime.observability import train_data_utils, train_metric_utils
+from slime.observability.communication_timeline import communication_context, flush_communication_timeline
 from slime.observability.logging_utils import init_tracking
 from slime.observability.profile_utils import TrainProfiler
 from slime.observability.timer import Timer, inverse_timer, timer, with_defer
@@ -604,7 +605,8 @@ class MegatronTrainRayActor(TrainRayActor):
 
         with torch_memory_saver.disable() if self.args.offload_train else nullcontext():
             print_memory("before update_weights")
-            self.weight_updater.update_weights()
+            with communication_context(rollout_id=self._communication_rollout_id):
+                self.weight_updater.update_weights()
             print_memory("after update_weights")
 
             if getattr(self.args, "keep_old_actor", False):
@@ -622,6 +624,7 @@ class MegatronTrainRayActor(TrainRayActor):
             self.sleep()
         elif self.args.offload_train:
             destroy_process_groups()
+        flush_communication_timeline(block=getattr(self.args, "release_train", False))
 
     def load_other_checkpoint(self, model_tag: str, path: str) -> None:
         old_args = (

--- a/slime/backends/megatron_utils/model.py
+++ b/slime/backends/megatron_utils/model.py
@@ -29,6 +29,11 @@ try:
 except ImportError:
     from megatron.core.utils import unwrap_model
 from slime.observability import logging_utils, train_metric_utils
+from slime.observability.communication_timeline import (
+    communication_context,
+    communication_phase,
+    flush_communication_timeline,
+)
 from slime.utils.memory_utils import clear_memory
 
 from .checkpoint import load_checkpoint, save_checkpoint
@@ -38,6 +43,11 @@ from .model_provider import get_model_provider_func
 from .stateless_adam import StatelessAdam
 
 logger = logging.getLogger(__name__)
+
+
+def _finalize_model_grads_with_trace(*args, **kwargs):
+    with communication_phase("grad_sync"):
+        return finalize_model_grads(*args, **kwargs)
 
 
 def _disable_tqdm_for_non_main_rank() -> bool:
@@ -519,6 +529,7 @@ def train_one_step(
     opt_param_scheduler: OptimizerParamScheduler,
     num_microbatches: int,
     step_global_batch_size: int,
+    global_step: int,
     microbatch_pbar=None,
 ) -> tuple[dict[str, float], float]:
     """Execute a single pipeline-parallel training step.
@@ -542,6 +553,8 @@ def train_one_step(
             normalizer inside the closure and as the LR scheduler
             ``increment``. In the common case (1 rollout = 1 sample) this
             equals the per-step sample count, so behavior is unchanged.
+        global_step (int): Monotonic train-step identifier used by the
+            communication timeline.
 
     Returns:
         tuple[dict[str, float], float]: Reduced loss dictionary (last stage only)
@@ -645,16 +658,23 @@ def train_one_step(
 
     # Forward pass.
     forward_backward_func = get_forward_backward_func()
-    losses_reduced = forward_backward_func(
-        forward_step_func=_wrap_forward_step_with_microbatch_pbar(forward_step, microbatch_pbar),
-        data_iterator=data_iterator,
-        model=model,
-        num_microbatches=num_microbatches,
-        seq_length=args.seq_length,
-        micro_batch_size=args.micro_batch_size,
-        decoder_seq_length=args.decoder_seq_length,
-        forward_only=False,
-    )
+    trace_context = {
+        "global_step": global_step,
+        "rollout_id": rollout_id,
+        "trainer_rank": getattr(args, "rank", None),
+    }
+    with communication_context(**trace_context):
+        with communication_phase("train_forward_backward", microbatch_count=num_microbatches):
+            losses_reduced = forward_backward_func(
+                forward_step_func=_wrap_forward_step_with_microbatch_pbar(forward_step, microbatch_pbar),
+                data_iterator=data_iterator,
+                model=model,
+                num_microbatches=num_microbatches,
+                seq_length=args.seq_length,
+                micro_batch_size=args.micro_batch_size,
+                decoder_seq_length=args.decoder_seq_length,
+                forward_only=False,
+            )
 
     valid_step = True
     grad_norm = float("nan")
@@ -678,7 +698,9 @@ def train_one_step(
 
     if valid_step:
         # Update parameters.
-        update_successful, grad_norm, num_zeros_in_grad = optimizer.step()
+        with communication_context(**trace_context):
+            with communication_phase("optimizer_step"):
+                update_successful, grad_norm, num_zeros_in_grad = optimizer.step()
 
         # Update learning rate. Use the per-step global_batch_size when dynamic
         # batching is on so the scheduler's samples-seen counter tracks reality.
@@ -690,6 +712,7 @@ def train_one_step(
         model_chunk.zero_grad_buffer()
     optimizer.zero_grad()
 
+    flush_communication_timeline(block=False)
     if mpu.is_pipeline_last_stage(ignore_virtual=True):
         loss_reduced = train_metric_utils.reduce_train_step_metrics(
             losses_reduced,
@@ -769,7 +792,7 @@ def train(
         config.param_sync_func = [model_chunk.start_param_sync for model_chunk in model]
         if len(model) == 1:
             config.param_sync_func = config.param_sync_func[0]
-    config.finalize_model_grads_func = finalize_model_grads
+    config.finalize_model_grads_func = _finalize_model_grads_with_trace
 
     pre_hook_enabled = False
 
@@ -825,6 +848,7 @@ def train(
 
     # Run training iterations till done.
     for step_id in range(num_steps_per_rollout):
+        global_step = rollout_id * num_steps_per_rollout + step_id
 
         # Run training step.
         loss_dict, grad_norm = train_one_step(
@@ -837,6 +861,7 @@ def train(
             opt_param_scheduler,
             num_microbatches[step_id],
             global_batch_sizes[step_id],
+            global_step,
             microbatch_pbar=microbatch_pbar,
         )
 
@@ -876,7 +901,7 @@ def train(
             and mpu.get_tensor_model_parallel_rank() == 0
             and mpu.get_pipeline_model_parallel_rank() == mpu.get_pipeline_model_parallel_world_size() - 1
         ):
-            accumulated_step_id = rollout_id * num_steps_per_rollout + step_id
+            accumulated_step_id = global_step
             role = getattr(model[0], "role", "actor")
             role_tag = "" if role == "actor" else f"{role}-"
             log_dict = {

--- a/slime/backends/megatron_utils/update_weight/update_weight_from_disk.py
+++ b/slime/backends/megatron_utils/update_weight/update_weight_from_disk.py
@@ -9,6 +9,12 @@ import torch
 import torch.distributed as dist
 from ray.actor import ActorHandle
 
+from slime.observability.communication_timeline import (
+    communication_context,
+    communication_event,
+    communication_phase,
+    flush_communication_timeline,
+)
 from slime.utils.distributed_utils import get_gloo_group
 
 from ..hf_checkpoint_saver import save_hf_model_to_path
@@ -71,24 +77,29 @@ class UpdateWeightFromDisk:
             shutil.rmtree(version_dir, ignore_errors=True)
         dist.barrier(group=get_gloo_group())
 
-        # every writing rank creates the dir itself: a non-POSIX shared filesystem may not surface
-        # one rank's mkdir to another until commit
-        version_dir.mkdir(parents=True, exist_ok=True)
-        save_hf_model_to_path(
-            self.args,
-            version_dir,
-            self.model,
-            model_name=self.model_name,
-            quantization_config=self.quantization_config,
-            progress_desc="Save HF  weights for update from disk",
-        )
-        dist.barrier(group=get_gloo_group())
+        with communication_context(weight_version=self.weight_version, transport="disk"):
+            # every writing rank creates the dir itself: a non-POSIX shared filesystem may not surface
+            # one rank's mkdir to another until commit
+            version_dir.mkdir(parents=True, exist_ok=True)
+            with communication_phase("weight_convert", bucket_id=0):
+                save_hf_model_to_path(
+                    self.args,
+                    version_dir,
+                    self.model,
+                    model_name=self.model_name,
+                    quantization_config=self.quantization_config,
+                    progress_desc="Save HF  weights for update from disk",
+                )
+            dist.barrier(group=get_gloo_group())
+            communication_event("weight_bucket_ready", bucket_id=0)
 
-        # every rank runs the hook (it gates itself): each container must publish
-        # its own writes
-        if self._post_write_hook is not None:
-            self._post_write_hook(self.args, str(version_dir), list(self.rollout_engines))
-        dist.barrier(group=get_gloo_group())
+            # every rank runs the hook (it gates itself): each container must publish
+            # its own writes
+            with communication_phase("weight_bucket_send", bucket_id=0):
+                if self._post_write_hook is not None:
+                    self._post_write_hook(self.args, str(version_dir), list(self.rollout_engines))
+                dist.barrier(group=get_gloo_group())
+            flush_communication_timeline(block=False)
 
         # SGLang reload is orchestrated by RayTrainGroup after the checkpoint
         # is fully written, so training-side lifecycle can decide whether

--- a/slime/backends/megatron_utils/update_weight/update_weight_from_disk_delta.py
+++ b/slime/backends/megatron_utils/update_weight/update_weight_from_disk_delta.py
@@ -22,6 +22,7 @@ from ray.actor import ActorHandle
 from slime.utils import accelerator
 from slime.utils.disk_delta import NUM_WORKERS, checksum, make_tensor_reader, overwrite_encode
 from slime.utils.distributed_utils import get_gloo_group
+from slime.utils.engine_group_wave import run_engine_group_waves
 
 from .update_weight_from_distributed import UpdateWeightFromDistributed
 
@@ -107,7 +108,16 @@ class UpdateWeightFromDiskDelta(UpdateWeightFromDistributed):
             os.makedirs(self.delta_dir, exist_ok=True)
             if self._post_write_hook is not None:
                 self._post_write_hook(self.args, self.delta_dir, list(self.rollout_engines))
-            pulls = [engine.pull_weights.remote(target_version=0) for engine in self.rollout_engines]
+            max_inflight_engine_groups = getattr(self.args, "update_weight_max_inflight_engine_groups", 0)
+            if 0 < max_inflight_engine_groups < len(self.rollout_engines):
+                run_engine_group_waves(
+                    self.rollout_engines,
+                    max_inflight_engine_groups,
+                    lambda _index, engine: engine.pull_weights.remote(target_version=0),
+                    ray.get,
+                )
+            else:
+                pulls = [engine.pull_weights.remote(target_version=0) for engine in self.rollout_engines]
         dist.barrier(group=get_gloo_group())
 
         read_hf = make_tensor_reader(self.args.hf_checkpoint)  # index the HF headers once
@@ -118,7 +128,8 @@ class UpdateWeightFromDiskDelta(UpdateWeightFromDistributed):
                 self._snapshot[name] = tensor.detach().cpu().contiguous().view(torch.uint8).numpy().reshape(-1)
                 logger.warning("seed: %s absent from hf_checkpoint; seeding from current weights", name)
         if dist.get_rank() == 0:
-            ray.get(pulls)
+            if pulls:
+                ray.get(pulls)
             logger.info(
                 "[disk delta] captured baseline snapshot of %d tensors from %s",
                 len(self._snapshot),
@@ -175,17 +186,23 @@ class UpdateWeightFromDiskDelta(UpdateWeightFromDistributed):
             self._post_write_hook(self.args, self._version_dir, list(self.rollout_engines))
         dist.barrier(group=get_gloo_group())
         if dist.get_rank() == 0:
-            ray.get([engine.pull_weights.remote(self.weight_version) for engine in self.rollout_engines])
+            max_inflight_engine_groups = getattr(self.args, "update_weight_max_inflight_engine_groups", 0)
+            run_engine_group_waves(
+                self.rollout_engines,
+                max_inflight_engine_groups,
+                lambda _index, engine: engine.pull_weights.remote(self.weight_version),
+                ray.get,
+            )
             ray.get([engine.pause_generation.remote() for engine in self.rollout_engines])
             ray.get([engine.flush_cache.remote() for engine in self.rollout_engines])
-            ray.get(
-                [
-                    engine.update_weights_from_disk.remote(
-                        model_path=self.args.update_weight_local_checkpoint_dir,
-                        weight_version=str(self.weight_version),
-                    )
-                    for engine in self.rollout_engines
-                ]
+            run_engine_group_waves(
+                self.rollout_engines,
+                max_inflight_engine_groups,
+                lambda _index, engine: engine.update_weights_from_disk.remote(
+                    model_path=self.args.update_weight_local_checkpoint_dir,
+                    weight_version=str(self.weight_version),
+                ),
+                ray.get,
             )
             ray.get([engine.continue_generation.remote() for engine in self.rollout_engines])
         dist.barrier(group=get_gloo_group())

--- a/slime/backends/megatron_utils/update_weight/update_weight_from_disk_delta.py
+++ b/slime/backends/megatron_utils/update_weight/update_weight_from_disk_delta.py
@@ -19,6 +19,12 @@ import zstandard
 from megatron.core import mpu
 from ray.actor import ActorHandle
 
+from slime.observability.communication_timeline import (
+    communication_context,
+    communication_event,
+    communication_phase,
+    flush_communication_timeline,
+)
 from slime.utils import accelerator
 from slime.utils.disk_delta import NUM_WORKERS, checksum, make_tensor_reader, overwrite_encode
 from slime.utils.distributed_utils import get_gloo_group
@@ -85,14 +91,20 @@ class UpdateWeightFromDiskDelta(UpdateWeightFromDistributed):
     def update_weights(self) -> None:
         # The first call only captures the baseline snapshot the next sync diffs against.
         if not self._baseline_captured:
-            self._capture_baseline()
+            with communication_context(weight_version=0, transport="disk_delta"):
+                with communication_phase("weight_convert", bucket_id=0, baseline_snapshot=True):
+                    self._capture_baseline()
+                flush_communication_timeline(block=False)
             self._baseline_captured = True
             return
 
         self.weight_version += 1
-        self._publish()
-        self._reload_engines()
-        self._record_metrics()
+        with communication_context(weight_version=self.weight_version, transport="disk_delta"):
+            self._publish()
+            self._reload_engines()
+            self._record_metrics()
+            communication_event("weight_sync_complete")
+            flush_communication_timeline(block=False)
 
     def _capture_baseline(self) -> None:
         """Capture the baseline snapshot the first delta diffs against (no publish), and clear any
@@ -138,9 +150,14 @@ class UpdateWeightFromDiskDelta(UpdateWeightFromDistributed):
 
     def _publish(self) -> None:
         """Encode this version's changed tensors (PP-src ranks), then write it as a canonical HF dir."""
-        self._encode_delta()
-        dist.barrier(group=get_gloo_group())
-        self._write_delta_files()
+        with communication_phase("weight_convert", bucket_id=0) as phase:
+            self._encode_delta()
+            phase.update(message_bytes=self.total_bytes, changed_bytes=self.changed_bytes)
+        communication_event("weight_bucket_ready", bucket_id=0, message_bytes=self.changed_bytes)
+        with communication_phase("weight_bucket_send", bucket_id=0, message_bytes=self.changed_bytes) as phase:
+            dist.barrier(group=get_gloo_group())
+            self._write_delta_files()
+            phase.update(wire_bytes=self.wire_bytes)
 
     def _write_delta_files(self) -> None:
         """Write this rank's changed tensors as one canonical model-NNNNN.safetensors, and on rank
@@ -187,23 +204,36 @@ class UpdateWeightFromDiskDelta(UpdateWeightFromDistributed):
         dist.barrier(group=get_gloo_group())
         if dist.get_rank() == 0:
             max_inflight_engine_groups = getattr(self.args, "update_weight_max_inflight_engine_groups", 0)
-            run_engine_group_waves(
-                self.rollout_engines,
-                max_inflight_engine_groups,
-                lambda _index, engine: engine.pull_weights.remote(self.weight_version),
-                ray.get,
-            )
+            shared_fields = {
+                "bucket_id": 0,
+                "message_bytes": self.wire_bytes,
+                "engine_count": len(self.rollout_engines),
+            }
+            with communication_phase(
+                "engine_bucket_receive",
+                observation="trainer_pull_request_complete",
+                **shared_fields,
+            ) as phase:
+                run_engine_group_waves(
+                    self.rollout_engines,
+                    max_inflight_engine_groups,
+                    lambda _index, engine: engine.pull_weights.remote(self.weight_version),
+                    ray.get,
+                )
+                phase.mark_consumer()
             ray.get([engine.pause_generation.remote() for engine in self.rollout_engines])
             ray.get([engine.flush_cache.remote() for engine in self.rollout_engines])
-            run_engine_group_waves(
-                self.rollout_engines,
-                max_inflight_engine_groups,
-                lambda _index, engine: engine.update_weights_from_disk.remote(
-                    model_path=self.args.update_weight_local_checkpoint_dir,
-                    weight_version=str(self.weight_version),
-                ),
-                ray.get,
-            )
+            with communication_phase("engine_load_weights", **shared_fields) as phase:
+                run_engine_group_waves(
+                    self.rollout_engines,
+                    max_inflight_engine_groups,
+                    lambda _index, engine: engine.update_weights_from_disk.remote(
+                        model_path=self.args.update_weight_local_checkpoint_dir,
+                        weight_version=str(self.weight_version),
+                    ),
+                    ray.get,
+                )
+                phase.mark_consumer()
             ray.get([engine.continue_generation.remote() for engine in self.rollout_engines])
         dist.barrier(group=get_gloo_group())
 

--- a/slime/backends/megatron_utils/update_weight/update_weight_from_distributed.py
+++ b/slime/backends/megatron_utils/update_weight/update_weight_from_distributed.py
@@ -109,6 +109,7 @@ class UpdateWeightFromDistributed:
         """
         Pause → flush → _send_weights → continue. Progress on PP source.
         """
+        sync_started = time.perf_counter()
         self.weight_version += 1
 
         if dist.get_rank() == 0:
@@ -126,19 +127,28 @@ class UpdateWeightFromDistributed:
 
         pbar = tqdm(desc=f"[{self._group_name}] Update weights", total=0) if self._is_pp_src_rank else None
         self._weight_sync_credit.begin_version(self.weight_version)
-        self._send_weights(pbar)
-        self._weight_sync_credit.commit_version(self.weight_version)
+        try:
+            self._send_weights(pbar)
 
-        if dist.get_rank() == 0:
-            # int4/fp4 post_process
-            if self.quantization_config and self.quantization_config["quant_method"] in ["compressed-tensors"]:
-                post_process_weights(
-                    restore_weights_before_load=False,
-                    post_process_quantization=True,
-                    rollout_engines=self.rollout_engines,
-                )
-            ray.get([engine.continue_generation.remote() for engine in self.rollout_engines])
-        dist.barrier(group=get_gloo_group())
+            if dist.get_rank() == 0:
+                # int4/fp4 post_process
+                if self.quantization_config and self.quantization_config["quant_method"] in ["compressed-tensors"]:
+                    post_process_weights(
+                        restore_weights_before_load=False,
+                        post_process_quantization=True,
+                        rollout_engines=self.rollout_engines,
+                    )
+                ray.get([engine.continue_generation.remote() for engine in self.rollout_engines])
+            dist.barrier(group=get_gloo_group())
+        except BaseException as error:
+            self._weight_sync_credit.fail_version(self.weight_version, error)
+            raise
+
+        # A version is committed only after all bucket resources are drained,
+        # post-processing has completed, and consumers have resumed.
+        self._weight_sync_credit.commit_version(self.weight_version)
+        self.update_weight_metrics.update(self._weight_sync_credit.metrics())
+        self.update_weight_metrics["perf/update_weights_sync_seconds"] = time.perf_counter() - sync_started
 
     def _send_weights(self, pbar: tqdm | None) -> None:
         """
@@ -153,8 +163,7 @@ class UpdateWeightFromDistributed:
                 for hf_chunk in chunk_iter:
                     self._on_chunk(hf_chunk)
                     reservation = self._reserve_weight_bucket(hf_chunk)
-                    self._update_bucket_weights_from_distributed(hf_chunk, pbar=pbar)
-                    self._weight_sync_credit.release(reservation)
+                    self._update_bucket_weights_from_distributed(hf_chunk, reservation, pbar=pbar)
             dist.barrier(group=get_gloo_group())
 
     def _reserve_weight_bucket(self, hf_chunk: Sequence[tuple[str, torch.Tensor]]) -> WeightBucketReservation:
@@ -213,13 +222,24 @@ class UpdateWeightFromDistributed:
                     self.rollout_engines,
                     converted_named_tensors,
                 )
+                self._weight_sync_credit.mark_launched(
+                    reservation,
+                    transport_bytes=reservation.bucket_bytes if handles else 0,
+                    staging_bytes=0,
+                    consumer_objects=len(refs),
+                )
                 launched.append((reservation, converted_named_tensors, refs, handles))
 
-            for reservation, converted_named_tensors, refs, handles in launched:
+            while launched:
+                reservation, converted_named_tensors, refs, handles = launched.pop(0)
                 for handle in handles:
                     handle.wait()
+                self._weight_sync_credit.mark_transport_complete(reservation)
                 ray.get(refs)
+                self._weight_sync_credit.mark_consumers_complete(reservation)
                 converted_named_tensors.clear()
+                del converted_named_tensors, refs, handles
+                self._weight_sync_credit.mark_staging_released(reservation)
                 self._weight_sync_credit.release(reservation)
                 if pbar is not None:
                     pbar.update(1)
@@ -321,6 +341,7 @@ class UpdateWeightFromDistributed:
     def _update_bucket_weights_from_distributed(
         self,
         converted_named_tensors: list[tuple[str, torch.Tensor]],
+        reservation: WeightBucketReservation,
         pbar: tqdm | None = None,
         load_format: str | None = None,
     ) -> None:
@@ -331,19 +352,33 @@ class UpdateWeightFromDistributed:
         while not ray.get(self.rollout_engine_lock.acquire.remote()):
             time.sleep(0.1)
 
-        refs = update_weights_from_distributed(
-            self._group_name,
-            self._model_update_groups,
-            self.weight_version,
-            self.rollout_engines,
-            converted_named_tensors,
-            load_format=load_format,
-        )
-
-        ray.get(refs)
-        converted_named_tensors.clear()
-        ray.get(self.rollout_engine_lock.release.remote())
-        pbar.update(1)
+        try:
+            refs, handles = launch_weights_from_distributed(
+                self._group_name,
+                self._model_update_groups,
+                self.weight_version,
+                self.rollout_engines,
+                converted_named_tensors,
+                load_format=load_format,
+            )
+            self._weight_sync_credit.mark_launched(
+                reservation,
+                transport_bytes=reservation.bucket_bytes if handles else 0,
+                staging_bytes=0,
+                consumer_objects=len(refs),
+            )
+            for handle in handles:
+                handle.wait()
+            self._weight_sync_credit.mark_transport_complete(reservation)
+            ray.get(refs)
+            self._weight_sync_credit.mark_consumers_complete(reservation)
+            converted_named_tensors.clear()
+            self._weight_sync_credit.mark_staging_released(reservation)
+            self._weight_sync_credit.release(reservation)
+        finally:
+            ray.get(self.rollout_engine_lock.release.remote())
+        if pbar is not None:
+            pbar.update(1)
 
 
 def connect_rollout_engines_from_distributed(

--- a/slime/backends/megatron_utils/update_weight/update_weight_from_distributed.py
+++ b/slime/backends/megatron_utils/update_weight/update_weight_from_distributed.py
@@ -4,6 +4,7 @@ import socket
 import time
 from argparse import Namespace
 from collections.abc import Callable, Iterator, Mapping, Sequence
+from dataclasses import dataclass
 from typing import Any
 
 import ray
@@ -16,11 +17,22 @@ from tqdm import tqdm
 
 from slime.utils import accelerator
 from slime.utils.distributed_utils import get_gloo_group, init_process_group
+from slime.utils.engine_group_wave import build_engine_group_waves, run_engine_group_waves
 from slime.utils.http_utils import _wrap_ipv6
 
 from ..megatron_to_hf import convert_to_hf
 from .common import all_gather_param, named_params_and_buffers
 from .weight_sync_credit import WeightBucketReservation, WeightSyncCreditController
+
+
+@dataclass(frozen=True)
+class DistributedWeightUpdateGroup:
+    """One trainer process group and the rollout engines that join it."""
+
+    engine_indices: tuple[int, ...]
+    group_name: str
+    process_group: dist.ProcessGroup
+    rollout_engines: tuple[ActorHandle, ...]
 
 
 class UpdateWeightFromDistributed:
@@ -47,7 +59,7 @@ class UpdateWeightFromDistributed:
         self.model_name = model_name
         self.quantization_config = quantization_config
         self.weight_version = 0
-        self._model_update_groups = None
+        self._model_update_groups: list[DistributedWeightUpdateGroup] = []
         self.update_weight_metrics: dict[str, float] = {}
         self._weight_sync_credit = WeightSyncCreditController(
             max_inflight_buckets=getattr(args, "update_weight_max_inflight_buckets", 0),
@@ -87,22 +99,21 @@ class UpdateWeightFromDistributed:
             self._group_name = f"slime-pp_{pp_rank}"
 
         if self._is_pp_src_rank:
-            if self._model_update_groups is not None:
-                disconnect_rollout_engines_from_distributed(
-                    self._group_name, self._model_update_groups, self.rollout_engines
-                )
-            self._model_update_groups = connect_rollout_engines_from_distributed(
+            if self._model_update_groups:
+                disconnect_rollout_engine_groups_from_distributed(self._model_update_groups)
+            self._model_update_groups = connect_rollout_engine_groups_from_distributed(
                 self.args,
                 self._group_name,
                 rollout_engines,
                 engine_gpu_counts=engine_gpu_counts,
+                max_inflight_engine_groups=getattr(self.args, "update_weight_max_inflight_engine_groups", 0),
             )
 
     def disconnect_rollout_engines(self) -> None:
-        if not getattr(self, "_is_pp_src_rank", False) or self._model_update_groups is None:
+        if not getattr(self, "_is_pp_src_rank", False) or not self._model_update_groups:
             return
-        disconnect_rollout_engines_from_distributed(self._group_name, self._model_update_groups, self.rollout_engines)
-        self._model_update_groups = None
+        disconnect_rollout_engine_groups_from_distributed(self._model_update_groups)
+        self._model_update_groups = []
 
     @torch.no_grad()
     def update_weights(self) -> None:
@@ -122,6 +133,7 @@ class UpdateWeightFromDistributed:
                     restore_weights_before_load=True,
                     post_process_quantization=False,
                     rollout_engines=self.rollout_engines,
+                    max_inflight_engine_groups=getattr(self.args, "update_weight_max_inflight_engine_groups", 0),
                 )
         dist.barrier(group=get_gloo_group())
 
@@ -137,6 +149,7 @@ class UpdateWeightFromDistributed:
                         restore_weights_before_load=False,
                         post_process_quantization=True,
                         rollout_engines=self.rollout_engines,
+                        max_inflight_engine_groups=getattr(self.args, "update_weight_max_inflight_engine_groups", 0),
                     )
                 ray.get([engine.continue_generation.remote() for engine in self.rollout_engines])
             dist.barrier(group=get_gloo_group())
@@ -202,6 +215,13 @@ class UpdateWeightFromDistributed:
         pending: Sequence[tuple[WeightBucketReservation, list[tuple[str, torch.Tensor]]]],
         pbar: tqdm | None,
     ) -> None:
+        if len(self._model_update_groups) > 1:
+            # Logical reservations remain bounded across the buffered window.
+            # Drain all waves of a bucket before another bucket starts, so the
+            # engine-group cap is global rather than multiplied by bucket count.
+            for reservation, tensors in pending:
+                self._update_bucket_weights_from_distributed(tensors, reservation, pbar=pbar)
+            return
         while not ray.get(self.rollout_engine_lock.acquire.remote()):
             time.sleep(0.1)
 
@@ -215,11 +235,12 @@ class UpdateWeightFromDistributed:
         ] = []
         try:
             for reservation, converted_named_tensors in pending:
+                update_group = self._model_update_groups[0]
                 refs, handles = launch_weights_from_distributed(
-                    self._group_name,
-                    self._model_update_groups,
+                    update_group.group_name,
+                    update_group.process_group,
                     self.weight_version,
-                    self.rollout_engines,
+                    update_group.rollout_engines,
                     converted_named_tensors,
                 )
                 self._weight_sync_credit.mark_launched(
@@ -234,6 +255,7 @@ class UpdateWeightFromDistributed:
                 reservation, converted_named_tensors, refs, handles = launched.pop(0)
                 for handle in handles:
                     handle.wait()
+                synchronize_weight_transfer(converted_named_tensors)
                 self._weight_sync_credit.mark_transport_complete(reservation)
                 ray.get(refs)
                 self._weight_sync_credit.mark_consumers_complete(reservation)
@@ -352,26 +374,30 @@ class UpdateWeightFromDistributed:
         while not ray.get(self.rollout_engine_lock.acquire.remote()):
             time.sleep(0.1)
 
-        try:
-            refs, handles = launch_weights_from_distributed(
-                self._group_name,
-                self._model_update_groups,
-                self.weight_version,
-                self.rollout_engines,
-                converted_named_tensors,
-                load_format=load_format,
-            )
-            self._weight_sync_credit.mark_launched(
+        def observe_wave_launch(refs, handles, group_count):
+            # Keep strong references on the poisoned updater if a consumer
+            # fails; remaining engine loads may still reference this buffer.
+            self._active_wave_resources = (converted_named_tensors, refs, handles)
+            self._weight_sync_credit.mark_next_wave(
                 reservation,
-                transport_bytes=reservation.bucket_bytes if handles else 0,
+                transport_bytes=reservation.bucket_bytes * group_count if handles else 0,
                 staging_bytes=0,
                 consumer_objects=len(refs),
             )
-            for handle in handles:
-                handle.wait()
-            self._weight_sync_credit.mark_transport_complete(reservation)
-            ray.get(refs)
-            self._weight_sync_credit.mark_consumers_complete(reservation)
+
+        try:
+            self._weight_sync_credit.mark_launched(reservation, transport_bytes=0, staging_bytes=0, consumer_objects=0)
+            update_weights_in_engine_group_waves(
+                self._model_update_groups,
+                self.weight_version,
+                converted_named_tensors,
+                max_inflight_engine_groups=getattr(self.args, "update_weight_max_inflight_engine_groups", 0),
+                load_format=load_format,
+                on_wave_launched=observe_wave_launch,
+                on_transport_complete=lambda: self._weight_sync_credit.mark_transport_complete(reservation),
+                on_consumers_complete=lambda: self._weight_sync_credit.mark_consumers_complete(reservation),
+            )
+            self._active_wave_resources = None
             converted_named_tensors.clear()
             self._weight_sync_credit.mark_staging_released(reservation)
             self._weight_sync_credit.release(reservation)
@@ -431,6 +457,82 @@ def connect_rollout_engines_from_distributed(
     return model_update_groups
 
 
+def connect_rollout_engine_groups_from_distributed(
+    args: Namespace,
+    group_name: str,
+    rollout_engines: Sequence[ActorHandle],
+    engine_gpu_counts: Sequence[int] | None = None,
+    *,
+    max_inflight_engine_groups: int = 0,
+    total_engine_groups: int | None = None,
+    engine_index_offset: int = 0,
+) -> list[DistributedWeightUpdateGroup]:
+    """Create aggregate or per-engine process groups for weight-update waves.
+
+    The aggregate group preserves the existing data path when every engine may
+    run together. A bounded policy needs one process group per logical engine;
+    otherwise an aggregate NCCL broadcast would still require every engine to
+    enter the collective at once and could not be admitted in waves.
+    """
+    if engine_gpu_counts is None:
+        engine_gpu_counts = [args.rollout_num_gpus_per_engine] * len(rollout_engines)
+    if len(engine_gpu_counts) != len(rollout_engines):
+        raise ValueError("engine_gpu_counts must have one entry per rollout engine")
+    if any(gpu_count <= 0 for gpu_count in engine_gpu_counts):
+        raise ValueError("engine GPU counts must be positive")
+    if max_inflight_engine_groups < 0:
+        raise ValueError("max_inflight_engine_groups must be non-negative")
+    if not rollout_engines:
+        return []
+
+    total = total_engine_groups if total_engine_groups is not None else len(rollout_engines)
+    if total < len(rollout_engines):
+        raise ValueError("total_engine_groups cannot be smaller than the distributed engine count")
+    if engine_index_offset < 0 or engine_index_offset + len(rollout_engines) > total:
+        raise ValueError("distributed engine indices must fit within total_engine_groups")
+    use_waves = 0 < max_inflight_engine_groups < total
+
+    if not use_waves:
+        process_group = connect_rollout_engines_from_distributed(
+            args,
+            group_name,
+            rollout_engines,
+            engine_gpu_counts=engine_gpu_counts,
+        )
+        return [
+            DistributedWeightUpdateGroup(
+                engine_indices=tuple(range(engine_index_offset, engine_index_offset + len(rollout_engines))),
+                group_name=group_name,
+                process_group=process_group,
+                rollout_engines=tuple(rollout_engines),
+            )
+        ]
+
+    update_groups = []
+    try:
+        for local_index, (engine, gpu_count) in enumerate(zip(rollout_engines, engine_gpu_counts, strict=True)):
+            engine_index = engine_index_offset + local_index
+            engine_group_name = f"{group_name}-engine-{engine_index}"
+            process_group = connect_rollout_engines_from_distributed(
+                args,
+                engine_group_name,
+                [engine],
+                engine_gpu_counts=[gpu_count],
+            )
+            update_groups.append(
+                DistributedWeightUpdateGroup(
+                    engine_indices=(engine_index,),
+                    group_name=engine_group_name,
+                    process_group=process_group,
+                    rollout_engines=(engine,),
+                )
+            )
+    except Exception:
+        disconnect_rollout_engine_groups_from_distributed(update_groups)
+        raise
+    return update_groups
+
+
 def disconnect_rollout_engines_from_distributed(group_name, model_update_groups, rollout_engines):
     """
     Destroy the weight-update process group on training and engines.
@@ -438,6 +540,42 @@ def disconnect_rollout_engines_from_distributed(group_name, model_update_groups,
     refs = [engine.destroy_weights_update_group.remote(group_name) for engine in rollout_engines]
     dist.destroy_process_group(model_update_groups)
     ray.get(refs)
+
+
+def disconnect_rollout_engine_groups_from_distributed(
+    update_groups: Sequence[DistributedWeightUpdateGroup],
+) -> None:
+    """Destroy all process groups created for aggregate or waved updates."""
+    for update_group in update_groups:
+        disconnect_rollout_engines_from_distributed(
+            update_group.group_name,
+            update_group.process_group,
+            update_group.rollout_engines,
+        )
+
+
+def launch_weights_from_distributed(
+    group_name: str,
+    group: dist.ProcessGroup,
+    weight_version: int,
+    rollout_engines: Sequence[ActorHandle],
+    converted_named_tensors: Sequence[tuple[str, torch.Tensor]],
+    load_format: str | None = None,
+) -> tuple[list[ObjectRef], list[dist.Work]]:
+    """Launch engine receives and broadcasts without waiting for completion."""
+    refs = [
+        engine.update_weights_from_distributed.remote(
+            names=[name for name, _ in converted_named_tensors],
+            dtypes=[param.dtype for _, param in converted_named_tensors],
+            shapes=[param.shape for _, param in converted_named_tensors],
+            group_name=group_name,
+            weight_version=str(weight_version),
+            load_format=load_format,
+        )
+        for engine in rollout_engines
+    ]
+    handles = [dist.broadcast(param.data, 0, group=group, async_op=True) for _, param in converted_named_tensors]
+    return refs, handles
 
 
 def update_weights_from_distributed(
@@ -464,46 +602,69 @@ def update_weights_from_distributed(
     return refs
 
 
-def launch_weights_from_distributed(
-    group_name: str,
-    group: dist.ProcessGroup,
+def synchronize_weight_transfer(converted_named_tensors: Sequence[tuple[str, torch.Tensor]]) -> None:
+    """Fence the stream dependency inserted by Work.wait before releasing credit."""
+    if any(getattr(getattr(tensor, "device", None), "type", "cpu") != "cpu" for _, tensor in converted_named_tensors):
+        accelerator.current_stream().synchronize()
+
+
+def update_weights_in_engine_group_waves(
+    update_groups: Sequence[DistributedWeightUpdateGroup],
     weight_version: int,
-    rollout_engines: Sequence[ActorHandle],
     converted_named_tensors: Sequence[tuple[str, torch.Tensor]],
+    *,
+    max_inflight_engine_groups: int,
     load_format: str | None = None,
-) -> tuple[list[ObjectRef], list[Any]]:
-    """Launch one bucket without waiting for its device collectives."""
-    refs = [
-        engine.update_weights_from_distributed.remote(
-            names=[name for name, _ in converted_named_tensors],
-            dtypes=[param.dtype for _, param in converted_named_tensors],
-            shapes=[param.shape for _, param in converted_named_tensors],
-            group_name=group_name,
-            weight_version=str(weight_version),
-            load_format=load_format,
-        )
-        for engine in rollout_engines
-    ]
-    handles = []
-    for _, param in converted_named_tensors:
-        handles.append(dist.broadcast(param.data, 0, group=group, async_op=True))
-    return refs, handles
+    on_wave_launched: Callable[[Sequence[ObjectRef], Sequence[Any], int], None] | None = None,
+    on_transport_complete: Callable[[], None] | None = None,
+    on_consumers_complete: Callable[[], None] | None = None,
+) -> list[ObjectRef]:
+    """Transfer one bucket to bounded waves of independent engine groups."""
+    all_refs = []
+    for wave in build_engine_group_waves(update_groups, max_inflight_engine_groups):
+        wave_refs = []
+        wave_handles = []
+        for _index, update_group in wave:
+            refs, handles = launch_weights_from_distributed(
+                update_group.group_name,
+                update_group.process_group,
+                weight_version,
+                update_group.rollout_engines,
+                converted_named_tensors,
+                load_format=load_format,
+            )
+            wave_refs.extend(refs)
+            wave_handles.extend(handles)
+        if on_wave_launched is not None:
+            on_wave_launched(wave_refs, wave_handles, len(wave))
+        for handle in wave_handles:
+            handle.wait()
+        if on_transport_complete is not None:
+            synchronize_weight_transfer(converted_named_tensors)
+            on_transport_complete()
+        if wave_refs:
+            ray.get(wave_refs)
+        if on_consumers_complete is not None:
+            on_consumers_complete()
+        all_refs.extend(wave_refs)
+    return all_refs
 
 
 def post_process_weights(
     restore_weights_before_load: bool,
     post_process_quantization: bool,
     rollout_engines: Sequence[ActorHandle],
+    max_inflight_engine_groups: int = 0,
 ):
     """
     Trigger post-process for int4/fp4 quantization on all rollout engines.
     """
-    ray.get(
-        [
-            engine.post_process_weights.remote(
-                restore_weights_before_load=restore_weights_before_load,
-                post_process_quantization=post_process_quantization,
-            )
-            for engine in rollout_engines
-        ]
+    run_engine_group_waves(
+        rollout_engines,
+        max_inflight_engine_groups,
+        lambda _index, engine: engine.post_process_weights.remote(
+            restore_weights_before_load=restore_weights_before_load,
+            post_process_quantization=post_process_quantization,
+        ),
+        ray.get,
     )

--- a/slime/backends/megatron_utils/update_weight/update_weight_from_distributed.py
+++ b/slime/backends/megatron_utils/update_weight/update_weight_from_distributed.py
@@ -4,6 +4,7 @@ import socket
 import time
 from argparse import Namespace
 from collections.abc import Callable, Iterator, Mapping, Sequence
+from typing import Any
 
 import ray
 import torch
@@ -19,6 +20,7 @@ from slime.utils.http_utils import _wrap_ipv6
 
 from ..megatron_to_hf import convert_to_hf
 from .common import all_gather_param, named_params_and_buffers
+from .weight_sync_credit import WeightBucketReservation, WeightSyncCreditController
 
 
 class UpdateWeightFromDistributed:
@@ -47,6 +49,10 @@ class UpdateWeightFromDistributed:
         self.weight_version = 0
         self._model_update_groups = None
         self.update_weight_metrics: dict[str, float] = {}
+        self._weight_sync_credit = WeightSyncCreditController(
+            max_inflight_buckets=getattr(args, "update_weight_max_inflight_buckets", 0),
+            max_inflight_bytes=getattr(args, "update_weight_max_inflight_bytes", 0),
+        )
 
     def pop_metrics(self) -> dict[str, float]:
         """
@@ -119,7 +125,9 @@ class UpdateWeightFromDistributed:
         dist.barrier(group=get_gloo_group())
 
         pbar = tqdm(desc=f"[{self._group_name}] Update weights", total=0) if self._is_pp_src_rank else None
+        self._weight_sync_credit.begin_version(self.weight_version)
         self._send_weights(pbar)
+        self._weight_sync_credit.commit_version(self.weight_version)
 
         if dist.get_rank() == 0:
             # int4/fp4 post_process
@@ -139,10 +147,84 @@ class UpdateWeightFromDistributed:
         override ``_on_chunk`` to inject per-chunk behaviour.
         """
         for chunk_iter in (self._iter_non_expert_chunks(), self._iter_expert_chunks()):
-            for hf_chunk in chunk_iter:
-                self._on_chunk(hf_chunk)
-                self._update_bucket_weights_from_distributed(hf_chunk, pbar=pbar)
+            if self._weight_sync_credit.enabled:
+                self._send_weight_bucket_windows(chunk_iter, pbar=pbar)
+            else:
+                for hf_chunk in chunk_iter:
+                    self._on_chunk(hf_chunk)
+                    reservation = self._reserve_weight_bucket(hf_chunk)
+                    self._update_bucket_weights_from_distributed(hf_chunk, pbar=pbar)
+                    self._weight_sync_credit.release(reservation)
             dist.barrier(group=get_gloo_group())
+
+    def _reserve_weight_bucket(self, hf_chunk: Sequence[tuple[str, torch.Tensor]]) -> WeightBucketReservation:
+        bucket_bytes = sum(tensor.numel() * tensor.element_size() for _, tensor in hf_chunk)
+        reservation = self._weight_sync_credit.reserve(bucket_bytes)
+        if reservation is None:
+            raise RuntimeError("weight bucket credits are full")
+        return reservation
+
+    def _send_weight_bucket_windows(
+        self,
+        chunk_iter: Iterator[list[tuple[str, torch.Tensor]]],
+        pbar: tqdm | None,
+    ) -> None:
+        pending: list[tuple[WeightBucketReservation, list[tuple[str, torch.Tensor]]]] = []
+        for hf_chunk in chunk_iter:
+            self._on_chunk(hf_chunk)
+            bucket_bytes = sum(tensor.numel() * tensor.element_size() for _, tensor in hf_chunk)
+            reservation = self._weight_sync_credit.reserve(bucket_bytes)
+            if reservation is None:
+                self._flush_weight_bucket_window(pending, pbar=pbar)
+                pending = []
+                reservation = self._weight_sync_credit.reserve(bucket_bytes)
+                if reservation is None:
+                    raise RuntimeError("weight bucket credit did not admit an empty window")
+            pending.append((reservation, hf_chunk))
+            if self._weight_sync_credit.full:
+                self._flush_weight_bucket_window(pending, pbar=pbar)
+                pending = []
+
+        if pending:
+            self._flush_weight_bucket_window(pending, pbar=pbar)
+
+    def _flush_weight_bucket_window(
+        self,
+        pending: Sequence[tuple[WeightBucketReservation, list[tuple[str, torch.Tensor]]]],
+        pbar: tqdm | None,
+    ) -> None:
+        while not ray.get(self.rollout_engine_lock.acquire.remote()):
+            time.sleep(0.1)
+
+        launched: list[
+            tuple[
+                WeightBucketReservation,
+                list[tuple[str, torch.Tensor]],
+                list[ObjectRef],
+                list[Any],
+            ]
+        ] = []
+        try:
+            for reservation, converted_named_tensors in pending:
+                refs, handles = launch_weights_from_distributed(
+                    self._group_name,
+                    self._model_update_groups,
+                    self.weight_version,
+                    self.rollout_engines,
+                    converted_named_tensors,
+                )
+                launched.append((reservation, converted_named_tensors, refs, handles))
+
+            for reservation, converted_named_tensors, refs, handles in launched:
+                for handle in handles:
+                    handle.wait()
+                ray.get(refs)
+                converted_named_tensors.clear()
+                self._weight_sync_credit.release(reservation)
+                if pbar is not None:
+                    pbar.update(1)
+        finally:
+            ray.get(self.rollout_engine_lock.release.remote())
 
     def _on_chunk(self, hf_chunk: list[tuple[str, torch.Tensor]]) -> None:
         """
@@ -334,6 +416,28 @@ def update_weights_from_distributed(
     """
     Send metadata through Ray and tensors through the configured transport.
     """
+    refs, handles = launch_weights_from_distributed(
+        group_name,
+        group,
+        weight_version,
+        rollout_engines,
+        converted_named_tensors,
+        load_format=load_format,
+    )
+    for handle in handles:
+        handle.wait()
+    return refs
+
+
+def launch_weights_from_distributed(
+    group_name: str,
+    group: dist.ProcessGroup,
+    weight_version: int,
+    rollout_engines: Sequence[ActorHandle],
+    converted_named_tensors: Sequence[tuple[str, torch.Tensor]],
+    load_format: str | None = None,
+) -> tuple[list[ObjectRef], list[Any]]:
+    """Launch one bucket without waiting for its device collectives."""
     refs = [
         engine.update_weights_from_distributed.remote(
             names=[name for name, _ in converted_named_tensors],
@@ -348,10 +452,7 @@ def update_weights_from_distributed(
     handles = []
     for _, param in converted_named_tensors:
         handles.append(dist.broadcast(param.data, 0, group=group, async_op=True))
-    for handle in handles:
-        handle.wait()
-
-    return refs
+    return refs, handles
 
 
 def post_process_weights(

--- a/slime/backends/megatron_utils/update_weight/update_weight_from_distributed.py
+++ b/slime/backends/megatron_utils/update_weight/update_weight_from_distributed.py
@@ -15,6 +15,7 @@ from ray import ObjectRef
 from ray.actor import ActorHandle
 from tqdm import tqdm
 
+from slime.observability.weight_sync_trace import trace_weight_update
 from slime.utils import accelerator
 from slime.utils.distributed_utils import get_gloo_group, init_process_group
 from slime.utils.engine_group_wave import build_engine_group_waves, run_engine_group_waves
@@ -116,6 +117,7 @@ class UpdateWeightFromDistributed:
         self._model_update_groups = []
 
     @torch.no_grad()
+    @trace_weight_update(transport="nccl")
     def update_weights(self) -> None:
         """
         Pause → flush → _send_weights → continue. Progress on PP source.
@@ -170,6 +172,9 @@ class UpdateWeightFromDistributed:
         override ``_on_chunk`` to inject per-chunk behaviour.
         """
         for chunk_iter in (self._iter_non_expert_chunks(), self._iter_expert_chunks()):
+            trace = getattr(self, "_weight_sync_trace", None)
+            if trace is not None:
+                chunk_iter = trace.converted_chunks(chunk_iter)
             if self._weight_sync_credit.enabled:
                 self._send_weight_bucket_windows(chunk_iter, pbar=pbar)
             else:
@@ -236,6 +241,9 @@ class UpdateWeightFromDistributed:
         try:
             for reservation, converted_named_tensors in pending:
                 update_group = self._model_update_groups[0]
+                trace = getattr(self, "_weight_sync_trace", None)
+                if trace is not None:
+                    trace.start(reservation, group_name=update_group.group_name)
                 refs, handles = launch_weights_from_distributed(
                     update_group.group_name,
                     update_group.process_group,
@@ -243,6 +251,8 @@ class UpdateWeightFromDistributed:
                     update_group.rollout_engines,
                     converted_named_tensors,
                 )
+                if trace is not None:
+                    trace.submitted(reservation)
                 self._weight_sync_credit.mark_launched(
                     reservation,
                     transport_bytes=reservation.bucket_bytes if handles else 0,
@@ -257,12 +267,20 @@ class UpdateWeightFromDistributed:
                     handle.wait()
                 synchronize_weight_transfer(converted_named_tensors)
                 self._weight_sync_credit.mark_transport_complete(reservation)
-                ray.get(refs)
+                if trace is not None:
+                    trace.complete(reservation)
+                    with trace.consumer(reservation) as phase:
+                        ray.get(refs)
+                        phase.mark_consumer()
+                else:
+                    ray.get(refs)
                 self._weight_sync_credit.mark_consumers_complete(reservation)
                 converted_named_tensors.clear()
                 del converted_named_tensors, refs, handles
                 self._weight_sync_credit.mark_staging_released(reservation)
                 self._weight_sync_credit.release(reservation)
+                if trace is not None:
+                    trace.released(reservation)
                 if pbar is not None:
                     pbar.update(1)
         finally:
@@ -396,11 +414,15 @@ class UpdateWeightFromDistributed:
                 on_wave_launched=observe_wave_launch,
                 on_transport_complete=lambda: self._weight_sync_credit.mark_transport_complete(reservation),
                 on_consumers_complete=lambda: self._weight_sync_credit.mark_consumers_complete(reservation),
+                trace=getattr(self, "_weight_sync_trace", None),
+                reservation=reservation,
             )
             self._active_wave_resources = None
             converted_named_tensors.clear()
             self._weight_sync_credit.mark_staging_released(reservation)
             self._weight_sync_credit.release(reservation)
+            if getattr(self, "_weight_sync_trace", None) is not None:
+                self._weight_sync_trace.released(reservation)
         finally:
             ray.get(self.rollout_engine_lock.release.remote())
         if pbar is not None:
@@ -618,12 +640,16 @@ def update_weights_in_engine_group_waves(
     on_wave_launched: Callable[[Sequence[ObjectRef], Sequence[Any], int], None] | None = None,
     on_transport_complete: Callable[[], None] | None = None,
     on_consumers_complete: Callable[[], None] | None = None,
+    trace=None,
+    reservation=None,
 ) -> list[ObjectRef]:
     """Transfer one bucket to bounded waves of independent engine groups."""
     all_refs = []
-    for wave in build_engine_group_waves(update_groups, max_inflight_engine_groups):
+    for wave_id, wave in enumerate(build_engine_group_waves(update_groups, max_inflight_engine_groups)):
         wave_refs = []
         wave_handles = []
+        if trace is not None:
+            trace.start(reservation, wave_id=wave_id, engine_group_count=len(wave))
         for _index, update_group in wave:
             refs, handles = launch_weights_from_distributed(
                 update_group.group_name,
@@ -635,14 +661,22 @@ def update_weights_in_engine_group_waves(
             )
             wave_refs.extend(refs)
             wave_handles.extend(handles)
+        if trace is not None:
+            trace.submitted(reservation)
         if on_wave_launched is not None:
             on_wave_launched(wave_refs, wave_handles, len(wave))
         for handle in wave_handles:
             handle.wait()
-        if on_transport_complete is not None:
+        if on_transport_complete is not None or trace is not None:
             synchronize_weight_transfer(converted_named_tensors)
+        if on_transport_complete is not None:
             on_transport_complete()
-        if wave_refs:
+        if trace is not None:
+            trace.complete(reservation)
+            with trace.consumer(reservation) as phase:
+                ray.get(wave_refs)
+                phase.mark_consumer()
+        elif wave_refs:
             ray.get(wave_refs)
         if on_consumers_complete is not None:
             on_consumers_complete()

--- a/slime/backends/megatron_utils/update_weight/update_weight_from_tensor.py
+++ b/slime/backends/megatron_utils/update_weight/update_weight_from_tensor.py
@@ -1,6 +1,7 @@
 from argparse import Namespace
 from collections import defaultdict
 from collections.abc import Callable, Iterator, Mapping, Sequence
+from time import perf_counter
 from typing import Any
 
 import ray
@@ -47,6 +48,19 @@ def _build_flattened_tensor_data(
         "flattened_tensor": flattened_tensor_bucket.get_flattened_tensor(),
         "metadata": flattened_tensor_bucket.get_metadata(),
     }
+
+
+def _tensor_tree_nbytes(value: Any) -> int:
+    """Count tensor storage represented by a nested staging object."""
+    numel = getattr(value, "numel", None)
+    element_size = getattr(value, "element_size", None)
+    if callable(numel) and callable(element_size):
+        return int(numel()) * int(element_size())
+    if isinstance(value, Mapping):
+        return sum(_tensor_tree_nbytes(item) for item in value.values())
+    if isinstance(value, (list, tuple)):
+        return sum(_tensor_tree_nbytes(item) for item in value)
+    return 0
 
 
 class UpdateWeightFromTensor:
@@ -110,6 +124,7 @@ class UpdateWeightFromTensor:
         Split colocated/distributed engines. Global source rank (DP=TP=PP=0) creates NCCL
         for distributed. Map ranks to colocated IPC engines.
         """
+        self._all_rollout_engines = rollout_engines
         self.rollout_engines = rollout_engines
 
         if engine_gpu_counts is None:
@@ -196,6 +211,65 @@ class UpdateWeightFromTensor:
         out, self.update_weight_metrics = self.update_weight_metrics, {}
         return out
 
+    def _consumer_engines(self) -> Sequence[ActorHandle]:
+        """Return colocated and distributed consumers as one lifecycle unit."""
+        return getattr(self, "_all_rollout_engines", self.rollout_engines)
+
+    def _wait_for_bucket_completion(
+        self,
+        reservation: WeightBucketReservation,
+        handles: Sequence[Any],
+        refs: Sequence[ObjectRef],
+    ) -> None:
+        """Wait for transport/load and share the engine acknowledgement within its TP group."""
+        local_error: Exception | None = None
+        try:
+            for handle in handles:
+                handle.wait()
+            ray.get(refs)
+        except Exception as error:
+            local_error = error
+
+        group_error: str | None = None
+        if self._ipc_gather_group is not None:
+            error_message = (
+                f"{type(local_error).__name__}: {local_error}"
+                if self.rank == self._ipc_gather_src and local_error is not None
+                else None
+            )
+            status = [error_message]
+            dist.broadcast_object_list(
+                status,
+                src=self._ipc_gather_src,
+                group=self._ipc_gather_group,
+            )
+            group_error = status[0]
+
+        if local_error is not None:
+            raise local_error
+        if group_error is not None:
+            raise RuntimeError(f"weight consumer failed on engine source rank: {group_error}")
+
+        # For colocated CUDA IPC, the Ray response is the first observable
+        # receive/load acknowledgement. Do not claim an earlier transport
+        # boundary when there is no separate Work handle.
+        self._weight_sync_credit.mark_transport_complete(reservation)
+        self._weight_sync_credit.mark_consumers_complete(reservation)
+
+    def _mark_bucket_launched(
+        self,
+        reservation: WeightBucketReservation,
+        refs: Sequence[ObjectRef],
+        handles: Sequence[Any],
+        long_lived_tensors: Any,
+    ) -> None:
+        self._weight_sync_credit.mark_launched(
+            reservation,
+            transport_bytes=reservation.bucket_bytes if refs or handles else 0,
+            staging_bytes=_tensor_tree_nbytes(long_lived_tensors),
+            consumer_objects=len(refs),
+        )
+
     def _prepare_expert_weight_batch(
         self,
         transfers: Sequence[Any],
@@ -269,11 +343,15 @@ class UpdateWeightFromTensor:
                     megatron_local_weights,
                     staging_buffers,
                 )
+                self._weight_sync_credit.set_persistent_staging_bytes(_tensor_tree_nbytes(staging_buffers))
                 reservation = self._reserve_weight_bucket(hf_named_tensors)
                 refs, handles, long_lived_tensors = self._send_hf_params(hf_named_tensors)
-                for handle in handles:
-                    handle.wait()
-                ray.get(refs)
+                self._mark_bucket_launched(reservation, refs, handles, long_lived_tensors)
+                self._wait_for_bucket_completion(reservation, handles, refs)
+                hf_named_tensors.clear()
+                if isinstance(long_lived_tensors, list):
+                    long_lived_tensors.clear()
+                self._weight_sync_credit.mark_staging_released(reservation)
                 self._weight_sync_credit.release(reservation)
                 dist.barrier(group=get_gloo_group())
                 accelerator.synchronize()
@@ -281,6 +359,7 @@ class UpdateWeightFromTensor:
                 accelerator.ipc_collect()
                 accelerator.empty_cache()
         del staging_buffers
+        self._weight_sync_credit.set_persistent_staging_bytes(0)
         accelerator.empty_cache()
 
     @torch.no_grad()
@@ -288,67 +367,81 @@ class UpdateWeightFromTensor:
         """
         version++, flush caches, process buckets. Progress on rank 0.
         """
+        sync_started = perf_counter()
         self.weight_version += 1
 
         if self.rank == 0:
-            ray.get([engine.pause_generation.remote() for engine in self.rollout_engines])
-            ray.get([engine.flush_cache.remote() for engine in self.rollout_engines])
+            consumer_engines = self._consumer_engines()
+            ray.get([engine.pause_generation.remote() for engine in consumer_engines])
+            ray.get([engine.flush_cache.remote() for engine in consumer_engines])
             if self.quantization_config and self.quantization_config["quant_method"] in ["compressed-tensors"]:
                 post_process_weights(
                     restore_weights_before_load=True,
                     post_process_quantization=False,
-                    rollout_engines=self.rollout_engines,
+                    rollout_engines=consumer_engines,
                 )
         dist.barrier(group=get_gloo_group())
 
         self._weight_sync_credit.begin_version(self.weight_version)
-        megatron_local_weights = self.weights_getter()
+        try:
+            megatron_local_weights = self.weights_getter()
 
-        param_info_buckets = (
-            self._non_expert_param_info_buckets if self._expert_transfer_plan else self._full_param_info_buckets
-        )
-        hf_chunks = self._hf_weight_iterator.get_hf_weight_chunks(
-            megatron_local_weights,
-            param_info_buckets=param_info_buckets,
-        )
-        if self._weight_sync_credit.enabled:
-            self._send_weight_bucket_windows(hf_chunks)
-        else:
-            for hf_named_tensors in hf_chunks:
-                reservation = self._reserve_weight_bucket(hf_named_tensors)
-                refs, handles, long_lived_tensors = self._send_hf_params(hf_named_tensors)
-                for handle in handles:
-                    handle.wait()
-                ray.get(refs)
-                self._weight_sync_credit.release(reservation)
-                # Free GPU tensors so the caching allocator can reuse the blocks,
-                # then release CUDA IPC cache entries whose consumers (sglang engines)
-                # have already closed their IPC handles.
-                del refs, handles, long_lived_tensors, hf_named_tensors
-                accelerator.ipc_collect()
-                accelerator.empty_cache()
+            param_info_buckets = (
+                self._non_expert_param_info_buckets if self._expert_transfer_plan else self._full_param_info_buckets
+            )
+            hf_chunks = self._hf_weight_iterator.get_hf_weight_chunks(
+                megatron_local_weights,
+                param_info_buckets=param_info_buckets,
+            )
+            if self._weight_sync_credit.enabled:
+                self._send_weight_bucket_windows(hf_chunks)
+            else:
+                for hf_named_tensors in hf_chunks:
+                    reservation = self._reserve_weight_bucket(hf_named_tensors)
+                    refs, handles, long_lived_tensors = self._send_hf_params(hf_named_tensors)
+                    self._mark_bucket_launched(reservation, refs, handles, long_lived_tensors)
+                    self._wait_for_bucket_completion(reservation, handles, refs)
+                    hf_named_tensors.clear()
+                    if isinstance(long_lived_tensors, list):
+                        long_lived_tensors.clear()
+                    self._weight_sync_credit.mark_staging_released(reservation)
+                    self._weight_sync_credit.release(reservation)
+                    # Free GPU tensors so the caching allocator can reuse the blocks,
+                    # then release CUDA IPC cache entries whose consumers (sglang engines)
+                    # have already closed their IPC handles.
+                    del refs, handles, long_lived_tensors, hf_named_tensors
+                    accelerator.ipc_collect()
+                    accelerator.empty_cache()
 
-        if self._expert_transfer_plan:
-            self._update_expert_weights(megatron_local_weights)
+            if self._expert_transfer_plan:
+                self._update_expert_weights(megatron_local_weights)
 
-        del megatron_local_weights
-        dist.barrier(group=get_gloo_group())
-        # After the barrier all engines have returned, so every rank's last-chunk
-        # IPC handles are now released by the consumers.  Clean them up.
-        accelerator.ipc_collect()
-        accelerator.empty_cache()
+            del megatron_local_weights
+            dist.barrier(group=get_gloo_group())
+            # After the barrier all engines have returned, so every rank's last-chunk
+            # IPC handles are now released by the consumers.  Clean them up.
+            accelerator.ipc_collect()
+            accelerator.empty_cache()
+
+            # int4/fp4 post_process
+            if self.rank == 0:
+                if self.quantization_config and self.quantization_config["quant_method"] in ["compressed-tensors"]:
+                    post_process_weights(
+                        restore_weights_before_load=False,
+                        post_process_quantization=True,
+                        rollout_engines=self._consumer_engines(),
+                    )
+                ray.get([engine.continue_generation.remote() for engine in self._consumer_engines()])
+            dist.barrier(group=get_gloo_group())
+        except BaseException as error:
+            self._weight_sync_credit.fail_version(self.weight_version, error)
+            raise
+
+        # Commit is the control-plane publication boundary: all loads and
+        # post-processing completed and every consumer has resumed.
         self._weight_sync_credit.commit_version(self.weight_version)
-
-        # int4/fp4 post_process
-        if self.rank == 0:
-            if self.quantization_config and self.quantization_config["quant_method"] in ["compressed-tensors"]:
-                post_process_weights(
-                    restore_weights_before_load=False,
-                    post_process_quantization=True,
-                    rollout_engines=self.rollout_engines,
-                )
-            ray.get([engine.continue_generation.remote() for engine in self.rollout_engines])
-        dist.barrier(group=get_gloo_group())
+        self.update_weight_metrics.update(self._weight_sync_credit.metrics())
+        self.update_weight_metrics["perf/update_weights_sync_seconds"] = perf_counter() - sync_started
 
     def _reserve_weight_bucket(self, hf_named_tensors: Sequence[tuple[str, torch.Tensor]]) -> WeightBucketReservation:
         bucket_bytes = self._weight_bucket_bytes(hf_named_tensors)
@@ -397,13 +490,17 @@ class UpdateWeightFromTensor:
         launched = []
         for reservation, hf_named_tensors in pending:
             refs, handles, long_lived_tensors = self._send_hf_params(hf_named_tensors)
+            self._mark_bucket_launched(reservation, refs, handles, long_lived_tensors)
             launched.append((reservation, hf_named_tensors, refs, handles, long_lived_tensors))
 
-        for reservation, hf_named_tensors, refs, handles, _long_lived_tensors in launched:
-            for handle in handles:
-                handle.wait()
-            ray.get(refs)
+        while launched:
+            reservation, hf_named_tensors, refs, handles, long_lived_tensors = launched.pop(0)
+            self._wait_for_bucket_completion(reservation, handles, refs)
             hf_named_tensors.clear()
+            if isinstance(long_lived_tensors, list):
+                long_lived_tensors.clear()
+            del hf_named_tensors, refs, handles, long_lived_tensors
+            self._weight_sync_credit.mark_staging_released(reservation)
             self._weight_sync_credit.release(reservation)
 
         accelerator.ipc_collect()

--- a/slime/backends/megatron_utils/update_weight/update_weight_from_tensor.py
+++ b/slime/backends/megatron_utils/update_weight/update_weight_from_tensor.py
@@ -14,6 +14,7 @@ from tqdm import tqdm
 
 from slime.utils import accelerator
 from slime.utils.distributed_utils import get_gloo_group
+from slime.utils.engine_group_wave import build_engine_group_waves
 from slime.utils.types import ParamInfo
 
 from ..megatron_to_hf import convert_to_hf
@@ -21,10 +22,11 @@ from ..sglang import FlattenedTensorBucket, MultiprocessingSerializer
 from .expert_routing import configure_expert_routing
 from .hf_weight_iterator_direct import HfWeightIteratorDirect
 from .update_weight_from_distributed import (
-    connect_rollout_engines_from_distributed,
-    disconnect_rollout_engines_from_distributed,
+    connect_rollout_engine_groups_from_distributed,
+    disconnect_rollout_engine_groups_from_distributed,
     launch_weights_from_distributed,
     post_process_weights,
+    synchronize_weight_transfer,
 )
 from .weight_sync_credit import WeightBucketReservation, WeightSyncCreditController
 
@@ -109,7 +111,11 @@ class UpdateWeightFromTensor:
         self._ipc_gather_group = None
         self._ipc_gather_src = None
         self._ipc_engine = None
-        self._model_update_groups = None
+        self._ipc_engine_index = None
+        self._model_update_groups = []
+        self._total_engine_groups = 0
+        self._max_inflight_engine_groups = getattr(args, "update_weight_max_inflight_engine_groups", 0)
+        self._wave_scheduling_enabled = False
         self._expert_transfer_plan = []
 
     def connect_rollout_engines(
@@ -126,6 +132,9 @@ class UpdateWeightFromTensor:
         """
         self._all_rollout_engines = rollout_engines
         self.rollout_engines = rollout_engines
+        self._total_engine_groups = len(rollout_engines)
+        self._max_inflight_engine_groups = getattr(self.args, "update_weight_max_inflight_engine_groups", 0)
+        self._wave_scheduling_enabled = 0 < self._max_inflight_engine_groups < self._total_engine_groups
 
         if engine_gpu_counts is None:
             engine_gpu_counts = [self.args.rollout_num_gpus_per_engine] * len(rollout_engines)
@@ -158,16 +167,17 @@ class UpdateWeightFromTensor:
             )
             self._group_name = "slime"
             if self._is_distributed_src_rank:
-                if self._model_update_groups is not None:
-                    disconnect_rollout_engines_from_distributed(
-                        self._group_name, self._model_update_groups, self.distributed_rollout_engines
-                    )
+                if self._model_update_groups:
+                    disconnect_rollout_engine_groups_from_distributed(self._model_update_groups)
 
-                self._model_update_groups = connect_rollout_engines_from_distributed(
+                self._model_update_groups = connect_rollout_engine_groups_from_distributed(
                     self.args,
                     self._group_name,
                     self.distributed_rollout_engines,
                     engine_gpu_counts=distributed_gpu_counts,
+                    max_inflight_engine_groups=self._max_inflight_engine_groups,
+                    total_engine_groups=self._total_engine_groups,
+                    engine_index_offset=colocate_engine_nums,
                 )
 
         colocate_gpu_offsets = engine_gpu_offsets[:colocate_engine_nums]
@@ -187,11 +197,13 @@ class UpdateWeightFromTensor:
                     self._ipc_gather_src = colocate_gpu_offsets[i]
 
         # Map training ranks to colocated engine actors.
+        self._ipc_engine_index = None
         for i, engine in enumerate(self.rollout_engines):
             start = colocate_gpu_offsets[i]
             end = start + colocate_gpu_counts[i]
             if start <= self.rank < end:
                 self._ipc_engine = engine
+                self._ipc_engine_index = i
 
         self._non_expert_param_info_buckets, self._expert_transfer_plan = configure_expert_routing(
             args=self.args,
@@ -220,12 +232,15 @@ class UpdateWeightFromTensor:
         reservation: WeightBucketReservation,
         handles: Sequence[Any],
         refs: Sequence[ObjectRef],
+        named_tensors: Sequence[tuple[str, torch.Tensor]] = (),
     ) -> None:
         """Wait for transport/load and share the engine acknowledgement within its TP group."""
         local_error: Exception | None = None
         try:
             for handle in handles:
                 handle.wait()
+            if handles:
+                synchronize_weight_transfer(named_tensors)
             ray.get(refs)
         except Exception as error:
             local_error = error
@@ -345,9 +360,8 @@ class UpdateWeightFromTensor:
                 )
                 self._weight_sync_credit.set_persistent_staging_bytes(_tensor_tree_nbytes(staging_buffers))
                 reservation = self._reserve_weight_bucket(hf_named_tensors)
-                refs, handles, long_lived_tensors = self._send_hf_params(hf_named_tensors)
-                self._mark_bucket_launched(reservation, refs, handles, long_lived_tensors)
-                self._wait_for_bucket_completion(reservation, handles, refs)
+                refs, handles, long_lived_tensors = self._submit_weight_bucket(hf_named_tensors, reservation)
+                self._wait_for_bucket_completion(reservation, handles, refs, hf_named_tensors)
                 hf_named_tensors.clear()
                 if isinstance(long_lived_tensors, list):
                     long_lived_tensors.clear()
@@ -379,6 +393,7 @@ class UpdateWeightFromTensor:
                     restore_weights_before_load=True,
                     post_process_quantization=False,
                     rollout_engines=consumer_engines,
+                    max_inflight_engine_groups=self._max_inflight_engine_groups,
                 )
         dist.barrier(group=get_gloo_group())
 
@@ -398,9 +413,8 @@ class UpdateWeightFromTensor:
             else:
                 for hf_named_tensors in hf_chunks:
                     reservation = self._reserve_weight_bucket(hf_named_tensors)
-                    refs, handles, long_lived_tensors = self._send_hf_params(hf_named_tensors)
-                    self._mark_bucket_launched(reservation, refs, handles, long_lived_tensors)
-                    self._wait_for_bucket_completion(reservation, handles, refs)
+                    refs, handles, long_lived_tensors = self._submit_weight_bucket(hf_named_tensors, reservation)
+                    self._wait_for_bucket_completion(reservation, handles, refs, hf_named_tensors)
                     hf_named_tensors.clear()
                     if isinstance(long_lived_tensors, list):
                         long_lived_tensors.clear()
@@ -430,6 +444,7 @@ class UpdateWeightFromTensor:
                         restore_weights_before_load=False,
                         post_process_quantization=True,
                         rollout_engines=self._consumer_engines(),
+                        max_inflight_engine_groups=self._max_inflight_engine_groups,
                     )
                 ray.get([engine.continue_generation.remote() for engine in self._consumer_engines()])
             dist.barrier(group=get_gloo_group())
@@ -489,13 +504,12 @@ class UpdateWeightFromTensor:
     ) -> None:
         launched = []
         for reservation, hf_named_tensors in pending:
-            refs, handles, long_lived_tensors = self._send_hf_params(hf_named_tensors)
-            self._mark_bucket_launched(reservation, refs, handles, long_lived_tensors)
+            refs, handles, long_lived_tensors = self._submit_weight_bucket(hf_named_tensors, reservation)
             launched.append((reservation, hf_named_tensors, refs, handles, long_lived_tensors))
 
         while launched:
             reservation, hf_named_tensors, refs, handles, long_lived_tensors = launched.pop(0)
-            self._wait_for_bucket_completion(reservation, handles, refs)
+            self._wait_for_bucket_completion(reservation, handles, refs, hf_named_tensors)
             hf_named_tensors.clear()
             if isinstance(long_lived_tensors, list):
                 long_lived_tensors.clear()
@@ -505,6 +519,15 @@ class UpdateWeightFromTensor:
 
         accelerator.ipc_collect()
         accelerator.empty_cache()
+
+    def _submit_weight_bucket(
+        self, hf_named_tensors, reservation: WeightBucketReservation
+    ) -> tuple[list[ObjectRef], list[Any], Any]:
+        if self._wave_scheduling_enabled:
+            return self._send_hf_params_in_waves(hf_named_tensors, reservation)
+        refs, handles, long_lived_tensors = self._send_hf_params(hf_named_tensors)
+        self._mark_bucket_launched(reservation, refs, handles, long_lived_tensors)
+        return refs, handles, long_lived_tensors
 
     def _send_hf_params(self, hf_named_tensors) -> tuple[list[ObjectRef], list[Any], Any]:
         all_refs = []
@@ -520,11 +543,12 @@ class UpdateWeightFromTensor:
         all_refs.extend(refs_colocated)
 
         if self.use_distribute and self._is_distributed_src_rank:
+            update_group = self._model_update_groups[0]
             refs_distributed, handles_distributed = launch_weights_from_distributed(
-                self._group_name,
-                self._model_update_groups,
+                update_group.group_name,
+                update_group.process_group,
                 self.weight_version,
-                self.distributed_rollout_engines,
+                update_group.rollout_engines,
                 hf_named_tensors,
             )
             if refs_distributed:
@@ -532,6 +556,72 @@ class UpdateWeightFromTensor:
             all_handles.extend(handles_distributed)
 
         return all_refs, all_handles, long_lived_tensors
+
+    def _send_hf_params_in_waves(
+        self, hf_named_tensors, reservation: WeightBucketReservation
+    ) -> tuple[list[ObjectRef], list[Any], None]:
+        """Send one bucket in globally coordinated colocated/distributed waves."""
+        self._weight_sync_credit.mark_launched(reservation, transport_bytes=0, staging_bytes=0, consumer_objects=0)
+        engine_indices = tuple(range(self._total_engine_groups))
+        for wave in build_engine_group_waves(engine_indices, self._max_inflight_engine_groups):
+            active_indices = {engine_index for _position, engine_index in wave}
+            wave_refs = []
+            wave_handles = []
+            wave_long_lived_tensors = None
+
+            if self._ipc_engine_index in active_indices:
+                refs_colocated, wave_long_lived_tensors = _send_to_colocated_engine(
+                    hf_named_tensors,
+                    ipc_engine=self._ipc_engine,
+                    ipc_gather_src=self._ipc_gather_src,
+                    ipc_gather_group=self._ipc_gather_group,
+                    weight_version=self.weight_version,
+                )
+                wave_refs.extend(refs_colocated)
+
+            if self.use_distribute and self._is_distributed_src_rank:
+                for update_group in self._model_update_groups:
+                    if not active_indices.intersection(update_group.engine_indices):
+                        continue
+                    refs, handles = launch_weights_from_distributed(
+                        update_group.group_name,
+                        update_group.process_group,
+                        self.weight_version,
+                        update_group.rollout_engines,
+                        hf_named_tensors,
+                    )
+                    wave_refs.extend(refs)
+                    wave_handles.extend(handles)
+
+            self._weight_sync_credit.mark_next_wave(
+                reservation,
+                transport_bytes=reservation.bucket_bytes if wave_handles or wave_refs else 0,
+                staging_bytes=_tensor_tree_nbytes(wave_long_lived_tensors),
+                consumer_objects=len(wave_refs),
+            )
+            error_message = None
+            try:
+                self._wait_for_bucket_completion(reservation, wave_handles, wave_refs, hf_named_tensors)
+            except Exception as error:
+                error_message = f"{type(error).__name__}: {error}"
+            # Propagate a load failure to inactive engines too, before anybody
+            # enters the next wave. This also keeps all IPC producers alive.
+            group = get_gloo_group()
+            errors = [None] * dist.get_world_size(group=group)
+            dist.all_gather_object(errors, error_message, group=group)
+            if any(errors):
+                self._active_wave_resources = (hf_named_tensors, wave_long_lived_tensors, wave_refs, wave_handles)
+                raise RuntimeError(f"weight wave failed: {errors}")
+
+            # Every training rank advances together, so IPC producers cannot
+            # release a bucket while another rank in the engine is still using it.
+            if isinstance(wave_long_lived_tensors, list):
+                wave_long_lived_tensors.clear()
+            del wave_long_lived_tensors
+            self._weight_sync_credit.mark_staging_released(reservation)
+
+        # Every Ray ref and IPC consumer completed at its wave boundary.
+        return [], [], None
 
 
 def _send_to_colocated_engine(

--- a/slime/backends/megatron_utils/update_weight/update_weight_from_tensor.py
+++ b/slime/backends/megatron_utils/update_weight/update_weight_from_tensor.py
@@ -1,6 +1,6 @@
 from argparse import Namespace
 from collections import defaultdict
-from collections.abc import Callable, Mapping, Sequence
+from collections.abc import Callable, Iterator, Mapping, Sequence
 from typing import Any
 
 import ray
@@ -22,9 +22,10 @@ from .hf_weight_iterator_direct import HfWeightIteratorDirect
 from .update_weight_from_distributed import (
     connect_rollout_engines_from_distributed,
     disconnect_rollout_engines_from_distributed,
+    launch_weights_from_distributed,
     post_process_weights,
-    update_weights_from_distributed,
 )
+from .weight_sync_credit import WeightBucketReservation, WeightSyncCreditController
 
 
 def _build_flattened_tensor_data(
@@ -77,6 +78,10 @@ class UpdateWeightFromTensor:
         self.quantization_config = quantization_config
         self.weight_version = 0
         self.update_weight_metrics: dict[str, float] = {}
+        self._weight_sync_credit = WeightSyncCreditController(
+            max_inflight_buckets=getattr(args, "update_weight_max_inflight_buckets", 0),
+            max_inflight_bytes=getattr(args, "update_weight_max_inflight_bytes", 0),
+        )
 
         self._hf_weight_iterator = HfWeightIteratorDirect(
             args=args, model=model, model_name=model_name, quantization_config=quantization_config
@@ -264,11 +269,15 @@ class UpdateWeightFromTensor:
                     megatron_local_weights,
                     staging_buffers,
                 )
-                refs, long_lived_tensors = self._send_hf_params(hf_named_tensors)
+                reservation = self._reserve_weight_bucket(hf_named_tensors)
+                refs, handles, long_lived_tensors = self._send_hf_params(hf_named_tensors)
+                for handle in handles:
+                    handle.wait()
                 ray.get(refs)
+                self._weight_sync_credit.release(reservation)
                 dist.barrier(group=get_gloo_group())
                 accelerator.synchronize()
-                del refs, long_lived_tensors, hf_named_tensors
+                del refs, handles, long_lived_tensors, hf_named_tensors
                 accelerator.ipc_collect()
                 accelerator.empty_cache()
         del staging_buffers
@@ -292,23 +301,32 @@ class UpdateWeightFromTensor:
                 )
         dist.barrier(group=get_gloo_group())
 
+        self._weight_sync_credit.begin_version(self.weight_version)
         megatron_local_weights = self.weights_getter()
 
         param_info_buckets = (
             self._non_expert_param_info_buckets if self._expert_transfer_plan else self._full_param_info_buckets
         )
-        for hf_named_tensors in self._hf_weight_iterator.get_hf_weight_chunks(
+        hf_chunks = self._hf_weight_iterator.get_hf_weight_chunks(
             megatron_local_weights,
             param_info_buckets=param_info_buckets,
-        ):
-            refs, long_lived_tensors = self._send_hf_params(hf_named_tensors)
-            ray.get(refs)
-            # Free GPU tensors so the caching allocator can reuse the blocks,
-            # then release CUDA IPC cache entries whose consumers (sglang engines)
-            # have already closed their IPC handles.
-            del refs, long_lived_tensors, hf_named_tensors
-            accelerator.ipc_collect()
-            accelerator.empty_cache()
+        )
+        if self._weight_sync_credit.enabled:
+            self._send_weight_bucket_windows(hf_chunks)
+        else:
+            for hf_named_tensors in hf_chunks:
+                reservation = self._reserve_weight_bucket(hf_named_tensors)
+                refs, handles, long_lived_tensors = self._send_hf_params(hf_named_tensors)
+                for handle in handles:
+                    handle.wait()
+                ray.get(refs)
+                self._weight_sync_credit.release(reservation)
+                # Free GPU tensors so the caching allocator can reuse the blocks,
+                # then release CUDA IPC cache entries whose consumers (sglang engines)
+                # have already closed their IPC handles.
+                del refs, handles, long_lived_tensors, hf_named_tensors
+                accelerator.ipc_collect()
+                accelerator.empty_cache()
 
         if self._expert_transfer_plan:
             self._update_expert_weights(megatron_local_weights)
@@ -319,6 +337,7 @@ class UpdateWeightFromTensor:
         # IPC handles are now released by the consumers.  Clean them up.
         accelerator.ipc_collect()
         accelerator.empty_cache()
+        self._weight_sync_credit.commit_version(self.weight_version)
 
         # int4/fp4 post_process
         if self.rank == 0:
@@ -331,8 +350,68 @@ class UpdateWeightFromTensor:
             ray.get([engine.continue_generation.remote() for engine in self.rollout_engines])
         dist.barrier(group=get_gloo_group())
 
-    def _send_hf_params(self, hf_named_tensors) -> tuple[list[ObjectRef], Any]:
+    def _reserve_weight_bucket(self, hf_named_tensors: Sequence[tuple[str, torch.Tensor]]) -> WeightBucketReservation:
+        bucket_bytes = self._weight_bucket_bytes(hf_named_tensors)
+        reservation = self._weight_sync_credit.reserve(bucket_bytes)
+        if reservation is None:
+            raise RuntimeError("weight bucket credits are full")
+        return reservation
+
+    def _weight_bucket_bytes(self, hf_named_tensors: Sequence[tuple[str, torch.Tensor]]) -> int:
+        bucket_bytes = sum(tensor.numel() * tensor.element_size() for _, tensor in hf_named_tensors)
+        if self._weight_sync_credit.max_inflight_bytes:
+            # Every rank must flush at the same bucket boundary before the next
+            # gather_object. Use the largest local representation so byte-credit
+            # decisions stay identical even when a rank contributes no tensors.
+            global_bucket_bytes = torch.tensor(bucket_bytes, dtype=torch.int64, device="cpu")
+            dist.all_reduce(global_bucket_bytes, op=dist.ReduceOp.MAX, group=get_gloo_group())
+            bucket_bytes = int(global_bucket_bytes.item())
+        return bucket_bytes
+
+    def _send_weight_bucket_windows(
+        self,
+        hf_chunks: Iterator[list[tuple[str, torch.Tensor]]],
+    ) -> None:
+        pending: list[tuple[WeightBucketReservation, list[tuple[str, torch.Tensor]]]] = []
+        for hf_named_tensors in hf_chunks:
+            bucket_bytes = self._weight_bucket_bytes(hf_named_tensors)
+            reservation = self._weight_sync_credit.reserve(bucket_bytes)
+            if reservation is None:
+                self._flush_weight_bucket_window(pending)
+                pending = []
+                reservation = self._weight_sync_credit.reserve(bucket_bytes)
+                if reservation is None:
+                    raise RuntimeError("weight bucket credit did not admit an empty window")
+            pending.append((reservation, hf_named_tensors))
+            if self._weight_sync_credit.full:
+                self._flush_weight_bucket_window(pending)
+                pending = []
+
+        if pending:
+            self._flush_weight_bucket_window(pending)
+
+    def _flush_weight_bucket_window(
+        self,
+        pending: Sequence[tuple[WeightBucketReservation, list[tuple[str, torch.Tensor]]]],
+    ) -> None:
+        launched = []
+        for reservation, hf_named_tensors in pending:
+            refs, handles, long_lived_tensors = self._send_hf_params(hf_named_tensors)
+            launched.append((reservation, hf_named_tensors, refs, handles, long_lived_tensors))
+
+        for reservation, hf_named_tensors, refs, handles, _long_lived_tensors in launched:
+            for handle in handles:
+                handle.wait()
+            ray.get(refs)
+            hf_named_tensors.clear()
+            self._weight_sync_credit.release(reservation)
+
+        accelerator.ipc_collect()
+        accelerator.empty_cache()
+
+    def _send_hf_params(self, hf_named_tensors) -> tuple[list[ObjectRef], list[Any], Any]:
         all_refs = []
+        all_handles = []
 
         refs_colocated, long_lived_tensors = _send_to_colocated_engine(
             hf_named_tensors,
@@ -344,7 +423,7 @@ class UpdateWeightFromTensor:
         all_refs.extend(refs_colocated)
 
         if self.use_distribute and self._is_distributed_src_rank:
-            refs_distributed = update_weights_from_distributed(
+            refs_distributed, handles_distributed = launch_weights_from_distributed(
                 self._group_name,
                 self._model_update_groups,
                 self.weight_version,
@@ -353,8 +432,9 @@ class UpdateWeightFromTensor:
             )
             if refs_distributed:
                 all_refs.extend(refs_distributed)
+            all_handles.extend(handles_distributed)
 
-        return all_refs, long_lived_tensors
+        return all_refs, all_handles, long_lived_tensors
 
 
 def _send_to_colocated_engine(

--- a/slime/backends/megatron_utils/update_weight/update_weight_from_tensor.py
+++ b/slime/backends/megatron_utils/update_weight/update_weight_from_tensor.py
@@ -12,6 +12,8 @@ from ray import ObjectRef
 from ray.actor import ActorHandle
 from tqdm import tqdm
 
+from slime.observability.communication_timeline import communication_phase
+from slime.observability.weight_sync_trace import trace_weight_update
 from slime.utils import accelerator
 from slime.utils.distributed_utils import get_gloo_group
 from slime.utils.engine_group_wave import build_engine_group_waves
@@ -236,13 +238,26 @@ class UpdateWeightFromTensor:
     ) -> None:
         """Wait for transport/load and share the engine acknowledgement within its TP group."""
         local_error: Exception | None = None
+        trace = getattr(self, "_weight_sync_trace", None)
+        if trace is not None and reservation.bucket_id not in trace.pending:
+            trace = None  # A waved submission already waited and recorded its consumers.
         try:
             for handle in handles:
                 handle.wait()
             if handles:
                 synchronize_weight_transfer(named_tensors)
-            ray.get(refs)
+            if trace is not None:
+                with trace.consumer(reservation) as phase:
+                    ray.get(refs)
+                    phase.mark_consumer()
+                # CUDA IPC has no separate transport Work; its first observed
+                # completion remains the engine receive/load acknowledgement.
+                trace.complete(reservation)
+            else:
+                ray.get(refs)
         except Exception as error:
+            if trace is not None:
+                trace.complete(reservation, error)
             local_error = error
 
         group_error: str | None = None
@@ -353,11 +368,17 @@ class UpdateWeightFromTensor:
             desc="Update expert weights",
         ):
             for transfer_batch in transfer_group:
-                hf_named_tensors = self._prepare_expert_weight_batch(
-                    transfer_batch,
-                    megatron_local_weights,
-                    staging_buffers,
-                )
+                trace = getattr(self, "_weight_sync_trace", None)
+                if trace is None:
+                    hf_named_tensors = self._prepare_expert_weight_batch(
+                        transfer_batch, megatron_local_weights, staging_buffers
+                    )
+                else:
+                    with communication_phase("weight_convert", bucket_id=trace.next_bucket_id, bucket_kind="expert"):
+                        hf_named_tensors = self._prepare_expert_weight_batch(
+                            transfer_batch, megatron_local_weights, staging_buffers
+                        )
+                    trace.next_bucket_id += 1
                 self._weight_sync_credit.set_persistent_staging_bytes(_tensor_tree_nbytes(staging_buffers))
                 reservation = self._reserve_weight_bucket(hf_named_tensors)
                 refs, handles, long_lived_tensors = self._submit_weight_bucket(hf_named_tensors, reservation)
@@ -367,6 +388,8 @@ class UpdateWeightFromTensor:
                     long_lived_tensors.clear()
                 self._weight_sync_credit.mark_staging_released(reservation)
                 self._weight_sync_credit.release(reservation)
+                if trace is not None:
+                    trace.released(reservation)
                 dist.barrier(group=get_gloo_group())
                 accelerator.synchronize()
                 del refs, handles, long_lived_tensors, hf_named_tensors
@@ -377,6 +400,7 @@ class UpdateWeightFromTensor:
         accelerator.empty_cache()
 
     @torch.no_grad()
+    @trace_weight_update
     def update_weights(self) -> None:
         """
         version++, flush caches, process buckets. Progress on rank 0.
@@ -408,6 +432,9 @@ class UpdateWeightFromTensor:
                 megatron_local_weights,
                 param_info_buckets=param_info_buckets,
             )
+            trace = getattr(self, "_weight_sync_trace", None)
+            if trace is not None:
+                hf_chunks = trace.converted_chunks(hf_chunks)
             if self._weight_sync_credit.enabled:
                 self._send_weight_bucket_windows(hf_chunks)
             else:
@@ -420,6 +447,8 @@ class UpdateWeightFromTensor:
                         long_lived_tensors.clear()
                     self._weight_sync_credit.mark_staging_released(reservation)
                     self._weight_sync_credit.release(reservation)
+                    if trace is not None:
+                        trace.released(reservation)
                     # Free GPU tensors so the caching allocator can reuse the blocks,
                     # then release CUDA IPC cache entries whose consumers (sglang engines)
                     # have already closed their IPC handles.
@@ -516,6 +545,8 @@ class UpdateWeightFromTensor:
             del hf_named_tensors, refs, handles, long_lived_tensors
             self._weight_sync_credit.mark_staging_released(reservation)
             self._weight_sync_credit.release(reservation)
+            if getattr(self, "_weight_sync_trace", None) is not None:
+                self._weight_sync_trace.released(reservation)
 
         accelerator.ipc_collect()
         accelerator.empty_cache()
@@ -525,7 +556,12 @@ class UpdateWeightFromTensor:
     ) -> tuple[list[ObjectRef], list[Any], Any]:
         if self._wave_scheduling_enabled:
             return self._send_hf_params_in_waves(hf_named_tensors, reservation)
+        trace = getattr(self, "_weight_sync_trace", None)
+        if trace is not None:
+            trace.start(reservation)
         refs, handles, long_lived_tensors = self._send_hf_params(hf_named_tensors)
+        if trace is not None:
+            trace.submitted(reservation)
         self._mark_bucket_launched(reservation, refs, handles, long_lived_tensors)
         return refs, handles, long_lived_tensors
 
@@ -563,11 +599,14 @@ class UpdateWeightFromTensor:
         """Send one bucket in globally coordinated colocated/distributed waves."""
         self._weight_sync_credit.mark_launched(reservation, transport_bytes=0, staging_bytes=0, consumer_objects=0)
         engine_indices = tuple(range(self._total_engine_groups))
-        for wave in build_engine_group_waves(engine_indices, self._max_inflight_engine_groups):
+        trace = getattr(self, "_weight_sync_trace", None)
+        for wave_id, wave in enumerate(build_engine_group_waves(engine_indices, self._max_inflight_engine_groups)):
             active_indices = {engine_index for _position, engine_index in wave}
             wave_refs = []
             wave_handles = []
             wave_long_lived_tensors = None
+            if trace is not None:
+                trace.start(reservation, wave_id=wave_id, engine_group_count=len(wave))
 
             if self._ipc_engine_index in active_indices:
                 refs_colocated, wave_long_lived_tensors = _send_to_colocated_engine(
@@ -593,6 +632,8 @@ class UpdateWeightFromTensor:
                     wave_refs.extend(refs)
                     wave_handles.extend(handles)
 
+            if trace is not None:
+                trace.submitted(reservation)
             self._weight_sync_credit.mark_next_wave(
                 reservation,
                 transport_bytes=reservation.bucket_bytes if wave_handles or wave_refs else 0,

--- a/slime/backends/megatron_utils/update_weight/weight_sync_credit.py
+++ b/slime/backends/megatron_utils/update_weight/weight_sync_credit.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class WeightBucketReservation:
+    """Credit held by one logical weight bucket."""
+
+    weight_version: int
+    bucket_id: int
+    bucket_bytes: int
+
+
+class WeightSyncCreditController:
+    """Track bounded, ordered weight buckets for one updater.
+
+    A zero limit disables that credit dimension. When both limits are zero,
+    callers keep the legacy synchronous transfer path while still using the
+    version/order checks in this controller.
+    """
+
+    def __init__(self, max_inflight_buckets: int = 0, max_inflight_bytes: int = 0) -> None:
+        if max_inflight_buckets < 0:
+            raise ValueError("max_inflight_buckets must be non-negative")
+        if max_inflight_bytes < 0:
+            raise ValueError("max_inflight_bytes must be non-negative")
+
+        self.max_inflight_buckets = max_inflight_buckets
+        self.max_inflight_bytes = max_inflight_bytes
+        self._active_version: int | None = None
+        self._last_committed_version: int | None = None
+        self._next_bucket_id = 0
+        self._inflight: deque[WeightBucketReservation] = deque()
+        self._inflight_bytes = 0
+
+    @property
+    def enabled(self) -> bool:
+        return self.max_inflight_buckets > 0 or self.max_inflight_bytes > 0
+
+    @property
+    def inflight_buckets(self) -> int:
+        return len(self._inflight)
+
+    @property
+    def inflight_bytes(self) -> int:
+        return self._inflight_bytes
+
+    @property
+    def full(self) -> bool:
+        return bool(
+            (self.max_inflight_buckets and len(self._inflight) >= self.max_inflight_buckets)
+            or (self.max_inflight_bytes and self._inflight_bytes >= self.max_inflight_bytes)
+        )
+
+    def begin_version(self, weight_version: int) -> None:
+        if self._active_version is not None:
+            raise RuntimeError(f"weight version {self._active_version} is still active")
+        if self._inflight:
+            raise RuntimeError("cannot begin a weight version with buckets still in flight")
+        if self._last_committed_version is not None and weight_version <= self._last_committed_version:
+            raise ValueError(
+                f"weight version {weight_version} must be newer than committed version {self._last_committed_version}"
+            )
+
+        self._active_version = weight_version
+        self._next_bucket_id = 0
+
+    def reserve(self, bucket_bytes: int) -> WeightBucketReservation | None:
+        """Reserve the next bucket, or return ``None`` when credits are full."""
+        if self._active_version is None:
+            raise RuntimeError("begin_version must be called before reserving a bucket")
+        if bucket_bytes < 0:
+            raise ValueError("bucket_bytes must be non-negative")
+        if self.max_inflight_bytes and bucket_bytes > self.max_inflight_bytes:
+            raise ValueError(
+                f"weight bucket requires {bucket_bytes} bytes, larger than "
+                f"--update-weight-max-inflight-bytes={self.max_inflight_bytes}"
+            )
+        if self.max_inflight_buckets and len(self._inflight) >= self.max_inflight_buckets:
+            return None
+        if self.max_inflight_bytes and self._inflight_bytes + bucket_bytes > self.max_inflight_bytes:
+            return None
+
+        reservation = WeightBucketReservation(
+            weight_version=self._active_version,
+            bucket_id=self._next_bucket_id,
+            bucket_bytes=bucket_bytes,
+        )
+        self._next_bucket_id += 1
+        self._inflight.append(reservation)
+        self._inflight_bytes += bucket_bytes
+        return reservation
+
+    def release(self, reservation: WeightBucketReservation) -> None:
+        """Release the oldest bucket, preserving engine load order."""
+        if not self._inflight:
+            raise RuntimeError("no weight bucket credit is in flight")
+        oldest = self._inflight[0]
+        if reservation != oldest:
+            raise RuntimeError(
+                f"weight buckets must complete in order: expected bucket {oldest.bucket_id}, "
+                f"got bucket {reservation.bucket_id}"
+            )
+
+        self._inflight.popleft()
+        self._inflight_bytes -= reservation.bucket_bytes
+
+    def commit_version(self, weight_version: int) -> None:
+        if weight_version != self._active_version:
+            raise RuntimeError(f"cannot commit inactive weight version {weight_version}")
+        if self._inflight:
+            raise RuntimeError(
+                f"cannot commit weight version {weight_version} with {len(self._inflight)} bucket(s) in flight"
+            )
+
+        self._last_committed_version = weight_version
+        self._active_version = None

--- a/slime/backends/megatron_utils/update_weight/weight_sync_credit.py
+++ b/slime/backends/megatron_utils/update_weight/weight_sync_credit.py
@@ -13,6 +13,31 @@ class WeightBucketReservation:
     bucket_bytes: int
 
 
+@dataclass(frozen=True, slots=True)
+class WeightSyncLifecycleSnapshot:
+    """Rank-local accounting for the active or most recently committed version."""
+
+    active_version: int | None
+    failed_reason: str | None
+    inflight_buckets: int
+    inflight_bytes: int
+    transport_outstanding_bytes: int
+    staging_resident_bytes: int
+    pending_consumer_objects: int
+    peak_inflight_buckets: int
+    peak_inflight_bytes: int
+    peak_transport_outstanding_bytes: int
+    peak_staging_resident_bytes: int
+    peak_pending_consumer_objects: int
+
+
+@dataclass(slots=True)
+class _BucketLifecycle:
+    transport_bytes: int
+    staging_bytes: int
+    consumer_objects: int
+
+
 class WeightSyncCreditController:
     """Track bounded, ordered weight buckets for one updater.
 
@@ -34,6 +59,17 @@ class WeightSyncCreditController:
         self._next_bucket_id = 0
         self._inflight: deque[WeightBucketReservation] = deque()
         self._inflight_bytes = 0
+        self._bucket_lifecycles: dict[WeightBucketReservation, _BucketLifecycle] = {}
+        self._transport_outstanding_bytes = 0
+        self._staging_resident_bytes = 0
+        self._persistent_staging_bytes = 0
+        self._pending_consumer_objects = 0
+        self._peak_inflight_buckets = 0
+        self._peak_inflight_bytes = 0
+        self._peak_transport_outstanding_bytes = 0
+        self._peak_staging_resident_bytes = 0
+        self._peak_pending_consumer_objects = 0
+        self._failed_reason: str | None = None
 
     @property
     def enabled(self) -> bool:
@@ -54,11 +90,41 @@ class WeightSyncCreditController:
             or (self.max_inflight_bytes and self._inflight_bytes >= self.max_inflight_bytes)
         )
 
+    @property
+    def snapshot(self) -> WeightSyncLifecycleSnapshot:
+        return WeightSyncLifecycleSnapshot(
+            active_version=self._active_version,
+            failed_reason=self._failed_reason,
+            inflight_buckets=len(self._inflight),
+            inflight_bytes=self._inflight_bytes,
+            transport_outstanding_bytes=self._transport_outstanding_bytes,
+            staging_resident_bytes=self._staging_resident_bytes,
+            pending_consumer_objects=self._pending_consumer_objects,
+            peak_inflight_buckets=self._peak_inflight_buckets,
+            peak_inflight_bytes=self._peak_inflight_bytes,
+            peak_transport_outstanding_bytes=self._peak_transport_outstanding_bytes,
+            peak_staging_resident_bytes=self._peak_staging_resident_bytes,
+            peak_pending_consumer_objects=self._peak_pending_consumer_objects,
+        )
+
+    def metrics(self) -> dict[str, float]:
+        """Return peak rank-local lifecycle counters for the current version."""
+        snapshot = self.snapshot
+        return {
+            "perf/update_weights_peak_inflight_buckets": float(snapshot.peak_inflight_buckets),
+            "perf/update_weights_peak_logical_inflight_bytes": float(snapshot.peak_inflight_bytes),
+            "perf/update_weights_peak_transport_outstanding_bytes": float(snapshot.peak_transport_outstanding_bytes),
+            "perf/update_weights_peak_staging_resident_bytes": float(snapshot.peak_staging_resident_bytes),
+            "perf/update_weights_peak_pending_consumer_objects": float(snapshot.peak_pending_consumer_objects),
+        }
+
     def begin_version(self, weight_version: int) -> None:
         if self._active_version is not None:
             raise RuntimeError(f"weight version {self._active_version} is still active")
         if self._inflight:
             raise RuntimeError("cannot begin a weight version with buckets still in flight")
+        if self._bucket_lifecycles or self._transport_outstanding_bytes or self._staging_resident_bytes:
+            raise RuntimeError("cannot begin a weight version with lifecycle resources still resident")
         if self._last_committed_version is not None and weight_version <= self._last_committed_version:
             raise ValueError(
                 f"weight version {weight_version} must be newer than committed version {self._last_committed_version}"
@@ -66,6 +132,12 @@ class WeightSyncCreditController:
 
         self._active_version = weight_version
         self._next_bucket_id = 0
+        self._failed_reason = None
+        self._peak_inflight_buckets = 0
+        self._peak_inflight_bytes = 0
+        self._peak_transport_outstanding_bytes = 0
+        self._peak_staging_resident_bytes = 0
+        self._peak_pending_consumer_objects = 0
 
     def reserve(self, bucket_bytes: int) -> WeightBucketReservation | None:
         """Reserve the next bucket, or return ``None`` when credits are full."""
@@ -91,7 +163,84 @@ class WeightSyncCreditController:
         self._next_bucket_id += 1
         self._inflight.append(reservation)
         self._inflight_bytes += bucket_bytes
+        self._peak_inflight_buckets = max(self._peak_inflight_buckets, len(self._inflight))
+        self._peak_inflight_bytes = max(self._peak_inflight_bytes, self._inflight_bytes)
         return reservation
+
+    def mark_launched(
+        self,
+        reservation: WeightBucketReservation,
+        *,
+        transport_bytes: int,
+        staging_bytes: int,
+        consumer_objects: int,
+    ) -> None:
+        """Record resources retained after a bucket has been submitted.
+
+        These counters are evidence only: admission remains governed by logical
+        bucket count and bytes. They make explicit when staging memory exceeds
+        the logical byte credit instead of silently treating the two as equal.
+        """
+        self._require_inflight(reservation)
+        if reservation in self._bucket_lifecycles:
+            raise RuntimeError(f"weight bucket {reservation.bucket_id} was already launched")
+        for name, value in (
+            ("transport_bytes", transport_bytes),
+            ("staging_bytes", staging_bytes),
+            ("consumer_objects", consumer_objects),
+        ):
+            if value < 0:
+                raise ValueError(f"{name} must be non-negative")
+
+        self._bucket_lifecycles[reservation] = _BucketLifecycle(
+            transport_bytes=transport_bytes,
+            staging_bytes=staging_bytes,
+            consumer_objects=consumer_objects,
+        )
+        self._transport_outstanding_bytes += transport_bytes
+        self._staging_resident_bytes += staging_bytes
+        self._pending_consumer_objects += consumer_objects
+        self._peak_transport_outstanding_bytes = max(
+            self._peak_transport_outstanding_bytes, self._transport_outstanding_bytes
+        )
+        self._peak_staging_resident_bytes = max(self._peak_staging_resident_bytes, self._staging_resident_bytes)
+        self._peak_pending_consumer_objects = max(self._peak_pending_consumer_objects, self._pending_consumer_objects)
+
+    def mark_transport_complete(self, reservation: WeightBucketReservation) -> None:
+        """Release transport accounting exactly once after its wait boundary."""
+        lifecycle = self._require_lifecycle(reservation)
+        if lifecycle.transport_bytes:
+            self._transport_outstanding_bytes -= lifecycle.transport_bytes
+            lifecycle.transport_bytes = 0
+
+    def mark_consumers_complete(self, reservation: WeightBucketReservation) -> None:
+        """Release consumer-object accounting exactly once after acknowledgement."""
+        lifecycle = self._require_lifecycle(reservation)
+        if lifecycle.consumer_objects:
+            self._pending_consumer_objects -= lifecycle.consumer_objects
+            lifecycle.consumer_objects = 0
+
+    def mark_staging_released(self, reservation: WeightBucketReservation) -> None:
+        """Release staging accounting exactly once after producer references are dropped."""
+        lifecycle = self._require_lifecycle(reservation)
+        if lifecycle.staging_bytes:
+            self._staging_resident_bytes -= lifecycle.staging_bytes
+            lifecycle.staging_bytes = 0
+
+    def set_persistent_staging_bytes(self, staging_bytes: int) -> None:
+        """Observe reusable staging that lives outside individual bucket objects."""
+        if staging_bytes < 0:
+            raise ValueError("staging_bytes must be non-negative")
+        self._staging_resident_bytes += staging_bytes - self._persistent_staging_bytes
+        self._persistent_staging_bytes = staging_bytes
+        self._peak_staging_resident_bytes = max(self._peak_staging_resident_bytes, self._staging_resident_bytes)
+
+    def fail_version(self, weight_version: int, error: BaseException | str) -> None:
+        """Poison a partially applied version so it can never be committed or reused."""
+        if weight_version != self._active_version:
+            raise RuntimeError(f"cannot fail inactive weight version {weight_version}")
+        if self._failed_reason is None:
+            self._failed_reason = str(error) if isinstance(error, str) else f"{type(error).__name__}: {error}"
 
     def release(self, reservation: WeightBucketReservation) -> None:
         """Release the oldest bucket, preserving engine load order."""
@@ -104,16 +253,47 @@ class WeightSyncCreditController:
                 f"got bucket {reservation.bucket_id}"
             )
 
+        lifecycle = self._bucket_lifecycles.get(reservation)
+        if lifecycle is not None:
+            if lifecycle.transport_bytes or lifecycle.staging_bytes or lifecycle.consumer_objects:
+                raise RuntimeError(
+                    f"cannot release weight bucket {reservation.bucket_id} before transport, "
+                    "consumers, and staging resources are complete"
+                )
+            del self._bucket_lifecycles[reservation]
+
         self._inflight.popleft()
         self._inflight_bytes -= reservation.bucket_bytes
 
     def commit_version(self, weight_version: int) -> None:
         if weight_version != self._active_version:
             raise RuntimeError(f"cannot commit inactive weight version {weight_version}")
+        if self._failed_reason is not None:
+            raise RuntimeError(f"cannot commit failed weight version {weight_version}: {self._failed_reason}")
         if self._inflight:
             raise RuntimeError(
                 f"cannot commit weight version {weight_version} with {len(self._inflight)} bucket(s) in flight"
             )
+        if (
+            self._bucket_lifecycles
+            or self._transport_outstanding_bytes
+            or self._staging_resident_bytes
+            or self._pending_consumer_objects
+        ):
+            raise RuntimeError(
+                f"cannot commit weight version {weight_version} with lifecycle resources still resident"
+            )
 
         self._last_committed_version = weight_version
         self._active_version = None
+
+    def _require_inflight(self, reservation: WeightBucketReservation) -> None:
+        if reservation not in self._inflight:
+            raise RuntimeError(f"weight bucket {reservation.bucket_id} is not in flight")
+
+    def _require_lifecycle(self, reservation: WeightBucketReservation) -> _BucketLifecycle:
+        self._require_inflight(reservation)
+        lifecycle = self._bucket_lifecycles.get(reservation)
+        if lifecycle is None:
+            raise RuntimeError(f"weight bucket {reservation.bucket_id} was not launched")
+        return lifecycle

--- a/slime/backends/megatron_utils/update_weight/weight_sync_credit.py
+++ b/slime/backends/megatron_utils/update_weight/weight_sync_credit.py
@@ -206,6 +206,30 @@ class WeightSyncCreditController:
         self._peak_staging_resident_bytes = max(self._peak_staging_resident_bytes, self._staging_resident_bytes)
         self._peak_pending_consumer_objects = max(self._peak_pending_consumer_objects, self._pending_consumer_objects)
 
+    def mark_next_wave(
+        self,
+        reservation: WeightBucketReservation,
+        *,
+        transport_bytes: int,
+        staging_bytes: int,
+        consumer_objects: int,
+    ) -> None:
+        """Observe another wave without releasing the logical bucket credit."""
+        previous = self._require_lifecycle(reservation)
+        if previous.transport_bytes or previous.staging_bytes or previous.consumer_objects:
+            raise RuntimeError("cannot advance a weight wave before its resources complete")
+        del self._bucket_lifecycles[reservation]
+        try:
+            self.mark_launched(
+                reservation,
+                transport_bytes=transport_bytes,
+                staging_bytes=staging_bytes,
+                consumer_objects=consumer_objects,
+            )
+        except BaseException:
+            self._bucket_lifecycles[reservation] = previous
+            raise
+
     def mark_transport_complete(self, reservation: WeightBucketReservation) -> None:
         """Release transport accounting exactly once after its wait boundary."""
         lifecycle = self._require_lifecycle(reservation)

--- a/slime/observability/communication_timeline.py
+++ b/slime/observability/communication_timeline.py
@@ -1,0 +1,542 @@
+from __future__ import annotations
+
+import atexit
+import contextvars
+import json
+import logging
+import os
+import socket
+import threading
+import time
+import uuid
+from collections.abc import Iterator, Mapping
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, ClassVar
+
+logger = logging.getLogger(__name__)
+
+COMMUNICATION_TIMELINE_VERSION = 2
+COMMUNICATION_TIMELINE_ENV = "SLIME_COMMUNICATION_TIMELINE"
+COMMUNICATION_TIMELINE_RUN_ID_ENV = "SLIME_COMMUNICATION_TIMELINE_RUN_ID"
+
+_STANDARD_FIELDS = (
+    "global_step",
+    "rollout_id",
+    "weight_version",
+    "bucket_id",
+    "trainer_rank",
+    "engine_id",
+    "message_bytes",
+    "transport",
+)
+_CONTEXT: contextvars.ContextVar[dict[str, Any] | None] = contextvars.ContextVar(
+    "slime_communication_timeline_context",
+    default=None,
+)
+_GLOBAL_LOCK = threading.RLock()
+_GLOBAL_TIMELINE: CommunicationTimeline | None = None
+_GLOBAL_CONFIGURED = False
+
+
+class _DisabledCommunicationPhase:
+    """Shared no-op phase used after tracing is configured off."""
+
+    enabled = False
+
+    def __enter__(self) -> _DisabledCommunicationPhase:
+        return self
+
+    def __exit__(self, exc_type, exc, traceback) -> bool:
+        return False
+
+    def update(self, **fields: Any) -> _DisabledCommunicationPhase:
+        return self
+
+    def mark_consumer(self) -> _DisabledCommunicationPhase:
+        return self
+
+    def mark_api_return(self) -> _DisabledCommunicationPhase:
+        return self
+
+    def cancel(self) -> None:
+        return None
+
+
+_DISABLED_PHASE = _DisabledCommunicationPhase()
+
+
+def _optional_torch():
+    try:
+        import torch
+
+        return torch
+    except ImportError:
+        return None
+
+
+def _detect_rank() -> int:
+    torch = _optional_torch()
+    if torch is not None and torch.distributed.is_available() and torch.distributed.is_initialized():
+        return torch.distributed.get_rank()
+    return int(os.environ.get("RANK", 0))
+
+
+def _detect_local_rank() -> int:
+    return int(os.environ.get("LOCAL_RANK", 0))
+
+
+def _detect_world_size() -> int:
+    torch = _optional_torch()
+    if torch is not None and torch.distributed.is_available() and torch.distributed.is_initialized():
+        return torch.distributed.get_world_size()
+    return int(os.environ.get("WORLD_SIZE", 1))
+
+
+def _resolve_path(template: str, *, rank: int, local_rank: int, role: str, world_size: int) -> Path:
+    values = {
+        "rank": rank,
+        "trainer_rank": rank,
+        "local_rank": local_rank,
+        "pid": os.getpid(),
+        "hostname": socket.gethostname(),
+        "role": role,
+        "world_size": world_size,
+    }
+    try:
+        resolved = template.format_map(values)
+    except (KeyError, ValueError) as exc:
+        raise ValueError(
+            "communication timeline path supports only {rank}, {trainer_rank}, {local_rank}, "
+            "{pid}, {hostname}, {role}, and {world_size} placeholders"
+        ) from exc
+    path = Path(resolved).expanduser()
+    if role != "trainer" and "{role}" not in template and "{pid}" not in template:
+        suffix = path.suffix
+        stem = path.name[: -len(suffix)] if suffix else path.name
+        path = path.with_name(f"{stem}.role-{role}{suffix}")
+    if world_size > 1 and not any(f"{{{name}}}" in template for name in ("rank", "trainer_rank", "pid")):
+        suffix = path.suffix
+        stem = path.name[: -len(suffix)] if suffix else path.name
+        path = path.with_name(f"{stem}.rank-{rank}{suffix}")
+    return path
+
+
+def _message_bytes(named_tensors) -> int:
+    total = 0
+    for item in named_tensors:
+        tensor = item[1] if isinstance(item, tuple) else item
+        total += int(tensor.numel()) * int(tensor.element_size())
+    return total
+
+
+@dataclass
+class _PendingRecord:
+    record: dict[str, Any] | None
+    gpu_start: Any = None
+    gpu_end: Any = None
+
+
+class CommunicationTimeline:
+    """Append-only trainer communication timeline.
+
+    CUDA events are queried without synchronizing the training stream during normal
+    operation. ``close()`` waits only for the outstanding end events so the final
+    records are not lost at process shutdown.
+    """
+
+    def __init__(
+        self,
+        path: str,
+        *,
+        rank: int | None = None,
+        local_rank: int | None = None,
+        world_size: int | None = None,
+        role: str = "trainer",
+        run_id: str | None = None,
+    ) -> None:
+        self.rank = _detect_rank() if rank is None else rank
+        self.local_rank = _detect_local_rank() if local_rank is None else local_rank
+        self.world_size = _detect_world_size() if world_size is None else world_size
+        self.role = role
+        self.run_id = run_id or os.environ.get(COMMUNICATION_TIMELINE_RUN_ID_ENV) or uuid.uuid4().hex
+        self.path = _resolve_path(
+            path,
+            rank=self.rank,
+            local_rank=self.local_rank,
+            role=role,
+            world_size=self.world_size,
+        )
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._file = self.path.open("a", encoding="utf-8", buffering=1)
+        self._lock = threading.RLock()
+        self._pending: dict[int, _PendingRecord] = {}
+        self._sequence_id = 0
+        self._next_write_sequence_id = 0
+        self._closed = False
+        self._write_failed = False
+
+    def next_sequence_id(self) -> int:
+        with self._lock:
+            sequence_id = self._sequence_id
+            self._sequence_id += 1
+            return sequence_id
+
+    def new_span(self, operation: str, fields: Mapping[str, Any]) -> CommunicationPhase:
+        return CommunicationPhase(self, operation, dict(fields))
+
+    def emit_event(self, operation: str, fields: Mapping[str, Any]) -> None:
+        now_wall = time.time_ns()
+        now_monotonic = time.perf_counter_ns()
+        record = self._base_record(operation, fields)
+        record.update(
+            {
+                "record_type": "event",
+                "api_launch_timestamp_ns": now_wall,
+                "api_return_timestamp_ns": now_wall,
+                "completion_timestamp_ns": now_wall,
+                "consumer_timestamp_ns": fields.get("consumer_timestamp_ns"),
+                "api_launch_monotonic_ns": now_monotonic,
+                "completion_monotonic_ns": now_monotonic,
+                "duration_ns": 0,
+                "gpu_start_timestamp_ns": None,
+                "gpu_end_timestamp_ns": None,
+                "gpu_elapsed_ns": None,
+                "status": "ok",
+            }
+        )
+        self._queue(_PendingRecord(record=record))
+        self.flush(block=False)
+
+    def _base_record(self, operation: str, fields: Mapping[str, Any]) -> dict[str, Any]:
+        context = dict(_CONTEXT.get() or {})
+        context.update(fields)
+        standard = {name: context.pop(name, None) for name in _STANDARD_FIELDS}
+        if standard["trainer_rank"] is None:
+            standard["trainer_rank"] = self.rank
+        sequence_id = self.next_sequence_id()
+        logical_parts = (
+            standard["global_step"],
+            standard["rollout_id"],
+            standard["weight_version"],
+            standard["bucket_id"],
+            operation,
+        )
+        logical_operation_id = "/".join("-" if value is None else str(value) for value in logical_parts)
+        if "wave_id" in context:
+            logical_operation_id += f"/wave/{context['wave_id']}"
+        return {
+            "schema_version": COMMUNICATION_TIMELINE_VERSION,
+            "framework": "slime",
+            "gpu_timestamp_semantics": "event-bracket",
+            "timestamp_domain": "process-realtime-projected-cuda-event",
+            "clock_sync_error_bound_us": None,
+            "run_id": self.run_id,
+            "role": self.role,
+            "rank": self.rank,
+            "local_rank": self.local_rank,
+            "world_size": self.world_size,
+            "hostname": socket.gethostname(),
+            "pid": os.getpid(),
+            "sequence_id": sequence_id,
+            "logical_operation_id": logical_operation_id,
+            "operation": operation,
+            **standard,
+            "metadata": context,
+        }
+
+    def finish_span(self, span: CommunicationPhase, error: BaseException | None) -> None:
+        if span.cancelled:
+            self._queue(_PendingRecord(record=None), sequence_id=span.record["sequence_id"])
+            self.flush(block=False)
+            return
+        end_wall = time.time_ns()
+        end_monotonic = time.perf_counter_ns()
+        if span.gpu_end is not None:
+            try:
+                span.gpu_end.record()
+            except Exception as exc:
+                span.record["metadata"]["gpu_event_error"] = str(exc)
+                span.gpu_start = span.gpu_end = None
+        record = span.record
+        record.update(
+            {
+                "api_return_timestamp_ns": span.api_return_timestamp_ns or end_wall,
+                "completion_timestamp_ns": end_wall,
+                "consumer_timestamp_ns": span.consumer_timestamp_ns,
+                "completion_monotonic_ns": end_monotonic,
+                "duration_ns": end_monotonic - span.start_monotonic_ns,
+                "gpu_start_timestamp_ns": None,
+                "gpu_end_timestamp_ns": None,
+                "gpu_elapsed_ns": None,
+                "status": "error" if error is not None else "ok",
+            }
+        )
+        if error is not None:
+            record["metadata"]["error_type"] = type(error).__name__
+            record["metadata"]["error_message"] = str(error)
+        pending = _PendingRecord(record=record, gpu_start=span.gpu_start, gpu_end=span.gpu_end)
+        self._queue(pending)
+        self.flush(block=False)
+
+    def _queue(self, pending: _PendingRecord, *, sequence_id: int | None = None) -> None:
+        if sequence_id is None:
+            assert pending.record is not None
+            sequence_id = pending.record["sequence_id"]
+        with self._lock:
+            self._pending[sequence_id] = pending
+
+    def flush(self, *, block: bool = False) -> None:
+        with self._lock:
+            while self._next_write_sequence_id in self._pending:
+                pending = self._pending[self._next_write_sequence_id]
+                if pending.record is None:
+                    del self._pending[self._next_write_sequence_id]
+                    self._next_write_sequence_id += 1
+                    continue
+                if pending.gpu_end is not None:
+                    try:
+                        if block:
+                            pending.gpu_end.synchronize()
+                        elif not pending.gpu_end.query():
+                            break
+                        elapsed_ns = int(round(pending.gpu_start.elapsed_time(pending.gpu_end) * 1_000_000))
+                        gpu_start_ns = pending.record["api_launch_timestamp_ns"]
+                        pending.record["gpu_start_timestamp_ns"] = gpu_start_ns
+                        pending.record["gpu_end_timestamp_ns"] = gpu_start_ns + elapsed_ns
+                        pending.record["gpu_elapsed_ns"] = elapsed_ns
+                    except Exception as exc:
+                        pending.record["metadata"]["gpu_timing_error"] = str(exc)
+                self._write_unlocked(pending.record)
+                del self._pending[self._next_write_sequence_id]
+                self._next_write_sequence_id += 1
+            try:
+                self._file.flush()
+            except OSError as exc:
+                self._mark_write_failed(exc)
+
+    def close(self) -> None:
+        with self._lock:
+            if self._closed:
+                return
+        try:
+            self.flush(block=True)
+        finally:
+            with self._lock:
+                if not self._closed:
+                    try:
+                        self._file.close()
+                    except OSError as exc:
+                        self._mark_write_failed(exc)
+                    self._closed = True
+
+    def _write_unlocked(self, record: Mapping[str, Any]) -> None:
+        if self._write_failed:
+            return
+        try:
+            self._file.write(json.dumps(record, sort_keys=True, separators=(",", ":"), default=str) + "\n")
+        except OSError as exc:
+            self._mark_write_failed(exc)
+
+    def _mark_write_failed(self, exc: OSError) -> None:
+        if not self._write_failed:
+            logger.warning("communication timeline disabled after write failure: %s", exc)
+            self._write_failed = True
+
+
+@dataclass
+class CommunicationPhase:
+    enabled: ClassVar[bool] = True
+    timeline: CommunicationTimeline | None
+    operation: str
+    fields: dict[str, Any] = field(default_factory=dict)
+    record: dict[str, Any] = field(default_factory=dict, init=False)
+    start_monotonic_ns: int = field(default=0, init=False)
+    consumer_timestamp_ns: int | None = field(default=None, init=False)
+    api_return_timestamp_ns: int | None = field(default=None, init=False)
+    gpu_start: Any = field(default=None, init=False)
+    gpu_end: Any = field(default=None, init=False)
+    cancelled: bool = field(default=False, init=False)
+    _nvtx: bool = field(default=False, init=False)
+
+    def __enter__(self) -> CommunicationPhase:
+        if self.timeline is None:
+            return self
+        start_wall = time.time_ns()
+        self.start_monotonic_ns = time.perf_counter_ns()
+        self.record = self.timeline._base_record(self.operation, self.fields)
+        self.record.update(
+            {
+                "record_type": "span",
+                "api_launch_timestamp_ns": start_wall,
+                "api_launch_monotonic_ns": self.start_monotonic_ns,
+            }
+        )
+        torch = _optional_torch()
+        if torch is not None and torch.cuda.is_available():
+            try:
+                self.record["stream_id"] = int(torch.cuda.current_stream().cuda_stream)
+                self.gpu_start = torch.cuda.Event(enable_timing=True)
+                self.gpu_end = torch.cuda.Event(enable_timing=True)
+                self.gpu_start.record()
+                torch.cuda.nvtx.range_push(f"slime.comm/{self.operation}")
+                self._nvtx = True
+            except Exception as exc:
+                self.record["metadata"]["gpu_event_error"] = str(exc)
+                self.gpu_start = self.gpu_end = None
+        else:
+            self.record["stream_id"] = None
+        return self
+
+    def __exit__(self, exc_type, exc, traceback) -> bool:
+        if self.timeline is None:
+            return False
+        self._close_nvtx()
+        try:
+            self.timeline.finish_span(self, exc)
+        except Exception as timeline_exc:
+            logger.warning("communication timeline phase %s could not be recorded: %s", self.operation, timeline_exc)
+        return False
+
+    def _close_nvtx(self) -> None:
+        if self._nvtx:
+            torch = _optional_torch()
+            try:
+                torch.cuda.nvtx.range_pop()
+            except Exception as nvtx_exc:
+                self.record["metadata"]["nvtx_error"] = str(nvtx_exc)
+            self._nvtx = False
+
+    def mark_api_return(self) -> CommunicationPhase:
+        """End the API/NVTX range while retaining the deferred GPU end event."""
+        if self.timeline is not None and self.api_return_timestamp_ns is None:
+            self.api_return_timestamp_ns = time.time_ns()
+            self._close_nvtx()
+        return self
+
+    def update(self, **fields: Any) -> CommunicationPhase:
+        if self.timeline is None:
+            return self
+        for name, value in fields.items():
+            if name in _STANDARD_FIELDS:
+                self.record[name] = value
+            else:
+                self.record.setdefault("metadata", {})[name] = value
+        return self
+
+    def mark_consumer(self) -> CommunicationPhase:
+        self.consumer_timestamp_ns = time.time_ns()
+        return self
+
+    def cancel(self) -> None:
+        self.cancelled = True
+
+
+def configure_communication_timeline(
+    path: str | None = None,
+    *,
+    rank: int | None = None,
+    local_rank: int | None = None,
+    world_size: int | None = None,
+    role: str = "trainer",
+    run_id: str | None = None,
+) -> CommunicationTimeline | None:
+    """Configure the process-local timeline; ``None`` uses the environment."""
+
+    global _GLOBAL_CONFIGURED, _GLOBAL_TIMELINE
+    path = path or os.environ.get(COMMUNICATION_TIMELINE_ENV)
+    with _GLOBAL_LOCK:
+        if _GLOBAL_TIMELINE is not None:
+            _GLOBAL_TIMELINE.close()
+        _GLOBAL_TIMELINE = (
+            CommunicationTimeline(
+                path,
+                rank=rank,
+                local_rank=local_rank,
+                world_size=world_size,
+                role=role,
+                run_id=run_id,
+            )
+            if path
+            else None
+        )
+        _GLOBAL_CONFIGURED = True
+        return _GLOBAL_TIMELINE
+
+
+def get_communication_timeline() -> CommunicationTimeline | None:
+    global _GLOBAL_CONFIGURED
+    with _GLOBAL_LOCK:
+        if not _GLOBAL_CONFIGURED:
+            configure_communication_timeline()
+        return _GLOBAL_TIMELINE
+
+
+def _configured_timeline() -> CommunicationTimeline | None:
+    if _GLOBAL_CONFIGURED:
+        return _GLOBAL_TIMELINE
+    return get_communication_timeline()
+
+
+def communication_phase(operation: str, **fields: Any) -> CommunicationPhase | _DisabledCommunicationPhase:
+    timeline = _configured_timeline()
+    if timeline is None:
+        return _DISABLED_PHASE
+    return CommunicationPhase(timeline, operation, fields)
+
+
+def communication_event(operation: str, **fields: Any) -> None:
+    timeline = _configured_timeline()
+    if timeline is not None:
+        timeline.emit_event(operation, fields)
+
+
+@contextmanager
+def communication_context(**fields: Any) -> Iterator[None]:
+    if _configured_timeline() is None:
+        yield
+        return
+    current = dict(_CONTEXT.get() or {})
+    current.update(fields)
+    token = _CONTEXT.set(current)
+    try:
+        yield
+    finally:
+        _CONTEXT.reset(token)
+
+
+def iter_communication_buckets(chunks, *, operation: str = "weight_convert", start_bucket_id: int = 0):
+    """Yield chunks while timing the generator work that produces each bucket."""
+
+    iterator = iter(chunks)
+    bucket_id = start_bucket_id
+    while True:
+        with communication_phase(operation, bucket_id=bucket_id) as phase:
+            try:
+                chunk = next(iterator)
+            except StopIteration:
+                phase.cancel()
+                break
+            if phase.enabled:
+                phase.update(message_bytes=_message_bytes(chunk))
+        yield bucket_id, chunk
+        bucket_id += 1
+
+
+def flush_communication_timeline(*, block: bool = False) -> None:
+    timeline = _configured_timeline()
+    if timeline is not None:
+        timeline.flush(block=block)
+
+
+def close_communication_timeline() -> None:
+    global _GLOBAL_CONFIGURED, _GLOBAL_TIMELINE
+    with _GLOBAL_LOCK:
+        timeline, _GLOBAL_TIMELINE = _GLOBAL_TIMELINE, None
+        _GLOBAL_CONFIGURED = True
+    if timeline is not None:
+        timeline.close()
+
+
+atexit.register(close_communication_timeline)

--- a/slime/observability/weight_sync_trace.py
+++ b/slime/observability/weight_sync_trace.py
@@ -1,0 +1,105 @@
+"""Opt-in tracing of the production updater's asynchronous bucket lifetime."""
+
+from __future__ import annotations
+
+from functools import partial, wraps
+
+from .communication_timeline import (
+    communication_context,
+    communication_event,
+    communication_phase,
+    flush_communication_timeline,
+    get_communication_timeline,
+    iter_communication_buckets,
+)
+
+
+class WeightSyncTrace:
+    """One version's transfer spans; never a replacement for credit accounting."""
+
+    def __init__(self):
+        self.pending = {}
+        self.fields = {}
+        self.next_bucket_id = 0
+
+    def converted_chunks(self, chunks):
+        for bucket_id, chunk in iter_communication_buckets(chunks, start_bucket_id=self.next_bucket_id):
+            self.next_bucket_id = bucket_id + 1
+            yield chunk
+
+    def start(self, reservation, **metadata):
+        bucket_id = reservation.bucket_id
+        if bucket_id in self.pending:
+            raise RuntimeError("duplicate active communication span for a weight bucket")
+        fields = {"bucket_id": bucket_id, "message_bytes": reservation.bucket_bytes, **metadata}
+        self.fields[bucket_id] = fields
+        communication_event("weight_bucket_ready", **fields)
+        phase = communication_phase("weight_bucket_send", **fields)
+        phase.__enter__()
+        self.pending[bucket_id] = phase
+
+    def submitted(self, reservation):
+        phase = self.pending.get(reservation.bucket_id)
+        if phase is not None:
+            phase.mark_api_return()
+
+    def complete(self, reservation, error=None):
+        phase = self.pending.pop(reservation.bucket_id, None)
+        if phase is not None:
+            phase.__exit__(type(error) if error else None, error, None)
+            if error is None:
+                communication_event(
+                    "engine_bucket_receive",
+                    **self.fields[reservation.bucket_id],
+                    observation="trainer_transport_or_ipc_ack_complete",
+                )
+
+    def consumer(self, reservation):
+        return communication_phase(
+            "engine_load_weights",
+            **self.fields[reservation.bucket_id],
+            observation="trainer_engine_load_ack_wait",
+        )
+
+    def released(self, reservation):
+        communication_event(
+            "weight_bucket_reusable", bucket_id=reservation.bucket_id, message_bytes=reservation.bucket_bytes
+        )
+        self.fields.pop(reservation.bucket_id, None)
+
+    def close(self, error):
+        for phase in self.pending.values():
+            phase.__exit__(type(error) if error else None, error, None)
+        self.pending.clear()
+        self.fields.clear()
+
+
+def trace_weight_update(function=None, *, transport="nccl_or_cuda_ipc"):
+    """Keep the disabled path free of trace objects, clocks and tensor scans."""
+
+    if function is None:
+        return partial(trace_weight_update, transport=transport)
+
+    @wraps(function)
+    def wrapped(self):
+        if get_communication_timeline() is None:
+            return function(self)
+        trace = self._weight_sync_trace = WeightSyncTrace()
+        with communication_context(weight_version=self.weight_version + 1, transport=transport):
+            try:
+                result = function(self)
+                if trace.pending:
+                    raise RuntimeError("weight update returned with incomplete transfer trace spans")
+            except BaseException as error:
+                trace.close(error)
+                communication_event("weight_sync_failed", error_type=type(error).__name__)
+                raise
+            else:
+                trace.close(None)
+                communication_event("weight_sync_complete")
+                return result
+            finally:
+                self._weight_sync_trace = None
+                flush_communication_timeline(block=False)
+
+    return wrapped

--- a/slime/ray/actor_group.py
+++ b/slime/ray/actor_group.py
@@ -1,12 +1,19 @@
+import atexit
 import os
 import shutil
 import time
+import uuid
 from pathlib import Path
 
 import ray
 from ray.util.placement_group import PlacementGroup
 from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 
+from slime.observability.communication_timeline import (
+    COMMUNICATION_TIMELINE_ENV,
+    COMMUNICATION_TIMELINE_RUN_ID_ENV,
+    CommunicationTimeline,
+)
 from slime.ray.utils import NOSET_VISIBLE_DEVICES_ENV_VARS_LIST, add_default_ray_env_vars
 from slime.utils.engine_group_wave import run_engine_group_waves
 
@@ -54,6 +61,25 @@ class RayTrainGroup:
         self._rollout_manager = None
         self._disk_weight_version = getattr(args, "update_weight_start_version", 0)
         self._actor_handlers = []
+        timeline_path = getattr(args, "communication_timeline", None) or os.environ.get(COMMUNICATION_TIMELINE_ENV)
+        self._communication_timeline_enabled = bool(timeline_path)
+        self._communication_timeline = None
+        timeline_run_id = getattr(args, "communication_timeline_run_id", None) or os.environ.get(
+            COMMUNICATION_TIMELINE_RUN_ID_ENV
+        )
+        if timeline_path and timeline_run_id is None:
+            timeline_run_id = uuid.uuid4().hex
+            args.communication_timeline_run_id = timeline_run_id
+        if timeline_path and self._full_disk_weight_update_enabled():
+            self._communication_timeline = CommunicationTimeline(
+                timeline_path,
+                rank=-1,
+                local_rank=-1,
+                world_size=1,
+                role=f"{role}-orchestrator",
+                run_id=timeline_run_id,
+            )
+            atexit.register(self._communication_timeline.close)
 
     def _allocate_gpus_for_actor(self, pg, num_gpus_per_actor):
         world_size = self._num_nodes * self._num_gpus_per_node
@@ -160,8 +186,10 @@ class RayTrainGroup:
             self.args.no_load_rng = False
         return ret
 
-    def update_weights(self):
+    def update_weights(self, rollout_id=None):
         """Broadcast weights from rank 0 to all other ranks."""
+        if self._communication_timeline_enabled:
+            ray.get([actor.set_communication_rollout_id.remote(rollout_id) for actor in self._actor_handlers])
         if not self._full_disk_weight_update_enabled():
             return ray.get([actor.update_weights.remote() for actor in self._actor_handlers])
 
@@ -171,7 +199,7 @@ class RayTrainGroup:
         self._disk_weight_version = weight_version
         if self._release_train_enabled():
             self.release()
-        self._reload_rollout_weights_from_disk(disk_weight_dir, str(weight_version))
+        self._reload_rollout_weights_from_disk(disk_weight_dir, str(weight_version), rollout_id=rollout_id)
 
     def onload(self):
         return ray.get([actor.wake_up.remote() for actor in self._actor_handlers])
@@ -225,7 +253,7 @@ class RayTrainGroup:
             and self.args.update_weight_transport == "disk"
         )
 
-    def _reload_rollout_weights_from_disk(self, disk_weight_dir, weight_version):
+    def _reload_rollout_weights_from_disk(self, disk_weight_dir, weight_version, *, rollout_id=None):
         assert self._rollout_manager is not None, "disk weight update requires a rollout manager."
         if self.args.offload_rollout:
             ray.get(self._rollout_manager.onload_weights.remote())
@@ -239,26 +267,62 @@ class RayTrainGroup:
             # each host pulls the published checkpoint onto local disk (e.g. NVMe) and
             # the engines reload from there; the pull is disk-only, so it runs before
             # pause and overlaps generation
-            run_engine_group_waves(
-                engines,
-                max_inflight_engine_groups,
-                lambda _index, engine: engine.pull_weights.remote(int(weight_version)),
-                ray.get,
-            )
+            def pull_wave():
+                run_engine_group_waves(
+                    engines,
+                    max_inflight_engine_groups,
+                    lambda _index, engine: engine.pull_weights.remote(int(weight_version)),
+                    ray.get,
+                )
+
+            if self._communication_timeline is None:
+                pull_wave()
+            else:
+                with self._communication_timeline.new_span(
+                    "engine_bucket_receive",
+                    {
+                        "weight_version": weight_version,
+                        "rollout_id": rollout_id,
+                        "bucket_id": 0,
+                        "transport": "disk",
+                        "engine_count": len(engines),
+                        "observation": "trainer_pull_request_complete",
+                    },
+                ) as phase:
+                    pull_wave()
+                    phase.mark_consumer()
             model_path = self.args.update_weight_local_checkpoint_dir
         else:
             model_path = str(disk_weight_dir)
         ray.get([engine.pause_generation.remote() for engine in engines])
         ray.get([engine.flush_cache.remote() for engine in engines])
-        run_engine_group_waves(
-            engines,
-            max_inflight_engine_groups,
-            lambda _index, engine: engine.update_weights_from_disk.remote(
-                model_path=model_path,
-                weight_version=weight_version,
-            ),
-            ray.get,
-        )
+
+        def load_wave():
+            run_engine_group_waves(
+                engines,
+                max_inflight_engine_groups,
+                lambda _index, engine: engine.update_weights_from_disk.remote(
+                    model_path=model_path,
+                    weight_version=weight_version,
+                ),
+                ray.get,
+            )
+
+        if self._communication_timeline is None:
+            load_wave()
+        else:
+            with self._communication_timeline.new_span(
+                "engine_load_weights",
+                {
+                    "weight_version": weight_version,
+                    "rollout_id": rollout_id,
+                    "bucket_id": 0,
+                    "transport": "disk",
+                    "engine_count": len(engines),
+                },
+            ) as phase:
+                load_wave()
+                phase.mark_consumer()
         if self.args.ci_test:
             engine_versions = ray.get([engine.get_weight_version.remote() for engine in engines])
             mismatches = [
@@ -274,3 +338,14 @@ class RayTrainGroup:
         if not self.args.update_weight_disk_keep_files:
             shutil.rmtree(disk_weight_dir, ignore_errors=True)
         ray.get([engine.continue_generation.remote() for engine in engines])
+        if self._communication_timeline is not None:
+            self._communication_timeline.emit_event(
+                "weight_sync_complete",
+                {
+                    "weight_version": weight_version,
+                    "rollout_id": rollout_id,
+                    "transport": "disk",
+                    "engine_count": len(engines),
+                },
+            )
+            self._communication_timeline.flush(block=False)

--- a/slime/ray/actor_group.py
+++ b/slime/ray/actor_group.py
@@ -8,6 +8,7 @@ from ray.util.placement_group import PlacementGroup
 from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 
 from slime.ray.utils import NOSET_VISIBLE_DEVICES_ENV_VARS_LIST, add_default_ray_env_vars
+from slime.utils.engine_group_wave import run_engine_group_waves
 
 
 class RayTrainGroup:
@@ -233,24 +234,30 @@ class RayTrainGroup:
             if not self.args.update_weight_disk_keep_files:
                 shutil.rmtree(disk_weight_dir, ignore_errors=True)
             return
+        max_inflight_engine_groups = getattr(self.args, "update_weight_max_inflight_engine_groups", 0)
         if self.args.update_weight_local_checkpoint_dir:
             # each host pulls the published checkpoint onto local disk (e.g. NVMe) and
             # the engines reload from there; the pull is disk-only, so it runs before
             # pause and overlaps generation
-            ray.get([engine.pull_weights.remote(int(weight_version)) for engine in engines])
+            run_engine_group_waves(
+                engines,
+                max_inflight_engine_groups,
+                lambda _index, engine: engine.pull_weights.remote(int(weight_version)),
+                ray.get,
+            )
             model_path = self.args.update_weight_local_checkpoint_dir
         else:
             model_path = str(disk_weight_dir)
         ray.get([engine.pause_generation.remote() for engine in engines])
         ray.get([engine.flush_cache.remote() for engine in engines])
-        ray.get(
-            [
-                engine.update_weights_from_disk.remote(
-                    model_path=model_path,
-                    weight_version=weight_version,
-                )
-                for engine in engines
-            ]
+        run_engine_group_waves(
+            engines,
+            max_inflight_engine_groups,
+            lambda _index, engine: engine.update_weights_from_disk.remote(
+                model_path=model_path,
+                weight_version=weight_version,
+            ),
+            ray.get,
         )
         if self.args.ci_test:
             engine_versions = ray.get([engine.get_weight_version.remote() for engine in engines])

--- a/slime/ray/train_actor.py
+++ b/slime/ray/train_actor.py
@@ -9,6 +9,7 @@ import torch
 import torch.distributed as dist
 
 import slime.utils.eval_config
+from slime.observability.communication_timeline import configure_communication_timeline
 from slime.observability.logging_utils import configure_logger
 from slime.ray.ray_actor import RayActor
 from slime.utils import accelerator
@@ -70,6 +71,15 @@ class TrainRayActor(RayActor):
 
         args.rank = dist.get_rank()
         args.world_size = dist.get_world_size()
+        configure_communication_timeline(
+            getattr(args, "communication_timeline", None),
+            rank=args.rank,
+            local_rank=local_rank,
+            world_size=args.world_size,
+            role=role,
+            run_id=getattr(args, "communication_timeline_run_id", None),
+        )
+        self._communication_rollout_id = None
 
         try:
             if torch.version.hip is not None:
@@ -119,6 +129,9 @@ class TrainRayActor(RayActor):
     @abc.abstractmethod
     def update_weights(self):
         raise NotImplementedError
+
+    def set_communication_rollout_id(self, rollout_id):
+        self._communication_rollout_id = rollout_id
 
     def set_rollout_manager(self, rollout_manager):
         self.rollout_manager = rollout_manager

--- a/slime/utils/arguments.py
+++ b/slime/utils/arguments.py
@@ -546,6 +546,26 @@ def get_slime_extra_args_provider(add_custom_arguments=None):
                 ),
             )
             parser.add_argument(
+                "--update-weight-max-inflight-buckets",
+                type=int,
+                default=0,
+                help=(
+                    "Maximum number of logical weight buckets launched before waiting for completion. "
+                    "0 disables the bucket-count credit. When both in-flight limits are 0, weight sync "
+                    "keeps the existing one-bucket-at-a-time behavior."
+                ),
+            )
+            parser.add_argument(
+                "--update-weight-max-inflight-bytes",
+                type=int,
+                default=0,
+                help=(
+                    "Maximum bytes across logical weight buckets launched before waiting for completion. "
+                    "Bytes are counted once per bucket, independent of rollout-engine fan-out; 0 disables "
+                    "the byte credit."
+                ),
+            )
+            parser.add_argument(
                 "--update-weights-interval",
                 type=int,
                 default=1,
@@ -2048,6 +2068,16 @@ def slime_validate_args(args):
         raise ValueError(
             "--update-weight-transport=disk requires --update-weight-disk-dir to point at "
             "a filesystem shared between the trainer and the rollout engines."
+        )
+    if args.update_weight_max_inflight_buckets < 0:
+        raise ValueError("--update-weight-max-inflight-buckets must be non-negative")
+    if args.update_weight_max_inflight_bytes < 0:
+        raise ValueError("--update-weight-max-inflight-bytes must be non-negative")
+    if (args.update_weight_max_inflight_buckets or args.update_weight_max_inflight_bytes) and (
+        args.update_weight_mode != "full" or args.update_weight_transport != "nccl"
+    ):
+        raise ValueError(
+            "weight bucket in-flight credits require --update-weight-mode=full " "and --update-weight-transport=nccl"
         )
     if args.release_train:
         if args.use_critic:

--- a/slime/utils/arguments.py
+++ b/slime/utils/arguments.py
@@ -1347,6 +1347,22 @@ def get_slime_extra_args_provider(add_custom_arguments=None):
                 default=None,
             )
             parser.add_argument(
+                "--communication-timeline",
+                type=str,
+                default=None,
+                help=(
+                    "Optional JSONL path for trainer communication phases. Supports {rank}, {trainer_rank}, "
+                    "{local_rank}, {pid}, {hostname}, {role}, and {world_size}; a rank suffix is added "
+                    "automatically for a shared multi-rank path."
+                ),
+            )
+            parser.add_argument(
+                "--communication-timeline-run-id",
+                type=str,
+                default=None,
+                help="Optional run identifier shared by all trainer communication timeline records.",
+            )
+            parser.add_argument(
                 "--memory-recorder",
                 type=str,
                 choices=["torch", "memray"],

--- a/slime/utils/arguments.py
+++ b/slime/utils/arguments.py
@@ -566,6 +566,15 @@ def get_slime_extra_args_provider(add_custom_arguments=None):
                 ),
             )
             parser.add_argument(
+                "--update-weight-max-inflight-engine-groups",
+                type=int,
+                default=0,
+                help=(
+                    "Maximum number of rollout engine groups that may receive or load one weight bucket "
+                    "concurrently. 0 keeps the existing all-at-once behavior."
+                ),
+            )
+            parser.add_argument(
                 "--update-weights-interval",
                 type=int,
                 default=1,
@@ -2079,6 +2088,8 @@ def slime_validate_args(args):
         raise ValueError(
             "weight bucket in-flight credits require --update-weight-mode=full " "and --update-weight-transport=nccl"
         )
+    if getattr(args, "update_weight_max_inflight_engine_groups", 0) < 0:
+        raise ValueError("--update-weight-max-inflight-engine-groups must be non-negative.")
     if args.release_train:
         if args.use_critic:
             raise ValueError("--release-train does not support critic training yet.")

--- a/slime/utils/engine_group_wave.py
+++ b/slime/utils/engine_group_wave.py
@@ -1,0 +1,42 @@
+"""Deterministic wave planning for rollout-engine operations."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from typing import TypeVar
+
+
+T = TypeVar("T")
+R = TypeVar("R")
+
+
+def build_engine_group_waves(
+    engine_groups: Sequence[T],
+    max_inflight_engine_groups: int,
+) -> tuple[tuple[tuple[int, T], ...], ...]:
+    """Partition engine groups into stable, bounded waves.
+
+    Each item is paired with its original index so callers can coordinate the
+    same wave across trainer ranks. ``0`` preserves the existing all-at-once
+    behavior. A limit larger than the number of groups is also one wave.
+    """
+    if max_inflight_engine_groups < 0:
+        raise ValueError("max_inflight_engine_groups must be non-negative")
+    if not engine_groups:
+        return ()
+
+    wave_size = max_inflight_engine_groups or len(engine_groups)
+    indexed_groups = tuple(enumerate(engine_groups))
+    return tuple(indexed_groups[start : start + wave_size] for start in range(0, len(indexed_groups), wave_size))
+
+
+def run_engine_group_waves(
+    engine_groups: Sequence[T],
+    max_inflight_engine_groups: int,
+    submit: Callable[[int, T], R],
+    wait: Callable[[list[R]], object],
+) -> None:
+    """Submit each wave concurrently and wait before admitting the next one."""
+    for wave in build_engine_group_waves(engine_groups, max_inflight_engine_groups):
+        pending = [submit(index, engine_group) for index, engine_group in wave]
+        wait(pending)

--- a/tests/observability/test_communication_timeline.py
+++ b/tests/observability/test_communication_timeline.py
@@ -1,0 +1,313 @@
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from slime.observability import communication_timeline as timeline
+
+
+class _Tensor:
+    def __init__(self, elements, element_size):
+        self._elements = elements
+        self._element_size = element_size
+
+    def numel(self):
+        return self._elements
+
+    def element_size(self):
+        return self._element_size
+
+
+@pytest.fixture(autouse=True)
+def _reset_timeline(monkeypatch):
+    timeline.close_communication_timeline()
+    monkeypatch.delenv(timeline.COMMUNICATION_TIMELINE_ENV, raising=False)
+    yield
+    timeline.close_communication_timeline()
+
+
+def _read_jsonl(path):
+    return [json.loads(line) for line in path.read_text().splitlines()]
+
+
+def test_disabled_timeline_does_not_create_a_file(tmp_path):
+    timeline.configure_communication_timeline(None)
+
+    with timeline.communication_phase("train_forward_backward") as phase:
+        phase.update(global_step=2)
+        phase.mark_consumer()
+    timeline.communication_event("weight_sync_complete", weight_version=1)
+
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_disabled_timeline_skips_clocks_torch_events_context_and_serialization(monkeypatch):
+    timeline.configure_communication_timeline(None)
+    monkeypatch.setattr(timeline.time, "time_ns", lambda: pytest.fail("disabled timeline read the wall clock"))
+    monkeypatch.setattr(
+        timeline.time,
+        "perf_counter_ns",
+        lambda: pytest.fail("disabled timeline read the monotonic clock"),
+    )
+    monkeypatch.setattr(timeline, "_optional_torch", lambda: pytest.fail("disabled timeline imported torch"))
+    monkeypatch.setattr(timeline.json, "dumps", lambda *_args, **_kwargs: pytest.fail("disabled timeline serialized"))
+
+    first = timeline.communication_phase("weight_bucket_send", message_bytes=8)
+    second = timeline.communication_phase("grad_sync")
+    assert first is second
+    assert not first.enabled
+    with first as phase:
+        phase.update(bucket_id=3)
+        phase.mark_api_return()
+        phase.mark_consumer()
+    timeline.communication_event("weight_sync_complete", weight_version=4)
+    with timeline.communication_context(global_step=2):
+        assert timeline._CONTEXT.get() is None
+    timeline.flush_communication_timeline(block=True)
+
+
+def test_disabled_bucket_iterator_does_not_scan_tensor_sizes():
+    class SizeMustNotBeRead:
+        def numel(self):
+            pytest.fail("disabled timeline scanned tensor elements")
+
+        def element_size(self):
+            pytest.fail("disabled timeline scanned tensor element size")
+
+    timeline.configure_communication_timeline(None)
+    bucket = [("weight", SizeMustNotBeRead())]
+    assert list(timeline.iter_communication_buckets([bucket])) == [(0, bucket)]
+
+
+def test_span_and_event_emit_stable_shared_schema(tmp_path):
+    path_template = str(tmp_path / "trainer-{rank}.jsonl")
+    resolved = tmp_path / "trainer-2.jsonl"
+    timeline.configure_communication_timeline(
+        path_template,
+        rank=2,
+        local_rank=0,
+        world_size=4,
+        run_id="run-1",
+    )
+
+    with timeline.communication_context(global_step=7, rollout_id=3, trainer_rank=2):
+        with timeline.communication_phase("weight_bucket_send", weight_version=5, bucket_id=1) as phase:
+            phase.update(message_bytes=4096, engine_count=2)
+            phase.mark_consumer()
+        timeline.communication_event("weight_sync_complete", weight_version=5)
+    timeline.close_communication_timeline()
+
+    span, event = _read_jsonl(resolved)
+    assert span["schema_version"] == timeline.COMMUNICATION_TIMELINE_VERSION
+    assert span["framework"] == "slime"
+    assert span["gpu_timestamp_semantics"] == "event-bracket"
+    assert span["timestamp_domain"] == "process-realtime-projected-cuda-event"
+    assert span["clock_sync_error_bound_us"] is None
+    assert span["run_id"] == "run-1"
+    assert span["operation"] == "weight_bucket_send"
+    assert span["logical_operation_id"] == "7/3/5/1/weight_bucket_send"
+    assert span["global_step"] == 7
+    assert span["rollout_id"] == 3
+    assert span["trainer_rank"] == 2
+    assert span["message_bytes"] == 4096
+    assert span["metadata"]["engine_count"] == 2
+    assert span["consumer_timestamp_ns"] is not None
+    assert span["completion_timestamp_ns"] >= span["api_launch_timestamp_ns"]
+    assert span["duration_ns"] >= 0
+    assert event["record_type"] == "event"
+    assert event["operation"] == "weight_sync_complete"
+    assert event["gpu_timestamp_semantics"] == "event-bracket"
+    assert event["clock_sync_error_bound_us"] is None
+    assert event["sequence_id"] == span["sequence_id"] + 1
+
+
+def test_world_size_uses_rank_suffix_when_template_is_shared(tmp_path):
+    configured = timeline.configure_communication_timeline(
+        str(tmp_path / "timeline.jsonl"),
+        rank=3,
+        local_rank=1,
+        world_size=4,
+    )
+
+    assert configured.path == tmp_path / "timeline.rank-3.jsonl"
+
+
+def test_non_trainer_roles_get_separate_files_without_role_placeholder(tmp_path):
+    configured = timeline.configure_communication_timeline(
+        str(tmp_path / "timeline-{rank}.jsonl"),
+        rank=0,
+        world_size=2,
+        role="critic",
+    )
+
+    assert configured.path == tmp_path / "timeline-0.role-critic.jsonl"
+
+
+def test_failed_span_is_recorded_and_reraised(tmp_path):
+    path = tmp_path / "failure.jsonl"
+    timeline.configure_communication_timeline(str(path), rank=0, world_size=1)
+
+    with pytest.raises(RuntimeError, match="boom"):
+        with timeline.communication_phase("optimizer_step"):
+            raise RuntimeError("boom")
+    timeline.close_communication_timeline()
+
+    record = _read_jsonl(path)[0]
+    assert record["status"] == "error"
+    assert record["metadata"]["error_type"] == "RuntimeError"
+    assert record["metadata"]["error_message"] == "boom"
+
+
+def test_iter_communication_buckets_times_only_produced_buckets(tmp_path):
+    path = tmp_path / "buckets.jsonl"
+    timeline.configure_communication_timeline(str(path), rank=0, world_size=1)
+    chunks = [
+        [("a", _Tensor(4, 2))],
+        [("b", _Tensor(3, 4)), ("c", _Tensor(1, 1))],
+    ]
+
+    yielded = list(timeline.iter_communication_buckets(chunks))
+    timeline.close_communication_timeline()
+
+    assert [bucket_id for bucket_id, _ in yielded] == [0, 1]
+    records = _read_jsonl(path)
+    assert [record["bucket_id"] for record in records] == [0, 1]
+    assert [record["message_bytes"] for record in records] == [8, 13]
+
+
+def test_nested_spans_are_written_in_launch_sequence_order(tmp_path):
+    path = tmp_path / "nested.jsonl"
+    timeline.configure_communication_timeline(str(path), rank=0, world_size=1)
+
+    with timeline.communication_phase("train_forward_backward"):
+        timeline.communication_event("weight_bucket_ready")
+        with timeline.communication_phase("grad_sync"):
+            pass
+    timeline.close_communication_timeline()
+
+    records = _read_jsonl(path)
+    assert [record["sequence_id"] for record in records] == [0, 1, 2]
+    assert [record["operation"] for record in records] == [
+        "train_forward_backward",
+        "weight_bucket_ready",
+        "grad_sync",
+    ]
+
+
+def test_cuda_events_are_resolved_without_changing_schema(tmp_path, monkeypatch):
+    class FakeEvent:
+        def __init__(self, enable_timing):
+            assert enable_timing
+
+        def record(self):
+            return None
+
+        def query(self):
+            return True
+
+        def synchronize(self):
+            return None
+
+        def elapsed_time(self, other):
+            assert isinstance(other, FakeEvent)
+            return 2.5
+
+    class FakeNvtx:
+        pushes = []
+        pops = 0
+
+        @classmethod
+        def range_push(cls, name):
+            cls.pushes.append(name)
+
+        @classmethod
+        def range_pop(cls):
+            cls.pops += 1
+
+    fake_cuda = SimpleNamespace(
+        is_available=lambda: True,
+        current_stream=lambda: SimpleNamespace(cuda_stream=123),
+        Event=FakeEvent,
+        nvtx=FakeNvtx,
+    )
+    monkeypatch.setattr(timeline, "_optional_torch", lambda: SimpleNamespace(cuda=fake_cuda))
+    path = tmp_path / "cuda.jsonl"
+    timeline.configure_communication_timeline(str(path), rank=0, local_rank=0, world_size=1)
+
+    with timeline.communication_phase("grad_sync") as phase:
+        phase.mark_api_return()
+        assert FakeNvtx.pops == 1
+    timeline.close_communication_timeline()
+
+    record = _read_jsonl(path)[0]
+    assert record["stream_id"] == 123
+    assert record["gpu_elapsed_ns"] == 2_500_000
+    assert record["gpu_end_timestamp_ns"] - record["gpu_start_timestamp_ns"] == 2_500_000
+    assert FakeNvtx.pushes == ["slime.comm/grad_sync"]
+    assert FakeNvtx.pops == 1
+
+
+def test_async_span_retains_api_return_before_later_completion(tmp_path, monkeypatch):
+    from slime.observability import weight_sync_trace
+
+    clock = iter(range(100, 1000, 10))
+    monkeypatch.setattr(timeline.time, "time_ns", lambda: next(clock))
+    monkeypatch.setattr(timeline, "_optional_torch", lambda: None)
+    path = tmp_path / "async.jsonl"
+    timeline.configure_communication_timeline(str(path), rank=0, world_size=1)
+    trace = weight_sync_trace.WeightSyncTrace()
+    first = SimpleNamespace(bucket_id=0, bucket_bytes=8)
+    second = SimpleNamespace(bucket_id=1, bucket_bytes=8)
+    trace.start(first)
+    trace.submitted(first)
+    first_api_return = trace.pending[0].api_return_timestamp_ns
+    trace.start(second)
+    trace.submitted(second)
+    trace.complete(first)
+    trace.complete(second)
+    timeline.close_communication_timeline()
+    sends = [row for row in _read_jsonl(path) if row["operation"] == "weight_bucket_send"]
+    assert sends[0]["api_return_timestamp_ns"] == first_api_return
+    assert sends[0]["api_return_timestamp_ns"] < sends[1]["api_launch_timestamp_ns"]
+    assert sends[0]["completion_timestamp_ns"] > sends[1]["api_return_timestamp_ns"]
+
+
+def test_failed_async_update_closes_pending_span_without_success_marker(tmp_path, monkeypatch):
+    from slime.observability.weight_sync_trace import trace_weight_update
+
+    monkeypatch.setattr(timeline, "_optional_torch", lambda: None)
+    path = tmp_path / "pending-failure.jsonl"
+    timeline.configure_communication_timeline(str(path), rank=0, world_size=1)
+
+    class Updater:
+        weight_version = 0
+
+        @trace_weight_update
+        def update(self):
+            self.weight_version += 1
+            reservation = SimpleNamespace(bucket_id=0, bucket_bytes=8)
+            self._weight_sync_trace.start(reservation)
+            self._weight_sync_trace.submitted(reservation)
+            raise RuntimeError("transport failed")
+
+    with pytest.raises(RuntimeError, match="transport failed"):
+        Updater().update()
+    timeline.close_communication_timeline()
+    records = _read_jsonl(path)
+    assert records[-1]["operation"] == "weight_sync_failed"
+    assert records[1]["operation"] == "weight_bucket_send"
+    assert records[1]["status"] == "error"
+    assert not any(record["operation"] == "weight_sync_complete" for record in records)
+
+
+def test_disabled_updater_wrapper_does_not_allocate_trace_state(monkeypatch):
+    from slime.observability import weight_sync_trace
+
+    timeline.configure_communication_timeline(None)
+    monkeypatch.setattr(
+        weight_sync_trace, "WeightSyncTrace", lambda: pytest.fail("disabled updater allocated trace state")
+    )
+    updater = SimpleNamespace()
+    wrapped = weight_sync_trace.trace_weight_update(lambda self: self)
+    assert wrapped(updater) is updater
+    assert not hasattr(updater, "_weight_sync_trace")

--- a/tests/test_empty_colocated_weight_bucket.py
+++ b/tests/test_empty_colocated_weight_bucket.py
@@ -143,10 +143,11 @@ def _install_fake_deps(monkeypatch):
     update_from_distributed_mod = types.ModuleType(
         "slime.backends.megatron_utils.update_weight.update_weight_from_distributed"
     )
-    update_from_distributed_mod.connect_rollout_engines_from_distributed = lambda *args, **kwargs: None
-    update_from_distributed_mod.disconnect_rollout_engines_from_distributed = lambda *args, **kwargs: None
+    update_from_distributed_mod.connect_rollout_engine_groups_from_distributed = lambda *args, **kwargs: []
+    update_from_distributed_mod.disconnect_rollout_engine_groups_from_distributed = lambda *args, **kwargs: None
     update_from_distributed_mod.launch_weights_from_distributed = lambda *args, **kwargs: ([], [])
     update_from_distributed_mod.post_process_weights = lambda *args, **kwargs: None
+    update_from_distributed_mod.synchronize_weight_transfer = lambda *args, **kwargs: None
 
     monkeypatch.setitem(sys.modules, "slime", slime_pkg)
     monkeypatch.setitem(sys.modules, "slime.backends", slime_backends_pkg)
@@ -274,6 +275,7 @@ def test_tensor_credit_window_launches_all_admitted_buckets_before_waiting(monke
     updater._weight_bucket_bytes = lambda bucket: sum(tensor.numel() for _, tensor in bucket)
     updater._ipc_gather_group = None
     updater._ipc_gather_src = None
+    updater._wave_scheduling_enabled = False
     updater.rank = 0
 
     def send_hf_params(bucket):
@@ -389,6 +391,80 @@ def test_colocated_non_source_observes_source_failure(monkeypatch):
         updater._wait_for_bucket_completion(reservation, [], [])
     assert updater._weight_sync_credit.snapshot.inflight_buckets == 1
     assert updater._weight_sync_credit.snapshot.transport_outstanding_bytes == 8
+
+
+@pytest.mark.parametrize("engine_count", [2, 4])
+@pytest.mark.parametrize("peer_failure", [False, True])
+def test_tensor_wave_holds_credit_staging_and_shares_peer_failure(monkeypatch, engine_count, peer_failure):
+    module, state = _load_update_weight_module(monkeypatch)
+    events = []
+    updater = object.__new__(module.UpdateWeightFromTensor)
+    updater.rank = 0
+    updater.weight_version = 3
+    updater._total_engine_groups = engine_count
+    updater._max_inflight_engine_groups = 1
+    updater._wave_scheduling_enabled = True
+    updater._ipc_engine_index = 0
+    updater._ipc_engine = object()
+    updater._ipc_gather_src = 0
+    updater._ipc_gather_group = object()
+    updater.use_distribute = True
+    updater._is_distributed_src_rank = True
+    updater._model_update_groups = [
+        types.SimpleNamespace(
+            engine_indices=(i,), group_name=f"group-{i}", process_group=i, rollout_engines=(object(),)
+        )
+        for i in range(1, engine_count)
+    ]
+    updater._weight_sync_credit = module.WeightSyncCreditController(max_inflight_buckets=1, max_inflight_bytes=8)
+    updater._weight_sync_credit.begin_version(3)
+    reservation = updater._weight_sync_credit.reserve(8)
+    tensor = types.SimpleNamespace(numel=lambda: 8, element_size=lambda: 1)
+    staging = [types.SimpleNamespace(numel=lambda: 16, element_size=lambda: 1)]
+
+    def colocated(*_args, **_kwargs):
+        events.append("ipc-launch")
+        return ["ipc-ref"], staging
+
+    def distributed(_name, group, *_args):
+        events.append(f"distributed-{group}")
+        assert staging == []
+        assert updater._weight_sync_credit.snapshot.inflight_buckets == 1
+        return [f"distributed-{group}"], [types.SimpleNamespace(wait=lambda: events.append("wait"))]
+
+    def all_gather(errors, local, group):
+        assert group is not None
+        assert state.broadcast_value is None
+        assert updater._weight_sync_credit.snapshot.inflight_buckets == 1
+        errors[:] = [local] * len(errors)
+        if peer_failure:
+            errors[-1] = "peer engine load failed"
+
+    monkeypatch.setattr(module, "_send_to_colocated_engine", colocated)
+    monkeypatch.setattr(module, "launch_weights_from_distributed", distributed)
+    monkeypatch.setattr(module.dist, "all_gather_object", all_gather, raising=False)
+    if peer_failure:
+        with pytest.raises(RuntimeError, match="peer engine load failed"):
+            updater._submit_weight_bucket([("weight", tensor)], reservation)
+        assert events == ["ipc-launch"]
+        assert staging
+        assert updater._active_wave_resources[1] is staging
+        assert updater._weight_sync_credit.snapshot.staging_resident_bytes == 16
+    else:
+        assert updater._submit_weight_bucket([("weight", tensor)], reservation) == ([], [], None)
+        assert staging == []
+        assert events == [
+            "ipc-launch",
+            *[phase for i in range(1, engine_count) for phase in (f"distributed-{i}", "wait")],
+        ]
+        snapshot = updater._weight_sync_credit.snapshot
+        assert snapshot.inflight_buckets == 1
+        assert snapshot.transport_outstanding_bytes == 0
+        assert snapshot.pending_consumer_objects == 0
+        assert snapshot.staging_resident_bytes == 0
+        assert snapshot.peak_staging_resident_bytes == 16
+        updater._weight_sync_credit.release(reservation)
+        updater._weight_sync_credit.commit_version(3)
 
 
 def _make_empty_update_updater(module, events, continue_result="continue-ref"):

--- a/tests/test_empty_colocated_weight_bucket.py
+++ b/tests/test_empty_colocated_weight_bucket.py
@@ -55,7 +55,13 @@ class _FakeEngine:
 
 
 def _install_fake_deps(monkeypatch):
-    dist_state = types.SimpleNamespace(rank=0, world_size=2, gathered=None, local_object=None)
+    dist_state = types.SimpleNamespace(
+        rank=0,
+        world_size=2,
+        gathered=None,
+        local_object=None,
+        broadcast_value=None,
+    )
 
     slime_pkg = types.ModuleType("slime")
     slime_pkg.__path__ = [str(REPO_ROOT / "slime")]
@@ -80,9 +86,17 @@ def _install_fake_deps(monkeypatch):
         if object_gather_list is not None:
             object_gather_list[:] = dist_state.gathered(obj)
 
+    def broadcast_object_list(status, src, group):
+        assert group is not None
+        if dist_state.rank == src:
+            dist_state.broadcast_value = status[0]
+        else:
+            status[0] = dist_state.broadcast_value
+
     dist_mod.get_rank = lambda: dist_state.rank
     dist_mod.get_world_size = lambda group=None: dist_state.world_size
     dist_mod.gather_object = gather_object
+    dist_mod.broadcast_object_list = broadcast_object_list
 
     torch_mod = types.ModuleType("torch")
     torch_mod.Tensor = object
@@ -258,6 +272,9 @@ def test_tensor_credit_window_launches_all_admitted_buckets_before_waiting(monke
     )
     updater._weight_sync_credit.begin_version(4)
     updater._weight_bucket_bytes = lambda bucket: sum(tensor.numel() for _, tensor in bucket)
+    updater._ipc_gather_group = None
+    updater._ipc_gather_src = None
+    updater.rank = 0
 
     def send_hf_params(bucket):
         name = bucket[0][0]
@@ -316,6 +333,141 @@ def test_tensor_byte_credit_uses_the_largest_trainer_rank_bucket(monkeypatch):
     monkeypatch.setattr(module.dist, "all_reduce", all_reduce, raising=False)
 
     assert updater._weight_bucket_bytes([("local", _Tensor())]) == 12
+
+
+def test_colocated_source_broadcasts_load_failure_before_credit_release(monkeypatch):
+    module, dist_state = _load_update_weight_module(monkeypatch)
+    error = RuntimeError("engine load failed")
+    updater = object.__new__(module.UpdateWeightFromTensor)
+    updater.rank = 0
+    updater._ipc_gather_src = 0
+    updater._ipc_gather_group = object()
+    updater._weight_sync_credit = module.WeightSyncCreditController(max_inflight_buckets=1)
+    updater._weight_sync_credit.begin_version(6)
+    reservation = updater._weight_sync_credit.reserve(8)
+    assert reservation is not None
+    updater._weight_sync_credit.mark_launched(
+        reservation,
+        transport_bytes=8,
+        staging_bytes=16,
+        consumer_objects=1,
+    )
+    module.ray.get = lambda _refs: (_ for _ in ()).throw(error)
+
+    with pytest.raises(RuntimeError, match="engine load failed") as raised:
+        updater._wait_for_bucket_completion(reservation, [], ["engine-ref"])
+    assert raised.value is error
+    assert dist_state.broadcast_value == "RuntimeError: engine load failed"
+    assert updater._weight_sync_credit.snapshot.inflight_buckets == 1
+    assert updater._weight_sync_credit.snapshot.pending_consumer_objects == 1
+
+    updater._weight_sync_credit.fail_version(6, error)
+    with pytest.raises(RuntimeError, match="cannot commit failed weight version"):
+        updater._weight_sync_credit.commit_version(6)
+
+
+def test_colocated_non_source_observes_source_failure(monkeypatch):
+    module, dist_state = _load_update_weight_module(monkeypatch)
+    dist_state.rank = 1
+    dist_state.broadcast_value = "RuntimeError: engine load failed"
+    updater = object.__new__(module.UpdateWeightFromTensor)
+    updater.rank = 1
+    updater._ipc_gather_src = 0
+    updater._ipc_gather_group = object()
+    updater._weight_sync_credit = module.WeightSyncCreditController(max_inflight_buckets=1)
+    updater._weight_sync_credit.begin_version(6)
+    reservation = updater._weight_sync_credit.reserve(8)
+    assert reservation is not None
+    updater._weight_sync_credit.mark_launched(
+        reservation,
+        transport_bytes=8,
+        staging_bytes=16,
+        consumer_objects=0,
+    )
+
+    with pytest.raises(RuntimeError, match="consumer failed on engine source rank"):
+        updater._wait_for_bucket_completion(reservation, [], [])
+    assert updater._weight_sync_credit.snapshot.inflight_buckets == 1
+    assert updater._weight_sync_credit.snapshot.transport_outstanding_bytes == 8
+
+
+def _make_empty_update_updater(module, events, continue_result="continue-ref"):
+    class _EventRemote:
+        def __init__(self, name, result):
+            self.name = name
+            self.result = result
+
+        def remote(self):
+            events.append(self.name)
+            return self.result
+
+    colocated_engine = types.SimpleNamespace(
+        pause_generation=_EventRemote("pause", "pause-ref"),
+        flush_cache=_EventRemote("flush", "flush-ref"),
+        continue_generation=_EventRemote("continue", continue_result),
+    )
+    distributed_engine = types.SimpleNamespace(
+        pause_generation=_EventRemote("pause-distributed", "pause-distributed-ref"),
+        flush_cache=_EventRemote("flush-distributed", "flush-distributed-ref"),
+        continue_generation=_EventRemote("continue-distributed", "continue-distributed-ref"),
+    )
+    updater = object.__new__(module.UpdateWeightFromTensor)
+    updater.rank = 0
+    updater.weight_version = 0
+    updater.rollout_engines = [colocated_engine]
+    updater._all_rollout_engines = [colocated_engine, distributed_engine]
+    updater.quantization_config = None
+    updater._weight_sync_credit = module.WeightSyncCreditController(max_inflight_buckets=1)
+    updater.weights_getter = lambda: {}
+    updater._expert_transfer_plan = []
+    updater._non_expert_param_info_buckets = None
+    updater._full_param_info_buckets = ()
+    updater._hf_weight_iterator = types.SimpleNamespace(get_hf_weight_chunks=lambda *args, **kwargs: iter(()))
+    updater.update_weight_metrics = {}
+    return updater
+
+
+def test_tensor_version_commits_only_after_consumers_resume(monkeypatch):
+    module, _ = _load_update_weight_module(monkeypatch)
+    events = []
+    updater = _make_empty_update_updater(module, events)
+    module.dist.barrier = lambda **_: events.append("barrier")
+    original_commit = updater._weight_sync_credit.commit_version
+
+    def commit_version(version):
+        assert "continue" in events
+        events.append("commit")
+        original_commit(version)
+
+    updater._weight_sync_credit.commit_version = commit_version
+    updater.update_weights()
+
+    assert events[-1] == "commit"
+    assert "continue-distributed" in events
+    assert updater._weight_sync_credit.snapshot.active_version is None
+    assert updater.update_weight_metrics["perf/update_weights_sync_seconds"] >= 0
+
+
+def test_tensor_resume_failure_poisons_version(monkeypatch):
+    module, _ = _load_update_weight_module(monkeypatch)
+    events = []
+    updater = _make_empty_update_updater(module, events, continue_result="failed-ref")
+    module.dist.barrier = lambda **_: events.append("barrier")
+    error = RuntimeError("resume failed")
+
+    def ray_get(refs):
+        if "failed-ref" in refs:
+            raise error
+        return refs
+
+    module.ray.get = ray_get
+    with pytest.raises(RuntimeError, match="resume failed") as raised:
+        updater.update_weights()
+    assert raised.value is error
+    assert updater._weight_sync_credit.snapshot.active_version == 1
+    assert updater._weight_sync_credit.snapshot.failed_reason == "RuntimeError: resume failed"
+    with pytest.raises(RuntimeError, match="cannot commit failed weight version"):
+        updater._weight_sync_credit.commit_version(1)
 
 
 if __name__ == "__main__":

--- a/tests/test_empty_colocated_weight_bucket.py
+++ b/tests/test_empty_colocated_weight_bucket.py
@@ -1,4 +1,5 @@
 import importlib.util
+import json
 import sys
 import types
 from pathlib import Path
@@ -393,12 +394,34 @@ def test_colocated_non_source_observes_source_failure(monkeypatch):
     assert updater._weight_sync_credit.snapshot.transport_outstanding_bytes == 8
 
 
+@pytest.fixture(params=[False, True], ids=["trace-off", "trace-on"])
+def tensor_updater_trace(request, tmp_path, monkeypatch):
+    from slime.observability import communication_timeline as timeline
+
+    timeline.close_communication_timeline()
+    monkeypatch.delenv(timeline.COMMUNICATION_TIMELINE_ENV, raising=False)
+    monkeypatch.setattr(timeline, "_optional_torch", lambda: None)
+    path = tmp_path / "tensor-updater.jsonl" if request.param else None
+    if path is not None:
+        timeline.configure_communication_timeline(str(path), rank=0, world_size=1, run_id="logical-tensor-test")
+    with timeline.communication_context(weight_version=3, transport="nccl_or_cuda_ipc"):
+        yield timeline, path
+    timeline.close_communication_timeline()
+
+
 @pytest.mark.parametrize("engine_count", [2, 4])
 @pytest.mark.parametrize("peer_failure", [False, True])
-def test_tensor_wave_holds_credit_staging_and_shares_peer_failure(monkeypatch, engine_count, peer_failure):
+def test_tensor_wave_holds_credit_staging_and_shares_peer_failure(
+    monkeypatch, engine_count, peer_failure, tensor_updater_trace
+):
     module, state = _load_update_weight_module(monkeypatch)
     events = []
     updater = object.__new__(module.UpdateWeightFromTensor)
+    timeline, path = tensor_updater_trace
+    if path is not None:
+        from slime.observability.weight_sync_trace import WeightSyncTrace
+
+        updater._weight_sync_trace = WeightSyncTrace()
     updater.rank = 0
     updater.weight_version = 3
     updater._total_engine_groups = engine_count
@@ -465,6 +488,19 @@ def test_tensor_wave_holds_credit_staging_and_shares_peer_failure(monkeypatch, e
         assert snapshot.peak_staging_resident_bytes == 16
         updater._weight_sync_credit.release(reservation)
         updater._weight_sync_credit.commit_version(3)
+
+    timeline.close_communication_timeline()
+    if path is not None:
+        records = [json.loads(line) for line in path.read_text().splitlines()]
+        sends = [row for row in records if row["operation"] == "weight_bucket_send"]
+        assert len(sends) == (1 if peer_failure else engine_count)
+        assert len({row["logical_operation_id"] for row in sends}) == len(sends)
+        assert all(row["weight_version"] == 3 for row in records)
+        assert all(row["gpu_start_timestamp_ns"] is None for row in records)
+        assert all(
+            row["api_launch_timestamp_ns"] <= row["api_return_timestamp_ns"] <= row["completion_timestamp_ns"]
+            for row in sends
+        )
 
 
 def _make_empty_update_updater(module, events, continue_result="continue-ref"):

--- a/tests/test_empty_colocated_weight_bucket.py
+++ b/tests/test_empty_colocated_weight_bucket.py
@@ -71,6 +71,7 @@ def _install_fake_deps(monkeypatch):
     accelerator_mod.device = lambda: "cuda:0"
     accelerator_mod.current_device = lambda: "cuda:0"
     accelerator_mod.ipc_collect = lambda: None
+    accelerator_mod.empty_cache = lambda: None
 
     dist_mod = types.ModuleType("torch.distributed")
 
@@ -95,6 +96,7 @@ def _install_fake_deps(monkeypatch):
 
     ray_mod = types.ModuleType("ray")
     ray_mod.ObjectRef = object
+    ray_mod.get = lambda refs: refs
     ray_actor_mod = types.ModuleType("ray.actor")
     ray_actor_mod.ActorHandle = object
 
@@ -129,8 +131,8 @@ def _install_fake_deps(monkeypatch):
     )
     update_from_distributed_mod.connect_rollout_engines_from_distributed = lambda *args, **kwargs: None
     update_from_distributed_mod.disconnect_rollout_engines_from_distributed = lambda *args, **kwargs: None
+    update_from_distributed_mod.launch_weights_from_distributed = lambda *args, **kwargs: ([], [])
     update_from_distributed_mod.post_process_weights = lambda *args, **kwargs: None
-    update_from_distributed_mod.update_weights_from_distributed = lambda *args, **kwargs: []
 
     monkeypatch.setitem(sys.modules, "slime", slime_pkg)
     monkeypatch.setitem(sys.modules, "slime.backends", slime_backends_pkg)
@@ -226,6 +228,94 @@ def test_source_rank_pads_empty_colocated_bucket_entries(monkeypatch):
             "weight_version": "7",
         }
     ]
+
+
+def test_tensor_credit_window_launches_all_admitted_buckets_before_waiting(monkeypatch):
+    module, _ = _load_update_weight_module(monkeypatch)
+    events = []
+
+    class _Tensor:
+        def __init__(self, size):
+            self.size = size
+
+        def numel(self):
+            return self.size
+
+        def element_size(self):
+            return 1
+
+    class _Handle:
+        def __init__(self, name):
+            self.name = name
+
+        def wait(self):
+            events.append(("wait", self.name))
+
+    updater = object.__new__(module.UpdateWeightFromTensor)
+    updater._weight_sync_credit = module.WeightSyncCreditController(
+        max_inflight_buckets=2,
+        max_inflight_bytes=10,
+    )
+    updater._weight_sync_credit.begin_version(4)
+    updater._weight_bucket_bytes = lambda bucket: sum(tensor.numel() for _, tensor in bucket)
+
+    def send_hf_params(bucket):
+        name = bucket[0][0]
+        events.append(("launch", name))
+        return [f"ref-{name}"], [_Handle(name)], object()
+
+    updater._send_hf_params = send_hf_params
+    module.ray.get = lambda refs: events.append(("get", refs[0]))
+    buckets = [[("b0", _Tensor(6))], [("b1", _Tensor(4))], [("b2", _Tensor(5))]]
+
+    updater._send_weight_bucket_windows(iter(buckets))
+    updater._weight_sync_credit.commit_version(4)
+
+    assert events == [
+        ("launch", "b0"),
+        ("launch", "b1"),
+        ("wait", "b0"),
+        ("get", "ref-b0"),
+        ("wait", "b1"),
+        ("get", "ref-b1"),
+        ("launch", "b2"),
+        ("wait", "b2"),
+        ("get", "ref-b2"),
+    ]
+    assert buckets == [[], [], []]
+
+
+def test_tensor_byte_credit_uses_the_largest_trainer_rank_bucket(monkeypatch):
+    module, _ = _load_update_weight_module(monkeypatch)
+
+    class _Tensor:
+        def numel(self):
+            return 5
+
+        def element_size(self):
+            return 1
+
+    class _Scalar:
+        def __init__(self, value):
+            self.value = value
+
+        def item(self):
+            return self.value
+
+    updater = object.__new__(module.UpdateWeightFromTensor)
+    updater._weight_sync_credit = module.WeightSyncCreditController(max_inflight_bytes=16)
+    monkeypatch.setattr(module.torch, "int64", "int64", raising=False)
+    monkeypatch.setattr(module.torch, "tensor", lambda value, **_: _Scalar(value), raising=False)
+    monkeypatch.setattr(module.dist, "ReduceOp", types.SimpleNamespace(MAX="max"), raising=False)
+
+    def all_reduce(value, *, op, group):
+        assert op == "max"
+        assert group is not None
+        value.value = 12
+
+    monkeypatch.setattr(module.dist, "all_reduce", all_reduce, raising=False)
+
+    assert updater._weight_bucket_bytes([("local", _Tensor())]) == 12
 
 
 if __name__ == "__main__":

--- a/tests/test_engine_group_wave.py
+++ b/tests/test_engine_group_wave.py
@@ -1,0 +1,79 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from slime.utils.engine_group_wave import build_engine_group_waves, run_engine_group_waves
+
+
+NUM_GPUS = 0
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("engine_count", [1, 2, 4])
+def test_zero_limit_preserves_all_at_once(engine_count):
+    engines = [f"engine-{index}" for index in range(engine_count)]
+
+    waves = build_engine_group_waves(engines, 0)
+
+    assert waves == (tuple(enumerate(engines)),)
+
+
+@pytest.mark.unit
+def test_positive_limit_builds_stable_bounded_waves():
+    engines = [f"engine-{index}" for index in range(4)]
+
+    waves = build_engine_group_waves(engines, 3)
+
+    assert waves == (
+        ((0, "engine-0"), (1, "engine-1"), (2, "engine-2")),
+        ((3, "engine-3"),),
+    )
+
+
+@pytest.mark.unit
+def test_limit_larger_than_population_is_one_wave():
+    assert build_engine_group_waves(["a", "b"], 4) == (((0, "a"), (1, "b")),)
+
+
+@pytest.mark.unit
+def test_empty_population_has_no_waves():
+    assert build_engine_group_waves([], 1) == ()
+
+
+@pytest.mark.unit
+def test_negative_limit_is_rejected():
+    with pytest.raises(ValueError, match="must be non-negative"):
+        build_engine_group_waves(["engine"], -1)
+
+
+@pytest.mark.unit
+def test_runner_waits_before_submitting_the_next_wave():
+    events = []
+
+    def submit(index, engine):
+        events.append(("submit", index, engine))
+        return f"ref-{index}"
+
+    def wait(refs):
+        events.append(("wait", tuple(refs)))
+
+    run_engine_group_waves(["a", "b", "c", "d"], 3, submit, wait)
+
+    assert events == [
+        ("submit", 0, "a"),
+        ("submit", 1, "b"),
+        ("submit", 2, "c"),
+        ("wait", ("ref-0", "ref-1", "ref-2")),
+        ("submit", 3, "d"),
+        ("wait", ("ref-3",)),
+    ]
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__]))

--- a/tests/test_engine_group_wave_distributed.py
+++ b/tests/test_engine_group_wave_distributed.py
@@ -1,0 +1,291 @@
+import importlib.util
+import sys
+import types
+from argparse import Namespace
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+NUM_GPUS = 0
+
+
+def _load_distributed_update_module(monkeypatch):
+    slime_pkg = types.ModuleType("slime")
+    slime_pkg.__path__ = [str(REPO_ROOT / "slime")]
+    slime_utils_pkg = types.ModuleType("slime.utils")
+    slime_utils_pkg.__path__ = [str(REPO_ROOT / "slime" / "utils")]
+    slime_backends_pkg = types.ModuleType("slime.backends")
+    slime_backends_pkg.__path__ = [str(REPO_ROOT / "slime" / "backends")]
+    megatron_utils_pkg = types.ModuleType("slime.backends.megatron_utils")
+    megatron_utils_pkg.__path__ = [str(REPO_ROOT / "slime" / "backends" / "megatron_utils")]
+    update_weight_pkg = types.ModuleType("slime.backends.megatron_utils.update_weight")
+    update_weight_pkg.__path__ = [str(REPO_ROOT / "slime" / "backends" / "megatron_utils" / "update_weight")]
+
+    ray_mod = types.ModuleType("ray")
+    ray_mod.ObjectRef = object
+    ray_mod.get = lambda refs: refs
+    ray_actor_mod = types.ModuleType("ray.actor")
+    ray_actor_mod.ActorHandle = object
+
+    dist_mod = types.ModuleType("torch.distributed")
+    dist_mod.ProcessGroup = object
+    dist_mod.Work = object
+    torch_mod = types.ModuleType("torch")
+    torch_mod.Tensor = object
+    torch_mod.nn = types.SimpleNamespace(Module=object)
+    torch_mod.no_grad = lambda: (lambda function: function)
+    torch_mod.distributed = dist_mod
+
+    megatron_mod = types.ModuleType("megatron")
+    megatron_core_mod = types.ModuleType("megatron.core")
+    mpu_mod = types.ModuleType("megatron.core.mpu")
+    megatron_core_mod.mpu = mpu_mod
+
+    accelerator_mod = types.ModuleType("slime.utils.accelerator")
+    distributed_utils_mod = types.ModuleType("slime.utils.distributed_utils")
+    distributed_utils_mod.get_gloo_group = lambda: object()
+    distributed_utils_mod.init_process_group = lambda **kwargs: object()
+    http_utils_mod = types.ModuleType("slime.utils.http_utils")
+    http_utils_mod._wrap_ipv6 = lambda address: address
+    megatron_to_hf_mod = types.ModuleType("slime.backends.megatron_utils.megatron_to_hf")
+    megatron_to_hf_mod.convert_to_hf = lambda *args, **kwargs: []
+    common_mod = types.ModuleType("slime.backends.megatron_utils.update_weight.common")
+    common_mod.all_gather_param = lambda _name, param: param
+    common_mod.named_params_and_buffers = lambda *_args, **_kwargs: []
+    tqdm_mod = types.ModuleType("tqdm")
+    tqdm_mod.tqdm = object
+
+    fake_modules = {
+        "slime": slime_pkg,
+        "slime.utils": slime_utils_pkg,
+        "slime.backends": slime_backends_pkg,
+        "slime.backends.megatron_utils": megatron_utils_pkg,
+        "slime.backends.megatron_utils.update_weight": update_weight_pkg,
+        "ray": ray_mod,
+        "ray.actor": ray_actor_mod,
+        "torch": torch_mod,
+        "torch.distributed": dist_mod,
+        "megatron": megatron_mod,
+        "megatron.core": megatron_core_mod,
+        "megatron.core.mpu": mpu_mod,
+        "slime.utils.accelerator": accelerator_mod,
+        "slime.utils.distributed_utils": distributed_utils_mod,
+        "slime.utils.http_utils": http_utils_mod,
+        "slime.backends.megatron_utils.megatron_to_hf": megatron_to_hf_mod,
+        "slime.backends.megatron_utils.update_weight.common": common_mod,
+        "tqdm": tqdm_mod,
+    }
+    for name, module in fake_modules.items():
+        monkeypatch.setitem(sys.modules, name, module)
+
+    module_name = "slime.backends.megatron_utils.update_weight.update_weight_from_distributed"
+    sys.modules.pop(module_name, None)
+    module_path = (
+        REPO_ROOT / "slime" / "backends" / "megatron_utils" / "update_weight" / "update_weight_from_distributed.py"
+    )
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, module_name, module)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("limit", [0, 2, 4])
+def test_unbounded_distributed_topology_keeps_one_aggregate_group(monkeypatch, limit):
+    module = _load_distributed_update_module(monkeypatch)
+    calls = []
+
+    def connect(_args, name, engines, engine_gpu_counts=None):
+        calls.append((name, tuple(engines), tuple(engine_gpu_counts)))
+        return f"pg-{name}"
+
+    monkeypatch.setattr(module, "connect_rollout_engines_from_distributed", connect)
+    engines = ["engine-0", "engine-1"]
+
+    groups = module.connect_rollout_engine_groups_from_distributed(
+        Namespace(rollout_num_gpus_per_engine=1),
+        "slime",
+        engines,
+        engine_gpu_counts=[1, 2],
+        max_inflight_engine_groups=limit,
+    )
+
+    assert calls == [("slime", tuple(engines), (1, 2))]
+    assert len(groups) == 1
+    assert groups[0].engine_indices == (0, 1)
+    assert groups[0].rollout_engines == tuple(engines)
+
+
+@pytest.mark.unit
+def test_partial_group_setup_is_torn_down_on_failure(monkeypatch):
+    module = _load_distributed_update_module(monkeypatch)
+    disconnected = []
+
+    def connect(_args, name, _engines, engine_gpu_counts=None):
+        assert engine_gpu_counts is not None
+        if name.endswith("-1"):
+            raise RuntimeError("engine setup failed")
+        return f"pg-{name}"
+
+    monkeypatch.setattr(module, "connect_rollout_engines_from_distributed", connect)
+    monkeypatch.setattr(
+        module,
+        "disconnect_rollout_engine_groups_from_distributed",
+        lambda groups: disconnected.extend(groups),
+    )
+
+    with pytest.raises(RuntimeError, match="engine setup failed"):
+        module.connect_rollout_engine_groups_from_distributed(
+            Namespace(rollout_num_gpus_per_engine=1),
+            "slime",
+            ["engine-a", "engine-b"],
+            max_inflight_engine_groups=1,
+        )
+
+    assert len(disconnected) == 1
+    assert disconnected[0].group_name == "slime-engine-0"
+
+
+@pytest.mark.unit
+def test_distributed_launch_starts_all_bucket_broadcasts_asynchronously(monkeypatch):
+    module = _load_distributed_update_module(monkeypatch)
+    remote_calls = []
+    broadcasts = []
+
+    class RemoteMethod:
+        def remote(self, **kwargs):
+            remote_calls.append(kwargs)
+            return "engine-ref"
+
+    class Engine:
+        update_weights_from_distributed = RemoteMethod()
+
+    class Tensor:
+        def __init__(self, name, dtype, shape):
+            self.data = f"data-{name}"
+            self.dtype = dtype
+            self.shape = shape
+
+    def broadcast(data, source, *, group, async_op):
+        broadcasts.append((data, source, group, async_op))
+        return f"work-{data}"
+
+    monkeypatch.setattr(module.dist, "broadcast", broadcast, raising=False)
+    named_tensors = [
+        ("weight-a", Tensor("a", "bf16", (2, 4))),
+        ("weight-b", Tensor("b", "fp32", (3,))),
+    ]
+
+    refs, works = module.launch_weights_from_distributed(
+        "slime-engine-0",
+        "pg-0",
+        17,
+        [Engine()],
+        named_tensors,
+        load_format="flattened_bucket",
+    )
+
+    assert refs == ["engine-ref"]
+    assert works == ["work-data-a", "work-data-b"]
+    assert broadcasts == [
+        ("data-a", 0, "pg-0", True),
+        ("data-b", 0, "pg-0", True),
+    ]
+    assert remote_calls == [
+        {
+            "names": ["weight-a", "weight-b"],
+            "dtypes": ["bf16", "fp32"],
+            "shapes": [(2, 4), (3,)],
+            "group_name": "slime-engine-0",
+            "weight_version": "17",
+            "load_format": "flattened_bucket",
+        }
+    ]
+
+
+@pytest.mark.unit
+def test_bounded_distributed_topology_builds_one_group_per_engine(monkeypatch):
+    module = _load_distributed_update_module(monkeypatch)
+    calls = []
+
+    def connect(_args, name, engines, engine_gpu_counts=None):
+        calls.append((name, tuple(engines), tuple(engine_gpu_counts)))
+        return f"pg-{name}"
+
+    monkeypatch.setattr(module, "connect_rollout_engines_from_distributed", connect)
+
+    groups = module.connect_rollout_engine_groups_from_distributed(
+        Namespace(rollout_num_gpus_per_engine=1),
+        "slime",
+        ["engine-a", "engine-b"],
+        engine_gpu_counts=[1, 2],
+        max_inflight_engine_groups=2,
+        total_engine_groups=4,
+        engine_index_offset=2,
+    )
+
+    assert calls == [
+        ("slime-engine-2", ("engine-a",), (1,)),
+        ("slime-engine-3", ("engine-b",), (2,)),
+    ]
+    assert [group.engine_indices for group in groups] == [(2,), (3,)]
+
+
+@pytest.mark.unit
+def test_distributed_wave_waits_before_admitting_next_engines(monkeypatch):
+    module = _load_distributed_update_module(monkeypatch)
+    events = []
+
+    class Work:
+        def __init__(self, engine_index):
+            self.engine_index = engine_index
+
+        def wait(self):
+            events.append(("work.wait", self.engine_index))
+
+    groups = [
+        module.DistributedWeightUpdateGroup(
+            engine_indices=(index,),
+            group_name=f"group-{index}",
+            process_group=f"pg-{index}",
+            rollout_engines=(f"engine-{index}",),
+        )
+        for index in range(4)
+    ]
+
+    def launch(group_name, _group, _version, _engines, _tensors, load_format=None):
+        engine_index = int(group_name.rsplit("-", 1)[1])
+        events.append(("launch", engine_index, load_format))
+        return [f"ref-{engine_index}"], [Work(engine_index)]
+
+    monkeypatch.setattr(module, "launch_weights_from_distributed", launch)
+    monkeypatch.setattr(module.ray, "get", lambda refs: events.append(("ray.get", tuple(refs))))
+
+    module.update_weights_in_engine_group_waves(
+        groups,
+        weight_version=9,
+        converted_named_tensors=[],
+        max_inflight_engine_groups=3,
+        load_format="test",
+    )
+
+    assert events == [
+        ("launch", 0, "test"),
+        ("launch", 1, "test"),
+        ("launch", 2, "test"),
+        ("work.wait", 0),
+        ("work.wait", 1),
+        ("work.wait", 2),
+        ("ray.get", ("ref-0", "ref-1", "ref-2")),
+        ("launch", 3, "test"),
+        ("work.wait", 3),
+        ("ray.get", ("ref-3",)),
+    ]
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__]))

--- a/tests/test_megatron_argument_validation.py
+++ b/tests/test_megatron_argument_validation.py
@@ -256,6 +256,8 @@ def make_slime_validate_args(**overrides):
         update_weight_disk_dir=None,
         update_weight_local_checkpoint_dir=None,
         update_weight_mode="full",
+        update_weight_max_inflight_buckets=0,
+        update_weight_max_inflight_bytes=0,
         rollout_temperature=1.0,
     )
     values.update(overrides)
@@ -388,6 +390,59 @@ def test_update_weight_delta_requires_local_checkpoint_dir(monkeypatch):
 
     with pytest.raises(ValueError, match="requires --update-weight-local-checkpoint-dir"):
         module.slime_validate_args(args)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("field", "option"),
+    [
+        ("update_weight_max_inflight_buckets", "--update-weight-max-inflight-buckets"),
+        ("update_weight_max_inflight_bytes", "--update-weight-max-inflight-bytes"),
+    ],
+)
+def test_weight_bucket_credit_rejects_negative_limits(monkeypatch, field, option):
+    module = load_slime_arguments_module(monkeypatch)
+    args = make_slime_validate_args(**{field: -1})
+
+    with pytest.raises(ValueError, match=option):
+        module.slime_validate_args(args)
+
+
+@pytest.mark.unit
+def test_weight_bucket_credit_requires_full_nccl_sync(monkeypatch):
+    module = load_slime_arguments_module(monkeypatch)
+    args = make_slime_validate_args(
+        update_weight_transport="disk",
+        update_weight_disk_dir="/shared/weights",
+        update_weight_max_inflight_buckets=2,
+    )
+
+    with pytest.raises(ValueError, match="require --update-weight-mode=full"):
+        module.slime_validate_args(args)
+
+
+@pytest.mark.unit
+def test_weight_bucket_credit_argument_defaults_preserve_synchronous_sync(monkeypatch):
+    module = load_slime_arguments_module(monkeypatch)
+    parser = argparse.ArgumentParser()
+    module.get_slime_extra_args_provider()(parser)
+
+    defaults = parser.parse_args(["--rollout-batch-size", "1"])
+    configured = parser.parse_args(
+        [
+            "--rollout-batch-size",
+            "1",
+            "--update-weight-max-inflight-buckets",
+            "3",
+            "--update-weight-max-inflight-bytes",
+            "1048576",
+        ]
+    )
+
+    assert defaults.update_weight_max_inflight_buckets == 0
+    assert defaults.update_weight_max_inflight_bytes == 0
+    assert configured.update_weight_max_inflight_buckets == 3
+    assert configured.update_weight_max_inflight_bytes == 1048576
 
 
 @pytest.mark.unit

--- a/tests/test_megatron_argument_validation.py
+++ b/tests/test_megatron_argument_validation.py
@@ -177,6 +177,15 @@ def test_update_weight_disk_dir_required_for_disk_transport(monkeypatch):
         module.slime_validate_args(args)
 
 
+@pytest.mark.unit
+def test_update_weight_engine_group_wave_limit_must_be_non_negative(monkeypatch):
+    module = load_slime_arguments_module(monkeypatch)
+    args = make_slime_validate_args(update_weight_max_inflight_engine_groups=-1)
+
+    with pytest.raises(ValueError, match="max-inflight-engine-groups"):
+        module.slime_validate_args(args)
+
+
 def make_slime_validate_args(**overrides):
     values = dict(
         eval_config=None,
@@ -456,6 +465,26 @@ def test_force_fp8_ue8m0_scale_argument(monkeypatch):
 
     assert defaults.force_fp8_ue8m0_scale is False
     assert configured.force_fp8_ue8m0_scale is True
+
+
+@pytest.mark.unit
+def test_update_weight_engine_group_wave_argument(monkeypatch):
+    module = load_slime_arguments_module(monkeypatch)
+    parser = argparse.ArgumentParser()
+    module.get_slime_extra_args_provider()(parser)
+
+    defaults = parser.parse_args(["--rollout-batch-size", "1"])
+    configured = parser.parse_args(
+        [
+            "--rollout-batch-size",
+            "1",
+            "--update-weight-max-inflight-engine-groups",
+            "3",
+        ]
+    )
+
+    assert defaults.update_weight_max_inflight_engine_groups == 0
+    assert configured.update_weight_max_inflight_engine_groups == 3
 
 
 if __name__ == "__main__":

--- a/tests/test_weight_sync_callsite_benchmark.py
+++ b/tests/test_weight_sync_callsite_benchmark.py
@@ -1,0 +1,187 @@
+import copy
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from tools.benchmark_weight_sync_callsite import (
+    EVIDENCE_ROLES,
+    POLICIES,
+    SCHEMA,
+    _load_production_callsite_from_source,
+    artifact_digest,
+    ordered_engine_indices,
+    parse_size,
+    resolve_policy,
+    summarize_artifacts,
+    verify_artifact,
+)
+
+
+NUM_GPUS = 0
+
+
+def test_policy_matrix_uses_production_native_limits_for_logical_four_rank_layout():
+    assert resolve_policy("isolated_a", 3, 2).active_engine_indices == (0,)
+    assert resolve_policy("isolated_b", 3, 2).active_engine_indices == (1,)
+    assert resolve_policy("baseline_overlap", 3, 2).max_inflight_engine_groups == 0
+    assert resolve_policy("current_legal", 3, 2).max_inflight_engine_groups == 3
+    assert resolve_policy("candidate_serialized", 3, 2).max_inflight_engine_groups == 1
+    assert resolve_policy("candidate_windowed", 3, 2).max_inflight_engine_groups == 2
+
+
+def test_policy_resolution_is_generic_and_has_no_special_world_size_branch():
+    resolved = resolve_policy("candidate_windowed", engine_count=7, window_size=4)
+
+    assert resolved.active_engine_indices == tuple(range(7))
+    assert resolved.max_inflight_engine_groups == 4
+
+
+def test_ba_order_only_swaps_the_named_pair():
+    assert ordered_engine_indices((0, 1, 2), "ab") == (0, 1, 2)
+    assert ordered_engine_indices((0, 1, 2), "ba") == (1, 0, 2)
+
+
+def test_parse_size_checks_exact_positive_elements():
+    assert parse_size("1MiB") == 1 << 20
+    assert parse_size("2.5MB") == 2_500_000
+    with pytest.raises(Exception, match="positive"):
+        parse_size("0")
+
+
+def test_minimal_container_source_loader_uses_the_production_function():
+    module = _load_production_callsite_from_source()
+
+    assert module.update_weights_in_engine_group_waves.__module__.endswith("update_weight_from_distributed")
+    assert module.update_weights_in_engine_group_waves.__code__.co_filename.endswith(
+        "slime/backends/megatron_utils/update_weight/update_weight_from_distributed.py"
+    )
+
+
+def _artifact(policy, role, run_index, *, world_size=4):
+    metrics = {
+        name: {"p50": float(run_index + 1), "p95": float(run_index + 2), "min": 1.0, "max": 3.0}
+        for name in (
+            "comm_a_ms",
+            "comm_b_ms",
+            "rank_local_pair_makespan_ms",
+            "realized_b_minus_a_launch_offset_us",
+            "consumer_a_wait_ms",
+            "consumer_b_wait_ms",
+            "consumer_ready_ms",
+            "callsite_return_ms",
+            "controller_device_ready_ms",
+            "step_sync_ready_ms",
+        )
+    }
+    payload = {
+        "schema": SCHEMA,
+        "run_id": f"{policy}-{role}-{run_index}",
+        "process_launch_id": f"launch-{policy}-{role}-{run_index}",
+        "evidence_role": role,
+        "policy": policy,
+        "order": "ab" if run_index % 2 == 0 else "ba",
+        "resolved_policy": {},
+        "timing_scope": {},
+        "compatibility": {
+            "backend": "gloo",
+            "python": "3.12.0",
+            "pytorch": "2.11.0",
+            "cuda_runtime": None,
+            "nccl": None,
+            "nccl_launch_order_implicit": None,
+            "dtype": "float32",
+            "message_bytes": 1024,
+            "tensor_elements": 256,
+            "launched_world_size": world_size,
+            "engine_group_count": world_size - 1,
+            "process_group_membership": [[0, rank] for rank in range(1, world_size)],
+            "graph_capture": False,
+            "hostname": "test-host",
+            "device": None,
+            "container_image_digest": None,
+        },
+        "iterations": [],
+        "summary": metrics,
+        "observed_ranks": list(range(world_size)),
+        "payload_validated": True,
+        "claim_limits": ["fixture"],
+    }
+    payload["artifact_sha256"] = artifact_digest(payload)
+    return payload
+
+
+def _write_campaign(tmp_path, runs_per_role=2):
+    paths = []
+    for policy in POLICIES:
+        for role in EVIDENCE_ROLES:
+            for run_index in range(runs_per_role):
+                path = tmp_path / f"{policy}-{role}-{run_index}.json"
+                path.write_text(json.dumps(_artifact(policy, role, run_index)))
+                paths.append(path)
+    return paths
+
+
+def test_campaign_counts_independent_processes_not_iterations(tmp_path):
+    paths = _write_campaign(tmp_path)
+
+    result = summarize_artifacts(paths, min_runs_per_role=2)
+
+    assert result["artifact_count"] == len(POLICIES) * len(EVIDENCE_ROLES) * 2
+    assert result["selection_and_confirmation_disjoint"] is True
+    assert result["automatic_policy_selection"] is False
+    for policy in POLICIES:
+        for role in EVIDENCE_ROLES:
+            summary = result["policy_summaries"][policy][role]
+            assert summary["independent_process_runs"] == 2
+            assert summary["orders"] == ["ab", "ba"]
+
+
+def test_campaign_fails_closed_on_too_few_independent_runs(tmp_path):
+    paths = _write_campaign(tmp_path, runs_per_role=1)
+
+    with pytest.raises(ValueError, match="requires 2 independent process runs"):
+        summarize_artifacts(paths, min_runs_per_role=2)
+
+
+def test_campaign_rejects_cross_cell_evidence(tmp_path):
+    paths = _write_campaign(tmp_path)
+    changed = json.loads(paths[-1].read_text())
+    changed["compatibility"]["message_bytes"] *= 2
+    changed["artifact_sha256"] = artifact_digest(changed)
+    paths[-1].write_text(json.dumps(changed))
+
+    with pytest.raises(ValueError, match="incompatible"):
+        summarize_artifacts(paths, min_runs_per_role=2)
+
+
+def test_campaign_rejects_reused_process_launch_identity(tmp_path):
+    paths = _write_campaign(tmp_path)
+    first = json.loads(paths[0].read_text())
+    second = json.loads(paths[1].read_text())
+    second["process_launch_id"] = first["process_launch_id"]
+    second["artifact_sha256"] = artifact_digest(second)
+    paths[1].write_text(json.dumps(second))
+
+    with pytest.raises(ValueError, match="process_launch_id values must be unique"):
+        summarize_artifacts(paths, min_runs_per_role=2)
+
+
+def test_artifact_digest_detects_timing_mutation():
+    payload = _artifact("baseline_overlap", "selection", 0)
+    verify_artifact(payload)
+    mutated = copy.deepcopy(payload)
+    mutated["summary"]["step_sync_ready_ms"]["p50"] += 1
+
+    with pytest.raises(ValueError, match="digest mismatch"):
+        verify_artifact(mutated)
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__]))

--- a/tests/test_weight_sync_credit.py
+++ b/tests/test_weight_sync_credit.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 import os
 import socket
 import sys
@@ -403,9 +404,25 @@ def test_wave_transition_keeps_bucket_credit_and_requires_every_resource_drained
     controller.commit_version(11)
 
 
+@pytest.fixture(params=[False, True], ids=["trace-off", "trace-on"])
+def capture_updater_trace(request, tmp_path, monkeypatch):
+    from slime.observability import communication_timeline as timeline
+
+    timeline.close_communication_timeline()
+    monkeypatch.delenv(timeline.COMMUNICATION_TIMELINE_ENV, raising=False)
+    monkeypatch.setattr(timeline, "_optional_torch", lambda: None)
+    path = tmp_path / "logical-updater.jsonl" if request.param else None
+    if path is not None:
+        timeline.configure_communication_timeline(str(path), rank=0, world_size=1, run_id="logical-updater-test")
+    yield timeline, path
+    timeline.close_communication_timeline()
+
+
 @pytest.mark.parametrize("engine_count", [2, 4])
 @pytest.mark.parametrize("fail_load", [False, True])
-def test_production_updater_composes_waves_credits_and_publication(monkeypatch, engine_count, fail_load):
+def test_production_updater_composes_waves_credits_and_publication(
+    monkeypatch, engine_count, fail_load, capture_updater_trace
+):
     module = _load_distributed_update_module(monkeypatch)
     events = []
 
@@ -495,6 +512,32 @@ def test_production_updater_composes_waves_credits_and_publication(monkeypatch, 
             for phase in ("launch", "wait", "load")
         ]
         assert events.count("resume") == engine_count
+
+    timeline, path = capture_updater_trace
+    timeline.close_communication_timeline()
+    if path is not None:
+        records = [json.loads(line) for line in path.read_text().splitlines()]
+        sequence_ids = [row["sequence_id"] for row in records]
+        assert sequence_ids == sorted(set(sequence_ids))
+        # Each exhausted conversion iterator cancels its terminal span. These
+        # are global trace sequence IDs, not communicator collective sequence.
+        assert sequence_ids[-1] + 1 - len(records) == (0 if fail_load else 2)
+        assert all(row["weight_version"] == 1 for row in records)
+        sends = [row for row in records if row["operation"] == "weight_bucket_send"]
+        assert len(sends) == (2 if fail_load else 3 * engine_count)
+        assert len({row["logical_operation_id"] for row in sends}) == len(sends)
+        assert all(row["gpu_start_timestamp_ns"] is None for row in records)
+        assert all(
+            row["api_launch_timestamp_ns"] <= row["api_return_timestamp_ns"] <= row["completion_timestamp_ns"]
+            for row in sends
+        )
+        if fail_load:
+            assert records[-1]["operation"] == "weight_sync_failed"
+            assert any(row["status"] == "error" and row["operation"] == "engine_load_weights" for row in records)
+            assert not any(row["operation"] in {"weight_sync_complete", "weight_bucket_reusable"} for row in records)
+        else:
+            assert records[-1]["operation"] == "weight_sync_complete"
+            assert sum(row["operation"] == "weight_bucket_reusable" for row in records) == 3
 
 
 if __name__ == "__main__":

--- a/tests/test_weight_sync_credit.py
+++ b/tests/test_weight_sync_credit.py
@@ -281,7 +281,7 @@ def test_distributed_credit_window_holds_one_lock_and_waits_fifo(monkeypatch) ->
 
     updater = object.__new__(module.UpdateWeightFromDistributed)
     updater._group_name = "weights"
-    updater._model_update_groups = "group"
+    updater._model_update_groups = [module.DistributedWeightUpdateGroup((0,), "weights", "group", (object(),))]
     updater.weight_version = 13
     updater.rollout_engines = [object()]
     updater.rollout_engine_lock = types.SimpleNamespace(
@@ -376,6 +376,125 @@ def _gloo_credit_worker(rank: int, world_size: int, port: int) -> None:
 @pytest.mark.unit
 def test_credit_window_drives_real_async_gloo_broadcasts() -> None:
     mp.spawn(_gloo_credit_worker, args=(2, _free_port()), nprocs=2, join=True)
+
+
+def test_wave_transition_keeps_bucket_credit_and_requires_every_resource_drained() -> None:
+    controller = WeightSyncCreditController(max_inflight_buckets=1, max_inflight_bytes=8)
+    controller.begin_version(11)
+    reservation = controller.reserve(8)
+    controller.mark_launched(reservation, transport_bytes=8, staging_bytes=12, consumer_objects=1)
+    for release in (
+        controller.mark_transport_complete,
+        controller.mark_consumers_complete,
+        controller.mark_staging_released,
+    ):
+        with pytest.raises(RuntimeError, match="cannot advance a weight wave"):
+            controller.mark_next_wave(reservation, transport_bytes=8, staging_bytes=0, consumer_objects=2)
+        release(reservation)
+    assert controller.reserve(0) is None
+    controller.mark_next_wave(reservation, transport_bytes=16, staging_bytes=0, consumer_objects=2)
+    assert controller.snapshot.inflight_bytes == 8
+    assert controller.snapshot.transport_outstanding_bytes == 16
+    controller.mark_transport_complete(reservation)
+    controller.mark_consumers_complete(reservation)
+    with pytest.raises(ValueError, match="non-negative"):
+        controller.mark_next_wave(reservation, transport_bytes=-1, staging_bytes=0, consumer_objects=0)
+    controller.release(reservation)
+    controller.commit_version(11)
+
+
+@pytest.mark.parametrize("engine_count", [2, 4])
+@pytest.mark.parametrize("fail_load", [False, True])
+def test_production_updater_composes_waves_credits_and_publication(monkeypatch, engine_count, fail_load):
+    module = _load_distributed_update_module(monkeypatch)
+    events = []
+
+    class Remote:
+        def __init__(self, name, result=None):
+            self.name, self.result = name, result
+
+        def remote(self):
+            events.append(self.name)
+            return self.result
+
+    engines = [
+        types.SimpleNamespace(
+            pause_generation=Remote("pause"),
+            flush_cache=Remote("flush"),
+            continue_generation=Remote("resume"),
+        )
+        for _ in range(engine_count)
+    ]
+    updater = module.UpdateWeightFromDistributed(
+        types.SimpleNamespace(
+            update_weight_max_inflight_buckets=2,
+            update_weight_max_inflight_bytes=32,
+            update_weight_max_inflight_engine_groups=1,
+        ),
+        [],
+        lambda: {},
+        model_name="logical-integration-fixture",
+        quantization_config=None,
+    )
+    updater.rollout_engines = engines
+    updater._is_pp_src_rank = False
+    updater._model_update_groups = [
+        module.DistributedWeightUpdateGroup((i,), f"engine-{i}", i, (engine,)) for i, engine in enumerate(engines)
+    ]
+    updater.rollout_engine_lock = types.SimpleNamespace(acquire=Remote("lock", True), release=Remote("unlock"))
+    updater._iter_non_expert_chunks = lambda: iter([[(f"bucket-{i}", torch.ones(4))] for i in range(3)])
+    updater._iter_expert_chunks = lambda: iter(())
+    monkeypatch.setattr(module.dist, "get_rank", lambda: 0)
+    monkeypatch.setattr(module.dist, "barrier", lambda **_: None)
+
+    def launch(_name, group, version, _engines, tensors, **_kwargs):
+        assert version == 1
+        bucket = tensors[0][0]
+        assert updater._weight_sync_credit.snapshot.active_version == 1
+        events.append(("launch", bucket, group))
+        handle = types.SimpleNamespace(wait=lambda: events.append(("wait", bucket, group)))
+        return [(bucket, group)], [handle]
+
+    def ray_get(refs):
+        if isinstance(refs, list) and refs and isinstance(refs[0], tuple):
+            bucket, group = refs[0]
+            snapshot = updater._weight_sync_credit.snapshot
+            assert snapshot.transport_outstanding_bytes == 0
+            assert snapshot.pending_consumer_objects == 1
+            assert snapshot.inflight_buckets > 0
+            events.append(("load", bucket, group))
+            if fail_load and group == 1:
+                raise RuntimeError("injected engine load failure")
+        return refs
+
+    monkeypatch.setattr(module, "launch_weights_from_distributed", launch)
+    module.ray.get = ray_get
+    if fail_load:
+        with pytest.raises(RuntimeError, match="injected engine load failure"):
+            updater.update_weights()
+        snapshot = updater._weight_sync_credit.snapshot
+        assert snapshot.active_version == 1
+        assert snapshot.failed_reason is not None
+        assert snapshot.pending_consumer_objects == 1
+        assert updater._active_wave_resources[0][0][0] == "bucket-0"
+        assert "resume" not in events
+        assert not any(event[:2] == ("launch", "bucket-1") for event in events if isinstance(event, tuple))
+    else:
+        updater.update_weights()
+        snapshot = updater._weight_sync_credit.snapshot
+        assert snapshot.active_version is None
+        assert snapshot.inflight_buckets == 0
+        assert snapshot.peak_inflight_buckets == 2
+        assert snapshot.peak_inflight_bytes == 32
+        assert snapshot.peak_pending_consumer_objects == 1
+        assert snapshot.peak_transport_outstanding_bytes == 16
+        assert [event for event in events if isinstance(event, tuple)] == [
+            (phase, f"bucket-{bucket}", group)
+            for bucket in range(3)
+            for group in range(engine_count)
+            for phase in ("launch", "wait", "load")
+        ]
+        assert events.count("resume") == engine_count
 
 
 if __name__ == "__main__":

--- a/tests/test_weight_sync_credit.py
+++ b/tests/test_weight_sync_credit.py
@@ -95,6 +95,80 @@ def test_release_is_fifo_and_commit_requires_a_drained_version() -> None:
         controller.begin_version(3)
 
 
+def test_lifecycle_accounting_tracks_distinct_resources_and_duplicate_completion() -> None:
+    controller = WeightSyncCreditController(max_inflight_buckets=2, max_inflight_bytes=10)
+    controller.begin_version(5)
+    first = controller.reserve(6)
+    second = controller.reserve(4)
+    assert first is not None
+    assert second is not None
+
+    controller.mark_launched(first, transport_bytes=6, staging_bytes=12, consumer_objects=2)
+    controller.mark_launched(second, transport_bytes=4, staging_bytes=8, consumer_objects=1)
+    snapshot = controller.snapshot
+    assert snapshot.inflight_bytes == 10
+    assert snapshot.transport_outstanding_bytes == 10
+    assert snapshot.staging_resident_bytes == 20
+    assert snapshot.pending_consumer_objects == 3
+    assert snapshot.peak_staging_resident_bytes > snapshot.peak_inflight_bytes
+
+    controller.mark_transport_complete(first)
+    controller.mark_transport_complete(first)
+    controller.mark_consumers_complete(first)
+    controller.mark_consumers_complete(first)
+    with pytest.raises(RuntimeError, match="before transport, consumers, and staging"):
+        controller.release(first)
+    controller.mark_staging_released(first)
+    controller.mark_staging_released(first)
+    controller.release(first)
+
+    controller.mark_transport_complete(second)
+    controller.mark_consumers_complete(second)
+    controller.mark_staging_released(second)
+    controller.release(second)
+    controller.commit_version(5)
+
+    metrics = controller.metrics()
+    assert metrics["perf/update_weights_peak_inflight_buckets"] == 2
+    assert metrics["perf/update_weights_peak_logical_inflight_bytes"] == 10
+    assert metrics["perf/update_weights_peak_transport_outstanding_bytes"] == 10
+    assert metrics["perf/update_weights_peak_staging_resident_bytes"] == 20
+    assert metrics["perf/update_weights_peak_pending_consumer_objects"] == 3
+
+
+def test_failed_version_is_poisoned_and_preserves_outstanding_evidence() -> None:
+    controller = WeightSyncCreditController(max_inflight_buckets=1)
+    controller.begin_version(8)
+    reservation = controller.reserve(7)
+    assert reservation is not None
+    controller.mark_launched(reservation, transport_bytes=7, staging_bytes=11, consumer_objects=1)
+
+    controller.fail_version(8, RuntimeError("consumer load failed"))
+    controller.fail_version(8, RuntimeError("later wrapper error"))
+    snapshot = controller.snapshot
+    assert snapshot.failed_reason == "RuntimeError: consumer load failed"
+    assert snapshot.transport_outstanding_bytes == 7
+    assert snapshot.staging_resident_bytes == 11
+    assert snapshot.pending_consumer_objects == 1
+    with pytest.raises(RuntimeError, match="cannot commit failed weight version 8"):
+        controller.commit_version(8)
+    with pytest.raises(RuntimeError, match="weight version 8 is still active"):
+        controller.begin_version(9)
+
+
+def test_persistent_staging_must_be_released_before_version_commit() -> None:
+    controller = WeightSyncCreditController()
+    controller.begin_version(2)
+    controller.set_persistent_staging_bytes(32)
+    controller.set_persistent_staging_bytes(48)
+    assert controller.snapshot.staging_resident_bytes == 48
+    assert controller.snapshot.peak_staging_resident_bytes == 48
+    with pytest.raises(RuntimeError, match="lifecycle resources still resident"):
+        controller.commit_version(2)
+    controller.set_persistent_staging_bytes(0)
+    controller.commit_version(2)
+
+
 def _load_distributed_update_module(monkeypatch):
     ray_mod = types.ModuleType("ray")
     ray_mod.ObjectRef = object

--- a/tests/test_weight_sync_credit.py
+++ b/tests/test_weight_sync_credit.py
@@ -1,0 +1,308 @@
+from __future__ import annotations
+
+import importlib.util
+import os
+import socket
+import sys
+import types
+from pathlib import Path
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+from slime.backends.megatron_utils.update_weight.weight_sync_credit import WeightSyncCreditController
+
+NUM_GPUS = 0
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _free_port() -> int:
+    with socket.socket() as sock:
+        sock.bind(("", 0))
+        return sock.getsockname()[1]
+
+
+def test_bucket_and_byte_credits_are_independent() -> None:
+    controller = WeightSyncCreditController(max_inflight_buckets=2, max_inflight_bytes=10)
+    controller.begin_version(7)
+
+    first = controller.reserve(6)
+    second = controller.reserve(4)
+    assert first is not None
+    assert second is not None
+    assert controller.inflight_buckets == 2
+    assert controller.inflight_bytes == 10
+    assert controller.full
+    assert controller.reserve(0) is None
+
+    controller.release(first)
+    third = controller.reserve(5)
+    assert third is not None
+    assert third.bucket_id == 2
+    assert controller.inflight_buckets == 2
+    assert controller.inflight_bytes == 9
+
+    controller.release(second)
+    controller.release(third)
+    controller.commit_version(7)
+
+
+@pytest.mark.parametrize(
+    ("max_buckets", "max_bytes", "third_admitted"),
+    [
+        (2, 0, False),
+        (0, 8, False),
+        (0, 0, True),
+    ],
+)
+def test_zero_disables_only_its_credit_dimension(max_buckets: int, max_bytes: int, third_admitted: bool) -> None:
+    controller = WeightSyncCreditController(max_buckets, max_bytes)
+    controller.begin_version(1)
+
+    assert controller.reserve(4) is not None
+    assert controller.reserve(4) is not None
+    assert (controller.reserve(4) is not None) is third_admitted
+
+
+def test_one_bucket_must_fit_the_byte_credit() -> None:
+    controller = WeightSyncCreditController(max_inflight_bytes=8)
+    controller.begin_version(1)
+
+    with pytest.raises(ValueError, match="requires 9 bytes"):
+        controller.reserve(9)
+
+
+def test_release_is_fifo_and_commit_requires_a_drained_version() -> None:
+    controller = WeightSyncCreditController(max_inflight_buckets=2)
+    controller.begin_version(3)
+    first = controller.reserve(4)
+    second = controller.reserve(4)
+    assert first is not None
+    assert second is not None
+
+    with pytest.raises(RuntimeError, match="must complete in order"):
+        controller.release(second)
+    with pytest.raises(RuntimeError, match=r"bucket\(s\) in flight"):
+        controller.commit_version(3)
+
+    controller.release(first)
+    controller.release(second)
+    controller.commit_version(3)
+
+    with pytest.raises(ValueError, match="must be newer"):
+        controller.begin_version(3)
+
+
+def _load_distributed_update_module(monkeypatch):
+    ray_mod = types.ModuleType("ray")
+    ray_mod.ObjectRef = object
+    ray_actor_mod = types.ModuleType("ray.actor")
+    ray_actor_mod.ActorHandle = object
+
+    mpu_mod = types.ModuleType("megatron.core.mpu")
+    megatron_mod = types.ModuleType("megatron")
+    megatron_core_mod = types.ModuleType("megatron.core")
+    megatron_core_mod.mpu = mpu_mod
+
+    accelerator_mod = types.ModuleType("slime.utils.accelerator")
+    accelerator_mod.current_device = lambda: "cpu"
+    accelerator_mod.weight_update_backend = lambda: "gloo"
+    distributed_utils_mod = types.ModuleType("slime.utils.distributed_utils")
+    distributed_utils_mod.get_gloo_group = lambda: object()
+    distributed_utils_mod.init_process_group = lambda **_: object()
+    http_utils_mod = types.ModuleType("slime.utils.http_utils")
+    http_utils_mod._wrap_ipv6 = lambda address: address
+    converter_mod = types.ModuleType("slime.backends.megatron_utils.megatron_to_hf")
+    converter_mod.convert_to_hf = lambda *args, **kwargs: []
+    common_mod = types.ModuleType("slime.backends.megatron_utils.update_weight.common")
+    common_mod.all_gather_param = lambda _name, param: param
+    common_mod.named_params_and_buffers = lambda *_: []
+
+    monkeypatch.setitem(sys.modules, "ray", ray_mod)
+    monkeypatch.setitem(sys.modules, "ray.actor", ray_actor_mod)
+    monkeypatch.setitem(sys.modules, "megatron", megatron_mod)
+    monkeypatch.setitem(sys.modules, "megatron.core", megatron_core_mod)
+    monkeypatch.setitem(sys.modules, "megatron.core.mpu", mpu_mod)
+    monkeypatch.setitem(sys.modules, "slime.utils.accelerator", accelerator_mod)
+    monkeypatch.setitem(sys.modules, "slime.utils.distributed_utils", distributed_utils_mod)
+    monkeypatch.setitem(sys.modules, "slime.utils.http_utils", http_utils_mod)
+    monkeypatch.setitem(sys.modules, "slime.backends.megatron_utils.megatron_to_hf", converter_mod)
+    monkeypatch.setitem(sys.modules, "slime.backends.megatron_utils.update_weight.common", common_mod)
+
+    module_name = "slime.backends.megatron_utils.update_weight.update_weight_from_distributed"
+    monkeypatch.delitem(sys.modules, module_name, raising=False)
+    module_path = (
+        REPO_ROOT / "slime" / "backends" / "megatron_utils" / "update_weight" / "update_weight_from_distributed.py"
+    )
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, module_name, module)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_distributed_bucket_launch_returns_before_collective_wait(monkeypatch) -> None:
+    module = _load_distributed_update_module(monkeypatch)
+    events = []
+
+    class _Tensor:
+        dtype = "float32"
+        shape = (4,)
+        data = "payload"
+
+    class _Handle:
+        def wait(self):
+            events.append("wait")
+
+    class _RemoteMethod:
+        def remote(self, **kwargs):
+            events.append(("metadata", kwargs))
+            return "engine-ref"
+
+    engine = types.SimpleNamespace(update_weights_from_distributed=_RemoteMethod())
+    monkeypatch.setattr(
+        module.dist,
+        "broadcast",
+        lambda tensor, src, group, async_op: events.append(("broadcast", tensor, src, group, async_op)) or _Handle(),
+    )
+
+    refs, handles = module.launch_weights_from_distributed(
+        "weights",
+        "group",
+        9,
+        [engine],
+        [("layer.weight", _Tensor())],
+    )
+
+    assert refs == ["engine-ref"]
+    assert len(handles) == 1
+    assert [event[0] for event in events] == ["metadata", "broadcast"]
+    assert events[0][1]["weight_version"] == "9"
+    handles[0].wait()
+    assert events[-1] == "wait"
+
+
+def test_distributed_credit_window_holds_one_lock_and_waits_fifo(monkeypatch) -> None:
+    module = _load_distributed_update_module(monkeypatch)
+    events = []
+
+    class _Handle:
+        def __init__(self, name):
+            self.name = name
+
+        def wait(self):
+            events.append(("wait", self.name))
+
+    class _RemoteMethod:
+        def __init__(self, name, result):
+            self.name = name
+            self.result = result
+
+        def remote(self):
+            events.append((self.name,))
+            return self.result
+
+    updater = object.__new__(module.UpdateWeightFromDistributed)
+    updater._group_name = "weights"
+    updater._model_update_groups = "group"
+    updater.weight_version = 13
+    updater.rollout_engines = [object()]
+    updater.rollout_engine_lock = types.SimpleNamespace(
+        acquire=_RemoteMethod("acquire", True),
+        release=_RemoteMethod("release", None),
+    )
+    updater._weight_sync_credit = WeightSyncCreditController(max_inflight_buckets=2)
+    updater._weight_sync_credit.begin_version(13)
+    first = updater._weight_sync_credit.reserve(4)
+    second = updater._weight_sync_credit.reserve(4)
+    assert first is not None
+    assert second is not None
+    first_bucket = [("b0", object())]
+    second_bucket = [("b1", object())]
+
+    def launch(_group_name, _group, _version, _engines, bucket):
+        name = bucket[0][0]
+        events.append(("launch", name))
+        return [f"ref-{name}"], [_Handle(name)]
+
+    def ray_get(value):
+        if isinstance(value, list):
+            events.append(("ray_get", value[0]))
+        return value
+
+    monkeypatch.setattr(module, "launch_weights_from_distributed", launch)
+    module.ray.get = ray_get
+
+    updater._flush_weight_bucket_window(
+        [(first, first_bucket), (second, second_bucket)],
+        pbar=None,
+    )
+    updater._weight_sync_credit.commit_version(13)
+
+    assert events == [
+        ("acquire",),
+        ("launch", "b0"),
+        ("launch", "b1"),
+        ("wait", "b0"),
+        ("ray_get", "ref-b0"),
+        ("wait", "b1"),
+        ("ray_get", "ref-b1"),
+        ("release",),
+    ]
+    assert first_bucket == []
+    assert second_bucket == []
+
+
+def _gloo_credit_worker(rank: int, world_size: int, port: int) -> None:
+    os.environ["MASTER_ADDR"] = "127.0.0.1"
+    os.environ["MASTER_PORT"] = str(port)
+    dist.init_process_group("gloo", rank=rank, world_size=world_size)
+    try:
+        controller = WeightSyncCreditController(max_inflight_buckets=2, max_inflight_bytes=40)
+        controller.begin_version(11)
+        pending = []
+        received = []
+        peak_buckets = 0
+        peak_bytes = 0
+
+        for bucket_id, elements in enumerate((4, 6, 2, 8)):
+            bucket_bytes = elements * torch.tensor([], dtype=torch.float32).element_size()
+            reservation = controller.reserve(bucket_bytes)
+            if reservation is None:
+                oldest_reservation, oldest_handle = pending.pop(0)
+                oldest_handle.wait()
+                controller.release(oldest_reservation)
+                reservation = controller.reserve(bucket_bytes)
+            assert reservation is not None
+
+            tensor = torch.full((elements,), float(bucket_id + 1)) if rank == 0 else torch.zeros(elements)
+            handle = dist.broadcast(tensor, src=0, async_op=True)
+            pending.append((reservation, handle))
+            received.append(tensor)
+            peak_buckets = max(peak_buckets, controller.inflight_buckets)
+            peak_bytes = max(peak_bytes, controller.inflight_bytes)
+
+        while pending:
+            reservation, handle = pending.pop(0)
+            handle.wait()
+            controller.release(reservation)
+        controller.commit_version(11)
+
+        assert peak_buckets == 2
+        assert peak_bytes == 40
+        for bucket_id, tensor in enumerate(received):
+            torch.testing.assert_close(tensor, torch.full_like(tensor, float(bucket_id + 1)))
+    finally:
+        dist.destroy_process_group()
+
+
+@pytest.mark.unit
+def test_credit_window_drives_real_async_gloo_broadcasts() -> None:
+    mp.spawn(_gloo_credit_worker, args=(2, _free_port()), nprocs=2, join=True)
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__]))

--- a/tests/test_weight_sync_lifecycle_cuda.py
+++ b/tests/test_weight_sync_lifecycle_cuda.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import json
+import os
+import resource
+import time
+from pathlib import Path
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+from slime.backends.megatron_utils.update_weight.weight_sync_credit import WeightSyncCreditController
+
+NUM_GPUS = 0
+
+
+def _nccl_lifecycle_worker(rank: int, world_size: int, init_method: str, artifact_dir: str) -> None:
+    torch.cuda.set_device(rank)
+    dist.init_process_group("nccl", init_method=init_method, rank=rank, world_size=world_size)
+    control_group = dist.new_group(ranks=list(range(world_size)), backend="gloo")
+    bucket_elements = (257, 1024)
+    element_size = torch.empty((), dtype=torch.float32).element_size()
+    controller = WeightSyncCreditController(
+        max_inflight_buckets=2,
+        max_inflight_bytes=sum(bucket_elements) * element_size,
+    )
+    try:
+        device = torch.device("cuda", rank)
+        torch.cuda.reset_peak_memory_stats(device)
+        sync_started = time.perf_counter()
+        tensors = [
+            (
+                torch.full((elements,), float(bucket_id + 1), device=device)
+                if rank == 0
+                else torch.zeros(elements, device=device)
+            )
+            for bucket_id, elements in enumerate(bucket_elements)
+        ]
+        works = []
+        reservations = []
+        if rank == 0:
+            controller.begin_version(17)
+
+        for tensor in tensors:
+            bucket_bytes = tensor.numel() * tensor.element_size()
+            if rank == 0:
+                reservation = controller.reserve(bucket_bytes)
+                assert reservation is not None
+                controller.mark_launched(
+                    reservation,
+                    transport_bytes=bucket_bytes,
+                    staging_bytes=bucket_bytes,
+                    consumer_objects=world_size - 1,
+                )
+                reservations.append(reservation)
+            works.append(dist.broadcast(tensor, src=0, async_op=True))
+
+        if rank == 0:
+            launched = controller.snapshot
+            assert launched.inflight_buckets == 2
+            assert launched.transport_outstanding_bytes == sum(bucket_elements) * element_size
+            assert launched.pending_consumer_objects == world_size - 1 + world_size - 1
+
+        for bucket_id, (tensor, work) in enumerate(zip(tensors, works, strict=True)):
+            work.wait()
+            if rank == 0:
+                reservation = reservations[bucket_id]
+                controller.mark_transport_complete(reservation)
+                # The consumer cannot acknowledge until the source has observed
+                # that transport is still distinct from consumer completion.
+                assert controller.snapshot.pending_consumer_objects > 0
+                ready = [bucket_id]
+                dist.broadcast_object_list(ready, src=0, group=control_group)
+                acknowledgements = [None] * world_size
+                dist.all_gather_object(acknowledgements, f"rank-{rank}-loaded-{bucket_id}", group=control_group)
+                assert acknowledgements == [f"rank-{member}-loaded-{bucket_id}" for member in range(world_size)]
+                controller.mark_consumers_complete(reservation)
+                controller.mark_staging_released(reservation)
+                controller.release(reservation)
+            else:
+                ready = [None]
+                dist.broadcast_object_list(ready, src=0, group=control_group)
+                assert ready[0] == bucket_id
+                torch.testing.assert_close(tensor, torch.full_like(tensor, float(bucket_id + 1)))
+                acknowledgements = [None] * world_size
+                dist.all_gather_object(acknowledgements, f"rank-{rank}-loaded-{bucket_id}", group=control_group)
+
+        if rank == 0:
+            controller.commit_version(17)
+            snapshot = controller.snapshot
+            assert snapshot.active_version is None
+            assert snapshot.inflight_buckets == 0
+            assert snapshot.transport_outstanding_bytes == 0
+            assert snapshot.staging_resident_bytes == 0
+            assert snapshot.pending_consumer_objects == 0
+            metrics = controller.metrics()
+        else:
+            metrics = {}
+
+        torch.cuda.synchronize(device)
+        sync_seconds = time.perf_counter() - sync_started
+
+        report = {
+            "backend": dist.get_backend(),
+            "bucket_bytes": [elements * element_size for elements in bucket_elements],
+            "committed_version": 17 if rank == 0 else None,
+            "control_backend": dist.get_backend(control_group),
+            "host_max_rss_bytes": resource.getrusage(resource.RUSAGE_SELF).ru_maxrss * 1024,
+            "metrics": metrics,
+            "peak_cuda_memory_allocated_bytes": torch.cuda.max_memory_allocated(device),
+            "peak_cuda_memory_reserved_bytes": torch.cuda.max_memory_reserved(device),
+            "physical_gpu_uuids": os.environ.get("PHYSICAL_GPU_UUIDS", "unknown"),
+            "process_group_membership": list(range(world_size)),
+            "rank": rank,
+            "sync_seconds": sync_seconds,
+            "torch_version": torch.__version__,
+            "world_size": world_size,
+        }
+        output = Path(artifact_dir) / f"weight-sync-lifecycle-nccl-rank-{rank}.json"
+        output.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    finally:
+        dist.destroy_process_group(control_group)
+        dist.destroy_process_group()
+
+
+@pytest.mark.skipif(
+    os.environ.get("SLIME_RUN_WEIGHT_SYNC_LIFECYCLE_NCCL_TEST") != "1",
+    reason="set SLIME_RUN_WEIGHT_SYNC_LIFECYCLE_NCCL_TEST=1 for the opt-in NCCL check",
+)
+def test_weight_sync_lifecycle_with_nccl_transport(tmp_path: Path) -> None:
+    world_size = int(os.environ.get("SLIME_WEIGHT_SYNC_LIFECYCLE_WORLD_SIZE", "2"))
+    if world_size not in (2, 4):
+        pytest.fail("SLIME_WEIGHT_SYNC_LIFECYCLE_WORLD_SIZE must be 2 or 4")
+    if not torch.cuda.is_available() or torch.cuda.device_count() < world_size:
+        pytest.skip(f"the NCCL check requires {world_size} visible CUDA devices")
+    artifact_dir = os.environ.get("SLIME_WEIGHT_SYNC_LIFECYCLE_ARTIFACT_DIR", str(tmp_path))
+    Path(artifact_dir).mkdir(parents=True, exist_ok=True)
+    mp.spawn(
+        _nccl_lifecycle_worker,
+        args=(world_size, f"file://{tmp_path / 'nccl_init'}", artifact_dir),
+        nprocs=world_size,
+        join=True,
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__]))

--- a/tools/benchmark_weight_sync_callsite.py
+++ b/tools/benchmark_weight_sync_callsite.py
@@ -1,0 +1,813 @@
+"""Measure engine-wave policies at slime's production weight-sync callsite.
+
+This probe invokes ``update_weights_in_engine_group_waves`` directly.  It does
+not reimplement the scheduler and it never changes slime's runtime defaults.
+Each engine uses the production two-rank ``[trainer, engine]`` process-group
+shape; the launched world may contain any number of such engine groups.
+
+One distributed process launch records exactly one policy/evidence-role/run.
+Use separate launches for selection and confirmation, then summarize the raw
+artifacts with ``--summarize``.  Continuous iterations inside one launch are
+never counted as independent runs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.util
+import json
+import os
+import platform
+import socket
+import subprocess
+import sys
+import time
+import types
+import uuid
+from collections.abc import Sequence
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+import torch
+import torch.distributed as dist
+
+
+POLICIES = (
+    "isolated_a",
+    "isolated_b",
+    "baseline_overlap",
+    "current_legal",
+    "candidate_serialized",
+    "candidate_windowed",
+)
+EVIDENCE_ROLES = ("selection", "confirmation")
+SCHEMA = "slime.weight_sync_callsite.v1"
+
+
+@dataclass(frozen=True)
+class CallsitePolicy:
+    active_engine_indices: tuple[int, ...]
+    max_inflight_engine_groups: int
+
+
+@dataclass
+class LaunchObservation:
+    engine_index: int
+    host_launch_ns: int
+    host_wait_return_ns: int | None = None
+    start_event: torch.cuda.Event | None = None
+    completion_event: torch.cuda.Event | None = None
+
+
+class _ReadyRemoteMethod:
+    """Minimal actor method used only to cross the real callsite boundary."""
+
+    def __init__(self, engine_index: int) -> None:
+        self.engine_index = engine_index
+
+    def remote(self, **metadata: Any) -> dict[str, Any]:
+        return {"engine_index": self.engine_index, "metadata": metadata}
+
+
+class _ReadyEngine:
+    def __init__(self, engine_index: int) -> None:
+        self.update_weights_from_distributed = _ReadyRemoteMethod(engine_index)
+
+
+class _ObservedWork:
+    def __init__(self, work: Any, observation: LaunchObservation, device: torch.device) -> None:
+        self._work = work
+        self._observation = observation
+        self._device = device
+
+    def wait(self) -> object:
+        result = self._work.wait()
+        if self._device.type == "cuda":
+            completion = torch.cuda.Event(enable_timing=True)
+            completion.record(torch.cuda.current_stream(self._device))
+            self._observation.completion_event = completion
+        self._observation.host_wait_return_ns = time.perf_counter_ns()
+        return result
+
+
+def parse_size(value: str) -> int:
+    suffixes = {
+        "b": 1,
+        "kib": 1 << 10,
+        "mib": 1 << 20,
+        "gib": 1 << 30,
+        "kb": 1_000,
+        "mb": 1_000_000,
+        "gb": 1_000_000_000,
+    }
+    normalized = value.strip().lower().replace("_", "")
+    for suffix in sorted(suffixes, key=len, reverse=True):
+        if normalized.endswith(suffix):
+            number = float(normalized[: -len(suffix)])
+            result = number * suffixes[suffix]
+            if result <= 0 or not result.is_integer():
+                raise argparse.ArgumentTypeError(f"invalid positive byte size: {value}")
+            return int(result)
+    try:
+        result = int(normalized)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"invalid byte size: {value}") from exc
+    if result <= 0:
+        raise argparse.ArgumentTypeError(f"invalid positive byte size: {value}")
+    return result
+
+
+def resolve_policy(policy: str, engine_count: int, window_size: int) -> CallsitePolicy:
+    """Resolve benchmark labels to the production callsite's native limit."""
+    if policy not in POLICIES:
+        raise ValueError(f"unsupported policy: {policy}")
+    if engine_count < 2:
+        raise ValueError("the A/B callsite probe requires at least two engine groups")
+    if window_size < 1:
+        raise ValueError("window_size must be positive")
+
+    all_engines = tuple(range(engine_count))
+    if policy == "isolated_a":
+        return CallsitePolicy((0,), 0)
+    if policy == "isolated_b":
+        return CallsitePolicy((1,), 0)
+    if policy == "baseline_overlap":
+        return CallsitePolicy(all_engines, 0)
+    if policy == "current_legal":
+        return CallsitePolicy(all_engines, engine_count)
+    if policy == "candidate_serialized":
+        return CallsitePolicy(all_engines, 1)
+    return CallsitePolicy(all_engines, min(window_size, engine_count))
+
+
+def ordered_engine_indices(indices: Sequence[int], order: str) -> tuple[int, ...]:
+    if order == "ab":
+        return tuple(indices)
+    if order == "ba":
+        reordered = list(indices)
+        if 0 in reordered and 1 in reordered:
+            first = reordered.index(0)
+            second = reordered.index(1)
+            reordered[first], reordered[second] = reordered[second], reordered[first]
+        return tuple(reordered)
+    raise ValueError(f"unsupported A/B order: {order}")
+
+
+def percentile(values: Sequence[float], quantile: float) -> float | None:
+    if not values:
+        return None
+    ordered = sorted(values)
+    position = (len(ordered) - 1) * quantile
+    lower = int(position)
+    upper = min(lower + 1, len(ordered) - 1)
+    fraction = position - lower
+    return float(ordered[lower] * (1.0 - fraction) + ordered[upper] * fraction)
+
+
+def summarize_values(values: Sequence[float]) -> dict[str, float | None]:
+    return {
+        "p50": percentile(values, 0.50),
+        "p95": percentile(values, 0.95),
+        "min": min(values) if values else None,
+        "max": max(values) if values else None,
+    }
+
+
+def _canonical_json(payload: object) -> bytes:
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode()
+
+
+def artifact_digest(payload: dict[str, Any]) -> str:
+    unsigned = {key: value for key, value in payload.items() if key != "artifact_sha256"}
+    return hashlib.sha256(_canonical_json(unsigned)).hexdigest()
+
+
+def verify_artifact(payload: dict[str, Any]) -> None:
+    if payload.get("schema") != SCHEMA:
+        raise ValueError(f"unsupported schema: {payload.get('schema')!r}")
+    claimed = payload.get("artifact_sha256")
+    realized = artifact_digest(payload)
+    if claimed != realized:
+        raise ValueError(f"artifact digest mismatch: expected {claimed}, computed {realized}")
+    if payload.get("evidence_role") not in EVIDENCE_ROLES:
+        raise ValueError("invalid evidence_role")
+    if payload.get("policy") not in POLICIES:
+        raise ValueError("invalid policy")
+    expected_ranks = list(range(payload["compatibility"]["launched_world_size"]))
+    if payload.get("observed_ranks") != expected_ranks:
+        raise ValueError("artifact does not cover every launched rank")
+    if not payload.get("payload_validated"):
+        raise ValueError("artifact did not validate the received payload")
+
+
+def _nccl_version() -> str | None:
+    if not torch.cuda.is_available() or not hasattr(torch.cuda, "nccl"):
+        return None
+    version = torch.cuda.nccl.version()
+    if isinstance(version, tuple):
+        return ".".join(str(item) for item in version)
+    return str(version)
+
+
+def _device_metadata(device: torch.device) -> dict[str, Any] | None:
+    if device.type != "cuda":
+        return None
+    properties = torch.cuda.get_device_properties(device)
+    return {
+        "name": properties.name,
+        "total_memory_bytes": properties.total_memory,
+        "uuid": getattr(properties, "uuid", None),
+        "pci_bus_id": getattr(properties, "pci_bus_id", None),
+    }
+
+
+def _source_commit() -> str | None:
+    declared = os.environ.get("SLIME_BENCHMARK_SOURCE_COMMIT")
+    if declared:
+        return declared
+    try:
+        return subprocess.check_output(
+            ["git", "rev-parse", "HEAD"],
+            cwd=Path(__file__).resolve().parents[1],
+            stderr=subprocess.DEVNULL,
+            text=True,
+            timeout=5,
+        ).strip()
+    except (OSError, subprocess.SubprocessError):
+        return None
+
+
+def _numa_nodes() -> str | None:
+    path = Path("/sys/devices/system/node/online")
+    try:
+        return path.read_text().strip()
+    except OSError:
+        return None
+
+
+def build_compatibility(
+    *,
+    backend: str,
+    dtype: torch.dtype,
+    message_bytes: int,
+    world_size: int,
+    engine_count: int,
+    device: torch.device,
+    callsite_import_mode: str,
+) -> dict[str, Any]:
+    return {
+        "backend": backend,
+        "source_commit": _source_commit(),
+        "python": platform.python_version(),
+        "cpu_machine": platform.machine(),
+        "cpu_count": os.cpu_count(),
+        "numa_nodes_online": _numa_nodes(),
+        "pytorch": torch.__version__,
+        "cuda_runtime": torch.version.cuda,
+        "nccl": _nccl_version(),
+        "nccl_launch_order_implicit": os.environ.get("NCCL_LAUNCH_ORDER_IMPLICIT"),
+        "dtype": str(dtype).removeprefix("torch."),
+        "message_bytes": message_bytes,
+        "tensor_elements": message_bytes // torch.empty((), dtype=dtype).element_size(),
+        "launched_world_size": world_size,
+        "engine_group_count": engine_count,
+        "process_group_membership": [[0, engine_rank] for engine_rank in range(1, world_size)],
+        "callsite_import_mode": callsite_import_mode,
+        "graph_capture": False,
+        "hostname": socket.gethostname(),
+        "cuda_visible_devices": os.environ.get("CUDA_VISIBLE_DEVICES"),
+        "device": _device_metadata(device),
+        "container_image_digest": os.environ.get("SLIME_BENCHMARK_CONTAINER_DIGEST"),
+    }
+
+
+def _load_production_callsite_from_source() -> Any:
+    """Load the exact source file while stubbing unrelated control-plane imports.
+
+    This mode exists for minimal PyTorch benchmark containers. The exercised
+    scheduler, process-group operations, tensors, and Work handles are real;
+    only Ray actor references and Megatron conversion helpers that the probe
+    never calls are replaced. It is opt-in and recorded in the artifact.
+    """
+    repo_root = Path(__file__).resolve().parents[1]
+    package_paths = {
+        "slime.backends.megatron_utils": repo_root / "slime" / "backends" / "megatron_utils",
+        "slime.backends.megatron_utils.update_weight": (
+            repo_root / "slime" / "backends" / "megatron_utils" / "update_weight"
+        ),
+    }
+    for name, path in package_paths.items():
+        package = types.ModuleType(name)
+        package.__path__ = [str(path)]
+        sys.modules[name] = package
+
+    ray_module = types.ModuleType("ray")
+    ray_module.ObjectRef = object
+    ray_module.get = lambda refs: refs
+    ray_actor_module = types.ModuleType("ray.actor")
+    ray_actor_module.ActorHandle = object
+    megatron_module = types.ModuleType("megatron")
+    megatron_core_module = types.ModuleType("megatron.core")
+    megatron_core_module.mpu = types.ModuleType("megatron.core.mpu")
+    accelerator_module = types.ModuleType("slime.utils.accelerator")
+    distributed_utils_module = types.ModuleType("slime.utils.distributed_utils")
+    distributed_utils_module.get_gloo_group = lambda: None
+    distributed_utils_module.init_process_group = lambda **_kwargs: None
+    http_utils_module = types.ModuleType("slime.utils.http_utils")
+    http_utils_module._wrap_ipv6 = lambda address: address
+    converter_module = types.ModuleType("slime.backends.megatron_utils.megatron_to_hf")
+    converter_module.convert_to_hf = lambda *_args, **_kwargs: []
+    common_module = types.ModuleType("slime.backends.megatron_utils.update_weight.common")
+    common_module.all_gather_param = lambda _name, param: param
+    common_module.named_params_and_buffers = lambda *_args, **_kwargs: []
+    sys.modules.update(
+        {
+            "ray": ray_module,
+            "ray.actor": ray_actor_module,
+            "megatron": megatron_module,
+            "megatron.core": megatron_core_module,
+            "megatron.core.mpu": megatron_core_module.mpu,
+            "slime.utils.accelerator": accelerator_module,
+            "slime.utils.distributed_utils": distributed_utils_module,
+            "slime.utils.http_utils": http_utils_module,
+            "slime.backends.megatron_utils.megatron_to_hf": converter_module,
+            "slime.backends.megatron_utils.update_weight.common": common_module,
+        }
+    )
+
+    module_name = "slime.backends.megatron_utils.update_weight.update_weight_from_distributed"
+    module_path = package_paths["slime.backends.megatron_utils.update_weight"] / "update_weight_from_distributed.py"
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load production callsite from {module_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _load_production_callsite() -> tuple[Any, str]:
+    repo_root = Path(__file__).resolve().parents[1]
+    if str(repo_root) not in sys.path:
+        sys.path.insert(0, str(repo_root))
+    try:
+        from slime.backends.megatron_utils.update_weight import update_weight_from_distributed
+
+        return update_weight_from_distributed, "installed_runtime"
+    except ModuleNotFoundError:
+        if os.environ.get("SLIME_CALLSITE_SOURCE_LOAD") != "1":
+            raise RuntimeError(
+                "the installed slime control-plane dependencies are incomplete; "
+                "set SLIME_CALLSITE_SOURCE_LOAD=1 to use the recorded source-loader mode"
+            ) from None
+        return _load_production_callsite_from_source(), "source_with_control_plane_stubs"
+
+
+def _make_engine_groups(backend: str, world_size: int) -> tuple[list[Any], Any]:
+    groups = []
+    for engine_rank in range(1, world_size):
+        groups.append(dist.new_group(ranks=[0, engine_rank], backend=backend))
+    control_group = (
+        dist.group.WORLD if backend == "gloo" else dist.new_group(ranks=list(range(world_size)), backend="gloo")
+    )
+    return groups, control_group
+
+
+def _sync_device(device: torch.device) -> None:
+    if device.type == "cuda":
+        torch.cuda.synchronize(device)
+
+
+def _run_one_iteration(
+    *,
+    module: Any,
+    policy: CallsitePolicy,
+    order: str,
+    process_groups: Sequence[Any],
+    control_group: Any,
+    rank: int,
+    device: torch.device,
+    dtype: torch.dtype,
+    tensor_elements: int,
+    iteration: int,
+) -> dict[str, Any]:
+    active_indices = ordered_engine_indices(policy.active_engine_indices, order)
+    value = float((iteration % 17) + 1)
+    sender_tensor = torch.full((tensor_elements,), value, device=device, dtype=dtype) if rank == 0 else None
+    receiver_tensor = (
+        torch.zeros((tensor_elements,), device=device, dtype=dtype)
+        if rank > 0 and rank - 1 in active_indices
+        else None
+    )
+
+    dist.barrier(group=control_group)
+    iteration_start_ns = time.perf_counter_ns()
+    rank_record: dict[str, Any] = {"rank": rank, "consumer": None}
+    controller_observations: list[LaunchObservation] = []
+
+    if rank == 0:
+        original_launch = module.launch_weights_from_distributed
+        original_ray_get = module.ray.get
+        index_by_group_name = {f"callsite-engine-{index}": index for index in active_indices}
+
+        def observed_launch(
+            group_name: str,
+            group: Any,
+            weight_version: int,
+            rollout_engines: Sequence[Any],
+            converted_named_tensors: Sequence[tuple[str, torch.Tensor]],
+            load_format: str | None = None,
+        ) -> tuple[list[Any], list[Any]]:
+            engine_index = index_by_group_name[group_name]
+            observation = LaunchObservation(engine_index=engine_index, host_launch_ns=time.perf_counter_ns())
+            if device.type == "cuda":
+                observation.start_event = torch.cuda.Event(enable_timing=True)
+                observation.start_event.record(torch.cuda.current_stream(device))
+            refs, works = original_launch(
+                group_name,
+                group,
+                weight_version,
+                rollout_engines,
+                converted_named_tensors,
+                load_format=load_format,
+            )
+            controller_observations.append(observation)
+            return refs, [_ObservedWork(work, observation, device) for work in works]
+
+        module.launch_weights_from_distributed = observed_launch
+        module.ray.get = lambda refs: refs
+        try:
+            update_groups = [
+                module.DistributedWeightUpdateGroup(
+                    engine_indices=(index,),
+                    group_name=f"callsite-engine-{index}",
+                    process_group=process_groups[index],
+                    rollout_engines=(_ReadyEngine(index),),
+                )
+                for index in active_indices
+            ]
+            module.update_weights_in_engine_group_waves(
+                update_groups,
+                weight_version=iteration + 1,
+                converted_named_tensors=[("probe.weight", sender_tensor)],
+                max_inflight_engine_groups=policy.max_inflight_engine_groups,
+                load_format="callsite_probe",
+            )
+        finally:
+            module.launch_weights_from_distributed = original_launch
+            module.ray.get = original_ray_get
+        callsite_return_ns = time.perf_counter_ns()
+        _sync_device(device)
+        controller_ready_ns = time.perf_counter_ns()
+        observations = []
+        for item in controller_observations:
+            if item.host_wait_return_ns is None:
+                raise RuntimeError("production callsite returned without waiting for a collective")
+            if item.start_event is not None:
+                if item.completion_event is None:
+                    raise RuntimeError("CUDA collective did not record a completion dependency")
+                duration_ms = item.start_event.elapsed_time(item.completion_event)
+                timing_kind = "event_bracket"
+            else:
+                duration_ms = (item.host_wait_return_ns - item.host_launch_ns) / 1_000_000
+                timing_kind = "host_blocking_interval"
+            observations.append(
+                {
+                    "engine_index": item.engine_index,
+                    "host_launch_ns": item.host_launch_ns,
+                    "host_wait_return_ns": item.host_wait_return_ns,
+                    "duration_ms": duration_ms,
+                    "timing_kind": timing_kind,
+                }
+            )
+        rank_record.update(
+            {
+                "controller_observations": observations,
+                "callsite_return_ms": (callsite_return_ns - iteration_start_ns) / 1_000_000,
+                "controller_device_ready_ms": (controller_ready_ns - iteration_start_ns) / 1_000_000,
+            }
+        )
+    elif rank - 1 in active_indices:
+        engine_index = rank - 1
+        consumer_wait_start_ns = time.perf_counter_ns()
+        work = dist.broadcast(receiver_tensor, src=0, group=process_groups[engine_index], async_op=True)
+        work.wait()
+        _sync_device(device)
+        consumer_ready_ns = time.perf_counter_ns()
+        expected = torch.full_like(receiver_tensor, value)
+        payload_valid = bool(torch.equal(receiver_tensor, expected))
+        rank_record["consumer"] = {
+            "engine_index": engine_index,
+            "wait_ms": (consumer_ready_ns - consumer_wait_start_ns) / 1_000_000,
+            "ready_ms": (consumer_ready_ns - iteration_start_ns) / 1_000_000,
+            "payload_valid": payload_valid,
+        }
+
+    dist.barrier(group=control_group)
+    sync_ready_ns = time.perf_counter_ns()
+    rank_record["step_sync_ready_ms"] = (sync_ready_ns - iteration_start_ns) / 1_000_000
+    gathered: list[dict[str, Any] | None] | None = [None] * dist.get_world_size() if rank == 0 else None
+    dist.gather_object(rank_record, gathered, dst=0, group=control_group)
+
+    if rank != 0:
+        return {}
+    assert gathered is not None
+    records = [item for item in gathered if item is not None]
+    controller = records[0]
+    observations_by_engine = {item["engine_index"]: item for item in controller["controller_observations"]}
+    consumers_by_engine = {
+        item["consumer"]["engine_index"]: item["consumer"] for item in records if item.get("consumer") is not None
+    }
+    pair = [observations_by_engine[index] for index in (0, 1) if index in observations_by_engine]
+    pair_makespan_ms = None
+    realized_offset_us = None
+    if len(pair) == 2:
+        pair_makespan_ms = (
+            max(item["host_wait_return_ns"] for item in pair) - min(item["host_launch_ns"] for item in pair)
+        ) / 1_000_000
+        realized_offset_us = (
+            observations_by_engine[1]["host_launch_ns"] - observations_by_engine[0]["host_launch_ns"]
+        ) / 1_000
+    return {
+        "iteration": iteration,
+        "controller_observations": controller["controller_observations"],
+        "comm_a_ms": observations_by_engine.get(0, {}).get("duration_ms"),
+        "comm_b_ms": observations_by_engine.get(1, {}).get("duration_ms"),
+        "rank_local_pair_makespan_ms": pair_makespan_ms,
+        "realized_b_minus_a_launch_offset_us": realized_offset_us,
+        "consumer_a_wait_ms": consumers_by_engine.get(0, {}).get("wait_ms"),
+        "consumer_b_wait_ms": consumers_by_engine.get(1, {}).get("wait_ms"),
+        "consumer_ready_ms": max(
+            (item["ready_ms"] for item in consumers_by_engine.values()),
+            default=None,
+        ),
+        "callsite_return_ms": controller["callsite_return_ms"],
+        "controller_device_ready_ms": controller["controller_device_ready_ms"],
+        "step_sync_ready_ms": max(item["step_sync_ready_ms"] for item in records),
+        "payload_valid": all(item["payload_valid"] for item in consumers_by_engine.values()),
+        "observed_ranks": sorted(item["rank"] for item in records),
+    }
+
+
+def _metric_summary(iterations: Sequence[dict[str, Any]], key: str) -> dict[str, float | None]:
+    return summarize_values([float(item[key]) for item in iterations if item.get(key) is not None])
+
+
+def run_distributed(args: argparse.Namespace) -> None:
+    if not dist.is_available():
+        raise RuntimeError("torch.distributed is unavailable")
+    backend = args.backend
+    if backend == "auto":
+        backend = "nccl" if torch.cuda.is_available() else "gloo"
+    if backend == "nccl" and not torch.cuda.is_available():
+        raise RuntimeError("NCCL requested without CUDA")
+
+    rank = int(os.environ["RANK"])
+    local_rank = int(os.environ.get("LOCAL_RANK", rank))
+    device = torch.device("cuda", local_rank) if backend == "nccl" else torch.device("cpu")
+    if device.type == "cuda":
+        torch.cuda.set_device(device)
+    dist.init_process_group(backend=backend)
+    try:
+        world_size = dist.get_world_size()
+        engine_count = world_size - 1
+        resolved = resolve_policy(args.policy, engine_count, args.window_size)
+        process_groups, control_group = _make_engine_groups(backend, world_size)
+        dtype = getattr(torch, args.dtype)
+        element_size = torch.empty((), dtype=dtype).element_size()
+        if args.message_bytes % element_size:
+            raise ValueError("message_bytes must be divisible by dtype element size")
+        tensor_elements = args.message_bytes // element_size
+
+        launch_id = str(uuid.uuid4()) if rank == 0 else None
+        launch_id_box = [launch_id]
+        dist.broadcast_object_list(launch_id_box, src=0, group=control_group)
+        launch_id = launch_id_box[0]
+        module, callsite_import_mode = _load_production_callsite()
+
+        for warmup_index in range(args.warmup):
+            _run_one_iteration(
+                module=module,
+                policy=resolved,
+                order=args.order,
+                process_groups=process_groups,
+                control_group=control_group,
+                rank=rank,
+                device=device,
+                dtype=dtype,
+                tensor_elements=tensor_elements,
+                iteration=-(warmup_index + 1),
+            )
+        iterations = []
+        for iteration in range(args.iterations):
+            result = _run_one_iteration(
+                module=module,
+                policy=resolved,
+                order=args.order,
+                process_groups=process_groups,
+                control_group=control_group,
+                rank=rank,
+                device=device,
+                dtype=dtype,
+                tensor_elements=tensor_elements,
+                iteration=iteration,
+            )
+            if rank == 0:
+                iterations.append(result)
+
+        if rank == 0:
+            compatibility = build_compatibility(
+                backend=backend,
+                dtype=dtype,
+                message_bytes=args.message_bytes,
+                world_size=world_size,
+                engine_count=engine_count,
+                device=device,
+                callsite_import_mode=callsite_import_mode,
+            )
+            payload = {
+                "schema": SCHEMA,
+                "run_id": args.run_id,
+                "process_launch_id": launch_id,
+                "evidence_role": args.evidence_role,
+                "policy": args.policy,
+                "order": args.order,
+                "resolved_policy": asdict(resolved),
+                "timing_scope": {
+                    "communication": "rank-local host interval for Gloo; CUDA event bracket for NCCL",
+                    "pair": "controller-rank host launch through Work.wait return",
+                    "consumer": "receiver Work.wait plus device synchronization and payload read",
+                    "sync_ready": "same-host control barrier after every receiver consumed the payload",
+                    "kernel_observed": False,
+                },
+                "compatibility": compatibility,
+                "iterations": iterations,
+                "summary": {
+                    key: _metric_summary(iterations, key)
+                    for key in (
+                        "comm_a_ms",
+                        "comm_b_ms",
+                        "rank_local_pair_makespan_ms",
+                        "realized_b_minus_a_launch_offset_us",
+                        "consumer_a_wait_ms",
+                        "consumer_b_wait_ms",
+                        "consumer_ready_ms",
+                        "callsite_return_ms",
+                        "controller_device_ready_ms",
+                        "step_sync_ready_ms",
+                    )
+                },
+                "observed_ranks": iterations[0]["observed_ranks"],
+                "payload_validated": all(item["payload_valid"] for item in iterations),
+                "claim_limits": [
+                    "This is the production scheduler callsite with synthetic tensors and ready metadata refs.",
+                    "It is not a Ray/SGLang load benchmark or an end-to-end training throughput claim.",
+                    "Event brackets are not labeled as profiler-observed kernel durations.",
+                    "One process launch is one independent run regardless of iteration count.",
+                ],
+            }
+            payload["artifact_sha256"] = artifact_digest(payload)
+            verify_artifact(payload)
+            output = Path(args.output_json)
+            output.parent.mkdir(parents=True, exist_ok=True)
+            output.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    finally:
+        dist.destroy_process_group()
+
+
+def compatibility_cell(payload: dict[str, Any]) -> bytes:
+    return _canonical_json(payload["compatibility"])
+
+
+def summarize_artifacts(paths: Sequence[Path], *, min_runs_per_role: int) -> dict[str, Any]:
+    if min_runs_per_role < 1:
+        raise ValueError("min_runs_per_role must be positive")
+    artifacts = [json.loads(path.read_text()) for path in paths]
+    if not artifacts:
+        raise ValueError("at least one artifact is required")
+    for artifact in artifacts:
+        verify_artifact(artifact)
+    reference_cell = compatibility_cell(artifacts[0])
+    if any(compatibility_cell(artifact) != reference_cell for artifact in artifacts[1:]):
+        raise ValueError("artifacts cross an incompatible runtime/message/topology cell")
+
+    run_ids = [artifact["run_id"] for artifact in artifacts]
+    launch_ids = [artifact["process_launch_id"] for artifact in artifacts]
+    if len(run_ids) != len(set(run_ids)):
+        raise ValueError("run_id values must be unique")
+    if len(launch_ids) != len(set(launch_ids)):
+        raise ValueError("process_launch_id values must be unique")
+
+    counts: dict[str, dict[str, int]] = {policy: {role: 0 for role in EVIDENCE_ROLES} for policy in POLICIES}
+    for artifact in artifacts:
+        counts[artifact["policy"]][artifact["evidence_role"]] += 1
+    missing = [
+        f"{policy}/{role}={count}"
+        for policy, by_role in counts.items()
+        for role, count in by_role.items()
+        if count < min_runs_per_role
+    ]
+    if missing:
+        raise ValueError(
+            f"each policy/evidence role requires {min_runs_per_role} independent process runs; " + ", ".join(missing)
+        )
+
+    metric_names = (
+        "comm_a_ms",
+        "comm_b_ms",
+        "rank_local_pair_makespan_ms",
+        "consumer_a_wait_ms",
+        "consumer_b_wait_ms",
+        "consumer_ready_ms",
+        "callsite_return_ms",
+        "controller_device_ready_ms",
+        "step_sync_ready_ms",
+    )
+    policy_summaries = {}
+    for policy in POLICIES:
+        policy_summaries[policy] = {}
+        for role in EVIDENCE_ROLES:
+            selected = [
+                artifact
+                for artifact in artifacts
+                if artifact["policy"] == policy and artifact["evidence_role"] == role
+            ]
+            policy_summaries[policy][role] = {
+                "independent_process_runs": len(selected),
+                "orders": sorted({artifact["order"] for artifact in selected}),
+                "metrics": {
+                    metric: summarize_values(
+                        [
+                            float(artifact["summary"][metric]["p50"])
+                            for artifact in selected
+                            if artifact["summary"][metric]["p50"] is not None
+                        ]
+                    )
+                    for metric in metric_names
+                },
+            }
+
+    result = {
+        "schema": "slime.weight_sync_callsite_campaign.v1",
+        "compatibility": artifacts[0]["compatibility"],
+        "artifact_count": len(artifacts),
+        "minimum_independent_runs_per_policy_role": min_runs_per_role,
+        "policy_summaries": policy_summaries,
+        "selection_and_confirmation_disjoint": True,
+        "automatic_policy_selection": False,
+        "claim_limits": artifacts[0]["claim_limits"],
+        "input_artifact_sha256": sorted(artifact["artifact_sha256"] for artifact in artifacts),
+    }
+    result["artifact_sha256"] = artifact_digest(result)
+    return result
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--summarize", nargs="+", type=Path)
+    parser.add_argument("--summary-json", type=Path)
+    parser.add_argument("--min-runs-per-role", type=int, default=5)
+    parser.add_argument("--backend", choices=("auto", "gloo", "nccl"), default="auto")
+    parser.add_argument("--policy", choices=POLICIES)
+    parser.add_argument("--evidence-role", choices=EVIDENCE_ROLES)
+    parser.add_argument("--run-id")
+    parser.add_argument("--order", choices=("ab", "ba"), default="ab")
+    parser.add_argument("--message-bytes", type=parse_size, default=parse_size("1MiB"))
+    parser.add_argument("--dtype", choices=("float32", "float16", "bfloat16"), default="float32")
+    parser.add_argument("--window-size", type=int, default=2)
+    parser.add_argument("--warmup", type=int, default=2)
+    parser.add_argument("--iterations", type=int, default=5)
+    parser.add_argument("--output-json", type=Path)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    if args.summarize:
+        if not args.summary_json:
+            raise SystemExit("--summary-json is required with --summarize")
+        result = summarize_artifacts(args.summarize, min_runs_per_role=args.min_runs_per_role)
+        args.summary_json.parent.mkdir(parents=True, exist_ok=True)
+        args.summary_json.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n")
+        print(f"wrote {args.summary_json} ({result['artifact_count']} independent process artifacts)")
+        return 0
+
+    required = {
+        "--policy": args.policy,
+        "--evidence-role": args.evidence_role,
+        "--run-id": args.run_id,
+        "--output-json": args.output_json,
+    }
+    missing = [flag for flag, value in required.items() if value is None]
+    if missing:
+        raise SystemExit("missing distributed-run arguments: " + ", ".join(missing))
+    if args.warmup < 0 or args.iterations < 1:
+        raise SystemExit("--warmup must be non-negative and --iterations must be positive")
+    run_distributed(args)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/train.py
+++ b/train.py
@@ -82,7 +82,7 @@ def train(args):
         offload_train(actor_trains)
         if args.offload_rollout and not release_train:
             ray.get(rollout_manager.onload_weights.remote())
-        actor_model.update_weights()
+        actor_model.update_weights(rollout_id=rollout_id)
 
         if args.offload_rollout:
             ray.get(rollout_manager.onload_kv.remote())

--- a/train_async.py
+++ b/train_async.py
@@ -67,7 +67,7 @@ def train(args):
             # sync generate before update weights to prevent update weight in the middle of generation
             rollout_data_curr_ref = ray.get(x) if (x := rollout_data_next_future) is not None else None
             rollout_data_next_future = None
-            actor_model.update_weights()
+            actor_model.update_weights(rollout_id=rollout_id)
 
         if should_run_periodic_action(rollout_id, args.eval_interval, num_rollout_per_epoch):
             ray.get(rollout_manager.eval.remote(rollout_id))


### PR DESCRIPTION
## Summary

Compose the engine-wave, bucket-credit and trainer-timeline proposals in #2351, #2352 and #2353. This is a Draft integration follow-up, not an additional competing scheduler. The new integration commits are 6ce21e4 and 58d5048; GitHub's main-based aggregate diff also includes their prerequisite stacks.

- Hold one logical bucket reservation across all engine waves; drain transport, staging and consumer acknowledgements before advancing a wave.
- Propagate peer failures, retain failed-wave resources, and publish the weight version only after successful loads and resume barriers.
- Keep API return distinct from subsequent completion; record wave identity, ACK spans and actual credit-release/publication boundaries.
- Keep tracing disabled by default. Multi-wave mode drains each bucket's waves before admitting the next bucket and does not claim inter-bucket overlap.

## Validation

Recorded on this exact integration revision before publication:

- 101 targeted CPU tests passed, covering timeline, credits, tensor/IPC updater contracts, wave helpers/callsites, benchmarks and arguments.
- Included a real two-rank asynchronous Gloo credit test; an additional four-rank Gloo callsite smoke passed with actual trainer/engine process groups and control-plane stubs.
- Pinned isort 5.13.2, Black 24.3.0 and Ruff 0.14.7 checks passed; patch application reproduced the exact integration tree.

The CPU engine fixtures and fake-CUDA event tests are not real SGLang loads. Full trainer-to-conversion-to-Ray/SGLang GPU execution, full-model numerical checks and independent performance confirmation remain outstanding. No new GPU run or performance improvement is claimed by this publication.

## Review notes

The prerequisite PRs remain separate review units. This draft records their composition fixes and tests; do not apply both its aggregate patch and the original stacks twice. Rebase/narrow the diff after prerequisites land. An open-PR search found the existing measurement/runtime proposals, not a separate implementation of these composition fixes.

AI assistance: OpenAI Codex. Keep Draft until human review and the outstanding production checks are complete.
